### PR TITLE
#42 Azure remote debugging - breaking doesn't work

### DIFF
--- a/Python/Product/Debugger/Debugger/PythonProcess.cs
+++ b/Python/Product/Debugger/Debugger/PythonProcess.cs
@@ -515,6 +515,7 @@ namespace Microsoft.PythonTools.Debugger {
                 using (var source = new FileStream(filename, FileMode.Open, FileAccess.Read, FileShare.Read)) {
                     ast = Parser.CreateParser(source, LanguageVersion).ParseFile();
                 }
+            } catch (ArgumentException) {
             } catch (IOException) {
             } catch (UnauthorizedAccessException) {
             } catch (NotSupportedException) {


### PR DESCRIPTION
We've started trying to read the source file when listing frames, but we weren't handling the case where we couldn't load the file.