### PR TITLE
Add assembly catalog _after_ verifying that the assembly can be loaded.

### DIFF
--- a/Common/Tests/MockVsTests/MockVs.cs
+++ b/Common/Tests/MockVsTests/MockVs.cs
@@ -372,13 +372,13 @@ namespace Microsoft.VisualStudioTools.MockVsTests {
                 }
 
                 Console.WriteLine("Including {0}", file);
-                catalogs.Add(new AssemblyCatalog(asm));
                 try {
                     foreach (var type in asm.GetTypes()) {
                         if (type.IsDefined(typeof(PackageRegistrationAttribute), false)) {
                             packageTypes.Add(type);
                         }
                     }
+                    catalogs.Add(new AssemblyCatalog(asm));
                 } catch (TypeInitializationException tix) {
                     Console.WriteLine(tix);
                 } catch (ReflectionTypeLoadException tlx) {


### PR DESCRIPTION
This fixes test errors where an assembly can't be loaded lazily, which we detect in GetTypes but it's still in the catalog, so MEF fails later on.