### PR TITLE
fixes #62 Crash collapsing region block

### DIFF
--- a/Python/Product/PythonTools/PythonTools/OutliningTaggerProvider.cs
+++ b/Python/Product/PythonTools/PythonTools/OutliningTaggerProvider.cs
@@ -171,12 +171,11 @@ namespace Microsoft.PythonTools {
                         headerIndex = startLineEnd;
                     }
 
-                    int testLen = headerIndex - start + 1;
                     if (start != -1 && end != -1) {
-                        int length = end - start - testLen;
+                        int length = end - headerIndex;
                         if (length > 0) {
                             var span = GetFinalSpan(snapshot,
-                                start + testLen,
+                                headerIndex,
                                 length
                             );
 
@@ -198,14 +197,6 @@ namespace Microsoft.PythonTools {
                 Debug.Assert(start + length <= snapshot.Length);
                 int cnt = 0;
                 var text = snapshot.GetText(start, length);
-
-                // The VS Provider is fragile to us splitting in between \r\n.  
-                // Check here that we haven't done that and correct the error.
-                if (text[0] == '\n' && start >= 1 && snapshot.GetText(start - 1, 1) == "\r") {
-                    start -= 1;
-                    length += 1;
-                    text = snapshot.GetText(start, length);
-                }
 
                 // remove up to 2 \r\n's if we just end with these, this will leave a space between the methods
                 while (length > 0 && ((Char.IsWhiteSpace(text[length - 1])) || ((text[length - 1] == '\r' || text[length - 1] == '\n') && cnt++ < 4))) {
@@ -331,7 +322,7 @@ namespace Microsoft.PythonTools {
             }
 
             public override bool Walk(ClassDefinition node) {
-                AddTagIfNecessary(node, node.HeaderIndex, node.Decorators);
+                AddTagIfNecessary(node, node.HeaderIndex + 1, node.Decorators);
 
                 return base.Walk(node);
             }

--- a/Python/Product/PythonTools/PythonTools/OutliningTaggerProvider.cs
+++ b/Python/Product/PythonTools/PythonTools/OutliningTaggerProvider.cs
@@ -199,6 +199,14 @@ namespace Microsoft.PythonTools {
                 int cnt = 0;
                 var text = snapshot.GetText(start, length);
 
+                // The VS Provider is fragile to us splitting in between \r\n.  
+                // Check here that we haven't done that and correct the error.
+                if (text[0] == '\n' && start >= 1 && snapshot.GetText(start - 1, 1) == "\r") {
+                    start -= 1;
+                    length += 1;
+                    text = snapshot.GetText(start, length);
+                }
+
                 // remove up to 2 \r\n's if we just end with these, this will leave a space between the methods
                 while (length > 0 && ((Char.IsWhiteSpace(text[length - 1])) || ((text[length - 1] == '\r' || text[length - 1] == '\n') && cnt++ < 4))) {
                     length--;

--- a/Python/Tests/Core/EditorTests.cs
+++ b/Python/Tests/Core/EditorTests.cs
@@ -53,8 +53,8 @@ class someClass:
 #    endregion someClass";
 
             SnapshotRegionTest(content,
-                new ExpectedTag(30, 77, "\nif param: \r\n    print('hello')\r\n    #endregion"),
-                new ExpectedTag(161, 269, "\nclass someClass:\r\n    def this( self ):\r\n        return self._hidden_variable * 2\r\n#    endregion someClass"));
+                new ExpectedTag(29, 77, "\r\nif param: \r\n    print('hello')\r\n    #endregion"),
+                new ExpectedTag(160, 269, "\r\nclass someClass:\r\n    def this( self ):\r\n        return self._hidden_variable * 2\r\n#    endregion someClass"));
         }
 
         [TestMethod, Priority(0), TestCategory("Core")]
@@ -66,7 +66,7 @@ class someClass:
 #region";
 
             SnapshotRegionTest(content,
-                new ExpectedTag(8, 19, "\n#endregion"));
+                new ExpectedTag(7, 19, "\r\n#endregion"));
         }
 
         #endregion Outlining Regions
@@ -97,10 +97,10 @@ if param and \
     print('!')";
 
             SnapshotOutlineTest(content,
-                new ExpectedTag(150, 205, "\n    print('hello')\r\n    print('world')\r\n    print('!')"),
-                new ExpectedTag(10, 65, "\n    print('hello')\r\n    print('world')\r\n    print('!')"),
-                new ExpectedTag(85, 140, "\n    print('hello')\r\n    print('world')\r\n    print('!')"),
-                new ExpectedTag(224, 291, "\n    param:\r\n    print('hello')\r\n    print('world')\r\n    print('!')"));
+                new ExpectedTag(149, 205, "\r\n    print('hello')\r\n    print('world')\r\n    print('!')"),
+                new ExpectedTag(9, 65, "\r\n    print('hello')\r\n    print('world')\r\n    print('!')"),
+                new ExpectedTag(84, 140, "\r\n    print('hello')\r\n    print('world')\r\n    print('!')"),
+                new ExpectedTag(223, 291, "\r\n    param:\r\n    print('hello')\r\n    print('world')\r\n    print('!')"));
         }
 
         [TestMethod, Priority(0), TestCategory("Core")]
@@ -111,7 +111,7 @@ if param and \
     print('hello')";
 
             SnapshotOutlineTest(content,
-               new ExpectedTag(22, 66, "\n    and e \\\r\n    and f:\r\n    print('hello')"));
+               new ExpectedTag(21, 66, "\r\n    and e \\\r\n    and f:\r\n    print('hello')"));
         }
 
         [TestMethod, Priority(0), TestCategory("Core")]
@@ -135,9 +135,9 @@ for x in [1,2,3,4]:
     print('for2')
     print('for2')";
             SnapshotOutlineTest(content,
-                new ExpectedTag(12, 64, "\n    1,\r\n    2,\r\n    3,\r\n    4\r\n]:\r\n    print('for')"),
-                new ExpectedTag(74, 133, "\n    print('final')\r\n    print('final')\r\n    print('final')"),
-                new ExpectedTag(159, 215, "\n    print('for2')\r\n    print('for2')\r\n    print('for2')"));
+                new ExpectedTag(11, 64, "\r\n    1,\r\n    2,\r\n    3,\r\n    4\r\n]:\r\n    print('for')"),
+                new ExpectedTag(73, 133, "\r\n    print('final')\r\n    print('final')\r\n    print('final')"),
+                new ExpectedTag(158, 215, "\r\n    print('for2')\r\n    print('for2')\r\n    print('for2')"));
         }
 
         [TestMethod, Priority(0), TestCategory("Core")]
@@ -167,13 +167,13 @@ finally:
     print('finally2')";
 
             SnapshotOutlineTest(content,
-                new ExpectedTag(8, 43, "\n    print('try')\r\n    print('try')"),
-                new ExpectedTag(63, 110, "\n    print('TypeError')\r\n    print('TypeError')"),
-                new ExpectedTag(130, 177, "\n    print('NameError')\r\n    print('NameError')"),
-                new ExpectedTag(233, 276, "\n    print('finally')\r\n    print('finally')"),
-                new ExpectedTag(185, 222, "\n    print('else')\r\n    print('else')"),
-                new ExpectedTag(286, 323, "\n    print('try2')\r\n    print('try2')"),
-                new ExpectedTag(334, 379, "\n    print('finally2')\r\n    print('finally2')"));
+                new ExpectedTag(7, 43, "\r\n    print('try')\r\n    print('try')"),
+                new ExpectedTag(62, 110, "\r\n    print('TypeError')\r\n    print('TypeError')"),
+                new ExpectedTag(129, 177, "\r\n    print('NameError')\r\n    print('NameError')"),
+                new ExpectedTag(232, 276, "\r\n    print('finally')\r\n    print('finally')"),
+                new ExpectedTag(184, 222, "\r\n    print('else')\r\n    print('else')"),
+                new ExpectedTag(285, 323, "\r\n    print('try2')\r\n    print('try2')"),
+                new ExpectedTag(333, 379, "\r\n    print('finally2')\r\n    print('finally2')"));
         }
 
         [TestMethod, Priority(0), TestCategory("Core")]
@@ -183,7 +183,7 @@ finally:
     print(line)";
 
             SnapshotOutlineTest(content,
-                new ExpectedTag(28, 69, "\n    line = f.readline()\r\n    print(line)"));
+                new ExpectedTag(27, 69, "\r\n    line = f.readline()\r\n    print(line)"));
         }
 
         [TestMethod, Priority(0), TestCategory("Core")]
@@ -198,8 +198,8 @@ def f():
         print('g')";
 
             SnapshotOutlineTest(content,
-                new ExpectedTag(34, 134, "\n    print('f')\r\n    def g(a, \r\n          b, \r\n          c):\r\n        print('g')\r\n        print('g')"),
-                new ExpectedTag(65, 134, "\n          b, \r\n          c):\r\n        print('g')\r\n        print('g')"));
+                new ExpectedTag(33, 134, "\r\n    print('f')\r\n    def g(a, \r\n          b, \r\n          c):\r\n        print('g')\r\n        print('g')"),
+                new ExpectedTag(64, 134, "\r\n          b, \r\n          c):\r\n        print('g')\r\n        print('g')"));
         }
 
         [TestMethod, Priority(0), TestCategory("Core")]
@@ -220,7 +220,7 @@ def f():
                c)";
 
             SnapshotOutlineTest(content,
-                new ExpectedTag(21, 58, "\n               b,\r\n               c)"));
+                new ExpectedTag(20, 58, "\r\n               b,\r\n               c)"));
         }
 
         #endregion Outline Compound Statements
@@ -244,9 +244,9 @@ def f():
 ";
 
             SnapshotOutlineTest(content,
-                new ExpectedTag(8, 25, "\n     2,\r\n     3]"),
-                new ExpectedTag(33, 123, "\n        [2,\r\n         3,\r\n         5, 6, 7,\r\n         9,\r\n         10],\r\n        4\r\n    ]"),
-                new ExpectedTag(46, 104, "\n         3,\r\n         5, 6, 7,\r\n         9,\r\n         10]"));
+                new ExpectedTag(7, 25, "\r\n     2,\r\n     3]"),
+                new ExpectedTag(32, 123, "\r\n        [2,\r\n         3,\r\n         5, 6, 7,\r\n         9,\r\n         10],\r\n        4\r\n    ]"),
+                new ExpectedTag(45, 104, "\r\n         3,\r\n         5, 6, 7,\r\n         9,\r\n         10]"));
         }
 
         [TestMethod, Priority(0), TestCategory("Core")]
@@ -256,7 +256,7 @@ def f():
   'value3')";
 
             SnapshotOutlineTest(content,
-                new ExpectedTag(13, 38, "\n  'value2',\r\n  'value3')"));
+                new ExpectedTag(12, 38, "\r\n  'value2',\r\n  'value3')"));
         }
 
         [TestMethod, Priority(0), TestCategory("Core")]
@@ -272,8 +272,8 @@ def f():
                   ""tuple4"")}";
 
             SnapshotOutlineTest(content,
-                new ExpectedTag(25, 283, 
-                    "\n        \"hello\":\"world\",\"hello\":[1,\r\n" + 
+                new ExpectedTag(24, 283, 
+                    "\r\n        \"hello\":\"world\",\"hello\":[1,\r\n" + 
                     "                                 2,3,4,\r\n" + 
                     "                                 5],\r\n" + 
                     "        \"hello\":\"world\",\r\n" + 
@@ -281,8 +281,8 @@ def f():
                     "                  \"tuple2\"," + 
                     "\r\n                  \"tuple3\"," +
                     "\r\n                  \"tuple4\")}"),
-                new ExpectedTag(62, 139, "\n                                 2,3,4,\r\n                                 5]"),
-                new ExpectedTag(196, 282, "\n                  \"tuple2\",\r\n                  \"tuple3\",\r\n                  \"tuple4\")"));
+                new ExpectedTag(61, 139, "\r\n                                 2,3,4,\r\n                                 5]"),
+                new ExpectedTag(195, 282, "\r\n                  \"tuple2\",\r\n                  \"tuple3\",\r\n                  \"tuple4\")"));
         }
 
         [TestMethod, Priority(0), TestCategory("Core")]
@@ -295,7 +295,7 @@ def f():
 )";
 
             SnapshotOutlineTest(content,
-                new ExpectedTag(12, 48, "\n    'def'\r\n    'qrt'\r\n    'quox'\r\n)"));
+                new ExpectedTag(11, 48, "\r\n    'def'\r\n    'qrt'\r\n    'quox'\r\n)"));
         }
 
         [TestMethod, Priority(0), TestCategory("Core")]
@@ -305,7 +305,7 @@ def f():
               arg3)";
 
             SnapshotOutlineTest(content,
-                new ExpectedTag(20, 61, "\n              arg2,\r\n              arg3)"));
+                new ExpectedTag(19, 61, "\r\n              arg2,\r\n              arg3)"));
         }
 
         [TestMethod, Priority(0), TestCategory("Core")]
@@ -315,7 +315,7 @@ import argv \
 as c";
 
             SnapshotOutlineTest(content,
-                new ExpectedTag(11, 31, "\nimport argv \\\r\nas c"));
+                new ExpectedTag(10, 31, "\r\nimport argv \\\r\nas c"));
         }
 
         [TestMethod, Priority(0), TestCategory("Core")]
@@ -325,7 +325,7 @@ as c";
  3}";
 
             SnapshotOutlineTest(content,
-                new ExpectedTag(4, 13, "\n 2,\r\n 3}"));
+                new ExpectedTag(3, 13, "\r\n 2,\r\n 3}"));
         }
 
         [TestMethod, Priority(0), TestCategory("Core")]
@@ -337,7 +337,7 @@ multiline
 string'''";
 
             SnapshotOutlineTest(content,
-                new ExpectedTag(8, 36, "\nis\r\na\r\nmultiline\r\nstring'''"));
+                new ExpectedTag(7, 36, "\r\nis\r\na\r\nmultiline\r\nstring'''"));
         }
 
         private void SnapshotOutlineTest(string fileContents, params ExpectedTag[] expected) {


### PR DESCRIPTION
We spoke with the VS Team and it seems splitting collapsed regions
between \r\n can be a bit fragile. Code has been added to handle this
and our test cases have been edited to account for the adjustment.