### PR TITLE
Fixes null reference exception when saving analysis.

### DIFF
--- a/Python/Product/Analysis/SaveAnalysis.cs
+++ b/Python/Product/Analysis/SaveAnalysis.cs
@@ -342,6 +342,9 @@ namespace Microsoft.PythonTools.Analysis {
         private object GetMemberValueInternal(AnalysisValue type, ModuleInfo declModule, bool isRef) {
             SpecializedNamespace specialCallable = type as SpecializedNamespace;
             if (specialCallable != null) {
+                if (specialCallable.Original == null) {
+                    return "function";
+                }
                 return GetMemberValueInternal(specialCallable.Original, declModule, isRef);
             }
 
@@ -455,7 +458,10 @@ namespace Microsoft.PythonTools.Analysis {
 
         private static string GetMemberKind(AnalysisValue type, ModuleInfo declModule, bool isRef) {
             SpecializedNamespace specialCallable = type as SpecializedNamespace;
-            if (specialCallable != null && specialCallable.Original != null) {
+            if (specialCallable != null) {
+                if (specialCallable.Original == null) {
+                    return "data";
+                }
                 return GetMemberKind(specialCallable.Original, declModule, isRef);
             }
 

--- a/Python/Product/Analysis/SaveAnalysis.cs
+++ b/Python/Product/Analysis/SaveAnalysis.cs
@@ -455,7 +455,7 @@ namespace Microsoft.PythonTools.Analysis {
 
         private static string GetMemberKind(AnalysisValue type, ModuleInfo declModule, bool isRef) {
             SpecializedNamespace specialCallable = type as SpecializedNamespace;
-            if (specialCallable != null) {
+            if (specialCallable != null && specialCallable.Original != null) {
                 return GetMemberKind(specialCallable.Original, declModule, isRef);
             }
 
@@ -475,7 +475,8 @@ namespace Microsoft.PythonTools.Analysis {
                 case PythonMemberType.Module:
                     return "moduleref";
                 case PythonMemberType.Instance:
-                default: return "data";
+                default:
+                    return "data";
             }
         }
 

--- a/Python/Product/Analysis/SaveAnalysis.cs
+++ b/Python/Product/Analysis/SaveAnalysis.cs
@@ -343,7 +343,7 @@ namespace Microsoft.PythonTools.Analysis {
             SpecializedNamespace specialCallable = type as SpecializedNamespace;
             if (specialCallable != null) {
                 if (specialCallable.Original == null) {
-                    return "function";
+                    return null;
                 }
                 return GetMemberValueInternal(specialCallable.Original, declModule, isRef);
             }

--- a/Python/Product/Analysis/Values/BuiltinModule.cs
+++ b/Python/Product/Analysis/Values/BuiltinModule.cs
@@ -139,9 +139,9 @@ namespace Microsoft.PythonTools.Analysis.Values {
                         IAnalysisSet instValue;
                         if (ci.Instance.TryGetMember(methodName, out instValue)) {
                             ci.Instance[methodName] = new SpecializedCallable(
-                                instValue.FirstOrDefault(), 
-                                ci.Instance, 
-                                callable, 
+                                instValue.FirstOrDefault(),
+                                ci.Instance,
+                                callable,
                                 mergeOriginalAnalysis).SelfSet;
                         } else {
                             ci.Instance[methodName] = new SpecializedCallable(
@@ -152,6 +152,8 @@ namespace Microsoft.PythonTools.Analysis.Values {
                         }
                     }
                 }
+            } else {
+                this[name] = new SpecializedCallable(null, callable, false);
             }
         }
 

--- a/Python/Tests/Analysis/AnalysisSaveTest.cs
+++ b/Python/Tests/Analysis/AnalysisSaveTest.cs
@@ -462,6 +462,21 @@ sys.modules['test.imported'] = test_import_2
             }
         }
 
+        [TestMethod, Priority(0)]
+        public void SpecializedCallableWithNoOriginal() {
+            string code = @"
+import unittest
+
+# skipIf is specialized and calling it returns a callable
+# with no original value to save.
+x = unittest.skipIf(False)
+";
+            using (var newPs = SaveLoad(PythonLanguageVersion.V27, new AnalysisModule("test", "test.py", code))) {
+                var entry = newPs.NewModule("test2", "import test; x = test.x");
+                AssertUtil.ContainsExactly(entry.Analysis.GetTypeIdsByIndex("x", 0));
+            }
+        }
+
         private SaveLoadResult SaveLoad(PythonLanguageVersion version, params AnalysisModule[] modules) {
             IPythonProjectEntry[] entries = new IPythonProjectEntry[modules.Length];
 


### PR DESCRIPTION
It's possible (and with a recent change, likely) to have a special callable with no original value. To avoid crashing in this case, we add a check.