### PR TITLE
#34 XAML designer doesn't work in VS 2015 RC

### DIFF
--- a/Common/Product/SharedProject/Automation/VSProject/OAReferenceBase.cs
+++ b/Common/Product/SharedProject/Automation/VSProject/OAReferenceBase.cs
@@ -167,8 +167,12 @@ namespace Microsoft.VisualStudioTools.Project.Automation {
             }
         }
 
-        public uint RefType {
-            get { throw new NotImplementedException(); }
+        public virtual uint RefType {
+            get {
+                // Default to native reference to help prevent callers from
+                // making incorrect assumptions
+                return (uint)__PROJECTREFERENCETYPE.PROJREFTYPE_NATIVE;
+            }
         }
 
         public virtual bool Resolved {

--- a/Python/Product/PythonTools/PythonTools/Project/Automation/OAPythonExtensionReference.cs
+++ b/Python/Product/PythonTools/PythonTools/Project/Automation/OAPythonExtensionReference.cs
@@ -16,6 +16,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 using Microsoft.VisualStudioTools.Project.Automation;
 using VSLangProj;
+using VSLangProj80;
 
 namespace Microsoft.PythonTools.Project.Automation {
     [ComVisible(true)]
@@ -34,6 +35,12 @@ namespace Microsoft.PythonTools.Project.Automation {
         public override prjReferenceType Type {
             get {
                 return prjReferenceType.prjReferenceTypeAssembly;
+            }
+        }
+
+        public override uint RefType {
+            get {
+                return (uint)__PROJECTREFERENCETYPE.PROJREFTYPE_ASSEMBLY;
             }
         }
 


### PR DESCRIPTION
Implements RefType so that the XAML designer no longer aborts initialization when getting our references.

There are other issues due to how the design host handles paths and a possible .NET bug relating to URIs, but this fix should clear up our side of the issue.