### PR TITLE
Adds Downloads section to top of gh.io page.

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,15 +16,18 @@
     <!-- HEADER -->
     <div id="header_wrap" class="outer">
         <header class="inner">
-          <a id="forkme_banner" href="https://github.com/Microsoft/PTVS">View on GitHub</a>
-
-          <h1 id="project_title">Python Tools for Visual Studio</h1>
-          <h2 id="project_tagline">Free, open source plugin that turns Visual Studio into a Python IDE</h2>
 
             <section id="downloads">
-              <a class="zip_download_link" href="https://github.com/Microsoft/PTVS/zipball/master">Download this project as a .zip file</a>
-              <a class="tar_download_link" href="https://github.com/Microsoft/PTVS/tarball/master">Download this project as a tar.gz file</a>
+              <h3 id="downloads_title">Downloads</h3>
+              <ul id="download_list">
+                <li><a href="https://pytools.codeplex.com/releases/view/614624">PTVS 2.2 RC</a></li>
+                <li><a href="https://pytools.codeplex.com/releases/view/109707">PTVS 2.1</a></li>
+                <li><a href="https://github.com/Microsoft/PTVS">View on GitHub</a></li>
+              </ul>
             </section>
+            
+          <h1 id="project_title">Python Tools for Visual Studio</h1>
+          <h2 id="project_tagline">Free, open source plugin that turns Visual Studio into a Python IDE</h2>
         </header>
     </div>
 

--- a/stylesheets/stylesheet.css
+++ b/stylesheets/stylesheet.css
@@ -316,13 +316,24 @@ Full-Width Styles
 }
 
 #downloads {
-  position: absolute;
-  width: 210px;
-  z-index: 10;
-  bottom: -40px;
+  float: right;
   right: 0;
-  height: 70px;
-  background: url('../images/icon_download.png') no-repeat 0% 90%;
+  background: #aaaaaa;
+  background: -moz-linear-gradient(top, #f0f0f0, #cccccc);
+  background: -webkit-linear-gradient(top, #f0f0f0, #cccccc);
+  background: -ms-linear-gradient(top, #f0f0f0, #cccccc);
+  background: -o-linear-gradient(top, #f0f0f0, #cccccc);
+  background: linear-gradient(top, #f0f0f0, #cccccc);
+}
+
+#downloads_title {
+    margin: 8px;
+}
+
+#download_list {
+    margin: 8px;
+    list-style: none;
+    padding: 0px;
 }
 
 .zip_download_link {


### PR DESCRIPTION
Looks like this:

![picture2](https://cloud.githubusercontent.com/assets/1693688/7642820/fb2397f2-fa48-11e4-8272-a7034ad6547a.png)

Feel free to propose improvements in the form of a pull request.