### PR TITLE
Scanning for UWP interpreters and moving CPython UWP targets import

### DIFF
--- a/Python/Product/Uwp/Interpreter/PythonUwpInterpreterFactory.cs
+++ b/Python/Product/Uwp/Interpreter/PythonUwpInterpreterFactory.cs
@@ -20,10 +20,10 @@ namespace Microsoft.PythonTools.Uwp.Interpreter {
         public const string InterpreterGuidString = "{86767848-40B4-4007-8BCC-A3835EDF0E69}";
         public static readonly Guid InterpreterGuid = new Guid(InterpreterGuidString);
 
-        public PythonUwpInterpreterFactory(InterpreterConfiguration configuration) 
+        public PythonUwpInterpreterFactory(InterpreterConfiguration configuration, string description) 
             : base(
-                  InterpreterGuid, 
-                  "Python UWP",
+                  InterpreterGuid,
+                  description,
                   configuration,
                   true) {
         }

--- a/Python/Product/Uwp/Microsoft.PythonTools.Uwp.targets
+++ b/Python/Product/Uwp/Microsoft.PythonTools.Uwp.targets
@@ -1,6 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
+  <PropertyGroup>
+    <CPythonTargetsFile>$(LocalAppData)\Microsoft\VisualStudio\$(VisualStudioVersion)Exp\Extensions\Microsoft\Python UWP\$(InterpreterVersion)\DesignTime\CommonConfiguration\Neutral\CPython.targets</CPythonTargetsFile>
+    <CPythonTargetsFile Condition="'$(CPythonTargetsFile)' == '' or !Exists('$(CPythonTargetsFile)')">$(MSBuildProgramFiles32)\Microsoft SDKs\Windows\v10.0\ExtensionSDKs\Python UWP\$(InterpreterVersion)\DesignTime\CommonConfiguration\Neutral\CPython.targets</CPythonTargetsFile>
+  </PropertyGroup>
+  
+  <Import Project="$(CPythonTargetsFile)" />
+
   <!-- Gets the fully qualified path to the project home.  -->
   <PropertyGroup>
     <AvailablePlatforms>ARM,x86,x64</AvailablePlatforms>

--- a/Python/Product/Uwp/Templates/Projects/BackgroundService/PythonBackgroundService.pyproj
+++ b/Python/Product/Uwp/Templates/Projects/BackgroundService/PythonBackgroundService.pyproj
@@ -43,11 +43,7 @@
     </AppxManifest>
     <None Include="$projectname$_TemporaryKey.pfx" />
   </ItemGroup>
-  <PropertyGroup>
-    <CPythonTargetsFile>$(LocalAppData)\Microsoft\VisualStudio\$(VisualStudioVersion)Exp\Extensions\Microsoft\Python UWP\$(InterpreterVersion)\DesignTime\CommonConfiguration\Neutral\CPython.targets</CPythonTargetsFile>
-    <CPythonTargetsFile Condition="'$(CPythonTargetsFile)' == '' or !Exists('$(CPythonTargetsFile)')">$(MSBuildProgramFiles32)\Microsoft SDKs\Windows\v10.0\ExtensionSDKs\PyUWP\$(InterpreterVersion)\DesignTime\CommonConfiguration\Neutral\CPython.targets</CPythonTargetsFile>
-  </PropertyGroup>
-  
+
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
     <PtvsVersion Condition="'$(PtvsVersion)' == ''">2.2</PtvsVersion>
@@ -55,7 +51,6 @@
     <PtvsTargetsFile Condition="'$(PtvsTargetsFile)' == '' or !Exists('$(PtvsTargetsFile)')">$(MSBuildProgramFiles32)\Microsoft Visual Studio $(VisualStudioVersion)\Common7\IDE\Extensions\Microsoft\Python Tools for Visual Studio - UWP\$(PtvsVersion)\Microsoft.PythonTools.Uwp.targets</PtvsTargetsFile>
   </PropertyGroup>
 
-  <Import Project="$(CPythonTargetsFile)" />
-  <Import Condition="Exists($(PtvsTargetsFile))" Project="$(PtvsTargetsFile)" />
+  <Import Project="$(PtvsTargetsFile)" />
 
 </Project>


### PR DESCRIPTION
Moving CPython.targets import into PTVS UWP targets file in lieu of the pyproj
Scanning for UWP interpreters and versions based on installed SDKs