### PR TITLE
#97 Trouble 'upgrading' project from PTVS 2.1 to 2.2 RC

### DIFF
--- a/Common/Product/SharedProject/ProjectFactory.cs
+++ b/Common/Product/SharedProject/ProjectFactory.cs
@@ -522,13 +522,13 @@ namespace Microsoft.VisualStudioTools.Project {
             out uint pUpgradeProjectCapabilityFlags
         ) {
             pUpgradeRequired = 0;
+            pguidNewProjectFactory = Guid.Empty;
+
             if (!File.Exists(bstrFileName)) {
-                pguidNewProjectFactory = Guid.Empty;
                 pUpgradeProjectCapabilityFlags = 0;
                 return VSConstants.E_INVALIDARG;
             }
 
-            pguidNewProjectFactory = GetType().GUID;
 
             var backupSupport = __VSPPROJECTUPGRADEVIAFACTORYFLAGS.PUVFF_BACKUPSUPPORTED |
                 __VSPPROJECTUPGRADEVIAFACTORYFLAGS.PUVFF_COPYBACKUP |
@@ -566,6 +566,13 @@ namespace Microsoft.VisualStudioTools.Project {
                 pUpgradeRequired = 0;
             }
             pUpgradeProjectCapabilityFlags = (uint)backupSupport;
+
+            // If the upgrade checker set the factory GUID to ourselves, we need
+            // to clear it
+            if (pguidNewProjectFactory == GetType().GUID) {
+                pguidNewProjectFactory = Guid.Empty;
+            }
+
             return VSConstants.S_OK;
         }
 
@@ -577,14 +584,14 @@ namespace Microsoft.VisualStudioTools.Project {
             out Guid pguidNewProjectFactory,
             out uint pUpgradeProjectCapabilityFlags
         ) {
+            pguidNewProjectFactory = Guid.Empty;
+
             if (!File.Exists(bstrFileName)) {
                 pUpgradeRequired = 0;
-                pguidNewProjectFactory = Guid.Empty;
                 pUpgradeProjectCapabilityFlags = 0;
                 return;
             }
 
-            pguidNewProjectFactory = GetType().GUID;
             var backupSupport = __VSPPROJECTUPGRADEVIAFACTORYFLAGS.PUVFF_BACKUPSUPPORTED |
                 __VSPPROJECTUPGRADEVIAFACTORYFLAGS.PUVFF_COPYBACKUP |
                 __VSPPROJECTUPGRADEVIAFACTORYFLAGS.PUVFF_SXSBACKUP;
@@ -640,6 +647,12 @@ namespace Microsoft.VisualStudioTools.Project {
                 pUpgradeRequired = (uint)__VSPPROJECTUPGRADEVIAFACTORYREPAIRFLAGS.VSPUVF_PROJECT_NOREPAIR;
             }
             pUpgradeProjectCapabilityFlags = (uint)backupSupport;
+
+            // If the upgrade checker set the factory GUID to ourselves, we need
+            // to clear it
+            if (pguidNewProjectFactory == GetType().GUID) {
+                pguidNewProjectFactory = Guid.Empty;
+            }
         }
 #endif
         #endregion

--- a/Python/Tests/Core/ProjectUpgradeTests.cs
+++ b/Python/Tests/Core/ProjectUpgradeTests.cs
@@ -58,7 +58,7 @@ namespace PythonToolsTests {
 
                 Assert.AreEqual(0, hr, string.Format("Wrong HR for {0}", testCase.Name));
                 Assert.AreEqual(testCase.Expected, actual, string.Format("Wrong result for {0}", testCase.Name));
-                Assert.AreEqual(typeof(PythonProjectFactory).GUID, factoryGuid);
+                Assert.AreEqual(Guid.Empty, factoryGuid);
             }
         }
 
@@ -111,7 +111,7 @@ namespace PythonToolsTests {
                         string.Format("Non-upgraded {0} has different content to original", testCase.Name)
                     );
                 }
-                Assert.AreEqual(typeof(PythonProjectFactory).GUID, factoryGuid);
+                Assert.AreEqual(Guid.Empty, factoryGuid);
             }
         }
 
@@ -158,7 +158,7 @@ namespace PythonToolsTests {
 
                 Assert.AreEqual(0, hr, string.Format("Wrong HR for ToolsVersion={0}", testCase.Name));
                 Assert.AreEqual(testCase.Expected, actual, string.Format("Wrong result for ToolsVersion={0}", testCase.Name));
-                Assert.AreEqual(typeof(PythonProjectFactory).GUID, factoryGuid);
+                Assert.AreEqual(Guid.Empty, factoryGuid);
             }
         }
 
@@ -220,7 +220,7 @@ namespace PythonToolsTests {
                         string.Format("Non-upgraded {0} has different content to original", testCase.Name)
                     );
                 }
-                Assert.AreEqual(typeof(PythonProjectFactory).GUID, factoryGuid);
+                Assert.AreEqual(Guid.Empty, factoryGuid);
             }
         }
 
@@ -259,7 +259,7 @@ namespace PythonToolsTests {
                 File.ReadAllText(tempProject).Contains("<Import Project=\"" + PythonProjectFactory.CommonProps),
                 string.Format("Upgraded OldCommonProps.pyproj should not import from $(VSToolsPath)")
             );
-            Assert.AreEqual(typeof(PythonProjectFactory).GUID, factoryGuid);
+            Assert.AreEqual(Guid.Empty, factoryGuid);
         }
 
         [TestMethod, Priority(1)]
@@ -309,7 +309,7 @@ namespace PythonToolsTests {
                 File.ReadAllText(tempProject).Contains("<Import Project=\"$(PtvsTargetsFile)\" Condition=\"Exists($(PtvsTargetsFile))\""),
                 string.Format("Upgraded OldCommonTargets.pyproj should import $(PtvsTargetsFile)")
             );
-            Assert.AreEqual(typeof(PythonProjectFactory).GUID, factoryGuid);
+            Assert.AreEqual(Guid.Empty, factoryGuid);
         }
 
 #if DEV12_OR_LATER


### PR DESCRIPTION
Changes project factory to return empty GUIDs by default to avoid circular references.