### PR TITLE
#21 Types in annotations are not highlighted

### DIFF
--- a/Common/Tests/Utilities/Mocks/MockClassificationTypeRegistryService.cs
+++ b/Common/Tests/Utilities/Mocks/MockClassificationTypeRegistryService.cs
@@ -38,7 +38,7 @@ namespace TestUtilities.Mocks {
             foreach (var def in classTypeDefs) {
                 string name = def.Metadata.Name;
                 var type = GetClasificationType(name);
-                foreach (var baseType in def.Metadata.BaseDefinition) {
+                foreach (var baseType in def.Metadata.BaseDefinition ?? Enumerable.Empty<string>()) {
                     type.AddBaseType(GetClasificationType(baseType));
                 }
             }

--- a/Python/Product/Analysis/ModuleAnalysis.cs
+++ b/Python/Product/Analysis/ModuleAnalysis.cs
@@ -960,7 +960,18 @@ namespace Microsoft.PythonTools.Analysis {
             }
 
             // Recurse to check children of candidate scope
-            return FindScope(candidate, tree, location);
+            var child = FindScope(candidate, tree, location);
+
+            var funcChild = child as FunctionScope;
+            if (funcChild != null &&
+                funcChild.Function.FunctionDefinition.IsLambda &&
+                child.GetStop(tree) < location.Index) {
+                // Do not want to extend a lambda function's scope to the end of
+                // the parent scope.
+                return parent;
+            }
+
+            return child;
         }
 
 

--- a/Python/Product/Analysis/Parsing/Ast/Parameter.cs
+++ b/Python/Product/Analysis/Parsing/Ast/Parameter.cs
@@ -85,6 +85,9 @@ namespace Microsoft.PythonTools.Parsing.Ast {
 
         public override void Walk(PythonWalker walker) {
             if (walker.Walk(this)) {
+                if (_annotation != null) {
+                    _annotation.Walk(walker);
+                }
                 if (_defaultValue != null) {
                     _defaultValue.Walk(walker);
                 }

--- a/Python/Tests/PythonToolsMockTests/ClassifierTests.cs
+++ b/Python/Tests/PythonToolsMockTests/ClassifierTests.cs
@@ -175,6 +175,23 @@ b = c
         }
 
         [TestMethod, Priority(0)]
+        public void ParameterAnnotationClassification() {
+            var code = @"class A: pass
+class B: pass
+
+def f(a = A, b : B):
+    pass
+";
+            using (var helper = new ClassifierHelper(code, PythonLanguageVersion.V27)) {
+                helper.CheckAstClassifierSpans("ki:k ki:k ki(i=i,i:i): k");
+
+                helper.Analyze();
+
+                helper.CheckAnalysisClassifierSpans("c<A>c<B>f<f>pc<A>pc<B>");
+            }
+        }
+
+        [TestMethod, Priority(0)]
         public void TrueFalseClassification() {
             var code = "True False";
 


### PR DESCRIPTION
Ensures AST walkers will walk parameter decorators.
Also fixes IntelliSense in functions that include lambda functions.