### PR TITLE
Don't add empty search paths to the environment.

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Project/PythonProjectLaunchProperties.cs
+++ b/Python/Product/PythonTools/PythonTools/Project/PythonProjectLaunchProperties.cs
@@ -305,8 +305,9 @@ namespace Microsoft.PythonTools.Project {
             IServiceProvider provider = null
         ) {
             var pathEnv = project.GetProjectAnalyzer().InterpreterFactory.Configuration.PathEnvironmentVariable;
-            if (pathEnv == null || pathEnv == String.Empty)
+            if (string.IsNullOrEmpty(pathEnv)) {
                 return;
+            }
 
             var paths = new List<string>();
             

--- a/Python/Product/PythonTools/PythonTools/Project/PythonProjectLaunchProperties.cs
+++ b/Python/Product/PythonTools/PythonTools/Project/PythonProjectLaunchProperties.cs
@@ -305,6 +305,9 @@ namespace Microsoft.PythonTools.Project {
             IServiceProvider provider = null
         ) {
             var pathEnv = project.GetProjectAnalyzer().InterpreterFactory.Configuration.PathEnvironmentVariable;
+            if (pathEnv == null || pathEnv == String.Empty)
+                return;
+
             var paths = new List<string>();
             
             string path;


### PR DESCRIPTION
Previously, the code would construct a key,value pair both consisting
of empty strings, which in turn would cause an empty entry to be
added to the environment block used to launch the process.

This would result in VsShellUtilities.LaunchProcess() failing
internally when launching the interpreter (and it would print
"Exception : Could not launch <python-interpreter>" to the debug
console.

With this patch, we just do nothing if the search paths are empty.