### PR TITLE
Add Python Engine guid to EXCEPTION_INFO object in AD7::GetException()

### DIFF
--- a/Python/Product/Debugger/Debugger/DebugEngine/AD7Events.cs
+++ b/Python/Product/Debugger/Debugger/DebugEngine/AD7Events.cs
@@ -281,6 +281,7 @@ namespace Microsoft.PythonTools.Debugger.DebugEngine {
         }
 
         public int GetException(EXCEPTION_INFO[] pExceptionInfo) {
+            pExceptionInfo[0].guidType = AD7Engine.DebugEngineGuid;
             pExceptionInfo[0].bstrExceptionName = _exception;
             if (_isUnhandled) {
                 pExceptionInfo[0].dwState = enum_EXCEPTION_STATE.EXCEPTION_STOP_USER_UNCAUGHT;


### PR DESCRIPTION
Add Python Engine guid to EXCEPTION_INFO object in AD7 call to GetException.

This completes the exception object for the VS Debugger UI to properly process changes to this exception when the user modifies its break settings via the exception thrown dialog.

This change fixes an issue where a user changes the break when thrown setting for a thrown exception via the Exception Assistant (or Exception Thrown Dialog) and it does nothing. The debugger ui relies on the exception's guidType to find the exception changed. Without a guid, the debugger does nothing.