### PR TITLE
Ensures missing imports calculate the target text on the UI thread.

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Intellisense/ProjectAnalyzer.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/ProjectAnalyzer.cs
@@ -633,7 +633,7 @@ namespace Microsoft.PythonTools.Intellisense {
             }
 
             var analyzer = analysis.ProjectState;
-            var index = span.GetStartPoint(snapshot).Position;
+            var index = (parser.GetStatementRange() ?? span.GetSpan(snapshot)).Start.Position;
 
             var location = TranslateIndex(
                 index,

--- a/Python/Product/PythonTools/PythonTools/Intellisense/PythonSuggestedActionsSource.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/PythonSuggestedActionsSource.cs
@@ -21,6 +21,7 @@ using Microsoft.PythonTools.Editor.Core;
 using Microsoft.VisualStudio.Language.Intellisense;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudioTools;
 
 namespace Microsoft.PythonTools.Intellisense {
 #if DEV14_OR_LATER
@@ -77,7 +78,9 @@ namespace Microsoft.PythonTools.Intellisense {
                 SpanTrackingMode.EdgePositive,
                 TrackingFidelityMode.Forward
             );
-            var imports = textBuffer.CurrentSnapshot.GetMissingImports(_provider, span);
+            var imports = await _provider
+                .GetUIThread()
+                .InvokeAsync(() => textBuffer.CurrentSnapshot.GetMissingImports(_provider, span));
 
             if (imports == MissingImportAnalysis.Empty) {
                 return false;


### PR DESCRIPTION
Fixes suggestions appearing when local variables are defined.