### PR TITLE
#247 Parse and analyse async/await syntax

### DIFF
--- a/Python/Product/Analysis/Analysis.csproj
+++ b/Python/Product/Analysis/Analysis.csproj
@@ -106,6 +106,7 @@
     <Compile Include="Interpreter\PythonLibraryPath.cs" />
     <Compile Include="LockedEnumerable.cs" />
     <Compile Include="ModulePath.cs" />
+    <Compile Include="Parsing\Ast\AwaitExpression.cs" />
     <Compile Include="Parsing\CodeFormattingCategoryAttribute.cs" />
     <Compile Include="Parsing\CodeFormattingDefaultSettingAttribute.cs" />
     <Compile Include="Parsing\CodeFormattingDescriptionAttribute.cs" />
@@ -166,6 +167,7 @@
     <Compile Include="Analyzer\ModuleScope.cs" />
     <Compile Include="Analyzer\OverviewWalker.cs" />
     <Compile Include="SingleDict.cs" />
+    <Compile Include="Values\CoroutineInfo.cs" />
     <Compile Include="Values\PartialFunctionInfo.cs" />
     <Compile Include="Values\SysModuleInfo.cs" />
     <Compile Include="VariableDef.cs" />

--- a/Python/Product/Analysis/AnalysisSetExtensions.cs
+++ b/Python/Product/Analysis/AnalysisSetExtensions.cs
@@ -96,6 +96,20 @@ namespace Microsoft.PythonTools.Analysis {
         }
 
         /// <summary>
+        /// Performs a get iterator operation propagating any iterator types
+        /// into the value and returns the associated types associated with the
+        /// object.
+        /// </summary>
+        public static IAnalysisSet GetAsyncIterator(this IAnalysisSet self, Node node, AnalysisUnit unit) {
+            var res = AnalysisSet.Empty;
+            foreach (var ns in self) {
+                res = res.Union(ns.GetAsyncIterator(node, unit));
+            }
+
+            return res;
+        }
+
+        /// <summary>
         /// Performs a get index operation propagating any index types into the
         /// value and returns the associated types associated with the object.
         /// </summary>
@@ -144,6 +158,19 @@ namespace Microsoft.PythonTools.Analysis {
             var res = AnalysisSet.Empty;
             foreach (var ns in self) {
                 res = res.Union(ns.GetEnumeratorTypes(node, unit));
+            }
+
+            return res;
+        }
+        /// <summary>
+        /// Returns the set of types which are accessible when code enumerates
+        /// over the object
+        /// in a for statement.
+        /// </summary>
+        public static IAnalysisSet GetAsyncEnumeratorTypes(this IAnalysisSet self, Node node, AnalysisUnit unit) {
+            var res = AnalysisSet.Empty;
+            foreach (var ns in self) {
+                res = res.Union(ns.GetAsyncEnumeratorTypes(node, unit));
             }
 
             return res;
@@ -228,6 +255,18 @@ namespace Microsoft.PythonTools.Analysis {
             return values
                 .Select(v => v.GetConstantValueAsString())
                 .Where(s => !string.IsNullOrEmpty(s));
+        }
+
+        /// <summary>
+        /// Performs an await operation.
+        /// </summary>
+        public static IAnalysisSet Await(this IAnalysisSet self, Node node, AnalysisUnit unit) {
+            var res = AnalysisSet.Empty;
+            foreach (var ns in self) {
+                res = res.Union(ns.Await(node, unit));
+            }
+
+            return res;
         }
 
     }

--- a/Python/Product/Analysis/AnalysisValue.cs
+++ b/Python/Product/Analysis/AnalysisValue.cs
@@ -253,8 +253,18 @@ namespace Microsoft.PythonTools.Analysis {
             return GetIndex(node, unit, unit.ProjectState.ClassInfos[BuiltinTypeId.Int].SelfSet);
         }
 
+        public virtual IAnalysisSet GetAsyncEnumeratorTypes(Node node, AnalysisUnit unit) {
+            return AnalysisSet.Empty;
+        }
+
         public virtual IAnalysisSet GetIterator(Node node, AnalysisUnit unit) {
             return GetMember(node, unit, "__iter__").Call(node, unit, ExpressionEvaluator.EmptySets, ExpressionEvaluator.EmptyNames);
+        }
+
+        public virtual IAnalysisSet GetAsyncIterator(Node node, AnalysisUnit unit) {
+            return GetMember(node, unit, "__aiter__")
+                .Call(node, unit, ExpressionEvaluator.EmptySets, ExpressionEvaluator.EmptyNames)
+                .Await(node, unit);
         }
 
         public virtual IAnalysisSet GetIndex(Node node, AnalysisUnit unit, IAnalysisSet index) {
@@ -288,6 +298,10 @@ namespace Microsoft.PythonTools.Analysis {
 
         public virtual IAnalysisSet GetInstanceType() {
             return SelfSet;
+        }
+
+        public virtual IAnalysisSet Await(Node node, AnalysisUnit unit) {
+            return AnalysisSet.Empty;
         }
 
         internal virtual bool IsOfType(IAnalysisSet klass) {

--- a/Python/Product/Analysis/Analyzer/DDG.cs
+++ b/Python/Product/Analysis/Analyzer/DDG.cs
@@ -201,14 +201,12 @@ namespace Microsoft.PythonTools.Analysis.Analyzer {
 
         public override bool Walk(ForStatement node) {
             if (node.List != null) {
-                var assignedTypes = _eval.Evaluate(node.List).ToArray();
-                if (assignedTypes.Length > 0) {
-                    foreach (var listType in assignedTypes) {
-                        _eval.AssignTo(node, node.Left, listType.GetEnumeratorTypes(node, _unit));
-                    }
-                } else {
-                    _eval.AssignTo(node, node.Left, AnalysisSet.Empty);
-                }
+                var list = _eval.Evaluate(node.List);
+                _eval.AssignTo(
+                    node,
+                    node.Left,
+                    node.IsAsync ? list.GetAsyncEnumeratorTypes(node, _unit) : list.GetEnumeratorTypes(node, _unit)
+                );
             }
 
             if (node.Body != null) {
@@ -454,8 +452,16 @@ namespace Microsoft.PythonTools.Analysis.Analyzer {
         public override bool Walk(WithStatement node) {
             foreach (var item in node.Items) {
                 var ctxMgr = _eval.Evaluate(item.ContextManager);
+                var enter = ctxMgr.GetMember(node, _unit, node.IsAsync ? "__aenter__" : "__enter__");
+                var exit = ctxMgr.GetMember(node, _unit, node.IsAsync ? "__aexit__" : "__exit__");
+                var ctxt = enter.Call(node, _unit, ExpressionEvaluator.EmptySets, ExpressionEvaluator.EmptyNames);
+                var exitRes = exit.Call(node, _unit, ExpressionEvaluator.EmptySets, ExpressionEvaluator.EmptyNames);
+                if (node.IsAsync) {
+                    ctxt = ctxt.Await(node, _unit);
+                    exitRes.Await(node, _unit);
+                }
                 if (item.Variable != null) {
-                    _eval.AssignTo(node, item.Variable, ctxMgr);
+                    _eval.AssignTo(node, item.Variable, ctxt);
                 }
             }
 

--- a/Python/Product/Analysis/Analyzer/ExpressionEvaluator.cs
+++ b/Python/Product/Analysis/Analyzer/ExpressionEvaluator.cs
@@ -147,6 +147,7 @@ namespace Microsoft.PythonTools.Analysis.Analyzer {
 
         private static Dictionary<Type, EvalDelegate> _evaluators = new Dictionary<Type, EvalDelegate> {
             { typeof(AndExpression), ExpressionEvaluator.EvaluateAnd },
+            { typeof(AwaitExpression), ExpressionEvaluator.EvaluateAwait },
             { typeof(BackQuoteExpression), ExpressionEvaluator.EvaluateBackQuote },
             { typeof(BinaryExpression), ExpressionEvaluator.EvaluateBinary },
             { typeof(CallExpression), ExpressionEvaluator.EvaluateCall },
@@ -277,6 +278,11 @@ namespace Microsoft.PythonTools.Analysis.Analyzer {
             var n = (AndExpression)node;
             var result = ee.Evaluate(n.Left);
             return result.Union(ee.Evaluate(n.Right));
+        }
+
+        private static IAnalysisSet EvaluateAwait(ExpressionEvaluator ee, Node node) {
+            var n = (AwaitExpression)node;
+            return ee.Evaluate(n.Expression).Await(node, ee._unit);
         }
 
         private static IAnalysisSet EvaluateCall(ExpressionEvaluator ee, Node node) {

--- a/Python/Product/Analysis/Parsing/Ast/AwaitExpression.cs
+++ b/Python/Product/Analysis/Parsing/Ast/AwaitExpression.cs
@@ -1,0 +1,65 @@
+/* ****************************************************************************
+ *
+ * Copyright (c) Microsoft Corporation. 
+ *
+ * This source code is subject to terms and conditions of the Apache License, Version 2.0. A 
+ * copy of the license can be found in the License.html file at the root of this distribution. If 
+ * you cannot locate the Apache License, Version 2.0, please send an email to 
+ * vspython@microsoft.com. By using this source code in any fashion, you are agreeing to be bound 
+ * by the terms of the Apache License, Version 2.0.
+ *
+ * You must not remove this notice, or any other, from this software.
+ *
+ * ***************************************************************************/
+
+using System.Text;
+
+namespace Microsoft.PythonTools.Parsing.Ast {
+
+    // New in Pep429 for Python 3.5. Await is an expression with a return value.
+    //    x = await z
+    // TODO: The return value (x) is provided by calling ...
+    public class AwaitExpression : Expression {
+        private readonly Expression _expression;
+
+        public AwaitExpression(Expression expression) {
+            _expression = expression;
+        }
+
+        public Expression Expression {
+            get { return _expression; }
+        }
+
+        public override void Walk(PythonWalker walker) {
+            if (walker.Walk(this)) {
+                if (_expression != null) {
+                    _expression.Walk(walker);
+                }
+            }
+            walker.PostWalk(this);
+        }
+
+        internal override string CheckAugmentedAssign() {
+            return CheckAssign();
+        }
+
+        public override string NodeName {
+            get {
+                return "await expression";
+            }
+        }
+
+        internal override void AppendCodeString(StringBuilder res, PythonAst ast, CodeFormattingOptions format) {
+            format.ReflowComment(res, this.GetProceedingWhiteSpace(ast));
+            res.Append("await");
+            if (!this.IsAltForm(ast)) {
+                _expression.AppendCodeString(res, ast, format);
+                var itemWhiteSpace = this.GetListWhiteSpace(ast);
+                if (itemWhiteSpace != null) {
+                    res.Append(",");
+                    res.Append(itemWhiteSpace[0]);
+                }
+            }
+        }
+    }
+}

--- a/Python/Product/Analysis/Parsing/Ast/ForStatement.cs
+++ b/Python/Product/Analysis/Parsing/Ast/ForStatement.cs
@@ -21,12 +21,18 @@ namespace Microsoft.PythonTools.Parsing.Ast {
         private Expression _list;
         private Statement _body;
         private readonly Statement _else;
+        private readonly bool _isAsync;
 
         public ForStatement(Expression left, Expression list, Statement body, Statement else_) {
             _left = left;
             _list = list;
             _body = body;
             _else = else_;
+        }
+
+        public ForStatement(Expression left, Expression list, Statement body, Statement else_, bool isAsync)
+            : this(left, list, body, else_) {
+            _isAsync = isAsync;
         }
 
         public int HeaderIndex {
@@ -49,6 +55,10 @@ namespace Microsoft.PythonTools.Parsing.Ast {
 
         public Statement Else {
             get { return _else; }
+        }
+
+        public bool IsAsync {
+            get { return _isAsync; }
         }
 
         public override void Walk(PythonWalker walker) {

--- a/Python/Product/Analysis/Parsing/Ast/FunctionDefinition.cs
+++ b/Python/Product/Analysis/Parsing/Ast/FunctionDefinition.cs
@@ -25,6 +25,7 @@ namespace Microsoft.PythonTools.Parsing.Ast {
         private Expression _returnAnnotation;
         private DecoratorStatement _decorators;
         private bool _generator;                        // The function is a generator
+        private bool _coroutine;
         private bool _isLambda;
 
         private PythonVariable _variable;               // The variable corresponding to the function name or null for lambdas
@@ -97,13 +98,22 @@ namespace Microsoft.PythonTools.Parsing.Ast {
         }
 
         /// <summary>
-        /// True is the function is a generator.  Generators contain at least one yield
+        /// True if the function is a generator.  Generators contain at least one yield
         /// expression and instead of returning a value when called they return a generator
         /// object which implements the iterator protocol.
         /// </summary>
         public bool IsGenerator {
             get { return _generator; }
             set { _generator = value; }
+        }
+
+        /// <summary>
+        /// True if the function is a coroutine. Coroutines are defined using
+        /// 'async def'.
+        /// </summary>
+        public bool IsCoroutine {
+            get { return _coroutine; }
+            set { _coroutine = value; }
         }
 
         /// <summary>

--- a/Python/Product/Analysis/Parsing/Ast/PythonWalker.Generated.cs
+++ b/Python/Product/Analysis/Parsing/Ast/PythonWalker.Generated.cs
@@ -22,6 +22,10 @@ namespace Microsoft.PythonTools.Parsing.Ast {
         public virtual bool Walk(AndExpression node) { return true; }
         public virtual void PostWalk(AndExpression node) { }
 
+        // AwaitExpression
+        public virtual bool Walk(AwaitExpression node) { return true; }
+        public virtual void PostWalk(AwaitExpression node) { }
+
         // BackQuoteExpression
         public virtual bool Walk(BackQuoteExpression node) { return true; }
         public virtual void PostWalk(BackQuoteExpression node) { }
@@ -279,6 +283,10 @@ namespace Microsoft.PythonTools.Parsing.Ast {
         // AndExpression
         public override bool Walk(AndExpression node) { return false; }
         public override void PostWalk(AndExpression node) { }
+
+        // AndExpression
+        public override bool Walk(AwaitExpression node) { return false; }
+        public override void PostWalk(AwaitExpression node) { }
 
         // BackQuoteExpression
         public override bool Walk(BackQuoteExpression node) { return false; }
@@ -542,6 +550,9 @@ namespace Microsoft.PythonTools.Parsing.Ast {
 
         // AndExpression
         public override bool Walk(AndExpression node) { return Location >= node.StartIndex && Location <= node.EndIndex; }
+
+        // AndExpression
+        public override bool Walk(AwaitExpression node) { return Location >= node.StartIndex && Location <= node.EndIndex; }
 
         // BackQuoteExpression
         public override bool Walk(BackQuoteExpression node) { return Location >= node.StartIndex && Location <= node.EndIndex; }

--- a/Python/Product/Analysis/Parsing/Ast/WithStatement.cs
+++ b/Python/Product/Analysis/Parsing/Ast/WithStatement.cs
@@ -20,12 +20,18 @@ namespace Microsoft.PythonTools.Parsing.Ast {
     public class WithStatement : Statement {
         private int _headerIndex;
         private readonly WithItem[] _items;
-        private Statement _body;
+        private readonly Statement _body;
+        private readonly bool _isAsync;
 
         public WithStatement(WithItem[] items, Statement body) {
             _items = items;
             _body = body;
         }
+
+        public WithStatement(WithItem[] items, Statement body, bool isAsync) : this(items, body) {
+            _isAsync = isAsync;
+        }
+
 
         public IList<WithItem> Items {
             get {
@@ -39,6 +45,10 @@ namespace Microsoft.PythonTools.Parsing.Ast {
 
         public Statement Body {
             get { return _body; }
+        }
+
+        public bool IsAsync {
+            get { return _isAsync; }
         }
 
         public override void Walk(PythonWalker walker) {

--- a/Python/Product/Analysis/Parsing/Parser.cs
+++ b/Python/Product/Analysis/Parsing/Parser.cs
@@ -40,7 +40,7 @@ namespace Microsoft.PythonTools.Parsing {
         private readonly PythonLanguageVersion _langVersion;
         // state:
         private TokenWithSpan _token;
-        private TokenWithSpan _lookahead;
+        private TokenWithSpan _lookahead, _lookahead2;
         private Stack<FunctionDefinition> _functions;
         private int _classDepth;
         private bool _fromFutureAllowed;
@@ -53,6 +53,7 @@ namespace Microsoft.PythonTools.Parsing {
         private readonly bool _verbatim;                            // true if we're in verbatim mode and the ASTs can be turned back into source code, preserving white space / comments
         private readonly bool _bindReferences;                      // true if we should bind the references in the ASTs
         private string _tokenWhiteSpace, _lookaheadWhiteSpace;      // the whitespace for the current and lookahead tokens as provided from the parser
+        private string _lookahead2WhiteSpace;
         private Dictionary<Node, Dictionary<object, object>> _attributes = new Dictionary<Node, Dictionary<object, object>>();  // attributes for each node, currently just round tripping information
 
         private static Encoding _utf8throwing;
@@ -360,6 +361,10 @@ namespace Microsoft.PythonTools.Parsing {
             public readonly string RealName;
             public readonly string VerbatimName;
 
+            public static readonly Name Empty = new Name();
+            public static readonly Name Async = new Name("async", "async");
+            public static readonly Name Await = new Name("await", "await");
+
             public Name(string name, string verbatimName) {
                 RealName = name;
                 VerbatimName = verbatimName;
@@ -373,17 +378,25 @@ namespace Microsoft.PythonTools.Parsing {
         }
 
         private Name ReadName() {
-            NameToken n = PeekToken() as NameToken;
-            if (n == null) {
+            var n = TokenToName(PeekToken());
+            if (n.HasName) {
+                NextToken();
+            } else {
                 ReportSyntaxError(_lookahead);
-                return new Name();
             }
-            NextToken();
-            return TokenToName(n);
+            return n;
         }
 
-        private Name TokenToName(NameToken n) {
-            return new Name(FixName(n.Name), n.Name);
+        private Name TokenToName(Token t) {
+            NameToken n;
+            if (t == Tokens.KeywordAwaitToken) {
+                return Name.Await;
+            } else if (t == Tokens.KeywordAsyncToken) {
+                return Name.Async;
+            } else if ((n = t as NameToken) != null) {
+                return new Name(FixName(n.Name), n.Name);
+            }
+            return Name.Empty;
         }
 
         //stmt: simple_stmt | compound_stmt
@@ -395,20 +408,51 @@ namespace Microsoft.PythonTools.Parsing {
                 case TokenKind.KeywordWhile:
                     return ParseWhileStmt();
                 case TokenKind.KeywordFor:
-                    return ParseForStmt();
+                    return ParseForStmt(isAsync: false);
                 case TokenKind.KeywordTry:
                     return ParseTryStatement();
                 case TokenKind.At:
                     return ParseDecorated();
                 case TokenKind.KeywordDef:
-                    return ParseFuncDef();
+                    return ParseFuncDef(isCoroutine: false);
                 case TokenKind.KeywordClass:
                     return ParseClassDef();
                 case TokenKind.KeywordWith:
-                    return ParseWithStmt();
+                    return ParseWithStmt(isAsync: false);
+                case TokenKind.KeywordAsync:
+                    return ParseAsyncStmt();
                 default:
                     return ParseSimpleStmt();
             }
+        }
+
+        private Statement ParseAsyncStmt() {
+            var token2 = PeekToken2();
+            if (token2.Kind == TokenKind.KeywordDef) {
+                Eat(TokenKind.KeywordAsync);
+                return ParseFuncDef(isCoroutine: true);
+            }
+
+            var currentFunction = CurrentFunction;
+            if (currentFunction == null || !currentFunction.IsCoroutine) {
+                // 'async', outside coroutine, and not followed by def, is a
+                // regular name
+                return ParseSimpleStmt();
+            }
+
+            NextToken();
+
+            switch (PeekToken().Kind) {
+                case TokenKind.KeywordFor:
+                    Eat(TokenKind.KeywordAsync);
+                    return ParseForStmt(isAsync: true);
+                case TokenKind.KeywordWith:
+                    Eat(TokenKind.KeywordAsync);
+                    return ParseWithStmt(isAsync: true);
+            }
+
+            ReportSyntaxError("syntax error");
+            return ParseStmt();
         }
 
         //simple_stmt: small_stmt (';' small_stmt)* [';'] Newline
@@ -617,6 +661,8 @@ namespace Microsoft.PythonTools.Parsing {
             FunctionDefinition current = CurrentFunction;
             if (current == null) {
                 ReportSyntaxError("misplaced yield");
+            } else if (current.IsCoroutine) {
+                ReportSyntaxError("'yield' inside async function");
             }
 
             _isGenerator = true;
@@ -650,7 +696,7 @@ namespace Microsoft.PythonTools.Parsing {
             //    g=((yield i) for i in range(5))
             // In that case, the genexp will mark IsGenerator. 
             FunctionDefinition current = CurrentFunction;
-            if (current != null) {
+            if (current != null && !current.IsCoroutine) {
                 current.IsGenerator = true;
             }
             string whitespace = _tokenWhiteSpace;
@@ -750,7 +796,11 @@ namespace Microsoft.PythonTools.Parsing {
                     left.Add(right);
                 }
 
-                if (_langVersion >= PythonLanguageVersion.V25 && MaybeEat(TokenKind.KeywordYield)) {
+                if (_langVersion >= PythonLanguageVersion.V25 && PeekToken(TokenKind.KeywordYield)) {
+                    if (CurrentFunction != null && CurrentFunction.IsCoroutine) {
+                        ReportSyntaxError("'yield' inside async function");
+                    }
+                    Eat(TokenKind.KeywordYield);
                     right = ParseYieldExpression();
                 } else {
                     right = ParseTestListAsExpr();
@@ -807,7 +857,11 @@ namespace Microsoft.PythonTools.Parsing {
                     string whiteSpace = _tokenWhiteSpace;
                     Expression rhs;
 
-                    if (_langVersion >= PythonLanguageVersion.V25 && MaybeEat(TokenKind.KeywordYield)) {
+                    if (_langVersion >= PythonLanguageVersion.V25 && PeekToken(TokenKind.KeywordYield)) {
+                        if (CurrentFunction != null && CurrentFunction.IsCoroutine) {
+                            ReportSyntaxError("'yield' inside async function");
+                        }
+                        Eat(TokenKind.KeywordYield);
                         rhs = ParseYieldExpression();
                     } else {
                         rhs = ParseTestListAsExpr();
@@ -1662,12 +1716,13 @@ namespace Microsoft.PythonTools.Parsing {
 
             Statement res;
 
-            if (PeekToken() == Tokens.KeywordDefToken) {
-                FunctionDefinition fnc = ParseFuncDef();
+            var next = PeekToken();
+            if (next == Tokens.KeywordDefToken || next == Tokens.KeywordAsyncToken) {
+                FunctionDefinition fnc = ParseFuncDef(isCoroutine: (next == Tokens.KeywordAsyncToken));
                 fnc.Decorators = decorators;
                 fnc.SetLoc(decorators.StartIndex, fnc.EndIndex);
                 res = fnc;
-            } else if (PeekToken() == Tokens.KeywordClassToken) {
+            } else if (next == Tokens.KeywordClassToken) {
                 if (_langVersion < PythonLanguageVersion.V26) {
                     ReportSyntaxError("invalid syntax, class decorators require 2.6 or later.");
                 }
@@ -1693,11 +1748,15 @@ namespace Microsoft.PythonTools.Parsing {
         // funcdef: [decorators] 'def' NAME parameters ':' suite
         // parameters: '(' [varargslist] ')'
         // this gets called with "def" as the look-ahead
-        private FunctionDefinition ParseFuncDef() {
+        private FunctionDefinition ParseFuncDef(bool isCoroutine) {
+            var start = isCoroutine ? GetStart() : 0;
             Eat(TokenKind.KeywordDef);
+            if (!isCoroutine) {
+                start = GetStart();
+            }
+
             string defWhitespace = _tokenWhiteSpace;
 
-            var start = GetStart();
             var name = ReadName();
             var nameExpr = MakeName(name);
             nameExpr.SetLoc(GetStart(), GetEnd());
@@ -1718,6 +1777,7 @@ namespace Microsoft.PythonTools.Parsing {
             if (parameters == null) {
                 // error in parameters
                 ret = new FunctionDefinition(nameExpr, new Parameter[0]);
+                ret.IsCoroutine = isCoroutine;
                 if (_verbatim) {
                     AddVerbatimName(name, ret);
                     AddPreceedingWhiteSpace(ret, defWhitespace);
@@ -1749,6 +1809,9 @@ namespace Microsoft.PythonTools.Parsing {
             AddVerbatimName(name, ret);
 
             PushFunction(ret);
+
+            // set IsCoroutine before parsing the body to enable use of 'await'
+            ret.IsCoroutine = isCoroutine;
 
             Statement body = ParseClassOrFuncBody();
             FunctionDefinition ret2 = PopFunction();
@@ -2017,7 +2080,7 @@ namespace Microsoft.PythonTools.Parsing {
 
                 case TokenKind.Name:  // identifier
                     NextToken();
-                    var name = TokenToName((NameToken)t);
+                    var name = TokenToName(t);
                     var paramStart = GetStart();
                     parameter = new Parameter(name.RealName, kind);
                     if (_verbatim) {
@@ -2071,7 +2134,7 @@ namespace Microsoft.PythonTools.Parsing {
                     break;
                 case TokenKind.Name:  // identifier
                     string name = FixName((string)t.Value);
-                    NameExpression ne = MakeName(TokenToName((NameToken)t));
+                    NameExpression ne = MakeName(TokenToName(t));
                     if (_verbatim) {
                         AddPreceedingWhiteSpace(ne, _tokenWhiteSpace);
                     }
@@ -2224,9 +2287,13 @@ namespace Microsoft.PythonTools.Parsing {
         
         //with_stmt: 'with' with_item (',' with_item)* ':' suite
         //with_item: test ['as' expr]
-        private WithStatement ParseWithStmt() {
-            var start = _lookahead.Span.Start;
+        private WithStatement ParseWithStmt(bool isAsync) {
+            var start = isAsync ? GetStart() : 0;
             Eat(TokenKind.KeywordWith);
+            if (!isAsync) {
+                start = GetStart();
+            }
+
             string withWhiteSpace = _tokenWhiteSpace;
             var itemWhiteSpace = MakeWhiteSpaceList();
 
@@ -2243,7 +2310,7 @@ namespace Microsoft.PythonTools.Parsing {
             var header = GetEnd();
             Statement body = ParseSuite();
 
-            WithStatement ret = new WithStatement(items.ToArray(), body);
+            WithStatement ret = new WithStatement(items.ToArray(), body, isAsync);
             if (_verbatim) {
                 AddPreceedingWhiteSpace(ret, withWhiteSpace);
                 AddListWhiteSpace(ret, itemWhiteSpace.ToArray());
@@ -2269,10 +2336,13 @@ namespace Microsoft.PythonTools.Parsing {
         }
 
         //for_stmt: 'for' target_list 'in' expression_list ':' suite ['else' ':' suite]
-        private Statement ParseForStmt() {
+        private Statement ParseForStmt(bool isAsync) {
+            var start = isAsync ? GetStart() : 0;
             Eat(TokenKind.KeywordFor);
+            if (!isAsync) {
+                start = GetStart();
+            }
             string forWhiteSpace = _tokenWhiteSpace;
-            var start = GetStart();
 
             bool trailingComma;
             List<string> listWhiteSpace;
@@ -2317,7 +2387,7 @@ namespace Microsoft.PythonTools.Parsing {
                 }
             }
 
-            ForStatement ret = new ForStatement(lhs, list, body, else_);
+            ForStatement ret = new ForStatement(lhs, list, body, else_, isAsync);
             if (_verbatim) {
                 AddPreceedingWhiteSpace(ret, forWhiteSpace);
                 if (inWhiteSpace != null) {
@@ -2867,7 +2937,7 @@ namespace Microsoft.PythonTools.Parsing {
                     }
                     break;
                 default:
-                    return ParsePower();
+                    return ParseAwaitExpr();
             }
             ret.SetLoc(start, GetEnd());
             return ret;
@@ -2907,6 +2977,23 @@ namespace Microsoft.PythonTools.Parsing {
                 AddPreceedingWhiteSpace(res, whitespace);
             }
             return res;
+        }
+
+        private Expression ParseAwaitExpr() {
+            if (_langVersion >= PythonLanguageVersion.V35) {
+                var currentFunction = CurrentFunction;
+                if (currentFunction != null && currentFunction.IsCoroutine && MaybeEat(TokenKind.KeywordAwait)) {
+                    var start = GetStart();
+                    string whitespace = _tokenWhiteSpace;
+                    var res = new AwaitExpression(ParsePower());
+                    if (_verbatim) {
+                        AddPreceedingWhiteSpace(res, whitespace);
+                    }
+                    res.SetLoc(start, GetEnd());
+                    return res;
+                }
+            }
+            return ParsePower();
         }
 
         // power: atom trailer* ['**' factor]
@@ -2951,9 +3038,13 @@ namespace Microsoft.PythonTools.Parsing {
                 case TokenKind.BackQuote:       // string_conversion
                     NextToken();
                     return FinishStringConversion();
+                case TokenKind.KeywordAsync:
+                case TokenKind.KeywordAwait:
+                // if we made it this far, treat await and async as names
+                // See ParseAwaitExpr() for treating 'await' as a keyword
                 case TokenKind.Name:            // identifier
                     NextToken();
-                    ret = MakeName(TokenToName((NameToken)t));
+                    ret = MakeName(TokenToName(t));
                     if (_verbatim) {
                         AddPreceedingWhiteSpace(ret);
                     }
@@ -3701,7 +3792,11 @@ namespace Microsoft.PythonTools.Parsing {
             if (MaybeEat(TokenKind.RightParenthesis)) {
                 ret = MakeTupleOrExpr(new List<Expression>(), MakeWhiteSpaceList(), false);
                 hasRightParenthesis = true;
-            } else if (MaybeEat(TokenKind.KeywordYield)) {
+            } else if (PeekToken(TokenKind.KeywordYield)) {
+                if (CurrentFunction != null && CurrentFunction.IsCoroutine) {
+                    ReportSyntaxError("'yield' inside async function");
+                }
+                Eat(TokenKind.KeywordYield);
                 ret = ParseYieldExpression();
                 Eat(TokenKind.RightParenthesis);                
                 hasRightParenthesis = true;
@@ -4597,9 +4692,24 @@ namespace Microsoft.PythonTools.Parsing {
             return _lookahead.Token;
         }
 
+        private Token PeekToken2() {
+            if (_lookahead2.Token == null) {
+                _lookahead2 = new TokenWithSpan(_tokenizer.GetNextToken(), _tokenizer.TokenSpan);
+                _lookahead2WhiteSpace = _tokenizer.PreceedingWhiteSpace;
+            }
+            return _lookahead2.Token;
+        }
+
         private void FetchLookahead() {
-            _lookahead = new TokenWithSpan(_tokenizer.GetNextToken(), _tokenizer.TokenSpan);
-            _lookaheadWhiteSpace = _tokenizer.PreceedingWhiteSpace;
+            if (_lookahead2.Token != null) {
+                _lookahead = _lookahead2;
+                _lookaheadWhiteSpace = _lookahead2WhiteSpace;
+                _lookahead2 = TokenWithSpan.Empty;
+                _lookahead2WhiteSpace = null;
+            } else {
+                _lookahead = new TokenWithSpan(_tokenizer.GetNextToken(), _tokenizer.TokenSpan);
+                _lookaheadWhiteSpace = _tokenizer.PreceedingWhiteSpace;
+            }
         }
 
         private bool PeekToken(TokenKind kind) {

--- a/Python/Product/Analysis/Parsing/Token.cs
+++ b/Python/Product/Analysis/Parsing/Token.cs
@@ -16,6 +16,8 @@ using System;
 
 namespace Microsoft.PythonTools.Parsing {
     internal struct TokenWithSpan {
+        public static readonly TokenWithSpan Empty = new TokenWithSpan();
+
         private readonly Token _token;
         private readonly IndexSpan _span;
 

--- a/Python/Product/Analysis/Parsing/TokenKind.Generated.cs
+++ b/Python/Product/Analysis/Parsing/TokenKind.Generated.cs
@@ -121,7 +121,10 @@ namespace Microsoft.PythonTools.Parsing {
         NLToken = 110,
         ExplicitLineJoin = 111,
         MatMultiply = 112,
-        MatMultiplyEqual = 113
+        MatMultiplyEqual = 113,
+
+        KeywordAsync = 114,
+        KeywordAwait = 115
     }
 
     internal static class Tokens {
@@ -389,6 +392,8 @@ namespace Microsoft.PythonTools.Parsing {
         private static readonly Token kwAndToken = new SymbolToken(TokenKind.KeywordAnd, "and");
         private static readonly Token kwAsToken = new SymbolToken(TokenKind.KeywordAs, "as");
         private static readonly Token kwAssertToken = new SymbolToken(TokenKind.KeywordAssert, "assert");
+        private static readonly Token kwAsyncToken = new SymbolToken(TokenKind.KeywordAsync, "async");
+        private static readonly Token kwAwaitToken = new SymbolToken(TokenKind.KeywordAwait, "await");
         private static readonly Token kwBreakToken = new SymbolToken(TokenKind.KeywordBreak, "break");
         private static readonly Token kwClassToken = new SymbolToken(TokenKind.KeywordClass, "class");
         private static readonly Token kwContinueToken = new SymbolToken(TokenKind.KeywordContinue, "continue");
@@ -432,6 +437,14 @@ namespace Microsoft.PythonTools.Parsing {
 
         public static Token KeywordAssertToken {
             get { return kwAssertToken; }
+        }
+
+        public static Token KeywordAsyncToken {
+            get { return kwAsyncToken; }
+        }
+
+        public static Token KeywordAwaitToken {
+            get { return kwAwaitToken; }
         }
 
         public static Token KeywordBreakToken {

--- a/Python/Product/Analysis/Parsing/Tokenizer.cs
+++ b/Python/Product/Analysis/Parsing/Tokenizer.cs
@@ -317,6 +317,11 @@ namespace Microsoft.PythonTools.Parsing {
                     result.Category = TokenCategory.Keyword;
                     break;
 
+                case TokenKind.KeywordAsync:
+                case TokenKind.KeywordAwait:
+                    result.Category = TokenCategory.Identifier;
+                    break;
+
                 default:
                     if (token.Kind >= TokenKind.FirstKeyword && token.Kind <= TokenKind.KeywordNonlocal) {
                         result.Category = TokenCategory.Keyword;
@@ -1453,8 +1458,21 @@ namespace Microsoft.PythonTools.Parsing {
                         MarkTokenEnd();
                         return Tokens.KeywordAsToken;
                     }
-                    if (NextChar() == 's' && NextChar() == 'e' && NextChar() == 'r' && NextChar() == 't' && !IsNamePart(Peek())) {
-                        return TransformStatementToken(Tokens.KeywordAssertToken);
+                    ch = NextChar();
+                    if (ch == 's') {
+                        if (NextChar() == 'e' && NextChar() == 'r' && NextChar() == 't' && !IsNamePart(Peek())) {
+                            return TransformStatementToken(Tokens.KeywordAssertToken);
+                        }
+                    } else if (ch == 'y') {
+                        if (_langVersion >= PythonLanguageVersion.V35 && NextChar() == 'n' && NextChar() == 'c' && !IsNamePart(Peek())) {
+                            MarkTokenEnd();
+                            return Tokens.KeywordAsyncToken;
+                        }
+                    }
+                } else if (ch == 'w') {
+                    if (_langVersion >= PythonLanguageVersion.V35 && NextChar() == 'a' && NextChar() == 'i' && NextChar() == 't' && !IsNamePart(Peek())) {
+                        MarkTokenEnd();
+                        return Tokens.KeywordAwaitToken;
                     }
                 }
             } else if (ch == 'y') {

--- a/Python/Product/Analysis/PythonKeywords.cs
+++ b/Python/Product/Analysis/PythonKeywords.cs
@@ -72,6 +72,9 @@ namespace Microsoft.PythonTools.Analysis {
         public static IEnumerable<string> Expression(PythonLanguageVersion version = PythonLanguageVersion.None) {
             yield return "and";
             yield return "as";
+            if (version >= PythonLanguageVersion.V35) {
+                yield return "await";
+            }
             yield return "else";
             if (version.Is3x()) {
                 yield return "False";
@@ -99,6 +102,9 @@ namespace Microsoft.PythonTools.Analysis {
         /// </summary>
         public static IEnumerable<string> Statement(PythonLanguageVersion version = PythonLanguageVersion.None) {
             yield return "assert";
+            if (version >= PythonLanguageVersion.V35) {
+                yield return "async";
+            }
             yield return "break";
             yield return "continue";
             yield return "class";
@@ -137,6 +143,9 @@ namespace Microsoft.PythonTools.Analysis {
         public static IEnumerable<string> InvalidOutsideFunction(
             PythonLanguageVersion version = PythonLanguageVersion.None
         ) {
+            if (version >= PythonLanguageVersion.V35) {
+                yield return "await";
+            }
             yield return "return";
             if (version == PythonLanguageVersion.None || version >= PythonLanguageVersion.V25) {
                 yield return "yield";

--- a/Python/Product/Analysis/Values/BoundMethodInfo.cs
+++ b/Python/Product/Analysis/Values/BoundMethodInfo.cs
@@ -80,8 +80,8 @@ namespace Microsoft.PythonTools.Analysis.Values {
                     result.Append(" objects ");
                 }
 
-                _function.AddReturnTypeString(result);
-                _function.AddDocumentationString(result);
+                FunctionInfo.AddReturnTypeString(result, _function.GetReturnValue);
+                FunctionInfo.AddDocumentationString(result, _function.Documentation);
 
                 return result.ToString();
             }

--- a/Python/Product/Analysis/Values/CoroutineInfo.cs
+++ b/Python/Product/Analysis/Values/CoroutineInfo.cs
@@ -1,0 +1,63 @@
+﻿/* ****************************************************************************
+ *
+ * Copyright (c) Microsoft Corporation. 
+ *
+ * This source code is subject to terms and conditions of the Apache License, Version 2.0. A 
+ * copy of the license can be found in the License.html file at the root of this distribution. If 
+ * you cannot locate the Apache License, Version 2.0, please send an email to 
+ * vspython@microsoft.com. By using this source code in any fashion, you are agreeing to be bound 
+ * by the terms of the Apache License, Version 2.0.
+ *
+ * You must not remove this notice, or any other, from this software.
+ *
+ * ***************************************************************************/
+
+using System.Linq;
+using System.Text;
+using Microsoft.PythonTools.Interpreter;
+using Microsoft.PythonTools.Parsing;
+using Microsoft.PythonTools.Parsing.Ast;
+
+namespace Microsoft.PythonTools.Analysis.Values {
+    /// <summary>
+    /// Represents a coroutine instance
+    /// </summary>
+    internal class CoroutineInfo : BuiltinInstanceInfo {
+        private readonly IPythonProjectEntry _declaringModule;
+        private readonly int _declaringVersion;
+        public readonly VariableDef Returns;
+
+        public CoroutineInfo(PythonAnalyzer projectState, IPythonProjectEntry entry)
+            : base(projectState.ClassInfos[BuiltinTypeId.Generator]) {
+            // Internally, coroutines are represented by generators with a CO_*
+            // flag on the code object. Here we represent it as a separate info,
+            // but reuse the underlying class info.
+
+            _declaringModule = entry;
+            _declaringVersion = entry.AnalysisVersion;
+            Returns = new VariableDef();
+        }
+
+        public override IPythonProjectEntry DeclaringModule { get { return _declaringModule; } }
+        public override int DeclaringVersion { get { return _declaringVersion; } }
+
+        public override string Description {
+            get {
+                // Generator lies about its name when it represents a coroutine
+                var sb = new StringBuilder("coroutine");
+                FunctionInfo.AddReturnTypeString(sb, Returns.TypesNoCopy.AsUnion);
+                return sb.ToString();
+            }
+        }
+
+        public override IAnalysisSet Await(Node node, AnalysisUnit unit) {
+            Returns.AddDependency(unit);
+            return Returns.TypesNoCopy;
+        }
+
+        public void AddReturn(Node node, AnalysisUnit unit, IAnalysisSet returnValue, bool enqueue = true) {
+            Returns.MakeUnionStrongerIfMoreThan(ProjectState.Limits.ReturnTypes, returnValue);
+            Returns.AddTypes(unit, returnValue, enqueue);
+        }
+    }
+}

--- a/Python/Product/PythonTools/PythonTools/Debugger/ProximityExpressionWalker.cs
+++ b/Python/Product/PythonTools/PythonTools/Debugger/ProximityExpressionWalker.cs
@@ -135,6 +135,11 @@ namespace Microsoft.PythonTools.Debugger {
         private class DetectSideEffectsWalker : PythonWalker {
             public bool HasSideEffects { get; private set; }
 
+            public override bool Walk(AwaitExpression node) {
+                HasSideEffects = true;
+                return false;
+            }
+
             public override bool Walk(CallExpression node) {
                 HasSideEffects = true;
                 return false;

--- a/Python/Product/PythonTools/PythonTools/Intellisense/IntellisenseController.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/IntellisenseController.cs
@@ -416,6 +416,12 @@ namespace Microsoft.PythonTools.Intellisense {
                 return base.Walk(node);
             }
 
+            public override bool Walk(AwaitExpression node) {
+                CanComplete = IsActualExpression(node.Expression);
+                CommitByDefault = true;
+                return base.Walk(node);
+            }
+
             public override bool Walk(DelStatement node) {
                 CanComplete = IsActualExpression(node.Expressions);
                 CommitByDefault = true;

--- a/Python/Product/PythonTools/PythonTools/PythonAnalysisClassifier.cs
+++ b/Python/Product/PythonTools/PythonTools/PythonAnalysisClassifier.cs
@@ -20,6 +20,7 @@ using Microsoft.PythonTools.Analysis;
 using Microsoft.PythonTools.Intellisense;
 using Microsoft.PythonTools.Interpreter;
 using Microsoft.PythonTools.Parsing.Ast;
+using Microsoft.VisualStudio.Language.StandardClassification;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Classification;
 
@@ -397,6 +398,10 @@ namespace Microsoft.PythonTools {
         }
 
         public override bool Walk(FunctionDefinition node) {
+            if (node.IsCoroutine) {
+                AddSpan(Tuple.Create("", new Span(node.StartIndex, 5)), PredefinedClassificationTypeNames.Keyword);
+            }
+
             Debug.Assert(_head != null);
             _head.Functions.Add(node.NameExpression.Name);
             node.NameExpression.Walk(this);
@@ -512,5 +517,24 @@ namespace Microsoft.PythonTools {
             base.PostWalk(node);
         }
 
+
+        public override bool Walk(AwaitExpression node) {
+            AddSpan(Tuple.Create("", new Span(node.StartIndex, 5)), PredefinedClassificationTypeNames.Keyword);
+            return base.Walk(node);
+        }
+
+        public override bool Walk(ForStatement node) {
+            if (node.IsAsync) {
+                AddSpan(Tuple.Create("", new Span(node.StartIndex, 5)), PredefinedClassificationTypeNames.Keyword);
+            }
+            return base.Walk(node);
+        }
+
+        public override bool Walk(WithStatement node) {
+            if (node.IsAsync) {
+                AddSpan(Tuple.Create("", new Span(node.StartIndex, 5)), PredefinedClassificationTypeNames.Keyword);
+            }
+            return base.Walk(node);
+        }
     }
 }

--- a/Python/Product/PythonTools/PythonTools/PythonAnalysisClassifierProvider.cs
+++ b/Python/Product/PythonTools/PythonTools/PythonAnalysisClassifierProvider.cs
@@ -120,6 +120,8 @@ namespace Microsoft.PythonTools {
             categoryMap[PythonPredefinedClassificationTypeNames.Parameter] = registry.GetClassificationType(PythonPredefinedClassificationTypeNames.Parameter);
             categoryMap[PythonPredefinedClassificationTypeNames.Module] = registry.GetClassificationType(PythonPredefinedClassificationTypeNames.Module);
             categoryMap[PythonPredefinedClassificationTypeNames.Function] = registry.GetClassificationType(PythonPredefinedClassificationTypeNames.Function);
+            // Include keyword for context-sensitive keywords
+            categoryMap[PredefinedClassificationTypeNames.Keyword] = registry.GetClassificationType(PredefinedClassificationTypeNames.Keyword);
 
             return categoryMap;
         }

--- a/Python/Tests/Analysis/ParserTests.cs
+++ b/Python/Tests/Analysis/ParserTests.cs
@@ -2026,6 +2026,39 @@ namespace AnalysisTests {
         }
 
         [TestMethod, Priority(0)]
+        public void CoroutineDef() {
+            foreach (var version in V35AndUp) {
+                var ast = ParseFile("CoroutineDef.py", ErrorSink.Null, version);
+                CheckAst(
+                    ast,
+                    CheckSuite(
+                        CheckCoroutineDef(CheckFuncDef("f", NoParameters, CheckSuite(
+                            CheckAsyncForStmt(CheckForStmt(Fob, Oar, CheckSuite(Pass))),
+                            CheckAsyncWithStmt(CheckWithStmt(Baz, CheckSuite(Pass)))
+                        )))
+                    )
+                );
+
+                ParseErrors("CoroutineDefIllegal.py", version,
+                    new ErrorInfo("'yield' inside async function", 20, 2, 5, 25, 2, 10),
+                    new ErrorInfo("'yield' inside async function", 40, 3, 9, 45, 3, 14),
+                    new ErrorInfo("unexpected token 'for'", 74, 6, 11, 77, 6, 14),
+                    new ErrorInfo("unexpected token ':'", 88, 6, 25, 89, 6, 26),
+                    new ErrorInfo("unexpected token '<newline>'", 89, 6, 26, 99, 7, 9),
+                    new ErrorInfo("unexpected token '<indent>'", 89, 6, 26, 99, 7, 9),
+                    new ErrorInfo("unexpected token '<dedent>'", 105, 8, 1, 107, 9, 1),
+                    new ErrorInfo("unexpected token 'async'", 107, 9, 1, 112, 9, 6),
+                    new ErrorInfo("unexpected token 'with'", 162, 13, 11, 166, 13, 15),
+                    new ErrorInfo("unexpected token ':'", 170, 13, 19, 171, 13, 20),
+                    new ErrorInfo("unexpected token '<newline>'", 171, 13, 20, 181, 14, 9),
+                    new ErrorInfo("unexpected token '<indent>'", 171, 13, 20, 181, 14, 9),
+                    new ErrorInfo("unexpected token '<dedent>'", 187, 15, 1, 189, 16, 1),
+                    new ErrorInfo("unexpected token 'async'", 189, 16, 1, 194, 16, 6)
+                );
+            }
+        }
+
+        [TestMethod, Priority(0)]
         public void ClassDef() {
             foreach (var version in AllVersions) {
                 CheckAst(
@@ -2217,6 +2250,99 @@ namespace AnalysisTests {
                     new ErrorInfo("can't assign to generator expression", 43, 5, 1, 63, 5, 21),
                     new ErrorInfo("illegal expression for augmented assignment", 69, 6, 1, 77, 6, 9),
                     new ErrorInfo("can't assign to yield expression", 98, 8, 5, 109, 8, 16)
+                );
+            }
+        }
+
+        [TestMethod, Priority(0)]
+        public void AwaitStmt() {
+            var AwaitFob = CheckAwaitExpression(Fob);
+            foreach (var version in V35AndUp) {
+                CheckAst(
+                    ParseFile("AwaitStmt.py", ErrorSink.Null, version),
+                    CheckSuite(CheckCoroutineDef(CheckFuncDef("quox", NoParameters, CheckSuite(
+                        CheckExprStmt(AwaitFob),
+                        CheckExprStmt(CheckAwaitExpression(CheckCallExpression(Fob))),
+                        CheckExprStmt(CheckCallExpression(CheckParenExpr(AwaitFob))),
+                        CheckBinaryStmt(One, PythonOperator.Add, AwaitFob),
+                        CheckBinaryStmt(One, PythonOperator.Power, AwaitFob),
+                        CheckBinaryStmt(One, PythonOperator.Power, CheckUnaryExpression(PythonOperator.Negate, AwaitFob))
+                    ))))
+                );
+                ParseErrors("AwaitStmt.py", version);
+            }
+        }
+
+        [TestMethod, Priority(0)]
+        public void AwaitStmtPreV35() {
+            foreach (var version in AllVersions.Except(V35AndUp)) {
+                ParseErrors("AwaitStmt.py", version,
+                    new ErrorInfo("unexpected token 'def'", 6, 1, 7, 9, 1, 10),
+                    new ErrorInfo("unexpected token ':'", 16, 1, 17, 17, 1, 18),
+                    new ErrorInfo("unexpected indent", 23, 2, 5, 28, 2, 10),
+                    new ErrorInfo("unexpected token 'fob'", 29, 2, 11, 32, 2, 14),
+                    new ErrorInfo("unexpected token 'fob'", 44, 3, 11, 47, 3, 14),
+                    new ErrorInfo("unexpected token 'fob'", 62, 4, 12, 65, 4, 15),
+                    new ErrorInfo("unexpected token 'fob'", 62, 4, 12, 65, 4, 15),
+                    new ErrorInfo("unexpected token ')'", 65, 4, 15, 66, 4, 16),
+                    new ErrorInfo("unexpected token '('", 66, 4, 16, 67, 4, 17),
+                    new ErrorInfo("unexpected token ')'", 67, 4, 17, 68, 4, 18),
+                    new ErrorInfo("unexpected token 'fob'", 84, 5, 15, 87, 5, 18),
+                    new ErrorInfo("unexpected token 'fob'", 104, 6, 16, 107, 6, 19),
+                    new ErrorInfo("unexpected token 'fob'", 125, 7, 17, 128, 7, 20),
+                    new ErrorInfo("unexpected token '<dedent>'", 128, 7, 20, 130, 8, 1)
+                );
+            }
+        }
+
+        [TestMethod, Priority(0)]
+        public void AwaitAsyncNames() {
+            var Async = CheckNameExpr("async");
+            var Await = CheckNameExpr("await");
+            foreach (var version in V35AndUp) {
+                var ast = ParseFile("AwaitAsyncNames.py", ErrorSink.Null, version);
+                CheckAst(
+                    ast,
+                    CheckSuite(
+                        CheckExprStmt(Async),
+                        CheckExprStmt(Await),
+                        CheckAssignment(Async, Fob),
+                        CheckAssignment(Await, Fob),
+                        CheckAssignment(Fob, Async),
+                        CheckAssignment(Fob, Await),
+                        CheckFuncDef("async", NoParameters, CheckSuite(Pass)),
+                        CheckFuncDef("await", NoParameters, CheckSuite(Pass)),
+                        CheckClassDef("async", CheckSuite(Pass)),
+                        CheckClassDef("await", CheckSuite(Pass)),
+                        CheckCallStmt(Async, CheckArg("fob")),
+                        CheckCallStmt(Await, CheckArg("fob")),
+                        CheckCallStmt(Fob, CheckArg("async")),
+                        CheckCallStmt(Fob, CheckArg("await"))
+                    )
+                );
+                ParseErrors("AwaitAsyncNames.py", version);
+            }
+        }
+
+        [TestMethod, Priority(0)]
+        public void AwaitStmtIllegal() {
+            //foreach (var version in V35AndUp) {
+            //    CheckAst(
+            //        ParseFile("AwaitStmtIllegal.py", ErrorSink.Null, version),
+            //        CheckSuite(
+            //        )
+            //    );
+            //}
+
+            foreach (var version in V35AndUp) {
+                ParseErrors("AwaitStmtIllegal.py", version,
+                    new ErrorInfo("invalid syntax", 6, 1, 7, 10, 1, 11),
+                    new ErrorInfo("unexpected token 'fob'", 37, 4, 11, 40, 4, 14),
+                    new ErrorInfo("unexpected token '<newline>'", 40, 4, 14, 42, 5, 1),
+                    new ErrorInfo("unexpected token '<NL>'", 42, 5, 1, 44, 6, 1),
+                    new ErrorInfo("unexpected token 'fob'", 67, 7, 11, 70, 7, 14),
+                    new ErrorInfo("unexpected token '<newline>'", 70, 7, 14, 72, 8, 1),
+                    new ErrorInfo("unexpected token '<NL>'", 72, 8, 1, 74, 9, 1)
                 );
             }
         }
@@ -2531,6 +2657,17 @@ namespace AnalysisTests {
             };
         }
 
+        private Action<Statement> CheckAsyncForStmt(Action<Statement> checkForStmt) {
+            return stmt => {
+                Assert.IsInstanceOfType(stmt, typeof(ForStatement));
+                var forStmt = (ForStatement)stmt;
+
+                Assert.IsTrue(forStmt.IsAsync);
+
+                checkForStmt(stmt);
+            };
+        }
+
         private static Action<Statement> CheckWhileStmt(Action<Expression> test, Action<Statement> body, Action<Statement> _else = null) {
             return stmt => {
                 Assert.AreEqual(typeof(WhileStatement), stmt.GetType());
@@ -2815,6 +2952,17 @@ namespace AnalysisTests {
             };
         }
 
+        private static Action<Statement> CheckCoroutineDef(Action<Statement> checkFuncDef) {
+            return stmt => {
+                Assert.IsInstanceOfType(stmt, typeof(FunctionDefinition));
+                var funcDef = (FunctionDefinition)stmt;
+
+                Assert.IsTrue(funcDef.IsCoroutine);
+
+                checkFuncDef(stmt);
+            };
+        }
+
         private static void CheckDecorators(Action<Expression>[] decorators, DecoratorStatement foundDecorators) {
             if (decorators != null) {
                 Assert.AreEqual(decorators.Length, foundDecorators.Decorators.Count);
@@ -2920,6 +3068,13 @@ namespace AnalysisTests {
             };
         }
 
+        private static Action<Expression> CheckAwaitExpression(Action<Expression> value) {
+            return expr => {
+                Assert.IsInstanceOfType(expr, typeof(AwaitExpression));
+                var await = (AwaitExpression)expr;
+                value(await.Expression);
+            };
+        }
         private static Action<Expression> CheckAndExpression(Action<Expression> lhs, Action<Expression> rhs) {
             return expr => {
                 Assert.AreEqual(typeof(AndExpression), expr.GetType());
@@ -3214,6 +3369,17 @@ namespace AnalysisTests {
                 }
 
                 body(with.Body);
+            };
+        }
+
+        private Action<Statement> CheckAsyncWithStmt(Action<Statement> checkWithStmt) {
+            return stmt => {
+                Assert.IsInstanceOfType(stmt, typeof(WithStatement));
+                var withStmt = (WithStatement)stmt;
+
+                Assert.IsTrue(withStmt.IsAsync);
+
+                checkWithStmt(stmt);
             };
         }
 

--- a/Python/Tests/TestData/Grammar/AwaitAsyncNames.py
+++ b/Python/Tests/TestData/Grammar/AwaitAsyncNames.py
@@ -1,0 +1,18 @@
+
+async
+await
+async = fob
+await = fob
+fob = async
+fob = await
+
+def async(): pass
+def await(): pass
+
+class async: pass
+class await: pass
+
+async(fob)
+await(fob)
+fob(async)
+fob(await)

--- a/Python/Tests/TestData/Grammar/AwaitStmt.py
+++ b/Python/Tests/TestData/Grammar/AwaitStmt.py
@@ -1,0 +1,7 @@
+async def quox():
+    await fob
+    await fob()
+    (await fob)()
+    1 + await fob
+    1 ** await fob
+    1 ** -await fob

--- a/Python/Tests/TestData/Grammar/AwaitStmtIllegal.py
+++ b/Python/Tests/TestData/Grammar/AwaitStmtIllegal.py
@@ -1,0 +1,8 @@
+await None
+
+def quox():
+    await fob
+
+class quox:
+    await fob
+

--- a/Python/Tests/TestData/Grammar/CoroutineDef.py
+++ b/Python/Tests/TestData/Grammar/CoroutineDef.py
@@ -1,0 +1,7 @@
+﻿async def f():
+    async for fob in oar:
+        pass
+    
+    async with baz:
+        pass
+

--- a/Python/Tests/TestData/Grammar/CoroutineDefIllegal.py
+++ b/Python/Tests/TestData/Grammar/CoroutineDefIllegal.py
@@ -1,0 +1,17 @@
+﻿async def f():
+    yield True
+    x = yield True
+
+def f():
+    async for fob in oar:
+        pass
+
+async for fob in oar:
+    pass
+
+def f():
+    async with baz:
+        pass
+
+async with baz:
+    pass


### PR DESCRIPTION
Adds support for async/await syntax.
Fixes analysis of user-defined __enter__, __iter__ and __next__/next methods.
Fixes some analysis tests
Fixes AnalysisHashSet to correctly update unioned types.