### PR TITLE
#272 await missing from completions

### DIFF
--- a/Python/Product/Analysis/PythonKeywords.cs
+++ b/Python/Product/Analysis/PythonKeywords.cs
@@ -104,6 +104,7 @@ namespace Microsoft.PythonTools.Analysis {
             yield return "assert";
             if (version >= PythonLanguageVersion.V35) {
                 yield return "async";
+                yield return "await";
             }
             yield return "break";
             yield return "continue";

--- a/Python/Product/PythonTools/PythonTools/Intellisense/NormalCompletionAnalysis.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/NormalCompletionAnalysis.cs
@@ -83,7 +83,7 @@ namespace Microsoft.PythonTools.Intellisense {
             }
 
 
-            statementExtent = parser.GetStatementRange() ?? default(SnapshotSpan);
+            statementExtent = parser.GetStatementRange() ?? new SnapshotSpan(Span.GetStartPoint(_snapshot), 0);
 
             return true;
         }

--- a/Python/Product/PythonTools/PythonTools/Intellisense/ReverseExpressionParser.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/ReverseExpressionParser.cs
@@ -540,10 +540,10 @@ namespace Microsoft.PythonTools.Intellisense {
                 eol = false;
                 while (e.MoveNext()) {
                     if (e.Current == null) {
-                        eol = true;
                         if (nesting == 0) {
                             break;
                         }
+                        eol = true;
                     } else {
                         eol = false;
                         if (setStart) {

--- a/Python/Tests/PythonToolsMockTests/CompletionTests.cs
+++ b/Python/Tests/PythonToolsMockTests/CompletionTests.cs
@@ -115,21 +115,22 @@ namespace PythonToolsMockTests {
 
         [TestMethod, Priority(0), TestCategory("Mock")]
         public void KeywordCompletions() {
-            using (var view = new PythonEditor()) {
+            using (var view = new PythonEditor(version: PythonLanguageVersion.V35)) {
                 var completionList = new HashSet<string>(view.GetCompletions(0));
 
                 // not in a function
                 AssertUtil.DoesntContain(completionList, "yield");
                 AssertUtil.DoesntContain(completionList, "return");
+                AssertUtil.DoesntContain(completionList, "await");
 
-                AssertUtil.ContainsAtLeast(completionList, "assert", "and");
+                AssertUtil.ContainsAtLeast(completionList, "assert", "and", "async");
 
                 var code = @"def f():
     |
     pass";
 
                 view.Text = code.Replace("|", "");
-                AssertUtil.ContainsAtLeast(view.GetCompletions(code.IndexOf("|")), "yield", "return");
+                AssertUtil.ContainsAtLeast(view.GetCompletions(code.IndexOf("|")), "yield", "return", "async", "await");
 
 
                 view.Text = "x = (abc, oar, )";


### PR DESCRIPTION
Fixes statement range calculation to correctly handle empty statements.
Allows "await" to appear as a statement keyword.