### PR TITLE
#256 Cannot extract async method

### DIFF
--- a/Python/Product/Analysis/Parsing/Ast/FunctionDefinition.cs
+++ b/Python/Product/Analysis/Parsing/Ast/FunctionDefinition.cs
@@ -33,6 +33,8 @@ namespace Microsoft.PythonTools.Parsing.Ast {
         internal bool _hasReturn;
         private int _headerIndex;
 
+        internal static readonly object WhitespaceAfterAsync = new object();
+
         public FunctionDefinition(NameExpression name, Parameter[] parameters)
             : this(name, parameters, (Statement)null) {            
         }
@@ -269,6 +271,10 @@ namespace Microsoft.PythonTools.Parsing.Ast {
                 Decorators.AppendCodeString(res, ast, format);
             }
             format.ReflowComment(res, this.GetProceedingWhiteSpaceDefaultNull(ast));
+            if (IsCoroutine) {
+                res.Append("async");
+                res.Append(NodeAttributes.GetWhiteSpace(this, ast, WhitespaceAfterAsync));
+            }
             res.Append("def");
             var name = this.GetVerbatimImage(ast) ?? Name;
             if (!String.IsNullOrEmpty(name)) {

--- a/Python/Product/Analysis/Parsing/Ast/NodeAttributes.cs
+++ b/Python/Product/Analysis/Parsing/Ast/NodeAttributes.cs
@@ -106,7 +106,7 @@ namespace Microsoft.PythonTools.Parsing.Ast {
             return GetWhiteSpace(node, ast, NodeAttributes.PreceedingWhiteSpace, null);
         }
 
-        private static string GetWhiteSpace(Node node, PythonAst ast, object kind, string defaultValue = " ") {
+        internal static string GetWhiteSpace(Node node, PythonAst ast, object kind, string defaultValue = " ") {
             object whitespace;
             if (ast.TryGetAttribute(node, kind, out whitespace)) {
                 return (string)whitespace;

--- a/Python/Product/Analysis/Parsing/Parser.cs
+++ b/Python/Product/Analysis/Parsing/Parser.cs
@@ -1749,13 +1749,20 @@ namespace Microsoft.PythonTools.Parsing {
         // parameters: '(' [varargslist] ')'
         // this gets called with "def" as the look-ahead
         private FunctionDefinition ParseFuncDef(bool isCoroutine) {
+            string preWhitespace = null, afterAsyncWhitespace = null;
+
             var start = isCoroutine ? GetStart() : 0;
+            if (isCoroutine) {
+                preWhitespace = _tokenWhiteSpace;
+            }
             Eat(TokenKind.KeywordDef);
-            if (!isCoroutine) {
+            
+            if (isCoroutine) {
+                afterAsyncWhitespace = _tokenWhiteSpace;
+            } else {
+                preWhitespace = _tokenWhiteSpace;
                 start = GetStart();
             }
-
-            string defWhitespace = _tokenWhiteSpace;
 
             var name = ReadName();
             var nameExpr = MakeName(name);
@@ -1780,7 +1787,10 @@ namespace Microsoft.PythonTools.Parsing {
                 ret.IsCoroutine = isCoroutine;
                 if (_verbatim) {
                     AddVerbatimName(name, ret);
-                    AddPreceedingWhiteSpace(ret, defWhitespace);
+                    AddPreceedingWhiteSpace(ret, preWhitespace);
+                    if (afterAsyncWhitespace != null) {
+                        GetNodeAttributes(ret)[FunctionDefinition.WhitespaceAfterAsync] = afterAsyncWhitespace;
+                    }
                     AddSecondPreceedingWhiteSpace(ret, nameWhiteSpace);
                     AddThirdPreceedingWhiteSpace(ret, parenWhiteSpace);
                     AddFourthPreceedingWhiteSpace(ret, closeParenWhiteSpace);
@@ -1821,7 +1831,10 @@ namespace Microsoft.PythonTools.Parsing {
             ret.ReturnAnnotation = returnAnnotation;
             ret.HeaderIndex = rEnd;
             if (_verbatim) {
-                AddPreceedingWhiteSpace(ret, defWhitespace);
+                AddPreceedingWhiteSpace(ret, preWhitespace);
+                if (afterAsyncWhitespace != null) {
+                    GetNodeAttributes(ret)[FunctionDefinition.WhitespaceAfterAsync] = afterAsyncWhitespace;
+                }
                 AddSecondPreceedingWhiteSpace(ret, nameWhiteSpace);
                 AddThirdPreceedingWhiteSpace(ret, parenWhiteSpace);
                 AddFourthPreceedingWhiteSpace(ret, closeParenWhiteSpace);

--- a/Python/Tests/Core/ExtractMethodTests.cs
+++ b/Python/Tests/Core/ExtractMethodTests.cs
@@ -1596,6 +1596,30 @@ def f(x):
     return (g())");
         }
 
+        [TestMethod]
+        public void ExtractAsyncFunction() {
+            // Ensure extracted bodies that use await generate async functions
+
+            var V35 = new Version(3, 5);
+            SuccessTest("x",
+@"async def f():
+    return await x",
+@"def g():
+    return x
+
+async def f():
+    return await g()", version: V35);
+
+            SuccessTest("await x",
+@"async def f():
+    return await x",
+@"async def g():
+    return await x
+
+async def f():
+    return await g()", version: V35);
+        }
+
         private void SuccessTest(Span extract, string input, string result, string scopeName = null, Version version = null, string[] parameters = null) {
             ExtractMethodTest(input, extract, TestResult.Success(result), scopeName: scopeName, version: version, parameters: parameters);
         }

--- a/Python/Tests/IronPython/IronPythonDatabaseTest.cs
+++ b/Python/Tests/IronPython/IronPythonDatabaseTest.cs
@@ -21,7 +21,8 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using TestUtilities.Mocks;
 
 namespace IronPythonTests {
-    class IronPythonDatabaseTest {
+    [TestClass]
+    public class IronPythonDatabaseTest {
         [TestMethod, Priority(0)]
         public void InvalidIronPythonDatabase() {
             using (var db = MockCompletionDB.Create(PythonLanguageVersion.V27,


### PR DESCRIPTION
Fixes verbatim parsing of async def to preserve correct whitespace
Ensures extracted method bodies that use await generate async functions

Also fixes IronPythonDatabaseTest