### PR TITLE
Issue 214

### DIFF
--- a/Common/Tests/Utilities/Mocks/MockReplWindow.cs
+++ b/Common/Tests/Utilities/Mocks/MockReplWindow.cs
@@ -43,6 +43,8 @@ namespace TestUtilities.Mocks {
         private readonly string _contentType;
 
 #if DEV14_OR_LATER
+        private PropertyCollection _properties;
+
         public event EventHandler<SubmissionBufferAddedEventArgs> SubmissionBufferAdded {
             add {
             }
@@ -55,7 +57,7 @@ namespace TestUtilities.Mocks {
             _eval = eval;
             _contentType = contentType;
             _view = new MockTextView(new MockTextBuffer(String.Empty, contentType, filename: "text"));
-            _eval.Initialize(this);
+            _eval._Initialize(this);
         }
 
         public bool ShowAnsiCodes { get; set; }
@@ -100,7 +102,7 @@ namespace TestUtilities.Mocks {
 #if DEV14_OR_LATER
         public ITextBuffer OutputBuffer {
             get {
-                throw new NotImplementedException();
+                return _view.TextBuffer;
             }
         }
 
@@ -142,7 +144,10 @@ namespace TestUtilities.Mocks {
 
         public PropertyCollection Properties {
             get {
-                throw new NotImplementedException();
+                if (_properties == null) {
+                    _properties = new PropertyCollection();
+                }
+                return _properties;
             }
         }
 #endif
@@ -284,7 +289,9 @@ namespace TestUtilities.Mocks {
         }
 
         Span IReplWindow.WriteLine(string text) {
-            throw new NotImplementedException();
+            var start = _output.Length;
+            _output.AppendLine(text);
+            return new Span(start, _output.Length - start);
         }
 
         public Task SubmitAsync(IEnumerable<string> inputs) {
@@ -292,7 +299,9 @@ namespace TestUtilities.Mocks {
         }
 
         public Span Write(string text) {
-            throw new NotImplementedException();
+            var start = _output.Length;
+            _output.Append(text);
+            return new Span(start, _output.Length - start);
         }
 
         public void Write(UIElement element) {
@@ -322,7 +331,7 @@ namespace TestUtilities.Mocks {
 
 #if DEV14_OR_LATER
     public static class ReplEvalExtensions {
-        public static Task<ExecutionResult> Initialize(this IReplEvaluator self, IReplWindow window) {
+        public static Task<ExecutionResult> _Initialize(this IReplEvaluator self, IReplWindow window) {
             self.CurrentWindow = window;
             return self.InitializeAsync();
         }

--- a/Common/Tests/Utilities/Mocks/MockReplWindow.cs
+++ b/Common/Tests/Utilities/Mocks/MockReplWindow.cs
@@ -329,8 +329,8 @@ namespace TestUtilities.Mocks {
         #endregion
     }
 
-#if DEV14_OR_LATER
     public static class ReplEvalExtensions {
+#if DEV14_OR_LATER
         public static Task<ExecutionResult> _Initialize(this IReplEvaluator self, IReplWindow window) {
             self.CurrentWindow = window;
             return self.InitializeAsync();
@@ -343,6 +343,10 @@ namespace TestUtilities.Mocks {
         public static Task<ExecutionResult> Reset(this IReplEvaluator self) {
             return self.ResetAsync();
         }
-    }
+#else
+        public static Task<ExecutionResult> _Initialize(this IReplEvaluator self, IReplWindow window) {
+            return self.Initialize(window);
+        }
 #endif
+    }
 }

--- a/Common/Tests/Utilities/Mocks/MockServiceProvider.cs
+++ b/Common/Tests/Utilities/Mocks/MockServiceProvider.cs
@@ -15,11 +15,17 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.Design;
+using Microsoft.VisualStudio.ComponentModelHost;
 
 namespace TestUtilities.Mocks {
     public class MockServiceProvider : IServiceProvider, IServiceContainer {
         public readonly Dictionary<Guid, object> Services = new Dictionary<Guid, object>();
-        
+        public readonly MockComponentModel ComponentModel = new MockComponentModel();
+
+        public MockServiceProvider() {
+            Services[typeof(SComponentModel).GUID] = ComponentModel;
+        }
+
         public object GetService(Type serviceType) {
             object service;
             Console.WriteLine("MockServiceProvider.GetService({0})", serviceType.Name);

--- a/Common/Tests/Utilities/Mocks/MockTextOptions.cs
+++ b/Common/Tests/Utilities/Mocks/MockTextOptions.cs
@@ -14,41 +14,36 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using Microsoft.VisualStudio.Text.Editor;
 
 namespace TestUtilities.Mocks {
     public class MockTextOptions : IEditorOptions {
+        private readonly Dictionary<string, object> _options = new Dictionary<string, object> {
+            { DefaultOptions.ConvertTabsToSpacesOptionName, true },
+            { DefaultOptions.IndentSizeOptionName, 4 },
+            { DefaultOptions.NewLineCharacterOptionName, "\r\n" },
+            { DefaultOptions.TabSizeOptionName, 4 }
+        };
+
         public bool ClearOptionValue<T>(EditorOptionKey<T> key) {
-            throw new NotImplementedException();
+            return _options.Remove(key.Name);
         }
 
         public bool ClearOptionValue(string optionId) {
-            throw new NotImplementedException();
+            return _options.Remove(optionId);
         }
 
         public object GetOptionValue(string optionId) {
-            if (optionId == DefaultOptions.ConvertTabsToSpacesOptionId.Name) {
-                return true;
-            } else if (optionId == DefaultOptions.IndentSizeOptionId.Name) {
-                return 4;
+            object value;
+            if (_options.TryGetValue(optionId, out value)) {
+                return value;
             }
 
             throw new InvalidOperationException();
         }
 
         public T GetOptionValue<T>(EditorOptionKey<T> key) {
-            if (key.Equals(DefaultOptions.ConvertTabsToSpacesOptionId)) {
-                return (T)(object)true;
-            } else if (key.Equals(DefaultOptions.IndentSizeOptionId)) {
-                return (T)(object)4;
-            } else if (key.Equals(DefaultOptions.NewLineCharacterOptionId)) {
-                return (T)(object)"\r\n";
-            } else if (key.Equals(DefaultOptions.TabSizeOptionId)) {
-                return (T)(object)4;
-            }
-            throw new InvalidOperationException();
+            return (T)GetOptionValue(key.Name);
         }
 
         public T GetOptionValue<T>(string optionId) {
@@ -56,37 +51,41 @@ namespace TestUtilities.Mocks {
         }
 
         public IEditorOptions GlobalOptions {
-            get { throw new NotImplementedException(); }
+            get {
+                IEditorOptions opt = this;
+                while (opt.Parent != null) {
+                    opt = opt.Parent;
+                }
+                return opt;
+            }
         }
 
         public bool IsOptionDefined<T>(EditorOptionKey<T> key, bool localScopeOnly) {
-            throw new NotImplementedException();
+            return IsOptionDefined(key.Name, localScopeOnly);
         }
 
         public bool IsOptionDefined(string optionId, bool localScopeOnly) {
-            throw new NotImplementedException();
+            if (localScopeOnly || Parent == null) {
+                return _options.ContainsKey(optionId);
+            }
+
+            return _options.ContainsKey(optionId) || Parent.IsOptionDefined(optionId, false);
         }
 
-        public event EventHandler<EditorOptionChangedEventArgs> OptionChanged {
-            add { }
-            remove { }
-        }
+        public event EventHandler<EditorOptionChangedEventArgs> OptionChanged;
 
-        public IEditorOptions Parent {
-            get {
-                throw new NotImplementedException();
-            }
-            set {
-                throw new NotImplementedException();
-            }
-        }
+        public IEditorOptions Parent { get; set; }
 
         public void SetOptionValue<T>(EditorOptionKey<T> key, T value) {
-            throw new NotImplementedException();
+            SetOptionValue(key.Name, value);
         }
 
         public void SetOptionValue(string optionId, object value) {
-            throw new NotImplementedException();
+            _options[optionId] = value;
+            var evt = OptionChanged;
+            if (evt != null) {
+                evt(this, new EditorOptionChangedEventArgs(optionId));
+            }
         }
 
         public IEnumerable<EditorOptionDefinition> SupportedOptions {

--- a/Python/Product/PythonTools/PythonTools/Repl/PythonDebugReplEvaluator.cs
+++ b/Python/Product/PythonTools/PythonTools/Repl/PythonDebugReplEvaluator.cs
@@ -35,6 +35,7 @@ using Microsoft.VisualStudio.Repl;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Projection;
 using Microsoft.VisualStudio.Utilities;
+using Microsoft.VisualStudioTools;
 #if DEV14_OR_LATER
 using IReplEvaluator = Microsoft.VisualStudio.InteractiveWindow.IInteractiveEvaluator;
 using IReplWindow = Microsoft.VisualStudio.InteractiveWindow.IInteractiveWindow;
@@ -502,6 +503,9 @@ namespace Microsoft.PythonTools.Repl {
             process.ProcessExited += new EventHandler<ProcessExitedEventArgs>(OnProcessExited);
             var evaluator = new PythonDebugProcessReplEvaluator(_serviceProvider, process, _pyService, threadIdMapper);
             evaluator.Window = _window;
+#if DEV14_OR_LATER
+            evaluator.InitializeAsync().WaitAndUnwrapExceptions();
+#endif
             evaluator.AvailableScopesChanged += new EventHandler<EventArgs>(evaluator_AvailableScopesChanged);
             evaluator.MultipleScopeSupportChanged += new EventHandler<EventArgs>(evaluator_MultipleScopeSupportChanged);
             _evaluators.Add(process.Id, evaluator);

--- a/Python/Tests/Core/DebugReplEvaluatorTests.cs
+++ b/Python/Tests/Core/DebugReplEvaluatorTests.cs
@@ -22,6 +22,7 @@ using Microsoft.PythonTools.Debugger;
 using Microsoft.PythonTools.Repl;
 #if DEV14_OR_LATER
 using Microsoft.VisualStudio.InteractiveWindow;
+using Microsoft.VisualStudio.InteractiveWindow.Commands;
 #else
 using Microsoft.VisualStudio.Repl;
 #endif
@@ -70,7 +71,7 @@ namespace PythonToolsTests {
             var serviceProvider = PythonToolsTestUtilities.CreateMockServiceProvider();
             _evaluator = new PythonDebugReplEvaluator(serviceProvider);
             _window = new MockReplWindow(_evaluator);
-            _evaluator.Initialize(_window);
+            _evaluator._Initialize(_window);
             _processes = new List<PythonProcess>();
         }
 

--- a/Python/Tests/Core/ReplEvaluatorTests.cs
+++ b/Python/Tests/Core/ReplEvaluatorTests.cs
@@ -41,7 +41,7 @@ namespace PythonToolsTests {
         public void ExecuteTest() {
             using (var evaluator = MakeEvaluator()) {
                 var window = new MockReplWindow(evaluator);
-                evaluator.Initialize(window);
+                evaluator._Initialize(window);
 
                 TestOutput(window, evaluator, "print 'hello'", true, "hello");
                 TestOutput(window, evaluator, "42", true, "42");
@@ -60,7 +60,7 @@ namespace PythonToolsTests {
         public void TestAbort() {
             using (var evaluator = MakeEvaluator()) {
                 var window = new MockReplWindow(evaluator);
-                evaluator.Initialize(window);
+                evaluator._Initialize(window);
 
                 TestOutput(
                     window,
@@ -99,7 +99,7 @@ namespace PythonToolsTests {
         public async Task TestGetAllMembers() {
             using (var evaluator = MakeEvaluator()) {
                 var window = new MockReplWindow(evaluator);
-                await evaluator.Initialize(window);
+                await evaluator._Initialize(window);
 
                 await evaluator.ExecuteText("globals()['my_new_value'] = 123");
                 var names = evaluator.GetMemberNames("");
@@ -280,7 +280,7 @@ g()",
             );
             var replEval = new PythonReplEvaluator(emptyFact, PythonToolsTestUtilities.CreateMockServiceProvider(), new ReplTestReplOptions());
             var replWindow = new MockReplWindow(replEval);
-            replEval.Initialize(replWindow);
+            replEval._Initialize(replWindow);
             var execute = replEval.ExecuteText("42");
             Console.WriteLine(replWindow.Error);
             Assert.IsTrue(
@@ -301,7 +301,7 @@ g()",
             );
             var replEval = new PythonReplEvaluator(emptyFact, PythonToolsTestUtilities.CreateMockServiceProvider(), new ReplTestReplOptions());
             var replWindow = new MockReplWindow(replEval);
-            replEval.Initialize(replWindow);
+            replEval._Initialize(replWindow);
             var execute = replEval.ExecuteText("42");
             var errorText = replWindow.Error;
             const string expected = 

--- a/Python/Tests/IronPython/ReplEvaluatorTests.cs
+++ b/Python/Tests/IronPython/ReplEvaluatorTests.cs
@@ -58,7 +58,7 @@ namespace ReplWindowUITests {
         public void IronPythonModuleName() {
             var replEval = new PythonReplEvaluator(IronPythonInterpreter, PythonToolsTestUtilities.CreateMockServiceProvider(), new ReplTestReplOptions());
             var replWindow = new MockReplWindow(replEval);
-            replEval.Initialize(replWindow).Wait();
+            replEval._Initialize(replWindow).Wait();
             replWindow.ClearScreen();
             var execute = replEval.ExecuteText("__name__");
             execute.Wait();
@@ -71,7 +71,7 @@ namespace ReplWindowUITests {
         public void IronPythonSignatures() {
             var replEval = new PythonReplEvaluator(IronPythonInterpreter, PythonToolsTestUtilities.CreateMockServiceProvider(), new ReplTestReplOptions());
             var replWindow = new MockReplWindow(replEval);
-            replEval.Initialize(replWindow).Wait();
+            replEval._Initialize(replWindow).Wait();
             var execute = replEval.ExecuteText("from System import Array");
             execute.Wait();
             Assert.AreEqual(execute.Result, ExecutionResult.Success);
@@ -86,7 +86,7 @@ namespace ReplWindowUITests {
             // http://pytools.codeplex.com/workitem/649
             var replEval = new PythonReplEvaluator(IronPythonInterpreter, PythonToolsTestUtilities.CreateMockServiceProvider(), new ReplTestReplOptions());
             var replWindow = new MockReplWindow(replEval);
-            replEval.Initialize(replWindow).Wait();
+            replEval._Initialize(replWindow).Wait();
             var execute = replEval.ExecuteText("#fob\n1+2");
             execute.Wait();
             Assert.AreEqual(execute.Result, ExecutionResult.Success);
@@ -97,7 +97,7 @@ namespace ReplWindowUITests {
             // http://pytools.codeplex.com/workitem/649
             var replEval = new PythonReplEvaluator(IronPythonInterpreter, PythonToolsTestUtilities.CreateMockServiceProvider(), new ReplTestReplOptions());
             var replWindow = new MockReplWindow(replEval);
-            replEval.Initialize(replWindow).Wait();
+            replEval._Initialize(replWindow).Wait();
             var execute = replEval.ExecuteText("import System");
             execute.Wait();
             Assert.AreEqual(execute.Result, ExecutionResult.Success);
@@ -124,7 +124,7 @@ namespace ReplWindowUITests {
             var fact = IronPythonInterpreter;
             var replEval = new PythonReplEvaluator(fact, PythonToolsTestUtilities.CreateMockServiceProvider(), new ReplTestReplOptions());
             var replWindow = new MockReplWindow(replEval);
-            replEval.Initialize(replWindow).Wait();
+            replEval._Initialize(replWindow).Wait();
             var execute = replEval.ExecuteText("from System.Threading.Tasks import Task");
             execute.Wait();
             Assert.AreEqual(execute.Result, ExecutionResult.Success);
@@ -155,7 +155,7 @@ namespace ReplWindowUITests {
             // http://pytools.codeplex.com/workitem/662
             var replEval = new PythonReplEvaluator(IronPythonInterpreter, PythonToolsTestUtilities.CreateMockServiceProvider(), new ReplTestReplOptions());
             var replWindow = new MockReplWindow(replEval);
-            replEval.Initialize(replWindow).Wait();
+            replEval._Initialize(replWindow).Wait();
             var execute = replEval.ExecuteText("import sys");
             execute.Wait();
             Assert.AreEqual(execute.Result, ExecutionResult.Success);
@@ -175,7 +175,7 @@ namespace ReplWindowUITests {
             // http://pytools.codeplex.com/workitem/659
             var replEval = new PythonReplEvaluator(IronPythonInterpreter, PythonToolsTestUtilities.CreateMockServiceProvider(), new ReplTestReplOptions());
             var replWindow = new MockReplWindow(replEval);
-            replEval.Initialize(replWindow).Wait();
+            replEval._Initialize(replWindow).Wait();
             var execute = replEval.ExecuteText("# fob\r\n\r\n    \r\n\t\t\r\na = 42");
             execute.Wait();
             Assert.AreEqual(execute.Result, ExecutionResult.Success);
@@ -189,7 +189,7 @@ namespace ReplWindowUITests {
             // http://pytools.codeplex.com/workitem/663
             var replEval = new PythonReplEvaluator(IronPythonInterpreter, PythonToolsTestUtilities.CreateMockServiceProvider(), new ReplTestReplOptions());
             var replWindow = new MockReplWindow(replEval);
-            replEval.Initialize(replWindow).Wait();
+            replEval._Initialize(replWindow).Wait();
             var code = new[] {
                 "import threading",
                 "def sayHello():\r\n    pass",

--- a/Python/Tests/Utilities.Python/MockInteractiveWindowCommandsFactory.cs
+++ b/Python/Tests/Utilities.Python/MockInteractiveWindowCommandsFactory.cs
@@ -1,0 +1,101 @@
+﻿/* ****************************************************************************
+ *
+ * Copyright (c) Microsoft Corporation. 
+ *
+ * This source code is subject to terms and conditions of the Apache License, Version 2.0. A 
+ * copy of the license can be found in the License.html file at the root of this distribution. If 
+ * you cannot locate the Apache License, Version 2.0, please send an email to 
+ * vspython@microsoft.com. By using this source code in any fashion, you are agreeing to be bound 
+ * by the terms of the Apache License, Version 2.0.
+ *
+ * You must not remove this notice, or any other, from this software.
+ *
+ * ***************************************************************************/
+
+#if DEV14_OR_LATER
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.InteractiveWindow;
+using Microsoft.VisualStudio.InteractiveWindow.Commands;
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Classification;
+
+namespace TestUtilities.Python {
+    class MockInteractiveWindowCommandsFactory : IInteractiveWindowCommandsFactory {
+        public IInteractiveWindowCommands CreateInteractiveCommands(
+            IInteractiveWindow window,
+            string prefix,
+            IEnumerable<IInteractiveWindowCommand> commands
+        ) {
+            return window.Properties.GetOrCreateSingletonProperty(() => new MockInteractiveWindowCommands(
+                window,
+                prefix,
+                commands
+            ));
+        }
+    }
+
+    class MockInteractiveWindowCommands : IInteractiveWindowCommands {
+        private readonly List<IInteractiveWindowCommand> _commands;
+        private readonly IInteractiveWindow _window;
+
+        public MockInteractiveWindowCommands(
+            IInteractiveWindow window,
+            string prefix,
+            IEnumerable<IInteractiveWindowCommand> commands
+        ) {
+            CommandPrefix = prefix;
+            _window = window;
+            _commands = commands.ToList();
+        }
+
+        public IInteractiveWindowCommand this[string name] {
+            get {
+                return _commands.FirstOrDefault(c => c.Names.Contains(name));
+            }
+        }
+
+        public string CommandPrefix { get; private set; }
+
+        public bool InCommand {
+            get {
+                throw new NotImplementedException();
+            }
+        }
+
+        public IEnumerable<ClassificationSpan> Classify(SnapshotSpan span) {
+            throw new NotImplementedException();
+        }
+
+        public void DisplayCommandHelp(IInteractiveWindowCommand command) {
+            throw new NotImplementedException();
+        }
+
+        public void DisplayCommandUsage(IInteractiveWindowCommand command, TextWriter writer, bool displayDetails) {
+            throw new NotImplementedException();
+        }
+
+        public void DisplayHelp() {
+            throw new NotImplementedException();
+        }
+
+        public IEnumerable<IInteractiveWindowCommand> GetCommands() {
+            return _commands;
+        }
+
+        public Task<ExecutionResult> TryExecuteCommand() {
+            var input = _window.CurrentLanguageBuffer.CurrentSnapshot.GetText();
+            Console.WriteLine("Executing {0} in REPL", input);
+            var args = input.Split(new[] { ' ' }, 2);
+            var command = this[args[0]];
+            return command == null ? null : command.Execute(_window, args[1]);
+        }
+    }
+}
+
+#endif

--- a/Python/Tests/Utilities.Python/PythonToolsTestUtilities.cs
+++ b/Python/Tests/Utilities.Python/PythonToolsTestUtilities.cs
@@ -12,12 +12,18 @@
  *
  * ***************************************************************************/
 
+using System;
 using Microsoft.PythonTools;
 using Microsoft.PythonTools.Intellisense;
 using Microsoft.PythonTools.Options;
 using Microsoft.VisualStudio.ComponentModelHost;
+using Microsoft.VisualStudio.Text.Adornments;
+using Microsoft.VisualStudio.Utilities;
 using Microsoft.VisualStudioTools;
 using TestUtilities.Mocks;
+#if DEV14_OR_LATER
+using Microsoft.VisualStudio.InteractiveWindow.Commands;
+#endif
 
 namespace TestUtilities.Python {
     public static class PythonToolsTestUtilities {
@@ -43,8 +49,23 @@ namespace TestUtilities.Python {
         public static MockServiceProvider CreateMockServiceProvider() {
             var serviceProvider = new MockServiceProvider();
             var errorProvider = new MockErrorProviderFactory();
-            serviceProvider.AddService(typeof(MockErrorProviderFactory), errorProvider, true);
-            serviceProvider.AddService(typeof(SComponentModel), new MockComponentModel());
+
+            serviceProvider.ComponentModel.AddExtension(
+                typeof(IErrorProviderFactory),
+                () => new MockErrorProviderFactory()
+            );
+            serviceProvider.ComponentModel.AddExtension(
+                typeof(IContentTypeRegistryService),
+                () => new MockClassificationTypeRegistryService()
+            );
+
+#if DEV14_OR_LATER
+            serviceProvider.ComponentModel.AddExtension(
+                typeof(IInteractiveWindowCommandsFactory),
+                () => new MockInteractiveWindowCommandsFactory()
+            );
+#endif
+
             serviceProvider.AddService(
                 typeof(ErrorTaskProvider),
                 (container, type) => new ErrorTaskProvider(serviceProvider, null, errorProvider),

--- a/Python/Tests/Utilities.Python/TestUtilities.Python.csproj
+++ b/Python/Tests/Utilities.Python/TestUtilities.Python.csproj
@@ -111,6 +111,7 @@
     <Compile Include="ComparePerfReports.cs" />
     <Compile Include="DefaultInterpreterSetter.cs" />
     <Compile Include="Django\NewAppDialog.cs" />
+    <Compile Include="MockInteractiveWindowCommandsFactory.cs" />
     <Compile Include="MockPythonToolsOptionsService.cs" />
     <Compile Include="MockReplOptions.cs" />
     <Compile Include="MockUIThread.cs" />


### PR DESCRIPTION
#214 NullReferenceException in debug REPL evaluator tests
Adds more mocks to support REPL tests on VS 2015
Fixes debug repl not initializing its child evaluators.