### PR TITLE
Fix #275: Exceptions on python 3.5 when debugging

### DIFF
--- a/Python/Product/PythonTools/visualstudio_py_debugger.py
+++ b/Python/Product/PythonTools/visualstudio_py_debugger.py
@@ -128,6 +128,8 @@ class SynthesizedValue(object):
 DONT_DEBUG = [path.normcase(__file__), path.normcase(_vspu.__file__)]
 if sys.version_info >= (3, 3):
     DONT_DEBUG.append(path.normcase('<frozen importlib._bootstrap>'))
+if sys.version_info >= (3, 5):
+    DONT_DEBUG.append(path.normcase('<frozen importlib._bootstrap_external>'))
 
 # Contains information about all breakpoints in the process. Keys are line numbers on which
 # there are breakpoints in any file, and values are dicts. For every line number, the

--- a/Python/Tests/DebuggerUITests/DebugProject.cs
+++ b/Python/Tests/DebuggerUITests/DebugProject.cs
@@ -463,6 +463,23 @@ namespace DebuggerUITests {
             }
         }
 
+        // https://github.com/Microsoft/PTVS/issues/275
+        [TestMethod, Priority(0), TestCategory("Core")]
+        [HostType("VSTestHost")]
+        public void TestExceptionInImportLibNotReported() {
+            using (var app = new VisualStudioApp()) {
+                bool justMyCode = (bool)app.Dte.Properties["Debugging", "General"].Item("EnableJustMyCode").Value;
+                app.Dte.Properties["Debugging", "General"].Item("EnableJustMyCode").Value = true;
+                try {
+                    OpenDebuggerProjectAndBreak(app, "ImportLibException.py", 2);
+                    app.Dte.Debugger.Go(WaitForBreakOrEnd: true);
+                    Assert.AreEqual(dbgDebugMode.dbgDesignMode, app.Dte.Debugger.CurrentMode);
+                } finally {
+                    app.Dte.Properties["Debugging", "General"].Item("EnableJustMyCode").Value = justMyCode;
+                }
+            }
+        }
+
         private static void ExceptionTest(string filename, string expectedTitle, string expectedDescription, string exceptionType, int expectedLine) {
             using (var app = new VisualStudioApp()) {
                 var debug3 = (Debugger3)app.Dte.Debugger;

--- a/Python/Tests/TestData/DebuggerProject/DebuggerProject.pyproj
+++ b/Python/Tests/TestData/DebuggerProject/DebuggerProject.pyproj
@@ -33,6 +33,7 @@
     <None Include="EnumChildTest.py" />
     <None Include="ExceptionalExit.py" />
     <None Include="FinallyExceptions.py" />
+    <None Include="ImportLibException.py" />
     <None Include="imports_other.py" />
     <None Include="is_imported.py" />
     <None Include="LocalsTest.py" />

--- a/Python/Tests/TestData/DebuggerProject/ImportLibException.py
+++ b/Python/Tests/TestData/DebuggerProject/ImportLibException.py
@@ -1,0 +1,2 @@
+from json import dumps
+print('ok')


### PR DESCRIPTION
Added '<frozen importlib._bootstrap_external>' to the list of modules to not debug on 3.5.