### PR TITLE
Fix #301: AttachWithOutputRedirection test asserting from incorrect t…

### DIFF
--- a/Python/Product/PythonTools/visualstudio_py_debugger.py
+++ b/Python/Product/PythonTools/visualstudio_py_debugger.py
@@ -13,6 +13,13 @@
  # ###########################################################################
 
 from __future__ import with_statement
+
+# This module MUST NOT import threading in global scope. This is because in a direct (non-ptvsd)
+# attach scenario, it is loaded on the injected debugger attach thread, and if threading module
+# hasn't been loaded already, it will assume that the thread on which it is being loaded is the
+# main thread. This will cause issues when the thread goes away after attach completes.
+_threading = None
+
 import sys
 import ctypes
 try:
@@ -1526,12 +1533,11 @@ class Thread(object):
                     write_object(conn, type_obj, safe_repr_obj, hex_repr_obj, type_name, obj_len)
 
     def enum_thread_frames_locally(self):
-        global threading
-        if threading is None:
+        global _threading
+        if _threading is None:
             import threading
-        self.send_frame_list(self.get_frame_list(), getattr(threading.currentThread(), 'name', 'Python Thread'))
-
-threading = None
+            _threading = threading
+        self.send_frame_list(self.get_frame_list(), getattr(_threading.currentThread(), 'name', 'Python Thread'))
 
 class Module(object):
     """tracks information about a loaded module"""
@@ -2127,16 +2133,24 @@ def write_object(conn, obj_type, obj_repr, hex_repr, type_name, obj_len, flags =
 
 debugger_thread_id = -1
 _INTERCEPTING_FOR_ATTACH = False
+
 def intercept_threads(for_attach = False):
     thread.start_new_thread = thread_creator
     thread.start_new = thread_creator
-    global threading
-    if threading is None:
-        # we need to patch threading._start_new_thread so that 
-        # we pick up new threads in the attach case when threading
-        # is already imported.
+
+    # If threading has already been imported (i.e. we're attaching), we must hot-patch threading._start_new_thread
+    # so that new threads started using it will be intercepted by our code.
+    #
+    # On the other hand, if threading has not been imported, we must not import it ourselves, because it will then
+    # treat the current thread as the main thread, which is incorrect when attaching because this code is executing
+    # on an ephemeral debugger attach thread that will go away shortly. We don't need to hot-patch it in that case
+    # anyway, because it will pick up the new thread.start_new_thread that we have set above when it's imported.
+    global _threading
+    if _threading is None and 'threading' in sys.modules:
         import threading
-        threading._start_new_thread = thread_creator
+        _threading = threading
+        _threading._start_new_thread = thread_creator
+
     global _INTERCEPTING_FOR_ATTACH
     _INTERCEPTING_FOR_ATTACH = for_attach
 
@@ -2458,11 +2472,12 @@ def debug(file, port_num, debug_id, debug_options, run_as = 'script'):
 
         # Give VS debugger a chance to process commands
         # by waiting for ack of "last" command
-        global threading
-        if threading is None:
+        global _threading
+        if _threading is None:
             import threading
+            _threading = threading
         global last_ack_event
-        last_ack_event = threading.Event()
+        last_ack_event = _threading.Event()
         with _SendLockCtx:
             write_bytes(conn, LAST)
         last_ack_event.wait(5)

--- a/Python/Product/PythonTools/visualstudio_py_repl.py
+++ b/Python/Product/PythonTools/visualstudio_py_repl.py
@@ -14,6 +14,11 @@
 
 from __future__ import with_statement
 
+# This module MUST NOT import threading in global scope. This is because in a direct (non-ptvsd)
+# attach scenario, it is loaded on the injected debugger attach thread, and if threading module
+# hasn't been loaded already, it will assume that the thread on which it is being loaded is the
+# main thread. This will cause issues when the thread goes away after attach completes.
+
 try:
     import thread
 except ImportError:
@@ -24,7 +29,6 @@ try:
 except:
     SSLError = None
 
-import threading
 import sys
 import socket
 import select
@@ -162,6 +166,7 @@ actual inspection and introspection."""
     _MODC = to_bytes('MODC')
     
     def __init__(self):
+        import threading
         self.conn = None
         self.send_lock = SafeSendLock()
         self.input_event = threading.Lock()
@@ -526,6 +531,7 @@ class BasicReplBackend(ReplBackend):
 
     """Basic back end which executes all Python code in-proc"""
     def __init__(self, mod_name = '__main__', launch_file = None):
+        import threading
         ReplBackend.__init__(self)
         if mod_name is not None:
             if sys.platform == 'cli':

--- a/Python/Product/PythonTools/visualstudio_py_util.py
+++ b/Python/Product/PythonTools/visualstudio_py_util.py
@@ -12,6 +12,11 @@
  #
  # ###########################################################################
 
+# This module MUST NOT import threading in global scope. This is because in a direct (non-ptvsd)
+# attach scenario, it is loaded on the injected debugger attach thread, and if threading module
+# hasn't been loaded already, it will assume that the thread on which it is being loaded is the
+# main thread. This will cause issues when the thread goes away after attach completes.
+
 import imp
 import os
 import sys

--- a/Python/Tests/TestData/DebuggerProject/AttachOutput.py
+++ b/Python/Tests/TestData/DebuggerProject/AttachOutput.py
@@ -1,6 +1,8 @@
 import sys
 
-while type(sys.stdout).__name__ != '_DebuggerOutput': pass
+attached = False # the test will manually set it to true after breaking on 'pass'
+while not attached:
+    pass
 
 sys.stdout.write('stdout')
 sys.stderr.write('stderr')


### PR DESCRIPTION
…hread

Rewrote the test to only capture output while running, and assert afterwards.

Fixed bug exposed by the updated test with Python 3.4 and 3.5 where directly attaching to the process that hasn't imported threading module yet would cause an assert in that module to fail on process shutdown because it incorrectly identified a debugger helper thread as a main thread.