### PR TITLE
#298 Incorrect encoding detection

### DIFF
--- a/Python/Product/Analysis/Parsing/Parser.cs
+++ b/Python/Product/Analysis/Parsing/Parser.cs
@@ -4802,7 +4802,7 @@ namespace Microsoft.PythonTools.Parsing {
         /// New in 1.1.
         /// </summary>
         public static Encoding GetEncodingFromStream(Stream stream) {
-            return GetStreamReaderWithEncoding(stream, PythonAsciiEncoding.Instance, ErrorSink.Null).CurrentEncoding;
+            return GetStreamReaderWithEncoding(stream, Encoding.UTF8, ErrorSink.Null).CurrentEncoding;
         }
 
         private static StreamReader/*!*/ GetStreamReaderWithEncoding(Stream/*!*/ stream, Encoding/*!*/ defaultEncoding, ErrorSink errors) {


### PR DESCRIPTION
Defaults to opening files with UTF-8 unless a coding comment is included.