### PR TITLE
Fixes #338 Failing to parse async correctly

### DIFF
--- a/Python/Tests/TestData/Grammar/AwaitAsyncNames.py
+++ b/Python/Tests/TestData/Grammar/AwaitAsyncNames.py
@@ -16,3 +16,8 @@ async(fob)
 await(fob)
 fob(async)
 fob(await)
+
+fob.async
+fob.await
+
+def fob(async, await): pass

--- a/Python/Tests/TestData/Grammar/DecoratorsAsyncFuncDef.py
+++ b/Python/Tests/TestData/Grammar/DecoratorsAsyncFuncDef.py
@@ -1,0 +1,17 @@
+﻿@fob
+async def f():
+    pass
+
+@fob.oar
+async def f():
+    pass
+
+@fob(oar)
+async def f():
+    pass
+
+
+@fob
+@oar
+async def f():
+    pass


### PR DESCRIPTION
Improves handling of async and await as names rather than keywords.
Adds and improves tests.