### PR TITLE
Prevents timeout in AttachPtvsd test (only occurs for Python 2.5)

### DIFF
--- a/Python/Tests/DebuggerTests/DebuggerTests.cs
+++ b/Python/Tests/DebuggerTests/DebuggerTests.cs
@@ -2685,7 +2685,7 @@ int main(int argc, char* argv[]) {
                     Assert.IsTrue(attached.WaitOne(20000), "Failed to attach within 20s");
                     Assert.IsTrue(bpHit.WaitOne(20000), "Failed to hit breakpoint within 20s");
 
-                    p.WaitForExit();
+                    p.WaitForExit(10000);
                     AssertUtil.ArrayEquals(expectedOutput, actualOutput);
                 } finally {
                     DetachProcess(proc);

--- a/Python/Tests/TestData/DebuggerProject/AttachPtvsd.py
+++ b/Python/Tests/TestData/DebuggerProject/AttachPtvsd.py
@@ -1,5 +1,5 @@
 import sys
-sys.path.append('.') # so that we can find ptvsd
+if '.' not in sys.path: sys.path.insert(0, '.') # so that we can find ptvsd
 
 import ptvsd
 ptvsd.enable_attach('secret', redirect_output=False)


### PR DESCRIPTION
Helps AttachPtvsd test work better when test target already has ptvsd installed.

See #340 