### PR TITLE
Fix #340: ptvsd.enable_attach causes process to never exit under Python 2.5

### DIFF
--- a/Python/Product/PythonTools/ptvsd/attach_server.py
+++ b/Python/Product/PythonTools/ptvsd/attach_server.py
@@ -271,7 +271,7 @@ def enable_attach(secret, address = ('0.0.0.0', DEFAULT_PORT), certfile = None, 
                     client.close()
 
     server_thread = threading.Thread(target = server_thread_func)
-    server_thread.daemon = True
+    server_thread.setDaemon(True)
     server_thread.start()
 
     frames = []


### PR DESCRIPTION
Use the older Thread.setDaemon API that is available on all supported Python versions, including 2.5.