### PR TITLE
Specify timeout when waiting for process exit in AttachWithOutputRedirection test

### DIFF
--- a/Python/Tests/DebuggerTests/DebuggerTests.cs
+++ b/Python/Tests/DebuggerTests/DebuggerTests.cs
@@ -2631,7 +2631,7 @@ int main(int argc, char* argv[]) {
                     Assert.IsTrue(frame.ExecuteTextAsync("attached = True").Wait(20000), "Failed to complete evaluation within 20s");
 
                     proc.Resume();
-                    proc.WaitForExit();
+                    WaitForExit(proc);
                     AssertUtil.ArrayEquals(expectedOutput, actualOutput);
                 } finally {
                     DetachProcess(proc);
@@ -2685,7 +2685,7 @@ int main(int argc, char* argv[]) {
                     Assert.IsTrue(attached.WaitOne(20000), "Failed to attach within 20s");
                     Assert.IsTrue(bpHit.WaitOne(20000), "Failed to hit breakpoint within 20s");
 
-                    p.WaitForExit(10000);
+                    p.WaitForExit(DefaultWaitForExitTimeout);
                     AssertUtil.ArrayEquals(expectedOutput, actualOutput);
                 } finally {
                     DetachProcess(proc);

--- a/Python/Tests/DebuggerTests/DebuggerTests.cs
+++ b/Python/Tests/DebuggerTests/DebuggerTests.cs
@@ -2540,7 +2540,7 @@ int main(int argc, char* argv[]) {
         }
 
         [TestMethod, Priority(0)]
-        public void AttachAndStepWithBlankSysPrefix() {
+        public virtual void AttachAndStepWithBlankSysPrefix() {
             string script = TestData.GetPath(@"TestData\DebuggerProject\InfiniteRunBlankPrefix.py");
             var p = Process.Start(Version.InterpreterPath, "\"" + script + "\"");
             try {
@@ -3124,6 +3124,7 @@ int main(int argc, char* argv[]) {
         public override void AttachTimeoutThreadsInitialized() { }
         public override void AttachTimeout() { }
         public override void AttachWithOutputRedirection() { }
+        public override void AttachAndStepWithBlankSysPrefix() { }
 
         protected override string UnassignedLocalRepr {
             get { return "None"; }


### PR DESCRIPTION
Use predefined constant for timeout in AttachPtvsd test.