### PR TITLE
Intellisense fixes

### DIFF
--- a/Python/Product/Analysis/Parsing/Parser.cs
+++ b/Python/Product/Analysis/Parsing/Parser.cs
@@ -56,6 +56,8 @@ namespace Microsoft.PythonTools.Parsing {
         private string _lookahead2WhiteSpace;
         private Dictionary<Node, Dictionary<object, object>> _attributes = new Dictionary<Node, Dictionary<object, object>>();  // attributes for each node, currently just round tripping information
 
+        private bool _alwaysAllowContextDependentSyntax;
+
         private static Encoding _utf8throwing;
         private static Regex _codingRegex;
 
@@ -228,7 +230,9 @@ namespace Microsoft.PythonTools.Parsing {
 
         public PythonAst ParseTopExpression() {
             // TODO: move from source unit  .TrimStart(' ', '\t')
+            _alwaysAllowContextDependentSyntax = true;
             ReturnStatement ret = new ReturnStatement(ParseTestListAsExpression());
+            _alwaysAllowContextDependentSyntax = false;
             ret.SetLoc(0, 0);
             return CreateAst(ret);
         }
@@ -389,7 +393,7 @@ namespace Microsoft.PythonTools.Parsing {
         }
 
         private Name TokenToName(Token t) {
-            if (CurrentFunction == null || !CurrentFunction.IsCoroutine) {
+            if (AllowAsyncAwaitSyntax) {
                 if (t.Kind == TokenKind.KeywordAwait) {
                     return Name.Await;
                 } else if (t.Kind == TokenKind.KeywordAsync) {
@@ -401,6 +405,29 @@ namespace Microsoft.PythonTools.Parsing {
                 return new Name(FixName(n.Name), n.Name);
             }
             return Name.Empty;
+        }
+
+        private bool AllowReturnSyntax {
+            get {
+                return _alwaysAllowContextDependentSyntax ||
+                    CurrentFunction != null;
+            }
+        }
+
+        private bool AllowYieldSyntax {
+            get {
+                FunctionDefinition cf;
+                return _alwaysAllowContextDependentSyntax ||
+                    ((cf = CurrentFunction) != null && !cf.IsCoroutine);
+            }
+        }
+
+        private bool AllowAsyncAwaitSyntax {
+            get {
+                FunctionDefinition cf;
+                return _alwaysAllowContextDependentSyntax ||
+                    ((cf = CurrentFunction) != null && cf.IsCoroutine);
+            }
         }
 
         //stmt: simple_stmt | compound_stmt
@@ -437,8 +464,7 @@ namespace Microsoft.PythonTools.Parsing {
                 return ParseFuncDef(isCoroutine: true);
             }
 
-            var currentFunction = CurrentFunction;
-            if (currentFunction == null || !currentFunction.IsCoroutine) {
+            if (!AllowAsyncAwaitSyntax) {
                 // 'async', outside coroutine, and not followed by def, is a
                 // regular name
                 return ParseSimpleStmt();
@@ -616,7 +642,7 @@ namespace Microsoft.PythonTools.Parsing {
         }
 
         private Statement ParseReturnStmt() {
-            if (CurrentFunction == null) {
+            if (!AllowReturnSyntax) {
                 ReportSyntaxError("'return' outside function");
             }
             var returnToken = _lookahead;
@@ -660,11 +686,12 @@ namespace Microsoft.PythonTools.Parsing {
         private Statement ParseYieldStmt() {
             // For yield statements, continue to enforce that it's currently in a function. 
             // This gives us better syntax error reporting for yield-statements than for yield-expressions.
-            FunctionDefinition current = CurrentFunction;
-            if (current == null) {
-                ReportSyntaxError("misplaced yield");
-            } else if (current.IsCoroutine) {
-                ReportSyntaxError("'yield' inside async function");
+            if (!AllowYieldSyntax) {
+                if (AllowAsyncAwaitSyntax) {
+                    ReportSyntaxError("'yield' inside async function");
+                } else {
+                    ReportSyntaxError("misplaced yield");
+                }
             }
 
             _isGenerator = true;
@@ -799,7 +826,7 @@ namespace Microsoft.PythonTools.Parsing {
                 }
 
                 if (_langVersion >= PythonLanguageVersion.V25 && PeekToken(TokenKind.KeywordYield)) {
-                    if (CurrentFunction != null && CurrentFunction.IsCoroutine) {
+                    if (!AllowYieldSyntax && AllowAsyncAwaitSyntax) {
                         ReportSyntaxError("'yield' inside async function");
                     }
                     Eat(TokenKind.KeywordYield);
@@ -860,7 +887,7 @@ namespace Microsoft.PythonTools.Parsing {
                     Expression rhs;
 
                     if (_langVersion >= PythonLanguageVersion.V25 && PeekToken(TokenKind.KeywordYield)) {
-                        if (CurrentFunction != null && CurrentFunction.IsCoroutine) {
+                        if (!AllowYieldSyntax && AllowAsyncAwaitSyntax) {
                             ReportSyntaxError("'yield' inside async function");
                         }
                         Eat(TokenKind.KeywordYield);
@@ -2993,8 +3020,7 @@ namespace Microsoft.PythonTools.Parsing {
 
         private Expression ParseAwaitExpr() {
             if (_langVersion >= PythonLanguageVersion.V35) {
-                var currentFunction = CurrentFunction;
-                if (currentFunction != null && currentFunction.IsCoroutine && MaybeEat(TokenKind.KeywordAwait)) {
+                if (AllowAsyncAwaitSyntax && MaybeEat(TokenKind.KeywordAwait)) {
                     var start = GetStart();
                     string whitespace = _tokenWhiteSpace;
                     var res = new AwaitExpression(ParsePower());
@@ -3805,7 +3831,7 @@ namespace Microsoft.PythonTools.Parsing {
                 ret = MakeTupleOrExpr(new List<Expression>(), MakeWhiteSpaceList(), false);
                 hasRightParenthesis = true;
             } else if (PeekToken(TokenKind.KeywordYield)) {
-                if (CurrentFunction != null && CurrentFunction.IsCoroutine) {
+                if (!AllowYieldSyntax && AllowAsyncAwaitSyntax) {
                     ReportSyntaxError("'yield' inside async function");
                 }
                 Eat(TokenKind.KeywordYield);

--- a/Python/Product/Analysis/Parsing/Parser.cs
+++ b/Python/Product/Analysis/Parsing/Parser.cs
@@ -393,7 +393,7 @@ namespace Microsoft.PythonTools.Parsing {
         }
 
         private Name TokenToName(Token t) {
-            if (AllowAsyncAwaitSyntax) {
+            if (!AllowAsyncAwaitSyntax) {
                 if (t.Kind == TokenKind.KeywordAwait) {
                     return Name.Await;
                 } else if (t.Kind == TokenKind.KeywordAsync) {

--- a/Python/Product/Analysis/Parsing/PythonLanguageVersion.cs
+++ b/Python/Product/Analysis/Parsing/PythonLanguageVersion.cs
@@ -43,6 +43,10 @@ namespace Microsoft.PythonTools.Parsing {
             return (((int)version >> 8) & 0xff) == 3;
         }
 
+        public static bool IsNone(this PythonLanguageVersion version) {
+            return version == PythonLanguageVersion.None;
+        }
+
         public static Version ToVersion(this PythonLanguageVersion version) {
             return new Version(((int)version) >> 8, ((int)version) & 0xff);
         }

--- a/Python/Product/Analysis/PythonKeywords.cs
+++ b/Python/Product/Analysis/PythonKeywords.cs
@@ -72,15 +72,15 @@ namespace Microsoft.PythonTools.Analysis {
         public static IEnumerable<string> Expression(PythonLanguageVersion version = PythonLanguageVersion.None) {
             yield return "and";
             yield return "as";
-            if (version == PythonLanguageVersion.None || version >= PythonLanguageVersion.V35) {
+            if (version.IsNone() || version >= PythonLanguageVersion.V35) {
                 yield return "await";
             }
             yield return "else";
-            if (version == PythonLanguageVersion.None || version.Is3x()) {
+            if (version.IsNone() || version.Is3x()) {
                 yield return "False";
             }
             yield return "for";
-            if (version == PythonLanguageVersion.None || version >= PythonLanguageVersion.V33) {
+            if (version.IsNone() || version >= PythonLanguageVersion.V33) {
                 yield return "from";
             }
             yield return "if";
@@ -90,7 +90,7 @@ namespace Microsoft.PythonTools.Analysis {
             yield return "None";
             yield return "not";
             yield return "or";
-            if (version == PythonLanguageVersion.None || version.Is3x()) {
+            if (version.IsNone() || version.Is3x()) {
                 yield return "True";
             }
             yield return "yield";
@@ -102,7 +102,7 @@ namespace Microsoft.PythonTools.Analysis {
         /// </summary>
         public static IEnumerable<string> Statement(PythonLanguageVersion version = PythonLanguageVersion.None) {
             yield return "assert";
-            if (version == PythonLanguageVersion.None || version >= PythonLanguageVersion.V35) {
+            if (version.IsNone() || version >= PythonLanguageVersion.V35) {
                 yield return "async";
                 yield return "await";
             }
@@ -111,7 +111,7 @@ namespace Microsoft.PythonTools.Analysis {
             yield return "class";
             yield return "def";
             yield return "del";
-            if (version == PythonLanguageVersion.None || version.Is2x()) {
+            if (version.IsNone() || version.Is2x()) {
                 yield return "exec";
             }
             yield return "if";
@@ -122,11 +122,11 @@ namespace Microsoft.PythonTools.Analysis {
             yield return "from";
             yield return "global";
             yield return "import";
-            if (version == PythonLanguageVersion.None || version.Is3x()) {
+            if (version.IsNone() || version.Is3x()) {
                 yield return "nonlocal";
             }
             yield return "pass";
-            if (version == PythonLanguageVersion.None || version.Is2x()) {
+            if (version.IsNone() || version.Is2x()) {
                 yield return "print";
             }
             yield return "raise";
@@ -144,11 +144,11 @@ namespace Microsoft.PythonTools.Analysis {
         public static IEnumerable<string> InvalidOutsideFunction(
             PythonLanguageVersion version = PythonLanguageVersion.None
         ) {
-            if (version == PythonLanguageVersion.None || version >= PythonLanguageVersion.V35) {
+            if (version.IsNone() || version >= PythonLanguageVersion.V35) {
                 yield return "await";
             }
             yield return "return";
-            if (version == PythonLanguageVersion.None || version >= PythonLanguageVersion.V25) {
+            if (version.IsNone() || version >= PythonLanguageVersion.V25) {
                 yield return "yield";
             }
         }

--- a/Python/Product/Analysis/PythonKeywords.cs
+++ b/Python/Product/Analysis/PythonKeywords.cs
@@ -72,15 +72,15 @@ namespace Microsoft.PythonTools.Analysis {
         public static IEnumerable<string> Expression(PythonLanguageVersion version = PythonLanguageVersion.None) {
             yield return "and";
             yield return "as";
-            if (version >= PythonLanguageVersion.V35) {
+            if (version == PythonLanguageVersion.None || version >= PythonLanguageVersion.V35) {
                 yield return "await";
             }
             yield return "else";
-            if (version.Is3x()) {
+            if (version == PythonLanguageVersion.None || version.Is3x()) {
                 yield return "False";
             }
             yield return "for";
-            if (version >= PythonLanguageVersion.V33) {
+            if (version == PythonLanguageVersion.None || version >= PythonLanguageVersion.V33) {
                 yield return "from";
             }
             yield return "if";
@@ -90,7 +90,7 @@ namespace Microsoft.PythonTools.Analysis {
             yield return "None";
             yield return "not";
             yield return "or";
-            if (version.Is3x()) {
+            if (version == PythonLanguageVersion.None || version.Is3x()) {
                 yield return "True";
             }
             yield return "yield";
@@ -102,7 +102,7 @@ namespace Microsoft.PythonTools.Analysis {
         /// </summary>
         public static IEnumerable<string> Statement(PythonLanguageVersion version = PythonLanguageVersion.None) {
             yield return "assert";
-            if (version >= PythonLanguageVersion.V35) {
+            if (version == PythonLanguageVersion.None || version >= PythonLanguageVersion.V35) {
                 yield return "async";
                 yield return "await";
             }
@@ -111,7 +111,7 @@ namespace Microsoft.PythonTools.Analysis {
             yield return "class";
             yield return "def";
             yield return "del";
-            if (version.Is2x()) {
+            if (version == PythonLanguageVersion.None || version.Is2x()) {
                 yield return "exec";
             }
             yield return "if";
@@ -122,11 +122,11 @@ namespace Microsoft.PythonTools.Analysis {
             yield return "from";
             yield return "global";
             yield return "import";
-            if (version.Is3x()) {
+            if (version == PythonLanguageVersion.None || version.Is3x()) {
                 yield return "nonlocal";
             }
             yield return "pass";
-            if (version.Is2x()) {
+            if (version == PythonLanguageVersion.None || version.Is2x()) {
                 yield return "print";
             }
             yield return "raise";
@@ -144,7 +144,7 @@ namespace Microsoft.PythonTools.Analysis {
         public static IEnumerable<string> InvalidOutsideFunction(
             PythonLanguageVersion version = PythonLanguageVersion.None
         ) {
-            if (version >= PythonLanguageVersion.V35) {
+            if (version == PythonLanguageVersion.None || version >= PythonLanguageVersion.V35) {
                 yield return "await";
             }
             yield return "return";

--- a/Python/Product/PythonTools/PythonTools/Intellisense/AnalysisQueue.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/AnalysisQueue.cs
@@ -124,6 +124,8 @@ namespace Microsoft.PythonTools.Intellisense {
             }
         }
 
+        public event EventHandler AnalysisStarted;
+
         public bool IsAnalyzing {
             get {
                 lock (_queueLock) {
@@ -178,6 +180,11 @@ namespace Microsoft.PythonTools.Intellisense {
                     workItem = GetNextItem(out pri);
                     _isAnalyzing = true;
                 }
+                var evt = AnalysisStarted;
+                if (evt != null) {
+                    evt(this, EventArgs.Empty);
+                }
+
                 if (workItem != null) {
                     var groupable = workItem as IGroupableAnalysisProjectEntry;
                     if (groupable != null) {

--- a/Python/Product/PythonTools/PythonTools/Intellisense/ProjectAnalyzer.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/ProjectAnalyzer.cs
@@ -116,6 +116,7 @@ namespace Microsoft.PythonTools.Intellisense {
 
             _queue = new ParseQueue(this);
             _analysisQueue = new AnalysisQueue(this);
+            _analysisQueue.AnalysisStarted += AnalysisQueue_AnalysisStarted;
             _allFactories = allFactories;
 
             _interpreterFactory = factory;
@@ -137,6 +138,13 @@ namespace Microsoft.PythonTools.Intellisense {
             }
 
             _userCount = 1;
+        }
+
+        private void AnalysisQueue_AnalysisStarted(object sender, EventArgs e) {
+            var evt = AnalysisStarted;
+            if (evt != null) {
+                evt(this, e);
+            }
         }
 
         internal PythonToolsService PyService {
@@ -707,6 +715,8 @@ namespace Microsoft.PythonTools.Intellisense {
                 return _queue.IsParsing || _analysisQueue.IsAnalyzing;
             }
         }
+
+        internal event EventHandler AnalysisStarted;
 
         internal void WaitForCompleteAnalysis(Func<int, bool> itemsLeftUpdated) {
             if (IsAnalyzing) {
@@ -1540,6 +1550,7 @@ namespace Microsoft.PythonTools.Intellisense {
                 _commentTaskProvider.Clear(entry, ParserTaskMoniker);
             }
 
+            _analysisQueue.AnalysisStarted -= AnalysisQueue_AnalysisStarted;
             ((IDisposable)_analysisQueue).Dispose();
             if (_pyAnalyzer != null) {
                 lock (_contentsLock) {

--- a/Python/Product/PythonTools/PythonTools/Intellisense/ReverseExpressionParser.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/ReverseExpressionParser.cs
@@ -31,8 +31,8 @@ namespace Microsoft.PythonTools.Intellisense {
         private IList<ClassificationSpan> _tokens;
         private ITextSnapshotLine _curLine;
         private PythonClassifier _classifier;
-        private static readonly string[] _assignOperators = new[] {
-            "=" ,  "+=" ,  "-=" ,  "/=" ,  "%=" ,  "^=" ,  "*=" ,  "//=" ,  "&=" ,  "|=" ,  ">>=" ,  "<<=" ,  "**="
+        private static readonly HashSet<string> _assignOperators = new HashSet<string> {
+            "=" ,  "+=" ,  "-=" ,  "/=" ,  "%=" ,  "^=" ,  "*=" ,  "//=" ,  "&=" ,  "|=" ,  ">>=" ,  "<<=" ,  "**=", "@="
         };
 
 
@@ -335,7 +335,8 @@ namespace Microsoft.PythonTools.Intellisense {
                             } else {
                                 break;
                             }
-                        } else if (token.ClassificationType == Classifier.Provider.Keyword && (text == "if" || text == "else")) {
+                        } else if (token.ClassificationType == Classifier.Provider.Keyword &&
+                            (text == "if" || text == "else")) {
                             // if and else can be used in an expression context or a statement context
                             if (currentParamAtLastColon != -1) {
                                 start = startAtLastToken;
@@ -364,7 +365,9 @@ namespace Microsoft.PythonTools.Intellisense {
                     } else if (token.ClassificationType == Classifier.Provider.Comment) {
                         return null;
                     } else if (!lastTokenWasCommaOrOperator) {
-                        break;
+                        if (nesting == 0 && otherNesting == 0) {
+                            break;
+                        }
                     } else {
                         if (lastTokenWasKeywordArgAssignment &&
                             token.ClassificationType.IsOfType(PredefinedClassificationTypeNames.Identifier) &&
@@ -396,7 +399,7 @@ namespace Microsoft.PythonTools.Intellisense {
         }
 
         private static bool IsAssignmentOperator(string text) {
-            return ((IList<string>)_assignOperators).Contains(text);
+            return _assignOperators.Contains(text);
         }
 
         internal static bool IsExplicitLineJoin(ClassificationSpan cur) {

--- a/Python/Product/PythonTools/PythonTools/PythonAnalysisClassifier.cs
+++ b/Python/Product/PythonTools/PythonTools/PythonAnalysisClassifier.cs
@@ -59,6 +59,11 @@ namespace Microsoft.PythonTools {
                 _entry = _buffer.GetPythonProjectEntry();
                 if (_entry != null) {
                     _entry.OnNewAnalysis += OnNewAnalysis;
+                    if (_entry.IsAnalyzed) {
+                        // Ensure we get classifications if we've already been
+                        // analyzed
+                        OnNewAnalysis(_entry, EventArgs.Empty);
+                    }
                 }
             }
         }
@@ -172,6 +177,7 @@ namespace Microsoft.PythonTools {
         }
 
         private void BufferChanged(object sender, TextContentChangedEventArgs e) {
+            EnsureAnalysis();
         }
 
         #endregion

--- a/Python/Tests/PythonToolsMockTests/CompletionTests.cs
+++ b/Python/Tests/PythonToolsMockTests/CompletionTests.cs
@@ -1022,6 +1022,35 @@ x = m.f(";
         }
 
         [TestMethod, Priority(0), TestCategory("Mock")]
+        public void YieldFromExpressionCompletion() {
+            const string code = @"
+def f():
+    yield 1
+    return 1
+
+def g():
+    f().
+    yield from f().
+    (yield from f()).
+";
+
+            using (var view = new PythonEditor(code, PythonLanguageVersion.V35)) {
+                AssertUtil.CheckCollection(view.GetCompletionsAfter("f()."),
+                    new[] { "next", "send", "throw" },
+                    new[] { "real", "imag" }
+                );
+                AssertUtil.CheckCollection(view.GetCompletionsAfter("yield from f()."),
+                    new[] { "next", "send", "throw" },
+                    new[] { "real", "imag" }
+                );
+                AssertUtil.CheckCollection(view.GetCompletionsAfter("(yield from f())."),
+                    new[] { "real", "imag" },
+                    new[] { "next", "send", "throw" }
+                );
+            }
+        }
+
+        [TestMethod, Priority(0), TestCategory("Mock")]
         public void AwaitExpressionCompletion() {
             const string code = @"
 async def f():


### PR DESCRIPTION
#370 Reverse expression parser needs updating for async
Always parses context-dependent keywords as keywords when parsing isolated expressions.
Improves stability of tests.

Fixes tokenizer crash when parsing invalid complex value.

#374 Local variables are not initially colorized
Ensures the event is hooked and classifications are calculated when analysis is complete before classifications are requested.
Improves test stability
(Originally wasn't going to look at #374 for 2.2, but needed the fix for test stability or we wouldn't ever get classifications.)