### PR TITLE
Fixes #121 IntelliSense suggestions in exceptions are missing

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Intellisense/ProjectAnalyzer.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/ProjectAnalyzer.cs
@@ -1156,7 +1156,7 @@ namespace Microsoft.PythonTools.Intellisense {
                 } else if (CompletionAnalysis.IsKeyword(first, "raise") || CompletionAnalysis.IsKeyword(first, "except")) {
                     if (tokens.Count == 1 ||
                         lastClass.ClassificationType.IsOfType(PythonPredefinedClassificationTypeNames.Comma) ||
-                        lastClass.IsOpenGrouping()) {
+                        (lastClass.IsOpenGrouping() && tokens.Count < 3)) {
                         return new ExceptionCompletionAnalysis(span, buffer, options);
                     }
                 }


### PR DESCRIPTION
Fixes #121 IntelliSense suggestions in exceptions are missing
Only keep suggesting exceptions when the grouping is the first item.

(Doesn't meet the bar, but it's such a trivial fix to something new since 2.1 that if people want to convince me to take it I won't argue too hard.)