### PR TITLE
Fixes #379 Cannot change architecture of a custom environment

### DIFF
--- a/Python/Product/EnvironmentsList/ConfigurationExtension.xaml.cs
+++ b/Python/Product/EnvironmentsList/ConfigurationExtension.xaml.cs
@@ -218,7 +218,7 @@ namespace Microsoft.PythonTools.EnvironmentsList {
                 WindowInterpreterPath = view.WindowsInterpreterPath,
                 LibraryPath = view.LibraryPath,
                 PathEnvironmentVariableName = view.PathEnvironmentVariable,
-                ArchitectureString = view.ArchitectureName,
+                Architecture = view.ArchitectureName == "64-bit" ? ProcessorArchitecture.Amd64 : ProcessorArchitecture.X86,
                 LanguageVersionString = view.VersionName
             });
         }


### PR DESCRIPTION
Fixes #379 Cannot change architecture of a custom environment
Converts architecture string to processor architecture, since the configurable provider expects different strings.