### PR TITLE
#364 Tools | Options | Text Editor | Python | Formatting | Spacing can't be loaded

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Intellisense/IntellisenseControllerProvider.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/IntellisenseControllerProvider.cs
@@ -31,6 +31,8 @@ using Microsoft.VisualStudio.Repl;
 
 namespace Microsoft.PythonTools.Intellisense {
     [Export(typeof(IIntellisenseControllerProvider)), ContentType(PythonCoreConstants.ContentType), Order]
+    [TextViewRole(PredefinedTextViewRoles.Analyzable)]
+    [TextViewRole(PredefinedTextViewRoles.Editable)]
     class IntellisenseControllerProvider : IIntellisenseControllerProvider {
         [Import]
         internal ICompletionBroker _CompletionBroker = null; // Set via MEF

--- a/Python/Product/PythonTools/PythonTools/Intellisense/PythonSuggestedActionsSourceProvider.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/PythonSuggestedActionsSourceProvider.cs
@@ -15,6 +15,8 @@ namespace Microsoft.PythonTools.Intellisense {
     [Export(typeof(ISuggestedActionsSourceProvider))]
     [Name("Python Suggested Actions")]
     [ContentType(PythonCoreConstants.ContentType)]
+    [TextViewRole(PredefinedTextViewRoles.Analyzable)]
+    [TextViewRole(PredefinedTextViewRoles.Editable)]
     class PythonSuggestedActionsSourceProvider : ISuggestedActionsSourceProvider {
         [Import(typeof(SVsServiceProvider))]
         internal IServiceProvider _provider = null;

--- a/Python/Product/PythonTools/PythonTools/Intellisense/SmartTagControllerProvider.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/SmartTagControllerProvider.cs
@@ -22,23 +22,25 @@ using Microsoft.VisualStudio.Utilities;
 namespace Microsoft.PythonTools.Intellisense {
 #if !DEV14_OR_LATER
     [Export(typeof(IIntellisenseControllerProvider)), ContentType(PythonCoreConstants.ContentType), Order]
+    [TextViewRole(PredefinedTextViewRoles.Analyzable)]
+    [TextViewRole(PredefinedTextViewRoles.Editable)]
     class SmartTagControllerProvider : IIntellisenseControllerProvider {
 
-        #region MEF Imports
+    #region MEF Imports
 
         [Import]
         public ISmartTagBroker smartTagBroker = null;
 
-        #endregion
+    #endregion
 
-        #region IIntellisenseControllerProvider Members
+    #region IIntellisenseControllerProvider Members
 
         public IIntellisenseController TryCreateIntellisenseController(ITextView textView,
                                                                        IList<ITextBuffer> subjectBuffers) {
             return SmartTagController.CreateInstance(this.smartTagBroker, textView, subjectBuffers);
         }
 
-        #endregion
+    #endregion
     }
 #endif
 }

--- a/Python/Product/PythonTools/PythonTools/Intellisense/SmartTagControllerProvider.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/SmartTagControllerProvider.cs
@@ -25,22 +25,13 @@ namespace Microsoft.PythonTools.Intellisense {
     [TextViewRole(PredefinedTextViewRoles.Analyzable)]
     [TextViewRole(PredefinedTextViewRoles.Editable)]
     class SmartTagControllerProvider : IIntellisenseControllerProvider {
-
-    #region MEF Imports
-
         [Import]
         public ISmartTagBroker smartTagBroker = null;
-
-    #endregion
-
-    #region IIntellisenseControllerProvider Members
 
         public IIntellisenseController TryCreateIntellisenseController(ITextView textView,
                                                                        IList<ITextBuffer> subjectBuffers) {
             return SmartTagController.CreateInstance(this.smartTagBroker, textView, subjectBuffers);
         }
-
-    #endregion
     }
 #endif
 }

--- a/Python/Product/PythonTools/PythonTools/Options/OptionsTreeView.cs
+++ b/Python/Product/PythonTools/PythonTools/Options/OptionsTreeView.cs
@@ -16,7 +16,6 @@ using System;
 using System.Drawing;
 using System.Windows.Forms;
 using System.Windows.Forms.VisualStyles;
-using Microsoft.PythonTools.Project;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudioTools.Project;
 
@@ -24,8 +23,6 @@ namespace Microsoft.PythonTools.Options {
     class OptionsTreeView : TreeView {
         private static ImageList _imageList;
         internal const int TransparentIndex = 0;
-        internal const int OpenFolderIndex = 1;
-        internal const int ClosedFolderIndex = 2;
 
         public OptionsTreeView() {
             InitializeImageList();
@@ -42,28 +39,16 @@ namespace Microsoft.PythonTools.Options {
 
         private void InitializeImageList() {
             if (_imageList == null) {
-                using (var imgHandler = new ImageHandler(typeof(OptionsTreeView).Assembly.GetManifestResourceStream("Microsoft.PythonTools.Project.Resources.imagelis.bmp"))) {
-#pragma warning disable 0618
-                    var openFolder = imgHandler.ImageList.Images[(int)ProjectNode.ImageName.OpenFolder];
-                    var closedFolder = imgHandler.ImageList.Images[(int)ProjectNode.ImageName.Folder];
-#pragma warning restore 0618
+                _imageList = new ImageList();
 
-                    _imageList = new ImageList();
+                Bitmap bmp = new Bitmap(16, 16);
 
-                    Bitmap bmp = new Bitmap(16, 16);
-
-                    // transparent image is the image we use for owner drawn icons
-                    _imageList.TransparentColor = Color.Magenta;
-                    using (var g = Graphics.FromImage(bmp)) {
-                        g.FillRectangle(
-                            Brushes.Magenta,
-                            new Rectangle(0, 0, 16, 16)
-                        );
-                    }
-                    _imageList.Images.Add(bmp);
-                    _imageList.Images.Add(openFolder);
-                    _imageList.Images.Add(closedFolder);
+                // transparent image is the image we use for owner drawn icons
+                _imageList.TransparentColor = Color.Magenta;
+                using (var g = Graphics.FromImage(bmp)) {
+                    g.FillRectangle(Brushes.Magenta, new Rectangle(0, 0, 16, 16));
                 }
+                _imageList.Images.Add(bmp);
             }
 
             StateImageList = _imageList;
@@ -130,7 +115,6 @@ namespace Microsoft.PythonTools.Options {
         protected override void OnAfterExpand(TreeViewEventArgs e) {
             OptionFolderNode node = e.Node as OptionFolderNode;
             if (node != null) {
-                node.SelectedImageIndex = node.ImageIndex = OpenFolderIndex;
                 InvalidateNodeIcon(node);
                 node.WasExpanded = true;
                 return;
@@ -141,7 +125,6 @@ namespace Microsoft.PythonTools.Options {
         protected override void OnAfterCollapse(TreeViewEventArgs e) {
             OptionFolderNode node = e.Node as OptionFolderNode;
             if (node != null) {
-                node.SelectedImageIndex = node.ImageIndex = ClosedFolderIndex;
                 InvalidateNodeIcon(node);
                 node.WasExpanded = false;
                 return;
@@ -404,9 +387,7 @@ namespace Microsoft.PythonTools.Options {
         public bool WasExpanded = true;
 
         public OptionFolderNode(string name)
-            : base(name) {
-            StateImageIndex = SelectedImageIndex = ImageIndex = OptionsTreeView.OpenFolderIndex;
-        }
+            : base(name) { }
     }
 
     abstract class OptionSettingNode : OptionNode {

--- a/Python/Product/PythonTools/PythonTools/Options/PythonFormattingOptionsControl.cs
+++ b/Python/Product/PythonTools/PythonTools/Options/PythonFormattingOptionsControl.cs
@@ -46,7 +46,7 @@ namespace Microsoft.PythonTools.Options {
             var textContentType = contentTypeRegistry.GetContentType("Python");
 
             _buffer = bufferFactory.CreateTextBuffer(textContentType);
-            var editor = editorFactory.CreateTextView(_buffer);
+            var editor = editorFactory.CreateTextView(_buffer, CreateRoleSet());
             
             _editorHost.Child = (UIElement)editor;
             _buffer.Replace(new Span(0, 0), DefaultText);
@@ -55,8 +55,6 @@ namespace Microsoft.PythonTools.Options {
         private ITextViewRoleSet/*!*/ CreateRoleSet() {
             var textEditorFactoryService = _serviceProvider.GetComponentModel().GetService<ITextEditorFactoryService>();
             return textEditorFactoryService.CreateTextViewRoleSet(
-                PredefinedTextViewRoles.Analyzable,
-                PredefinedTextViewRoles.Editable,
                 PredefinedTextViewRoles.Interactive,
                 PredefinedTextViewRoles.PrimaryDocument,
                 PredefinedTextViewRoles.Zoomable,


### PR DESCRIPTION
Fixes #364 Tools | Options | Text Editor | Python | Formatting | Spacing can't be loaded
Removes folder images from treeview.
Also prevents IntelliSense providers from loading against the preview editor to avoid many assertions.