### PR TITLE
Fixes #336 Do not recognise generator_stop future

### DIFF
--- a/Python/Product/Analysis/Parsing/Parser.cs
+++ b/Python/Product/Analysis/Parsing/Parser.cs
@@ -1185,6 +1185,10 @@ namespace Microsoft.PythonTools.Parsing {
                 } else if (_langVersion >= PythonLanguageVersion.V26 && name.Name == "unicode_literals") {
                     _tokenizer.UnicodeLiterals = true;
                     _languageFeatures |= FutureOptions.UnicodeLiterals;
+
+                    // v3.5:
+                } else if (_langVersion >= PythonLanguageVersion.V35 && name.Name == "generator_stop") {
+                    // No behavior change, but we don't want to display an error
                 } else {
                     string strName = name.Name;
 

--- a/Python/Tests/Analysis/ParserTests.cs
+++ b/Python/Tests/Analysis/ParserTests.cs
@@ -2437,7 +2437,7 @@ namespace AnalysisTests {
         public void FromFuture() {
             foreach (var version in AllVersions) {
                 CheckAst(
-                    ParseFile("FromFuture24.py", ErrorSink.Null, version),
+                    ParseFileNoErrors("FromFuture24.py", version),
                     CheckSuite(
                         CheckFromImport("__future__", new[] { "division" }),
                         CheckFromImport("__future__", new[] { "generators" })
@@ -2451,7 +2451,7 @@ namespace AnalysisTests {
                     );
                 } else {
                     CheckAst(
-                        ParseFile("FromFuture25.py", ErrorSink.Null, version),
+                        ParseFileNoErrors("FromFuture25.py", version),
                         CheckSuite(
                             CheckFromImport("__future__", new[] { "with_statement" }),
                             CheckFromImport("__future__", new[] { "absolute_import" })
@@ -2466,10 +2466,23 @@ namespace AnalysisTests {
                     );
                 } else {
                     CheckAst(
-                        ParseFile("FromFuture26.py", ErrorSink.Null, version),
+                        ParseFileNoErrors("FromFuture26.py", version),
                         CheckSuite(
                             CheckFromImport("__future__", new[] { "print_function" }),
                             CheckFromImport("__future__", new[] { "unicode_literals" })
+                        )
+                    );
+                }
+
+                if (version < PythonLanguageVersion.V35) {
+                    ParseErrors("FromFuture35.py", version,
+                        new ErrorInfo("future feature is not defined: generator_stop", 0, 1, 1, 37, 1, 38)
+                    );
+                } else {
+                    CheckAst(
+                        ParseFileNoErrors("FromFuture35.py", version),
+                        CheckSuite(
+                            CheckFromImport("__future__", new[] { "generator_stop" })
                         )
                     );
                 }

--- a/Python/Tests/TestData/Grammar/FromFuture35.py
+++ b/Python/Tests/TestData/Grammar/FromFuture35.py
@@ -1,0 +1,1 @@
+﻿from __future__ import generator_stop


### PR DESCRIPTION
Fixes #336 Do not recognise generator_stop future
Stops reporting an error for generator_stop on Python 3.5

(Meets the bar because it's a trivial fix for recent Python 3.5 additions.)