### PR TITLE
Fixes #393 NullReferenceException getting completions

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Intellisense/CompletionAnalysis.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/CompletionAnalysis.cs
@@ -108,9 +108,15 @@ namespace Microsoft.PythonTools.Intellisense {
 
         internal ModuleAnalysis GetAnalysisEntry() {
             IPythonProjectEntry entry;
-            return TextBuffer.TryGetPythonProjectEntry(out entry) && entry != null ?
-                entry.Analysis :
-                null;
+            if (TextBuffer.TryGetPythonProjectEntry(out entry) && entry != null) {
+                Debug.Assert(
+                    entry.Analysis != null,
+                    string.Format("Failed to get analysis for buffer {0} with file {1}", TextBuffer, entry.FilePath)
+                );
+                return entry.Analysis;
+            }
+            Debug.Fail("Failed to get project entry for buffer " + TextBuffer.ToString());
+            return null;
         }
 
         private static Stopwatch MakeStopWatch() {
@@ -121,6 +127,9 @@ namespace Microsoft.PythonTools.Intellisense {
 
         protected IEnumerable<MemberResult> GetModules(string[] package, bool modulesOnly = true) {
             var analysis = GetAnalysisEntry();
+            if (analysis == null) {
+                return Enumerable.Empty<MemberResult>();
+            }
 
             IPythonReplIntellisense pyReplEval = null;
             IReplEvaluator eval;

--- a/Python/Product/PythonTools/PythonTools/Intellisense/DecoratorCompletionAnalysis.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/DecoratorCompletionAnalysis.cs
@@ -52,6 +52,10 @@ namespace Microsoft.PythonTools.Intellisense {
             var start = _stopwatch.ElapsedMilliseconds;
 
             var analysis = GetAnalysisEntry();
+            if (analysis == null) {
+                return null;
+            }
+
             var index = VsProjectAnalyzer.TranslateIndex(
                 Span.GetEndPoint(TextBuffer.CurrentSnapshot).Position,
                 TextBuffer.CurrentSnapshot,

--- a/Python/Product/PythonTools/PythonTools/Intellisense/ExceptionCompletionAnalysis.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/ExceptionCompletionAnalysis.cs
@@ -61,6 +61,10 @@ namespace Microsoft.PythonTools.Intellisense {
             var start = _stopwatch.ElapsedMilliseconds;
 
             var analysis = GetAnalysisEntry();
+            if (analysis == null) {
+                return null;
+            }
+
             var index = VsProjectAnalyzer.TranslateIndex(
                 Span.GetEndPoint(TextBuffer.CurrentSnapshot).Position,
                 TextBuffer.CurrentSnapshot,

--- a/Python/Product/PythonTools/PythonTools/Intellisense/OVERRIDECOMPLETIONANALYSIS.CS
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/OVERRIDECOMPLETIONANALYSIS.CS
@@ -73,7 +73,8 @@ namespace Microsoft.PythonTools.Intellisense {
             if (result.Parameters.Length > 0) {
                 var parameterString = string.Join(", ", result.Parameters.Skip(1).Select((p, i) => GetSafeArgumentName(p, i + 1)));
 
-                if (GetAnalysisEntry().ProjectState.LanguageVersion.Is3x()) {
+                var analysis = GetAnalysisEntry();
+                if (analysis != null && analysis.ProjectState.LanguageVersion.Is3x()) {
                     sb.AppendFormat("return super().{0}({1})",
                         result.Name,
                         parameterString);


### PR DESCRIPTION
Fixes #393 NullReferenceException getting completions
Handles when GetAnalysisEntry() returns null.
Adds assertions to detect this case earlier.