### PR TITLE
Fixes #395 Interactive Window DTE commands no longer accept arguments

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Intellisense/IntellisenseController.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/IntellisenseController.cs
@@ -818,7 +818,7 @@ namespace Microsoft.PythonTools.Intellisense {
                     }
                 }
 
-                int res = _oldTarget.Exec(ref pguidCmdGroup, nCmdID, nCmdexecopt, pvaIn, pvaOut);
+                int res = _oldTarget != null ? _oldTarget.Exec(ref pguidCmdGroup, nCmdID, nCmdexecopt, pvaIn, pvaOut) : VSConstants.S_OK;
                 
                 HandleChar((char)(ushort)System.Runtime.InteropServices.Marshal.GetObjectForNativeVariant(pvaIn));
 
@@ -866,7 +866,7 @@ namespace Microsoft.PythonTools.Intellisense {
                         case VSConstants.VSStd2KCmdID.DELETE:
                         case VSConstants.VSStd2KCmdID.DELETEWORDLEFT:
                         case VSConstants.VSStd2KCmdID.DELETEWORDRIGHT:
-                            int res = _oldTarget.Exec(ref pguidCmdGroup, nCmdID, nCmdexecopt, pvaIn, pvaOut);
+                            int res = _oldTarget != null ? _oldTarget.Exec(ref pguidCmdGroup, nCmdID, nCmdexecopt, pvaIn, pvaOut) : VSConstants.S_OK;
                             if (_activeSession != null && !_activeSession.IsDismissed) {
                                 _activeSession.Filter();
                             }
@@ -935,7 +935,10 @@ namespace Microsoft.PythonTools.Intellisense {
                 }
             }
 
-            return _oldTarget.Exec(ref pguidCmdGroup, nCmdID, nCmdexecopt, pvaIn, pvaOut);
+            if (_oldTarget != null) {
+                return _oldTarget.Exec(ref pguidCmdGroup, nCmdID, nCmdexecopt, pvaIn, pvaOut);
+            }
+            return (int)Constants.OLECMDERR_E_UNKNOWNGROUP;
         }
 
         private void TriggerSnippet(uint nCmdID) {
@@ -1050,7 +1053,10 @@ namespace Microsoft.PythonTools.Intellisense {
                 }
             }
 
-            return _oldTarget.QueryStatus(ref pguidCmdGroup, cCmds, prgCmds, pCmdText);
+            if (_oldTarget != null) {
+                return _oldTarget.QueryStatus(ref pguidCmdGroup, cCmds, prgCmds, pCmdText);
+            }
+            return (int)Constants.OLECMDERR_E_UNKNOWNGROUP;
         }
 
         #endregion

--- a/Python/Product/PythonTools/PythonTools/Navigation/EditFilter.cs
+++ b/Python/Product/PythonTools/PythonTools/Navigation/EditFilter.cs
@@ -719,16 +719,6 @@ namespace Microsoft.PythonTools.Language {
                     case PkgCmdIDList.cmdidExtractMethodIntegratedShell:
                         ExtractMethod();
                         return VSConstants.S_OK;
-                    default:
-                        lock (PythonToolsPackage.CommandsLock) {
-                            foreach (var command in PythonToolsPackage.Commands.Keys) {
-                                if (command.CommandId == nCmdID) {
-                                    command.DoCommand(this, EventArgs.Empty);
-                                    return VSConstants.S_OK;
-                                }
-                            }
-                        }
-                        break;
                 }
 
             }


### PR DESCRIPTION
Fixes #395 Interactive Window DTE commands no longer accept arguments
Removes eager (and incorrect) handling of commands in the edit filter and lets the global handler deal with them.
Avoids crashing in IntellisenseController after failing to get the view adapter for a particular view.

(All the repl window tests depend on this, so it's well tested.)