### PR TITLE
Makes PythonEditor wait for analyzer to load before continuing

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Intellisense/ProjectAnalyzer.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/ProjectAnalyzer.cs
@@ -96,6 +96,8 @@ namespace Microsoft.PythonTools.Intellisense {
 
         private readonly object _contentsLock = new object();
 
+        internal Task ReloadTask;
+
         internal VsProjectAnalyzer(
             IServiceProvider serviceProvider,
             IPythonInterpreterFactory factory,
@@ -124,7 +126,8 @@ namespace Microsoft.PythonTools.Intellisense {
 
             if (interpreter != null) {
                 _pyAnalyzer = PythonAnalyzer.Create(factory, interpreter);
-                _pyAnalyzer.ReloadModulesAsync().HandleAllExceptions(SR.ProductName, GetType()).DoNotWait();
+                ReloadTask = _pyAnalyzer.ReloadModulesAsync().HandleAllExceptions(SR.ProductName, GetType());
+                ReloadTask.ContinueWith(_ => ReloadTask = null);
                 interpreter.ModuleNamesChanged += OnModulesChanged;
             }
 

--- a/Python/Tests/PythonToolsMockTests/PythonEditor.cs
+++ b/Python/Tests/PythonToolsMockTests/PythonEditor.cs
@@ -24,6 +24,7 @@ using Microsoft.PythonTools.Parsing;
 using Microsoft.VisualStudio.Language.Intellisense;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudioTools;
 using Microsoft.VisualStudioTools.MockVsTests;
 using TestUtilities;
 
@@ -61,6 +62,10 @@ namespace PythonToolsMockTests {
                 if (analyzer == null) {
                     _disposeAnalyzer = true;
                     analyzer = new VsProjectAnalyzer(vs.ServiceProvider, factory, new[] { factory });
+                    var task = analyzer.ReloadTask;
+                    if (task != null) {
+                        task.WaitAndUnwrapExceptions();
+                    }
                 }
 
                 var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));

--- a/Python/Tests/PythonToolsMockTests/RefactorRenameTests.cs
+++ b/Python/Tests/PythonToolsMockTests/RefactorRenameTests.cs
@@ -2404,16 +2404,8 @@ def g(a, b, c):
 
                     // test runs twice, one w/ original buffer, once w/ re-analyzed buffers.
                     if (loops == 1) {
-                        using (new DebugTimer("Waiting for previous analysis before raising change events")) {
-                            analyzer.WaitForCompleteAnalysis(x => true);
-                        }
-                        Console.WriteLine("Running w/ re-anlyzed buffers");
                         // do it again w/ a changed buffer
                         mainView.Text = mainView.Text;
-                    }
-
-                    using (new DebugTimer("Waiting for analysis")) {
-                        analyzer.WaitForCompleteAnalysis(x => true);
                     }
 
                     var caretPos = inputs[0].Input.IndexOf(caretText);


### PR DESCRIPTION
Makes PythonEditor wait for analyzer to load before continuing. This stabilises (at least) the refactor rename tests.