### PR TITLE
Fixes #402 NullReferenceException getting smart tags

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Intellisense/SmartTagSource.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/SmartTagSource.cs
@@ -168,6 +168,9 @@ namespace Microsoft.PythonTools.Intellisense {
 
             SmartTagController controller;
             session.Properties.TryGetProperty<SmartTagController>(typeof(SmartTagController), out controller);
+            if (controller == null) {
+                return;
+            }
 
             var task = Volatile.Read(ref controller._curTask);
             var origTask = task;


### PR DESCRIPTION
Fixes #402 NullReferenceException getting smart tags
Checks whether our session has a controller. If not, no tags. (This seems to occur while debugging.)