### PR TITLE
Fixes #421 and #422

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Project/InterpretersNode.cs
+++ b/Python/Product/PythonTools/PythonTools/Project/InterpretersNode.cs
@@ -195,6 +195,8 @@ namespace Microsoft.PythonTools.Project {
                 return;
             } catch (NoInterpretersException) {
                 return;
+            } catch (FileNotFoundException) {
+                return;
             }
 
             // Ensure we are back on the UI thread

--- a/Python/Product/PythonTools/PythonTools/Project/PythonProjectNode.cs
+++ b/Python/Product/PythonTools/PythonTools/Project/PythonProjectNode.cs
@@ -2161,8 +2161,13 @@ namespace Microsoft.PythonTools.Project {
             var path = factory.Configuration.PrefixPath;
             if (removeFromStorage && Directory.Exists(path)) {
                 var t = Task.Run(() => {
-                    Directory.Delete(path, true);
-                    return true;
+                    try {
+                        Directory.Delete(path, true);
+                        return true;
+                    } catch (IOException) {
+                    } catch (UnauthorizedAccessException) {
+                    }
+                    return false;
                 }).HandleAllExceptions(SR.ProductName, GetType());
 
                 if (!await t) {


### PR DESCRIPTION
Fixes #421 Unhandled Python-not-runnable exception
Adds unhandled exception type to try/catch statement.

Fixes #422 Unhandled exception in PythonProjectNode.RemoveInterpreter
Suppresses extra message box for "normal" errors when deleting directories.