### PR TITLE
Fixes #407 Interactive options does not load environment list

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Options/GlobalInterpreterOptions.cs
+++ b/Python/Product/PythonTools/PythonTools/Options/GlobalInterpreterOptions.cs
@@ -41,8 +41,10 @@ namespace Microsoft.PythonTools.Options {
         }
 
         public void Load() {
-            DefaultInterpreter = _interpreterOptions.DefaultInterpreter.Id;
-            DefaultInterpreterVersion = _interpreterOptions.DefaultInterpreter.Configuration.Version;
+            if (_interpreterOptions != null) {
+                DefaultInterpreter = _interpreterOptions.DefaultInterpreter.Id;
+                DefaultInterpreterVersion = _interpreterOptions.DefaultInterpreter.Configuration.Version;
+            }
         }
 
         public void Save() {

--- a/Python/Product/PythonTools/PythonTools/Options/PythonInterpreterOptionsPage.cs
+++ b/Python/Product/PythonTools/PythonTools/Options/PythonInterpreterOptionsPage.cs
@@ -67,9 +67,6 @@ namespace Microsoft.PythonTools.Options {
         }
 
         public override void LoadSettingsFromStorage() {
-            PyService.GlobalInterpreterOptions.Load();
-            PyService.LoadInterpreterOptions();
-
             if (_window != null) {
                 _window.UpdateInterpreters();
             }

--- a/Python/Product/PythonTools/PythonToolsService.cs
+++ b/Python/Product/PythonTools/PythonToolsService.cs
@@ -94,6 +94,7 @@ namespace Microsoft.PythonTools {
             if (_interpreterOptionsService != null) {   // not available in some test cases...
                 _interpreterOptionsService.InterpretersChanged += InterpretersChanged;
                 _interpreterOptionsService.DefaultInterpreterChanged += UpdateDefaultAnalyzer;
+                LoadInterpreterOptions();
             }
 
             _idleManager = new IdleManager(container);
@@ -102,6 +103,7 @@ namespace Microsoft.PythonTools {
             _generalOptions = new GeneralOptions(this);
             _surveyNews = new SurveyNewsService(container);
             _globalInterpreterOptions = new GlobalInterpreterOptions(this, _interpreterOptionsService);
+            _globalInterpreterOptions.Load();
             _debugInteractiveOptions = new PythonInteractiveCommonOptions(this, "Debug Interactive Window", "");
 
             _logger = new PythonToolsLogger(ComponentModel.GetExtensions<IPythonToolsLogger>().ToArray());


### PR DESCRIPTION
Fixes #407 Interactive options does not load environment list
Loads options dialog state when creating the Python Tool service.