### PR TITLE
Fixes #273 opened files don't completely refresh when switching between python 2 and 3

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Intellisense/ProjectAnalyzer.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/ProjectAnalyzer.cs
@@ -232,6 +232,10 @@ namespace Microsoft.PythonTools.Intellisense {
                     if (classifier != null) {
                         classifier.NewVersion();
                     }
+                    var classifier2 = buffer.GetPythonAnalysisClassifier();
+                    if (classifier2 != null) {
+                        classifier2.NewVersion();
+                    }
 
                     ConnectErrorList(projEntry, buffer);
                     if (doSquiggles) {

--- a/Python/Product/PythonTools/PythonTools/Project/PythonProjectNode.cs
+++ b/Python/Product/PythonTools/PythonTools/Project/PythonProjectNode.cs
@@ -1032,16 +1032,19 @@ namespace Microsoft.PythonTools.Project {
                 }
 
                 Reanalyze(analyzer);
-                if (_analyzer != null) {
-                    analyzer.SwitchAnalyzers(_analyzer);
-                    if (_analyzer.RemoveUser()) {
-                        _analyzer.Dispose();
+                var oldAnalyzer = Interlocked.Exchange(ref _analyzer, analyzer);
+
+                if (oldAnalyzer != null) {
+                    if (analyzer != null) {
+                        analyzer.SwitchAnalyzers(oldAnalyzer);
+                    }
+                    if (oldAnalyzer.RemoveUser()) {
+                        oldAnalyzer.Dispose();
                     }
                 }
 
-                _analyzer = analyzer;
                 var searchPath = ParseSearchPath();
-                if (searchPath != null && _analyzer != null) {
+                if (searchPath != null && analyzer != null) {
                     AnalyzeSearchPaths(searchPath);
                 }
 


### PR DESCRIPTION
Fixes #273 opened files don't completely refresh when switching between python 2 and 3
Corrects ordering of calls vs. updating _analyzer
Adds NewVersion function to PythonAnalysisClassifier