### PR TITLE
Fixes #431 Survey/News command crashes VS

### DIFF
--- a/Common/Product/SharedProject/IdleManager.cs
+++ b/Common/Product/SharedProject/IdleManager.cs
@@ -75,12 +75,16 @@ namespace Microsoft.VisualStudioTools {
 
         internal event EventHandler<ComponentManagerEventArgs> OnIdle {
             add {
-                EnsureInit();
-                _onIdle += value;
+                _serviceProvider.GetUIThread().Invoke(() => {
+                    EnsureInit();
+                    _onIdle += value;
+                });
             }
             remove {
-                EnsureInit();
-                _onIdle -= value;
+                _serviceProvider.GetUIThread().Invoke(() => {
+                    EnsureInit();
+                    _onIdle -= value;
+                });
             }
         }
 


### PR DESCRIPTION
Fixes #431 Survey/News command crashes VS
Ensures IdleManager manipulates its events and accesses COM objects on the UI thread.