### PR TITLE
Some fixes for debugger tests that require compiling C++ code

### DIFF
--- a/Common/Tests/Utilities/VCCompiler.cs
+++ b/Common/Tests/Utilities/VCCompiler.cs
@@ -85,7 +85,7 @@ namespace TestUtilities {
                 bins = bin + ";" + bins;
             }
             if (!string.IsNullOrEmpty(vsDir)) {
-                bins += ";" + vsDir;
+                bins += ";" + vsDir + ";" + vsDir + @"\Common7\IDE";
             }
 
             string include = Path.Combine(vcDir, "include");
@@ -114,7 +114,7 @@ namespace TestUtilities {
                 return;
             }
 
-            if (vcVersion == "10.0" || vcVersion == "11.0" || vcVersion == "12.0") {
+            if (vcVersion == "11.0" || vcVersion == "12.0") {
                 // If we find a Windows 8 kit, then return
                 if (AddWindows8KitPaths(isX64, ref includePaths, ref libPaths)) {
                     return;

--- a/Python/Tests/DebuggerTests/DebuggerTests.cs
+++ b/Python/Tests/DebuggerTests/DebuggerTests.cs
@@ -224,11 +224,11 @@ namespace DebuggerTests {
                 AssertWaited(evalComplete);
                 Assert.IsNotNull(evalRes, "didn't get evaluation result");
 
-
                 if (children == null) {
                     Assert.IsFalse(evalRes.IsExpandable, "result should not be expandable");
                     Assert.IsNull(evalRes.GetChildren(Int32.MaxValue), "result should not have children");
                 } else {
+                    Assert.IsNull(evalRes.ExceptionText, "exception while evaluating: " + evalRes.ExceptionText);
                     Assert.IsTrue(evalRes.IsExpandable, "result is not expandable");
                     var childrenReceived = new List<PythonEvaluationResult>(evalRes.GetChildren(Int32.MaxValue));
 
@@ -2769,7 +2769,7 @@ int main(int argc, char* argv[]) {
 
             // compile our host code...
             var env = new Dictionary<string, string>();
-            env["PATH"] = Environment.GetEnvironmentVariable("PATH") + ";" + vc.BinPaths;
+            env["PATH"] = vc.BinPaths + ";" + Environment.GetEnvironmentVariable("PATH");
             env["INCLUDE"] = vc.IncludePaths + ";" + Path.Combine(Version.PrefixPath, "Include");
             env["LIB"] = vc.LibPaths + ";" + Path.Combine(Version.PrefixPath, "libs");
 


### PR DESCRIPTION
- Add Common7\IDE to PATH to pick up some DLLs for VC10.
- Prepend rather than append new entries to PATH to ensure that they override everything else there.
- Always use Win7 SDK for VC10 rather than Win8 SDK (the latter has headers that don't compile with VC10).

Add extra error logging to debugger tests for child properties to help diagnose test run issues.