### PR TITLE
Fix #411: Cannot attach debugger to interactive window

### DIFF
--- a/Python/Product/Debugger/Debugger/PythonProcess.cs
+++ b/Python/Product/Debugger/Debugger/PythonProcess.cs
@@ -85,7 +85,7 @@ namespace Microsoft.PythonTools.Debugger {
             }
         }
 
-        private PythonProcess(Stream stream, int pid, PythonLanguageVersion version) {
+        private PythonProcess(Stream stream, int pid, PythonLanguageVersion version, PythonDebugOptions debugOptions) {
             _pid = pid;
             _process = Process.GetProcessById(pid);
             _process.EnableRaisingEvents = true;
@@ -97,6 +97,7 @@ namespace Microsoft.PythonTools.Debugger {
 
             stream.WriteInt32(DebugConnectionListener.ListenerPort);
             stream.WriteString(_processGuid.ToString());
+            stream.WriteString(debugOptions.ToString());
         }
 
         public PythonProcess(PythonLanguageVersion languageVersion, string exe, string args, string dir, string env, string interpreterOptions, PythonDebugOptions options = PythonDebugOptions.None, List<string[]> dirMapping = null)
@@ -145,8 +146,8 @@ namespace Microsoft.PythonTools.Debugger {
             return new PythonProcess(pid, debugOptions);
         }
 
-        public static PythonProcess AttachRepl(Stream stream, int pid, PythonLanguageVersion version) {
-            return new PythonProcess(stream, pid, version);
+        public static PythonProcess AttachRepl(Stream stream, int pid, PythonLanguageVersion version, PythonDebugOptions debugOptions = PythonDebugOptions.None) {
+            return new PythonProcess(stream, pid, version, debugOptions);
         }
 
         #region Public Process API

--- a/Python/Product/PythonTools/PythonTools/Repl/BasePythonReplEvaluator.cs
+++ b/Python/Product/PythonTools/PythonTools/Repl/BasePythonReplEvaluator.cs
@@ -444,10 +444,18 @@ namespace Microsoft.PythonTools.Repl {
                     return "Cannot attach to debugger when already attached.";
                 }
 
+                var pyService = _eval._serviceProvider.GetPythonToolsService();
+
+                // Only pass options that make sense for the REPL.
+                var debugOptions = PythonDebugOptions.None;
+                if (pyService.DebuggerOptions.DebugStdLib) {
+                    debugOptions |= PythonDebugOptions.DebugStdLib;
+                }
+
                 PythonProcess debugProcess;
                 using (new StreamLock(this, throwIfDisconnected: true)) {
                     _stream.Write(DebugAttachCommandBytes);
-                    debugProcess = PythonProcess.AttachRepl(_stream, _process.Id, _eval.AnalyzerProjectLanguageVersion);
+                    debugProcess = PythonProcess.AttachRepl(_stream, _process.Id, _eval.AnalyzerProjectLanguageVersion, debugOptions);
                 }
 
                 var debugTarget = new VsDebugTargetInfo2();

--- a/Python/Product/PythonTools/visualstudio_py_repl.py
+++ b/Python/Product/PythonTools/visualstudio_py_repl.py
@@ -344,9 +344,11 @@ actual inspection and introspection."""
         self.execute_file_ex(filetype, filename, args)
 
     def _cmd_debug_attach(self):
+        import visualstudio_py_debugger
         port = read_int(self.conn)
         id = read_string(self.conn)
-        self.attach_process(port, id)
+        debug_options = visualstudio_py_debugger.parse_debug_options(read_string(self.conn))
+        self.attach_process(port, id, debug_options)
 
     _COMMANDS = {
         to_bytes('run '): _cmd_run,
@@ -489,7 +491,7 @@ actual inspection and introspection."""
         """flushes the stdout/stderr buffers"""
         raise NotImplementedError
 
-    def attach_process(self, port, debugger_id):
+    def attach_process(self, port, debugger_id, debug_options):
         """starts processing execution requests"""
         raise NotImplementedError
     
@@ -989,11 +991,11 @@ due to the exec, so we do it here"""
         visualstudio_py_debugger.DETACH_CALLBACKS.remove(self.do_detach)
         self.on_debugger_detach()
 
-    def attach_process(self, port, debugger_id):
+    def attach_process(self, port, debugger_id, debug_options):
         def execute_attach_process_work_item():
             import visualstudio_py_debugger
             visualstudio_py_debugger.DETACH_CALLBACKS.append(self.do_detach)
-            visualstudio_py_debugger.attach_process(port, debugger_id, report = True, block = True)
+            visualstudio_py_debugger.attach_process(port, debugger_id, debug_options, report=True, block=True)
         
         self.execute_item = execute_attach_process_work_item
         self.execute_item_lock.release()


### PR DESCRIPTION
Propagate debug options (that make sense in that context) to the REPL, and then from the REPL to the main debugger script, when using $attach command.