### PR TITLE
Fix #419: ErrorListTaskListTests not seeing any items on VS 2013

### DIFF
--- a/Common/Tests/Utilities.UI/UI/VisualStudioApp.cs
+++ b/Common/Tests/Utilities.UI/UI/VisualStudioApp.cs
@@ -970,7 +970,7 @@ namespace TestUtilities.UI {
                 System.Threading.Thread.Sleep(5000);
             }
 
-            for (int retries = 10; retries > 0; --retries) {
+            for (int retries = 20; retries > 0; --retries) {
                 allItems.Clear();
                 IVsEnumTaskItems items;
                 ErrorHandler.ThrowOnFailure(errorList.EnumTaskItems(out items));


### PR DESCRIPTION
Increase number of retries while waiting for Error List to asynchronously update before giving up.