### PR TITLE
Fixes #412 ReplWindowPython354Tests are poorly named

### DIFF
--- a/Python/Tests/ReplWindowUITests/ReplWindowPythonTestEntryPoints.cs
+++ b/Python/Tests/ReplWindowUITests/ReplWindowPythonTestEntryPoints.cs
@@ -136,7 +136,7 @@ namespace ReplWindowUITests {
     }
 
     [TestClass]
-    public class ReplWindowPython354Tests : ReplWindowPythonIPythonTests {
+    public class ReplWindowPython35Tests : ReplWindowPythonIPythonTests {
         internal override PythonReplWindowProxySettings Settings {
             get {
                 return new PythonReplWindowProxySettings {


### PR DESCRIPTION
Renames test class.