### PR TITLE
Fix #441: Crash debugging multithreaded project

### DIFF
--- a/Python/Product/Debugger/Debugger/IdDispenser.cs
+++ b/Python/Product/Debugger/Debugger/IdDispenser.cs
@@ -23,7 +23,7 @@ namespace Microsoft.PythonTools.Debugger {
             lock (this) {
                 if (_freedInts.Count > 0) {
                     int res = _freedInts[_freedInts.Count - 1];
-                    _freedInts.Remove(_freedInts.Count - 1);
+                    _freedInts.RemoveAt(_freedInts.Count - 1);
                     return res;
                 } else {
                     int res = _curValue++;

--- a/Python/Product/Debugger/Debugger/PythonProcess.cs
+++ b/Python/Product/Debugger/Debugger/PythonProcess.cs
@@ -667,10 +667,13 @@ namespace Microsoft.PythonTools.Debugger {
         private void HandleExecutionException(Stream stream) {
             int execId = stream.ReadInt32();
             CompletionInfo completion;
-
             lock (_pendingExecutes) {
-                completion = _pendingExecutes[execId];
-                _pendingExecutes.Remove(execId);
+                if (_pendingExecutes.TryGetValue(execId, out completion)) {
+                    _pendingExecutes.Remove(execId);
+                    _ids.Free(execId);
+                } else {
+                    Debug.Fail("Received REPL execution result with unknown execution ID " + execId);
+                }
             }
 
             string exceptionText = stream.ReadString();


### PR DESCRIPTION
Fix IdDispenser issuing the same ID over and over again in some circumstances.

Do not crash on error response with unknown request ID.