### PR TITLE
Fixes #447 [Watson] clr20r3: CLR_EXCEPTION_System.ArgumentNullExcepti…

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Project/CustomCommand.cs
+++ b/Python/Product/PythonTools/PythonTools/Project/CustomCommand.cs
@@ -869,8 +869,8 @@ namespace Microsoft.PythonTools.Project {
                     Arguments = string.Format(
                         "/C \"{0}{1}{2}\" & if errorlevel 1 pause",
                         ProcessOutput.QuoteSingleArgument(Filename),
-                        string.IsNullOrEmpty(Arguments) ? "" : " ",
-                        Arguments ?? ""
+                        string.IsNullOrEmpty(Arguments) ? string.Empty : " ",
+                        Arguments ?? string.Empty
                     );
                     Filename = Path.Combine(Environment.SystemDirectory, "cmd.exe");
                     ExecuteIn = CreatePythonCommandItem.ExecuteInConsole;
@@ -880,8 +880,8 @@ namespace Microsoft.PythonTools.Project {
                     Arguments = string.Format(
                         "/C \"{0}{1}{2}\" & pause",
                         ProcessOutput.QuoteSingleArgument(Filename),
-                        string.IsNullOrEmpty(Arguments) ? "" : " ",
-                        Arguments ?? ""
+                        string.IsNullOrEmpty(Arguments) ? string.Empty : " ",
+                        Arguments ?? string.Empty
                     );
                     Filename = Path.Combine(Environment.SystemDirectory, "cmd.exe");
                     ExecuteIn = CreatePythonCommandItem.ExecuteInConsole;

--- a/Python/Product/PythonTools/PythonTools/Project/CustomCommand.cs
+++ b/Python/Product/PythonTools/PythonTools/Project/CustomCommand.cs
@@ -13,7 +13,6 @@
  * ***************************************************************************/
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
@@ -32,7 +31,7 @@ using Microsoft.PythonTools.Navigation;
 using Microsoft.PythonTools.Repl;
 using Microsoft.VisualStudio;
 #if DEV14_OR_LATER
-using Microsoft.VisualStudio.InteractiveWindow;
+using IReplWindowProvider = Microsoft.PythonTools.Repl.InteractiveWindowProvider;
 #else
 using Microsoft.VisualStudio.Repl;
 #endif
@@ -43,9 +42,6 @@ using Microsoft.VisualStudioTools.Project;
 using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.PythonTools.Project {
-#if DEV14_OR_LATER
-    using IReplWindowProvider = InteractiveWindowProvider;
-#endif
     sealed class CustomCommand : IAsyncCommand, IDisposable {
         private readonly PythonProjectNode _project;
         private readonly string _target;
@@ -431,7 +427,9 @@ namespace Microsoft.PythonTools.Project {
                     await Pip.Install(
                         _project.Site,
                         interpFactory,
-                        string.Format("{0} {1}", startInfo.Filename, startInfo.Arguments),
+                        string.IsNullOrEmpty(startInfo.Arguments) ?
+                            startInfo.Filename :
+                            string.Format("{0} {1}", startInfo.Filename, startInfo.Arguments),
                         project.Site,
                         false,
                         OutputWindowRedirector.GetGeneral(project.Site)
@@ -651,7 +649,7 @@ namespace Microsoft.PythonTools.Project {
             if (result.IsSuccessful) {
                 try {
                     var filename = startInfo.Filename;
-                    var arguments = startInfo.Arguments;
+                    var arguments = startInfo.Arguments ?? string.Empty;
 
                     if (startInfo.IsScript) {
                         pyEvaluator.Window.WriteLine(string.Format("Executing {0} {1}", Path.GetFileName(filename), arguments));
@@ -734,11 +732,19 @@ namespace Microsoft.PythonTools.Project {
         public string[] RequiredPackages;
 
         public void AddArgumentAtStart(string argument) {
-            Arguments = ProcessOutput.QuoteSingleArgument(argument) + " " + Arguments;
+            if (string.IsNullOrEmpty(Arguments)) {
+                Arguments = ProcessOutput.QuoteSingleArgument(argument);
+            } else {
+                Arguments = ProcessOutput.QuoteSingleArgument(argument) + Arguments;
+            }
         }
 
         public void AddArgumentAtEnd(string argument) {
-            Arguments += " " + ProcessOutput.QuoteSingleArgument(argument);
+            if (string.IsNullOrEmpty(Arguments)) {
+                Arguments = ProcessOutput.QuoteSingleArgument(argument);
+            } else {
+                Arguments += " " + ProcessOutput.QuoteSingleArgument(argument);
+            }
         }
 
         public bool ExecuteInRepl {
@@ -861,9 +867,10 @@ namespace Microsoft.PythonTools.Project {
             } else if (ExecuteInConsole) {
                 if (handleConsoleAndPause) {
                     Arguments = string.Format(
-                        "/C \"{0} {1}\" & if errorlevel 1 pause",
+                        "/C \"{0}{1}{2}\" & if errorlevel 1 pause",
                         ProcessOutput.QuoteSingleArgument(Filename),
-                        Arguments
+                        string.IsNullOrEmpty(Arguments) ? "" : " ",
+                        Arguments ?? ""
                     );
                     Filename = Path.Combine(Environment.SystemDirectory, "cmd.exe");
                     ExecuteIn = CreatePythonCommandItem.ExecuteInConsole;
@@ -871,16 +878,17 @@ namespace Microsoft.PythonTools.Project {
             } else if (ExecuteInConsoleAndPause) {
                 if (handleConsoleAndPause) {
                     Arguments = string.Format(
-                        "/C \"{0} {1}\" & pause",
+                        "/C \"{0}{1}{2}\" & pause",
                         ProcessOutput.QuoteSingleArgument(Filename),
-                        Arguments
+                        string.IsNullOrEmpty(Arguments) ? "" : " ",
+                        Arguments ?? ""
                     );
                     Filename = Path.Combine(Environment.SystemDirectory, "cmd.exe");
                     ExecuteIn = CreatePythonCommandItem.ExecuteInConsole;
                 }
             }
 
-            if (EnvironmentVariables != null) {
+            if (EnvironmentVariables != null && !string.IsNullOrEmpty(Arguments)) {
                 Arguments = Regex.Replace(Arguments, @"%(\w+)%", m => {
                     string envVar;
                     return EnvironmentVariables.TryGetValue(m.Groups[1].Value, out envVar) ? envVar : string.Empty;

--- a/Python/Product/PythonTools/PythonTools/Repl/BasePythonReplEvaluator.cs
+++ b/Python/Product/PythonTools/PythonTools/Repl/BasePythonReplEvaluator.cs
@@ -756,10 +756,10 @@ namespace Microsoft.PythonTools.Repl {
                         _stream.Write(ExecuteFileCommandBytes);
                     } else {
                         _stream.Write(ExecuteFileExCommandBytes);
-                        SendString(fileType);
+                        SendString(fileType ?? string.Empty);
                     }
-                    SendString(filename);
-                    SendString(extraArgs ?? String.Empty);
+                    SendString(filename ?? string.Empty);
+                    SendString(extraArgs ?? string.Empty);
                 };
 
                 using (new StreamLock(this, throwIfDisconnected: false)) {
@@ -977,7 +977,8 @@ namespace Microsoft.PythonTools.Repl {
             }
 
             private void SendString(string text) {
-                byte[] bytes = System.Text.Encoding.UTF8.GetBytes(text);
+                Debug.Assert(!string.IsNullOrEmpty(text), "text should not be null or empty");
+                byte[] bytes = Encoding.UTF8.GetBytes(text);
                 _stream.WriteInt32(bytes.Length);
                 _stream.Write(bytes);
             }
@@ -1213,6 +1214,8 @@ namespace Microsoft.PythonTools.Repl {
         }
 
         public Task<ExecutionResult> ExecuteFile(string filename, string extraArgs) {
+            Utilities.ArgumentNotNullOrEmpty("filename", filename);
+            Utilities.ArgumentNotNull("extraArgs", extraArgs);
             EnsureConnected();
 
             if (_curListener != null) {
@@ -1224,6 +1227,7 @@ namespace Microsoft.PythonTools.Repl {
         }
 
         public void ExecuteFile(string filename) {
+            Utilities.ArgumentNotNullOrEmpty("filename", filename);
             EnsureConnected();
 
             string startupFilename, startupDir, extraArgs = null;
@@ -1245,6 +1249,8 @@ namespace Microsoft.PythonTools.Repl {
         }
 
         public Task<ExecutionResult> ExecuteModule(string moduleName, string arguments) {
+            Utilities.ArgumentNotNullOrEmpty("moduleName", moduleName);
+            Utilities.ArgumentNotNull("arguments", arguments);
             EnsureConnected();
 
             if (_curListener != null) {
@@ -1256,6 +1262,8 @@ namespace Microsoft.PythonTools.Repl {
         }
 
         public Task<ExecutionResult> ExecuteProcess(string filename, string arguments) {
+            Utilities.ArgumentNotNullOrEmpty("filename", filename);
+            Utilities.ArgumentNotNull("arguments", arguments);
             EnsureConnected();
 
             if (_curListener != null) {

--- a/Python/Product/PythonTools/PythonTools/Repl/BasePythonReplEvaluator.cs
+++ b/Python/Product/PythonTools/PythonTools/Repl/BasePythonReplEvaluator.cs
@@ -977,7 +977,7 @@ namespace Microsoft.PythonTools.Repl {
             }
 
             private void SendString(string text) {
-                Debug.Assert(!string.IsNullOrEmpty(text), "text should not be null or empty");
+                Debug.Assert(text != null, "text should not be null");
                 byte[] bytes = Encoding.UTF8.GetBytes(text);
                 _stream.WriteInt32(bytes.Length);
                 _stream.Write(bytes);


### PR DESCRIPTION
Fixes #447 [Watson] clr20r3: CLR_EXCEPTION_System.ArgumentNullException_80004003_Microsoft.PythonTools.dll!Microsoft.PythonTools.Repl.BasePythonReplEvaluator+CommandProcessorThread.SendString
Ensures StartInfo.Arguments is always treated as if it may be null (which it may be).