### PR TITLE
Fixes #455 NullReferenceException in EnvironmentReplWorkingDirectory test

### DIFF
--- a/Common/Tests/Utilities.UI/UI/InteractiveWindow.cs
+++ b/Common/Tests/Utilities.UI/UI/InteractiveWindow.cs
@@ -73,7 +73,12 @@ namespace TestUtilities.UI {
 
             var compModel = _app.GetService<IComponentModel>(typeof(SComponentModel));
             var replWindowProvider = compModel.GetService<InteractiveWindowProvider>();
-            _replWindow = replWindowProvider.GetReplWindows()
+            _replWindow = replWindowProvider
+#if DEV14_OR_LATER
+                .GetReplToolWindows()
+#else
+                .GetReplWindows()
+#endif
                 .OfType<ToolWindowPane>()
                 .FirstOrDefault(p => p.Caption.Equals(title, StringComparison.CurrentCulture));
 #if DEV14_OR_LATER

--- a/Python/Product/PythonTools/PythonTools/Repl/InteractiveWindowProvider.cs
+++ b/Python/Product/PythonTools/PythonTools/Repl/InteractiveWindowProvider.cs
@@ -180,6 +180,10 @@ namespace Microsoft.PythonTools.Repl {
             return _windows.Values.Select(x => x.Window.InteractiveWindow);
         }
 
+        internal IEnumerable<ToolWindowPane> GetReplToolWindows() {
+            return _windows.Values.Select(x => x.Window).OfType<ToolWindowPane>();
+        }
+
         private static IInteractiveEvaluator GetReplEvaluator(IComponentModel model, string replId, out string[] roles) {
             roles = new string[0];
             foreach (var provider in model.GetExtensions<IReplEvaluatorProvider>()) {

--- a/Python/Tests/Core.UI/VirtualEnvTests.cs
+++ b/Python/Tests/Core.UI/VirtualEnvTests.cs
@@ -510,7 +510,9 @@ namespace PythonToolsUITests {
                 app.Dte.ExecuteCommand("Python.Interactive");
 
                 var window = app.GetInteractiveWindow(string.Format("{0} Interactive", envName));
+                Assert.IsNotNull(window, string.Format("Failed to find '{0} Interactive'", envName));
                 try {
+                    window.Reset();
                     window.ReplWindow.Evaluator.ExecuteText("import os; os.getcwd()").Wait();
                     window.WaitForTextEnd(
                         string.Format("'{0}'", path1.Replace("\\", "\\\\")),

--- a/Python/Tests/Utilities.Python/PythonVisualStudioApp.cs
+++ b/Python/Tests/Utilities.Python/PythonVisualStudioApp.cs
@@ -190,11 +190,23 @@ namespace TestUtilities.UI.Python {
         }
 
         public InteractiveWindow GetInteractiveWindow(string title) {
+#if !DEV14_OR_LATER
             string autoId = GetName(title);
+#endif
             AutomationElement element = null;
             for (int i = 0; i < 5 && element == null; i++) {
                 element = Element.FindFirst(TreeScope.Descendants,
                     new AndCondition(
+#if DEV14_OR_LATER
+                        new PropertyCondition(
+                            AutomationElement.NameProperty,
+                            title
+                        ),
+                        new PropertyCondition(
+                            AutomationElement.ControlTypeProperty,
+                            ControlType.Pane
+                        )
+#else
                         new PropertyCondition(
                             AutomationElement.AutomationIdProperty,
                             autoId
@@ -203,6 +215,7 @@ namespace TestUtilities.UI.Python {
                             AutomationElement.ClassNameProperty,
                             ""
                         )
+#endif
                     )
                 );
                 if (element == null) {


### PR DESCRIPTION
Fixes #455 NullReferenceException in EnvironmentReplWorkingDirectory test
Fails test if we can't find the interactive window.
Fixes GetInteractiveWindow for VS 2015