### PR TITLE
Fixes #465 Analyzer does not follow .pth files when a library path is provided

### DIFF
--- a/Python/Product/Analyzer/PyLibAnalyzer.cs
+++ b/Python/Product/Analyzer/PyLibAnalyzer.cs
@@ -333,6 +333,8 @@ namespace Microsoft.PythonTools.Analysis {
                     var sitePackagesDir = Path.Combine(value, "site-packages");
                     if (Directory.Exists(sitePackagesDir)) {
                         library.Add(new PythonLibraryPath(sitePackagesDir, false, null));
+                        library.AddRange(ModulePath.ExpandPathFiles(sitePackagesDir)
+                            .Select(p => new PythonLibraryPath(p, false, null)));
                     }
                 }
             }


### PR DESCRIPTION
Fixes #465 Analyzer does not follow .pth files when a library path is provided
Expands path files when handling the fallback case of a library path being passed to the analyzer.

As far as regressions go this one is pretty non-fatal, though it is a break with our old behaviour. It *shouldn't* affect normal use through the IDE, but the point was to keep the old behaviour when expected.