### PR TITLE
Fixes #469 Virtual environments always refresh DB even when option is disabled

### DIFF
--- a/Python/Product/VSInterpreters/DerivedInterpreterFactory.cs
+++ b/Python/Product/VSInterpreters/DerivedInterpreterFactory.cs
@@ -145,7 +145,6 @@ namespace Microsoft.PythonTools.Interpreter {
             }
 
             if (!IsCurrent || !Directory.Exists(databasePath)) {
-                GenerateDatabase(GenerateDatabaseOptions.SkipUnchanged);
                 return _baseDb;
             }
 


### PR DESCRIPTION
Fixes #469 Virtual environments always refresh DB even when option is disabled
Removes unnecessary call to GenerateDatabase
Updates virtual environment test that exposed this issue