### PR TITLE
Fixes #472 Execute in REPL should not create a window in QueryStatus

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Commands/ExecuteInReplCommand.cs
+++ b/Python/Product/PythonTools/PythonTools/Commands/ExecuteInReplCommand.cs
@@ -112,7 +112,6 @@ namespace Microsoft.PythonTools.Commands {
 
                 IWpfTextView textView;
                 var pyProj = CommonPackage.GetStartupProject(_serviceProvider) as PythonProjectNode;
-                var window = (IReplWindow)EnsureReplWindow(_serviceProvider, analyzer, pyProj);
                 if (pyProj != null) {
                     // startup project, enabled in Start in REPL mode.
                     oleMenu.Visible = true;


### PR DESCRIPTION
Fixes #472 Execute in REPL should not create a window in QueryStatus
Removes unnecessary call to EnsureReplWindow