### PR TITLE
Fixes #475 NullReferenceException disposing TaskProvider

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Intellisense/TaskProvider.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/TaskProvider.cs
@@ -348,7 +348,7 @@ namespace Microsoft.PythonTools.Intellisense {
                         _workerQueue.Enqueue(WorkerMessage.Abort());
                         _workerQueueChanged.Set();
                     }
-                    bool stopped = _worker.Join(10000);
+                    bool stopped = worker.Join(10000);
                     Debug.Assert(stopped, "Failed to terminate TaskProvider worker thread");
                 }
 


### PR DESCRIPTION
Fixes #475 NullReferenceException disposing TaskProvider
Switches from the instance variable that is cleared by the background thread to the local where we've already captured and checked the value.