### PR TITLE
Fixes #300 Race condition refreshing environments

### DIFF
--- a/Common/Tests/Utilities/Mocks/MockSettingsStore.cs
+++ b/Common/Tests/Utilities/Mocks/MockSettingsStore.cs
@@ -23,38 +23,46 @@ namespace TestUtilities.Mocks {
         private readonly List<Tuple<string, string, object>> Settings = new List<Tuple<string, string, object>>();
 
         public void AddSetting(string path, string name, object value) {
-            if (string.IsNullOrEmpty(path)) {
-                path = Settings.Last().Item1;
-            } else if (path.StartsWith(" ")) {
-                path = Settings.Last().Item1 + "\\" + path.TrimStart();
-            }
+            lock (Settings) {
+                if (string.IsNullOrEmpty(path)) {
+                    path = Settings.Last().Item1;
+                } else if (path.StartsWith(" ")) {
+                    path = Settings.Last().Item1 + "\\" + path.TrimStart();
+                }
 
-            Settings.Add(Tuple.Create(path, name, value));
+                Settings.Add(Tuple.Create(path, name, value));
+            }
         }
 
         public void Clear() {
-            Settings.Clear();
+            lock (Settings) {
+                Settings.Clear();
+            }
         }
 
         private int FindValue<T>(string collectionPath, string propertyName, ref T value) {
-            var tuple = Settings.FirstOrDefault(t => t.Item1 == collectionPath && t.Item2 == propertyName);
-            if (tuple == null) {
-                return VSConstants.S_FALSE;
+            lock (Settings) {
+                var tuple = Settings.FirstOrDefault(t => t.Item1 == collectionPath && t.Item2 == propertyName);
+                if (tuple == null) {
+                    return VSConstants.S_FALSE;
+                }
+                if (!(tuple.Item3 is T)) {
+                    return VSConstants.E_INVALIDARG;
+                }
+                value = (T)tuple.Item3;
+                return VSConstants.S_OK;
             }
-            if (!(tuple.Item3 is T)) {
-                return VSConstants.E_INVALIDARG;
-            }
-            value = (T)tuple.Item3;
-            return VSConstants.S_OK;
         }
 
         public int CollectionExists(string collectionPath, out int pfExists) {
-            var collectionSeq = collectionPath.Split('\\');
-            pfExists = Settings
-                .Select(t => t.Item1.Split('\\'))
-                .Where(seq => seq.Length >= collectionSeq.Length)
-                .Any(seq => seq.Take(collectionSeq.Length).SequenceEqual(collectionSeq)) ? 1 : 0;
-            return VSConstants.S_OK;
+            lock (Settings) {
+                var collectionSeq = collectionPath.Split('\\');
+                pfExists = Settings
+                    .Select(t => t.Item1.Split('\\'))
+                    .Where(seq => seq.Length >= collectionSeq.Length)
+                    .Any(seq => seq.Take(collectionSeq.Length).SequenceEqual(collectionSeq)) ? 1 : 0;
+                return VSConstants.S_OK;
+            }
         }
 
         public int GetBinary(string collectionPath, string propertyName, uint byteLength, byte[] pBytes = null, uint[] actualByteLength = null) {
@@ -97,13 +105,17 @@ namespace TestUtilities.Mocks {
         }
 
         public int GetPropertyCount(string collectionPath, out uint propertyCount) {
-            propertyCount = (uint)Settings.Count(t => t.Item1 == collectionPath);
+            lock (Settings) {
+                propertyCount = (uint)Settings.Count(t => t.Item1 == collectionPath);
+            }
             return VSConstants.S_OK;
         }
 
         public int GetPropertyName(string collectionPath, uint index, out string propertyName) {
             try {
-                propertyName = Settings.Where(t => t.Item1 == collectionPath).ElementAt((int)index).Item2;
+                lock (Settings) {
+                    propertyName = Settings.Where(t => t.Item1 == collectionPath).ElementAt((int)index).Item2;
+                }
                 return VSConstants.S_OK;
             } catch (InvalidOperationException) {
                 propertyName = null;
@@ -127,44 +139,48 @@ namespace TestUtilities.Mocks {
 
         public int GetSubCollectionCount(string collectionPath, out uint subCollectionCount) {
             var collectionSeq = collectionPath.Split('\\');
-            if (!Settings
-                .Select(t => t.Item1.Split('\\'))
-                .Where(seq => seq.Length >= collectionSeq.Length)
-                .Where(seq => seq.Take(collectionSeq.Length).SequenceEqual(collectionSeq))
-                .Any()) {
-                subCollectionCount = 0;
-                return VSConstants.E_INVALIDARG;
+            lock (Settings) {
+                if (!Settings
+                    .Select(t => t.Item1.Split('\\'))
+                    .Where(seq => seq.Length >= collectionSeq.Length)
+                    .Where(seq => seq.Take(collectionSeq.Length).SequenceEqual(collectionSeq))
+                    .Any()) {
+                    subCollectionCount = 0;
+                    return VSConstants.E_INVALIDARG;
+                }
+
+                subCollectionCount = (uint)Settings
+                    .Select(t => t.Item1.Split('\\'))
+                    .Where(seq => seq.Length > collectionSeq.Length)
+                    .Where(seq => seq.Take(collectionSeq.Length).SequenceEqual(collectionSeq))
+                    .Select(seq => seq[collectionSeq.Length])
+                    .Distinct()
+                    .Count();
+                return VSConstants.S_OK;
             }
-            
-            subCollectionCount = (uint)Settings
-                .Select(t => t.Item1.Split('\\'))
-                .Where(seq => seq.Length > collectionSeq.Length)
-                .Where(seq => seq.Take(collectionSeq.Length).SequenceEqual(collectionSeq))
-                .Select(seq => seq[collectionSeq.Length])
-                .Distinct()
-                .Count();
-            return VSConstants.S_OK;
         }
 
         public int GetSubCollectionName(string collectionPath, uint index, out string subCollectionName) {
             var collectionSeq = collectionPath.Split('\\');
-            if (!Settings
-                .Select(t => t.Item1.Split('\\'))
-                .Where(seq => seq.Length >= collectionSeq.Length)
-                .Where(seq => seq.Take(collectionSeq.Length).SequenceEqual(collectionSeq))
-                .Any()) {
-                subCollectionName = null;
-                return VSConstants.E_INVALIDARG;
-            }
+            lock (Settings) {
+                if (!Settings
+                    .Select(t => t.Item1.Split('\\'))
+                    .Where(seq => seq.Length >= collectionSeq.Length)
+                    .Where(seq => seq.Take(collectionSeq.Length).SequenceEqual(collectionSeq))
+                    .Any()) {
+                    subCollectionName = null;
+                    return VSConstants.E_INVALIDARG;
+                }
 
-            subCollectionName = Settings
-                .Select(t => t.Item1.Split('\\'))
-                .Where(seq => seq.Length > collectionSeq.Length)
-                .Where(seq => seq.Take(collectionSeq.Length).SequenceEqual(collectionSeq))
-                .Select(seq => seq[collectionSeq.Length])
-                .Distinct()
-                .ElementAt((int)index);
-            return VSConstants.S_OK;
+                subCollectionName = Settings
+                    .Select(t => t.Item1.Split('\\'))
+                    .Where(seq => seq.Length > collectionSeq.Length)
+                    .Where(seq => seq.Take(collectionSeq.Length).SequenceEqual(collectionSeq))
+                    .Select(seq => seq[collectionSeq.Length])
+                    .Distinct()
+                    .ElementAt((int)index);
+                return VSConstants.S_OK;
+            }
         }
 
         public int GetUnsignedInt(string collectionPath, string propertyName, out uint value) {
@@ -188,7 +204,9 @@ namespace TestUtilities.Mocks {
         }
 
         public int PropertyExists(string collectionPath, string propertyName, out int pfExists) {
-            pfExists = Settings.Any(t => t.Item1 == collectionPath && t.Item2 == propertyName) ? 1 : 0;
+            lock (Settings) {
+                pfExists = Settings.Any(t => t.Item1 == collectionPath && t.Item2 == propertyName) ? 1 : 0;
+            }
             return VSConstants.S_OK;
         }
 
@@ -211,11 +229,13 @@ namespace TestUtilities.Mocks {
             }
 
             var collectionSeq = collectionPath.Split('\\');
-            return Settings.RemoveAll(t => {
-                var seq = t.Item1.Split('\\');
-                return seq.Length >= collectionSeq.Length &&
-                    seq.Take(collectionSeq.Length).SequenceEqual(collectionSeq);
-            }) > 0 ? VSConstants.S_OK : VSConstants.S_FALSE;
+            lock (Settings) {
+                return Settings.RemoveAll(t => {
+                    var seq = t.Item1.Split('\\');
+                    return seq.Length >= collectionSeq.Length &&
+                        seq.Take(collectionSeq.Length).SequenceEqual(collectionSeq);
+                }) > 0 ? VSConstants.S_OK : VSConstants.S_FALSE;
+            }
         }
 
         public int DeleteProperty(string collectionPath, string propertyName) {
@@ -224,9 +244,11 @@ namespace TestUtilities.Mocks {
             }
 
             var collectionSeq = collectionPath.Split('\\');
-            return Settings.RemoveAll(t => t.Item1 == collectionPath && t.Item2 == propertyName) > 0 ?
-                VSConstants.S_OK :
-                VSConstants.S_FALSE;
+            lock (Settings) {
+                return Settings.RemoveAll(t => t.Item1 == collectionPath && t.Item2 == propertyName) > 0 ?
+                    VSConstants.S_OK :
+                    VSConstants.S_FALSE;
+            }
         }
 
         public int SetBinary(string collectionPath, string propertyName, uint byteLength, byte[] pBytes) {
@@ -236,7 +258,9 @@ namespace TestUtilities.Mocks {
                     return VSConstants.E_INVALIDARG;
                 }
             }
-            Settings.Add(Tuple.Create(collectionPath, propertyName, (object)pBytes));
+            lock (Settings) {
+                Settings.Add(Tuple.Create(collectionPath, propertyName, (object)pBytes));
+            }
             return VSConstants.S_OK;
         }
 
@@ -247,7 +271,9 @@ namespace TestUtilities.Mocks {
                     return VSConstants.E_INVALIDARG;
                 }
             }
-            Settings.Add(Tuple.Create(collectionPath, propertyName, (object)value));
+            lock (Settings) {
+                Settings.Add(Tuple.Create(collectionPath, propertyName, (object)value));
+            }
             return VSConstants.S_OK;
         }
 
@@ -258,7 +284,9 @@ namespace TestUtilities.Mocks {
                     return VSConstants.E_INVALIDARG;
                 }
             }
-            Settings.Add(Tuple.Create(collectionPath, propertyName, (object)value));
+            lock (Settings) {
+                Settings.Add(Tuple.Create(collectionPath, propertyName, (object)value));
+            }
             return VSConstants.S_OK;
         }
 
@@ -269,7 +297,9 @@ namespace TestUtilities.Mocks {
                     return VSConstants.E_INVALIDARG;
                 }
             }
-            Settings.Add(Tuple.Create(collectionPath, propertyName, (object)value));
+            lock (Settings) {
+                Settings.Add(Tuple.Create(collectionPath, propertyName, (object)value));
+            }
             return VSConstants.S_OK;
         }
 
@@ -280,7 +310,9 @@ namespace TestUtilities.Mocks {
                     return VSConstants.E_INVALIDARG;
                 }
             }
-            Settings.Add(Tuple.Create(collectionPath, propertyName, (object)value));
+            lock (Settings) {
+                Settings.Add(Tuple.Create(collectionPath, propertyName, (object)value));
+            }
             return VSConstants.S_OK;
         }
 
@@ -291,7 +323,9 @@ namespace TestUtilities.Mocks {
                     return VSConstants.E_INVALIDARG;
                 }
             }
-            Settings.Add(Tuple.Create(collectionPath, propertyName, (object)value));
+            lock (Settings) {
+                Settings.Add(Tuple.Create(collectionPath, propertyName, (object)value));
+            }
             return VSConstants.S_OK;
         }
 
@@ -302,7 +336,9 @@ namespace TestUtilities.Mocks {
                     return VSConstants.E_INVALIDARG;
                 }
             }
-            Settings.Add(Tuple.Create(collectionPath, propertyName, (object)value));
+            lock (Settings) {
+                Settings.Add(Tuple.Create(collectionPath, propertyName, (object)value));
+            }
             return VSConstants.S_OK;
         }
     }


### PR DESCRIPTION
Fixes #300 Race condition refreshing environments
Adds enumerable implementation for getting the list of interpreters from the service. This enumerable will suppress change events during enumeration and try harder to get a coherent list of factories from the providers.
Adds a race-condition test to flush out threading issues.
Hardens mock classes to avoid causing false positives in the race-condition test. The actual VS classes are either thread-safe or marshal back to the UI thread, but there's no value in forcing that here.