### PR TITLE
Fixes #486 Launch with errors - invisible errors after switching from…

### DIFF
--- a/Common/Tests/MockVsTests/MockVsSolution.cs
+++ b/Common/Tests/MockVsTests/MockVsSolution.cs
@@ -154,7 +154,7 @@ namespace Microsoft.VisualStudioTools.MockVsTests {
             public int Next(uint celt, IVsHierarchy[] rgelt, out uint pceltFetched) {
                 pceltFetched = 0;
                 for (int i = 0; i < celt && _index < _projects.Length; i++) {
-                    rgelt[i] = _projects[++_index].Hierarchy;
+                    rgelt[i] = _projects[_index++].Hierarchy;
                     pceltFetched++;
                 }
                 return VSConstants.S_OK;

--- a/Python/Product/PythonTools/PythonTools/Project/PythonProjectNode.cs
+++ b/Python/Product/PythonTools/PythonTools/Project/PythonProjectNode.cs
@@ -922,6 +922,7 @@ namespace Microsoft.PythonTools.Project {
 
         private void UnHookErrorsAndWarnings(VsProjectAnalyzer res) {
             res.ShouldWarnOnLaunchChanged -= OnShouldWarnOnLaunchChanged;
+            _warnOnLaunchFiles.Clear();
         }
 
         private void OnShouldWarnOnLaunchChanged(object sender, EntryEventArgs e) {

--- a/Python/Tests/PythonToolsMockTests/PythonToolsMockTests.csproj
+++ b/Python/Tests/PythonToolsMockTests/PythonToolsMockTests.csproj
@@ -51,6 +51,9 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="EnvDTE, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <EmbedInteropTypes>False</EmbedInteropTypes>
+    </Reference>
     <Reference Include="IronPython">
       <HintPath>$(BuildRoot)Python\Product\IronPython\IronPython.dll</HintPath>
     </Reference>
@@ -109,7 +112,7 @@
     <Reference Include="WindowsBase" />
   </ItemGroup>
   <Choose>
-    <When Condition="$(VSMajorVersion) >= 14">
+    <When Condition="$(VSMajorVersion) &gt;= 14">
       <ItemGroup>
         <Reference Include="Microsoft.VisualStudio.InteractiveWindow">
           <HintPath>$(DevEnvDir)PrivateAssemblies\Microsoft.VisualStudio.InteractiveWindow.dll</HintPath>


### PR DESCRIPTION
Fixes #486 Launch with errors - invisible errors after switching from python 3.x to python 2.x

Clears list of files with errors when changing interpreter.
Fixes missing functionality in MockVs.
Adds test.