### PR TITLE
Fixes #508 Open Command Prompt here doesn't set PATH correctly

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Project/DefaultPythonLauncher.cs
+++ b/Python/Product/PythonTools/PythonTools/Project/DefaultPythonLauncher.cs
@@ -185,7 +185,7 @@ namespace Microsoft.PythonTools.Project {
                 }
             }
 
-            var env = new Dictionary<string, string>(props.GetEnvironment(true));
+            var env = new Dictionary<string, string>(props.GetEnvironment(true), StringComparer.OrdinalIgnoreCase);
             PythonProjectLaunchProperties.MergeEnvironmentBelow(env, null, true);
             if (env.Any()) {
                 //Environment variables should be passed as a
@@ -243,7 +243,7 @@ namespace Microsoft.PythonTools.Project {
             //In order to update environment variables we have to set UseShellExecute to false
             startInfo.UseShellExecute = false;
 
-            var env = new Dictionary<string, string>(props.GetEnvironment(true));
+            var env = new Dictionary<string, string>(props.GetEnvironment(true), StringComparer.OrdinalIgnoreCase);
             PythonProjectLaunchProperties.MergeEnvironmentBelow(env, null, true);
             foreach (var kv in env) {
                 startInfo.EnvironmentVariables[kv.Key] = kv.Value;

--- a/Python/Product/PythonTools/PythonTools/Project/PythonProjectNode.cs
+++ b/Python/Product/PythonTools/PythonTools/Project/PythonProjectNode.cs
@@ -1151,7 +1151,7 @@ namespace Microsoft.PythonTools.Project {
                 );
 
                 var props = PythonProjectLaunchProperties.Create(this);
-                var env = new Dictionary<string, string>(props.GetEnvironment(true));
+                var env = new Dictionary<string, string>(props.GetEnvironment(true), StringComparer.OrdinalIgnoreCase);
 
                 var paths = new List<string>();
                 paths.Add(CommonUtils.GetParent(((IPythonProjectLaunchProperties)this).GetInterpreterPath()));

--- a/Python/Product/PythonTools/PythonTools/WebProject/PythonWebLauncher.cs
+++ b/Python/Product/PythonTools/PythonTools/WebProject/PythonWebLauncher.cs
@@ -438,7 +438,7 @@ namespace Microsoft.PythonTools.Project.Web {
                 UseShellExecute = false
             };
 
-            var env = new Dictionary<string, string>(startInfo.EnvironmentVariables);
+            var env = new Dictionary<string, string>(startInfo.EnvironmentVariables, StringComparer.OrdinalIgnoreCase);
             PythonProjectLaunchProperties.MergeEnvironmentBelow(env, new Dictionary<string, string> {
                 { "SERVER_HOST", "localhost" },
                 { "SERVER_PORT", TestServerPortString }


### PR DESCRIPTION
Fixes #508 Open Command Prompt here doesn't set PATH correctly
Sets the string comparer for environment dictionaries.

I want this for 2.2 because it fixes a regression and is a trivial/safe fix.