### PR TITLE
Auto-list identifier fixes

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Intellisense/IntellisenseController.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/IntellisenseController.cs
@@ -275,13 +275,18 @@ namespace Microsoft.PythonTools.Intellisense {
                 snapshot.TextBuffer,
                 snapshot.CreateTrackingSpan(caretPoint.Value.Position, 0, SpanTrackingMode.EdgeNegative)
             ).GetStatementRange();
-            if (!statement.HasValue) {
+            if (!statement.HasValue || caretPoint.Value <= statement.Value.Start) {
+                return false;
+            }
+
+            var text = new SnapshotSpan(statement.Value.Start, caretPoint.Value).GetText();
+            if (string.IsNullOrEmpty(text)) {
                 return false;
             }
 
             var languageVersion = _bufferParser._parser.InterpreterFactory.Configuration.Version.ToLanguageVersion();
             PythonAst ast;
-            using (var parser = Parser.CreateParser(new StringReader(statement.Value.GetText()), languageVersion, new ParserOptions())) {
+            using (var parser = Parser.CreateParser(new StringReader(text), languageVersion, new ParserOptions())) {
                 ast = parser.ParseSingleStatement();
             }
 
@@ -325,7 +330,10 @@ namespace Microsoft.PythonTools.Intellisense {
             public override bool Walk(AssignmentStatement node) {
                 CanComplete = true;
                 CommitByDefault = true;
-                return base.Walk(node);
+                if (node.Right != null) {
+                    node.Right.Walk(this);
+                }
+                return false;
             }
 
             public override bool Walk(Arg node) {
@@ -370,9 +378,15 @@ namespace Microsoft.PythonTools.Intellisense {
             }
 
             public override bool Walk(ComprehensionFor node) {
-                CanComplete = IsActualExpression(node.List);
-                CommitByDefault = true;
-                return base.Walk(node);
+                if (!IsActualExpression(node.Left) || HasCaret(node.Left)) {
+                    CanComplete = false;
+                    CommitByDefault = false;
+                } else if (IsActualExpression(node.List)) {
+                    CanComplete = true;
+                    CommitByDefault = true;
+                    node.List.Walk(this);
+                }
+                return false;
             }
 
             public override bool Walk(ComprehensionIf node) {
@@ -381,28 +395,40 @@ namespace Microsoft.PythonTools.Intellisense {
                 return base.Walk(node);
             }
 
-            public override bool Walk(ListExpression node) {
+            private bool WalkCollection(Expression node, IEnumerable<Expression> items) {
                 CanComplete = HasCaret(node);
-                CommitByDefault = node.Items.Count > 1;
-                return base.Walk(node);
+                int count = 0;
+                Expression last = null;
+                foreach (var e in items) {
+                    count += 1;
+                    last = e;
+                }
+                if (count == 0) {
+                    CommitByDefault = false;
+                } else if (count == 1) {
+                    last.Walk(this);
+                    CommitByDefault = false;
+                } else {
+                    CommitByDefault = true;
+                    last.Walk(this);
+                }
+                return false;
+            }
+
+            public override bool Walk(ListExpression node) {
+                return WalkCollection(node, node.Items);
             }
 
             public override bool Walk(DictionaryExpression node) {
-                CanComplete = HasCaret(node);
-                CommitByDefault = node.Items.Count > 1;
-                return base.Walk(node);
+                return WalkCollection(node, node.Items);
             }
 
             public override bool Walk(SetExpression node) {
-                CanComplete = HasCaret(node);
-                CommitByDefault = node.Items.Count > 1;
-                return base.Walk(node);
+                return WalkCollection(node, node.Items);
             }
 
             public override bool Walk(TupleExpression node) {
-                CanComplete = HasCaret(node);
-                CommitByDefault = node.Items.Count > 1;
-                return base.Walk(node);
+                return WalkCollection(node, node.Items);
             }
 
             public override bool Walk(ParenthesisExpression node) {
@@ -441,10 +467,25 @@ namespace Microsoft.PythonTools.Intellisense {
                 return base.Walk(node);
             }
 
-            public override bool Walk(ForStatement node) {
-                CanComplete = IsActualExpression(node.List);
-                CommitByDefault = true;
+            public override bool Walk(ExpressionStatement node) {
+                if (node.Expression is TupleExpression) {
+                    node.Expression.Walk(this);
+                    CommitByDefault = false;
+                    return false;
+                }
                 return base.Walk(node);
+            }
+
+            public override bool Walk(ForStatement node) {
+                if (!IsActualExpression(node.Left) || HasCaret(node.Left)) {
+                    CanComplete = false;
+                    CommitByDefault = false;
+                } else if (IsActualExpression(node.List)) {
+                    CanComplete = true;
+                    CommitByDefault = true;
+                    node.List.Walk(this);
+                }
+                return false;
             }
 
             public override bool Walk(IfStatementTest node) {

--- a/Python/Tests/PythonToolsMockTests/EditorTests.cs
+++ b/Python/Tests/PythonToolsMockTests/EditorTests.cs
@@ -321,10 +321,11 @@ namespace PythonToolsMockTests {
             // TODO: Make completions trigger after spaces
             // eg: AutoListTest("[a for a in b]", 1, 3, 9, 12);
 
-            AutoListTest("[a for a in b for c in d if x]", 1, 12, 23, 28);
-            AutoListTest("{a for a in b for c in d if x}", 1, 12, 23, 28);
-            AutoListTest("(a for a in b for c in d if x)", 1, 12, 23, 28);
-            AutoListTest("{a: b for a, b in b for c, d in e if x}", 1, 4, 18, 32, 37);
+            AutoListTest("[a for a in b for c in d if x]", 1, -7, 12, -18, 23, 28);
+            AutoListTest("{a for a in b for c in d if x}", 1, -7, 12, -18, 23, 28);
+            AutoListTest("(a for a in b for c in d if x)", 1, -7, 12, -18, 23, 28);
+            AutoListTest("{a: b for a, b in b for c, d in e if x}", 1, 4, -10, -13, 18, 32, 37);
+            AutoListTest("x = [a for a in b for c in d if x]", -1, 5, -11, 16, -22, 27, 32);
         }
 
         [TestMethod, TestCategory("Mock")]


### PR DESCRIPTION
Fixes #504 Should not auto-commit identifiers when comma-separating on LHS
Fixes #506 Should not be auto-listing identifiers in the `for` part of a complete statement
Updates the expression scanner to only look up to the caret and not take into account the rest of the statement.
Prevents recursing into parts of statements we have already skipped. This was in some cases causing the expression on (for example) a LHS to affect completions on a RHS when there's no point even walking the LHS.

(Personally, I will probably disable this feature for my own use without these fixes. That doesn't necessarily mean it meets the bar - the fact that it's a new feature for this release is the only thing that gives it any chance at all. I believe the change is safe.)