### PR TITLE
Fixes #454 NullReferenceException in CreateOrAddVirtualEnvironment

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Project/PythonProjectNode.cs
+++ b/Python/Product/PythonTools/PythonTools/Project/PythonProjectNode.cs
@@ -1366,7 +1366,7 @@ namespace Microsoft.PythonTools.Project {
 
                 var interpreters = _interpreters;
                 if (interpreters != null) {
-                    factory = _interpreters.GetInterpreterFactories().FirstOrDefault(
+                    factory = interpreters.GetInterpreterFactories().FirstOrDefault(
                         // Description is a localized string, hence CCIC
                         f => description.Equals(f.Description, StringComparison.CurrentCultureIgnoreCase)
                     );


### PR DESCRIPTION
Fixes #454 NullReferenceException in CreateOrAddVirtualEnvironment
Improves (adds) null handling for the _interpreters variable, which is set to null when disposing.