### PR TITLE
Fixes #517 Prevent installation on prerelease versions of VS

### DIFF
--- a/Common/Setup/LaunchConditions.wxs
+++ b/Common/Setup/LaunchConditions.wxs
@@ -65,11 +65,16 @@
 
   <Fragment>
     <Property Id="VS_PRERELEASE" Secure="yes">
-      <?if "$(var.VSTargetVersion)"="12.0" ?>
-      <DirectorySearch Id="VSDevEnvFilePathSearch" Path="[VSINSTALLPATH]">
-        <FileSearch Id="VSDevEnvFileVersionSearch" Name="devenv.exe" MinVersion="12.0.0.0" MaxVersion="12.0.21004.0"/>
-      </DirectorySearch>
-      <?endif ?>
+      <RegistrySearch Id="VSPrereleaseInstallDir" Root="HKLM" Key="Software\Microsoft\VisualStudio\$(var.VSTargetVersion)\Setup\VS" Name="ProductDir" Type="directory">
+        <DirectorySearch Id="VSPrereleaseInstallDir_Common7_IDE" Path="Common7\IDE" Depth="1">
+          <?if "$(var.VSTargetVersion)"="14.0" ?>
+          <!-- TODO: Update MaxVersion when we know the final version number -->
+          <FileSearch Id="VSPrerelease_Common7_IDE_msenv_dll" Name="msenv.dll" MinVersion="14.0.0.0" MaxVersion="14.0.23026.0"/>
+          <?elseif "$(var.VSTargetVersion)"="12.0" ?>
+          <FileSearch Id="VSPrerelease_Common7_IDE_msenv_dll" Name="msenv.dll" MinVersion="12.0.0.0" MaxVersion="12.0.21004.0"/>
+          <?endif ?>
+        </DirectorySearch>
+      </RegistrySearch>
     </Property>
   </Fragment>
 

--- a/Python/Setup/PythonToolsInstaller/Strings10.0.wxl
+++ b/Python/Setup/PythonToolsInstaller/Strings10.0.wxl
@@ -12,7 +12,7 @@
   <String Id="NoExePath">Your version of !(loc.VSProductName) is not supported.  Please install the latest update from http://www.visualstudio.com/.</String>
   <String Id="WDInstallPathButNoExe">Your version of !(loc.WDProductName) is not supported.  Please install the latest update from http://www.visualstudio.com/.</String>
   <String Id="VWDInstallPathButNoExe">Your version of !(loc.VWDProductName) is not supported.  Please install the latest update from http://www.visualstudio.com/.</String>
-  <String Id="VSPrerelease">A pre-release version of !(loc.VSProductName) was detected.  This version of !(loc.ProductName) is not supported on pre-release builds of !(loc.VSProductName).  Please upgrade to !(loc.VSProductName).</String>
+  <String Id="VSPrerelease">A pre-release version of !(loc.VSProductName) was detected that is not supported by Python Tools.  Please upgrade to the final release from http://www.visualstudio.com.</String>
   <String Id="IronPythonToolsInstalled">The IronPython Tools feature of IronPython 2.7 must be uninstalled.  !(loc.ProductName) replaces IronPython Tools and supports all the same features and more.</String>
   <String Id="PTVS15PerUserInstalled">Python Tools 1.5 was installed per-user.  Python Tools 1.5 must be uninstalled via Add\Remove Programs before continuing installation.</String>
   <String Id="NetFx45NotInstalled">The Microsoft .NET Framework 4.5 is required. Please install it from http://go.microsoft.com/fwlink/?LinkId=398711</String>

--- a/Python/Setup/PythonToolsInstaller/Strings10.0.wxl
+++ b/Python/Setup/PythonToolsInstaller/Strings10.0.wxl
@@ -5,8 +5,8 @@
   <String Id="VSProductName">Visual Studio 2010</String>
   <String Id="WDProductName">(unsupported product)</String>
   <String Id="VWDProductName">Visual Web Developer 2010 Express</String>
+  <String Id="ProductDescription">Python Tools for Visual Studio 2010</String>
 
-  <String Id="ProductDescription">!(loc.ProductName) !(loc.ForVisualStudio)</String>
   <String Id="DowngradeErrorMessage">A newer version of !(loc.ProductDescription) is already installed.</String>
   <String Id="NoInstallPath">!(loc.VSProductName) is required.  An installer for other versions of Visual Studio can be downloaded from http://pytools.codeplex.com/.</String>
   <String Id="NoExePath">Your version of !(loc.VSProductName) is not supported.  Please install the latest update from http://www.visualstudio.com/.</String>

--- a/Python/Setup/PythonToolsInstaller/Strings10.0.wxl
+++ b/Python/Setup/PythonToolsInstaller/Strings10.0.wxl
@@ -12,7 +12,7 @@
   <String Id="NoExePath">Your version of !(loc.VSProductName) is not supported.  Please install the latest update from http://www.visualstudio.com/.</String>
   <String Id="WDInstallPathButNoExe">Your version of !(loc.WDProductName) is not supported.  Please install the latest update from http://www.visualstudio.com/.</String>
   <String Id="VWDInstallPathButNoExe">Your version of !(loc.VWDProductName) is not supported.  Please install the latest update from http://www.visualstudio.com/.</String>
-  <String Id="VSPrerelease">A pre-release version of !(loc.VSProductName) was detected that is not supported by Python Tools.  Please upgrade to the final release from http://www.visualstudio.com.</String>
+  <String Id="VSPrerelease">A pre-release version of !(loc.VSProductName) was detected that is not supported by !(loc.ProductName).  Please upgrade to the final release from http://www.visualstudio.com.</String>
   <String Id="IronPythonToolsInstalled">The IronPython Tools feature of IronPython 2.7 must be uninstalled.  !(loc.ProductName) replaces IronPython Tools and supports all the same features and more.</String>
   <String Id="PTVS15PerUserInstalled">Python Tools 1.5 was installed per-user.  Python Tools 1.5 must be uninstalled via Add\Remove Programs before continuing installation.</String>
   <String Id="NetFx45NotInstalled">The Microsoft .NET Framework 4.5 is required. Please install it from http://go.microsoft.com/fwlink/?LinkId=398711</String>

--- a/Python/Setup/PythonToolsInstaller/Strings11.0.wxl
+++ b/Python/Setup/PythonToolsInstaller/Strings11.0.wxl
@@ -12,7 +12,7 @@
   <String Id="NoExePath">Your version of !(loc.VSProductName) is not supported.  Please install the latest update from http://www.visualstudio.com/.</String>
   <String Id="WDInstallPathButNoExe">Your version of !(loc.WDProductName) is not supported.  Please install the latest update from http://www.visualstudio.com/.</String>
   <String Id="VWDInstallPathButNoExe">Your version of !(loc.VWDProductName) is not supported.  Please install the latest update from http://www.visualstudio.com/.</String>
-  <String Id="VSPrerelease">A pre-release version of !(loc.VSProductName) was detected.  This version of !(loc.ProductName) is not supported on pre-release builds of !(loc.VSProductName).  Please upgrade to !(loc.VSProductName).</String>
+  <String Id="VSPrerelease">A pre-release version of !(loc.VSProductName) was detected that is not supported by Python Tools.  Please upgrade to the final release from http://www.visualstudio.com.</String>
   <String Id="IronPythonToolsInstalled">The IronPython Tools feature of IronPython 2.7 must be uninstalled.  !(loc.ProductName) replaces IronPython Tools and supports all the same features and more.</String>
   <String Id="PTVS15PerUserInstalled">Python Tools 1.5 was installed per-user.  Python Tools 1.5 must be uninstalled via Add\Remove Programs before continuing installation.</String>
   <String Id="NetFx45NotInstalled">The Microsoft .NET Framework 4.5 is required. Please install it from http://go.microsoft.com/fwlink/?LinkId=398711</String>

--- a/Python/Setup/PythonToolsInstaller/Strings11.0.wxl
+++ b/Python/Setup/PythonToolsInstaller/Strings11.0.wxl
@@ -5,8 +5,8 @@
   <String Id="VSProductName">Visual Studio 2012</String>
   <String Id="WDProductName">Visual Studio Express 2012 for Desktop</String>
   <String Id="VWDProductName">Visual Studio Express 2012 for Web</String>
+  <String Id="ProductDescription">Python Tools for Visual Studio 2012</String>
 
-  <String Id="ProductDescription">!(loc.ProductName) !(loc.ForVisualStudio)</String>
   <String Id="DowngradeErrorMessage">A newer version of !(loc.ProductDescription) is already installed.</String>
   <String Id="NoInstallPath">!(loc.VSProductName) is required.  An installer for other versions of Visual Studio can be downloaded from http://pytools.codeplex.com/.</String>
   <String Id="NoExePath">Your version of !(loc.VSProductName) is not supported.  Please install the latest update from http://www.visualstudio.com/.</String>

--- a/Python/Setup/PythonToolsInstaller/Strings11.0.wxl
+++ b/Python/Setup/PythonToolsInstaller/Strings11.0.wxl
@@ -12,7 +12,7 @@
   <String Id="NoExePath">Your version of !(loc.VSProductName) is not supported.  Please install the latest update from http://www.visualstudio.com/.</String>
   <String Id="WDInstallPathButNoExe">Your version of !(loc.WDProductName) is not supported.  Please install the latest update from http://www.visualstudio.com/.</String>
   <String Id="VWDInstallPathButNoExe">Your version of !(loc.VWDProductName) is not supported.  Please install the latest update from http://www.visualstudio.com/.</String>
-  <String Id="VSPrerelease">A pre-release version of !(loc.VSProductName) was detected that is not supported by Python Tools.  Please upgrade to the final release from http://www.visualstudio.com.</String>
+  <String Id="VSPrerelease">A pre-release version of !(loc.VSProductName) was detected that is not supported by !(loc.ProductName).  Please upgrade to the final release from http://www.visualstudio.com.</String>
   <String Id="IronPythonToolsInstalled">The IronPython Tools feature of IronPython 2.7 must be uninstalled.  !(loc.ProductName) replaces IronPython Tools and supports all the same features and more.</String>
   <String Id="PTVS15PerUserInstalled">Python Tools 1.5 was installed per-user.  Python Tools 1.5 must be uninstalled via Add\Remove Programs before continuing installation.</String>
   <String Id="NetFx45NotInstalled">The Microsoft .NET Framework 4.5 is required. Please install it from http://go.microsoft.com/fwlink/?LinkId=398711</String>

--- a/Python/Setup/PythonToolsInstaller/Strings12.0.wxl
+++ b/Python/Setup/PythonToolsInstaller/Strings12.0.wxl
@@ -13,7 +13,7 @@
   <String Id="WDInstallPathButNoExe">Your version of !(loc.WDProductName) is not supported.  Please install the latest update from http://www.visualstudio.com/.</String>
   <String Id="VWDInstallPathButNoExe">Your version of !(loc.VWDProductName) is not supported.  Please install the latest update from http://www.visualstudio.com/.</String>
   <String Id="VSPrerelease">A pre-release version of !(loc.VSProductName) was detected that is not supported by !(loc.ProductName).  Please upgrade to the final release from http://www.visualstudio.com.</String>
-  <String Id="IronPythonToolsInstalled">The IronPython Tools feature of IronPython 2.7 must be uninstalled.  Python Tools replaces IronPython Tools and supports all the same features and more.</String>
+  <String Id="IronPythonToolsInstalled">The IronPython Tools feature of IronPython 2.7 must be uninstalled.  !(loc.ProductName) replaces IronPython Tools and supports all the same features and more.</String>
   <String Id="PTVS15PerUserInstalled">Python Tools 1.5 was installed per-user.  Python Tools 1.5 must be uninstalled via Add\Remove Programs before continuing installation.</String>
   <String Id="NetFx45NotInstalled">The Microsoft .NET Framework 4.5 is required. Please install it from http://go.microsoft.com/fwlink/?LinkId=398711</String>
   <String Id="DevEnvSetup">Registering extension in !(loc.VSProductName)...</String>

--- a/Python/Setup/PythonToolsInstaller/Strings12.0.wxl
+++ b/Python/Setup/PythonToolsInstaller/Strings12.0.wxl
@@ -5,8 +5,8 @@
   <String Id="VSProductName">Visual Studio 2013</String>
   <String Id="WDProductName">Visual Studio Express 2013 for Desktop</String>
   <String Id="VWDProductName">Visual Studio Express 2013 for Web</String>
+  <String Id="ProductDescription">Python Tools for Visual Studio 2013</String>
 
-  <String Id="ProductDescription">!(loc.ProductName) !(loc.ForVisualStudio)</String>
   <String Id="DowngradeErrorMessage">A newer version of !(loc.ProductDescription) is already installed.</String>
   <String Id="NoInstallPath">!(loc.VSProductName) is required.  The free !(loc.WDProductName) and !(loc.VWDProductName) editions, as well as the required !(loc.VSProductName) Update 2, can be downloaded from http://www.visualstudio.com/.</String>
   <String Id="NoExePath">Your version of !(loc.VSProductName) is not supported.  Please install the latest update from http://www.visualstudio.com/.</String>

--- a/Python/Setup/PythonToolsInstaller/Strings12.0.wxl
+++ b/Python/Setup/PythonToolsInstaller/Strings12.0.wxl
@@ -12,7 +12,7 @@
   <String Id="NoExePath">Your version of !(loc.VSProductName) is not supported.  Please install the latest update from http://www.visualstudio.com/.</String>
   <String Id="WDInstallPathButNoExe">Your version of !(loc.WDProductName) is not supported.  Please install the latest update from http://www.visualstudio.com/.</String>
   <String Id="VWDInstallPathButNoExe">Your version of !(loc.VWDProductName) is not supported.  Please install the latest update from http://www.visualstudio.com/.</String>
-  <String Id="VSPrerelease">A pre-release version of !(loc.VSProductName) was detected that is not supported by Python Tools.  Please upgrade to the final release from http://www.visualstudio.com.</String>
+  <String Id="VSPrerelease">A pre-release version of !(loc.VSProductName) was detected that is not supported by !(loc.ProductName).  Please upgrade to the final release from http://www.visualstudio.com.</String>
   <String Id="IronPythonToolsInstalled">The IronPython Tools feature of IronPython 2.7 must be uninstalled.  Python Tools replaces IronPython Tools and supports all the same features and more.</String>
   <String Id="PTVS15PerUserInstalled">Python Tools 1.5 was installed per-user.  Python Tools 1.5 must be uninstalled via Add\Remove Programs before continuing installation.</String>
   <String Id="NetFx45NotInstalled">The Microsoft .NET Framework 4.5 is required. Please install it from http://go.microsoft.com/fwlink/?LinkId=398711</String>

--- a/Python/Setup/PythonToolsInstaller/Strings12.0.wxl
+++ b/Python/Setup/PythonToolsInstaller/Strings12.0.wxl
@@ -12,7 +12,7 @@
   <String Id="NoExePath">Your version of !(loc.VSProductName) is not supported.  Please install the latest update from http://www.visualstudio.com/.</String>
   <String Id="WDInstallPathButNoExe">Your version of !(loc.WDProductName) is not supported.  Please install the latest update from http://www.visualstudio.com/.</String>
   <String Id="VWDInstallPathButNoExe">Your version of !(loc.VWDProductName) is not supported.  Please install the latest update from http://www.visualstudio.com/.</String>
-  <String Id="VSPrerelease">A pre-release version of !(loc.VSProductName) was detected.  This version of Python Tools is not supported on pre-release builds of !(loc.VSProductName).  Please upgrade to !(loc.VSProductName).</String>
+  <String Id="VSPrerelease">A pre-release version of !(loc.VSProductName) was detected that is not supported by Python Tools.  Please upgrade to the final release from http://www.visualstudio.com.</String>
   <String Id="IronPythonToolsInstalled">The IronPython Tools feature of IronPython 2.7 must be uninstalled.  Python Tools replaces IronPython Tools and supports all the same features and more.</String>
   <String Id="PTVS15PerUserInstalled">Python Tools 1.5 was installed per-user.  Python Tools 1.5 must be uninstalled via Add\Remove Programs before continuing installation.</String>
   <String Id="NetFx45NotInstalled">The Microsoft .NET Framework 4.5 is required. Please install it from http://go.microsoft.com/fwlink/?LinkId=398711</String>

--- a/Python/Setup/PythonToolsInstaller/Strings14.0.wxl
+++ b/Python/Setup/PythonToolsInstaller/Strings14.0.wxl
@@ -12,8 +12,8 @@
   <String Id="NoExePath">Your version of !(loc.VSProductName) is not supported.  Please install the latest update from http://www.visualstudio.com/.</String>
   <String Id="WDInstallPathButNoExe">Your version of !(loc.WDProductName) is not supported.  Please install the latest update from http://www.visualstudio.com/.</String>
   <String Id="VWDInstallPathButNoExe">Your version of !(loc.VWDProductName) is not supported.  Please install the latest update from http://www.visualstudio.com/.</String>
-  <String Id="VSPrerelease">A pre-release version of !(loc.VSProductName) was detected that is not supported by Python Tools.  Please upgrade to the final release from http://www.visualstudio.com.</String>
-  <String Id="IronPythonToolsInstalled">The IronPython Tools feature of IronPython 2.7 must be uninstalled.  Python Tools replaces IronPython Tools and supports all the same features and more.</String>
+  <String Id="VSPrerelease">A pre-release version of !(loc.VSProductName) was detected that is not supported by !(loc.ProductName).  Please upgrade to the final release from http://www.visualstudio.com.</String>
+  <String Id="IronPythonToolsInstalled">The IronPython Tools feature of IronPython 2.7 must be uninstalled.  !(loc.ProductName) replaces IronPython Tools and supports all the same features and more.</String>
   <String Id="NetFx45NotInstalled">The Microsoft .NET Framework 4.5 is required. Please install it from http://go.microsoft.com/fwlink/?LinkId=398711</String>
   <String Id="DevEnvSetup">Registering extension in !(loc.VSProductName)...</String>
   <String Id="DevEnvSetup_Rollback">Removing extension from !(loc.VSProductName)...</String>

--- a/Python/Setup/PythonToolsInstaller/Strings14.0.wxl
+++ b/Python/Setup/PythonToolsInstaller/Strings14.0.wxl
@@ -5,8 +5,8 @@
   <String Id="VSProductName">Visual Studio 2015</String>
   <String Id="WDProductName">Visual Studio Express 2015 for Desktop</String>
   <String Id="VWDProductName">Visual Studio Express 2015 for Web</String>
+  <String Id="ProductDescription">Python Tools for Visual Studio 2015</String>
 
-  <String Id="ProductDescription">!(loc.ProductName) !(loc.ForVisualStudio)</String>
   <String Id="DowngradeErrorMessage">A newer version of !(loc.ProductDescription) is already installed.</String>
   <String Id="NoInstallPath">!(loc.VSProductName) is required.  The free Community edition can be downloaded from http://www.visualstudio.com/.</String>
   <String Id="NoExePath">Your version of !(loc.VSProductName) is not supported.  Please install the latest update from http://www.visualstudio.com/.</String>

--- a/Python/Setup/PythonToolsInstaller/Strings14.0.wxl
+++ b/Python/Setup/PythonToolsInstaller/Strings14.0.wxl
@@ -12,7 +12,7 @@
   <String Id="NoExePath">Your version of !(loc.VSProductName) is not supported.  Please install the latest update from http://www.visualstudio.com/.</String>
   <String Id="WDInstallPathButNoExe">Your version of !(loc.WDProductName) is not supported.  Please install the latest update from http://www.visualstudio.com/.</String>
   <String Id="VWDInstallPathButNoExe">Your version of !(loc.VWDProductName) is not supported.  Please install the latest update from http://www.visualstudio.com/.</String>
-  <String Id="VSPrerelease">A pre-release version of !(loc.VSProductName) was detected.  This version of Python Tools is not supported on pre-release builds of !(loc.VSProductName).  Please upgrade to !(loc.VSProductName).</String>
+  <String Id="VSPrerelease">A pre-release version of !(loc.VSProductName) was detected that is not supported by Python Tools.  Please upgrade to the final release from http://www.visualstudio.com.</String>
   <String Id="IronPythonToolsInstalled">The IronPython Tools feature of IronPython 2.7 must be uninstalled.  Python Tools replaces IronPython Tools and supports all the same features and more.</String>
   <String Id="NetFx45NotInstalled">The Microsoft .NET Framework 4.5 is required. Please install it from http://go.microsoft.com/fwlink/?LinkId=398711</String>
   <String Id="DevEnvSetup">Registering extension in !(loc.VSProductName)...</String>


### PR DESCRIPTION
Fixes #517 Prevent installation on prerelease versions of VS
Fixes version check to avoid ordering issue.
Improves message.

There'll be one more update to this after the final VS build, but this way we can test the logic against older builds and the later change will be safer.