### PR TITLE
Fix redundant registry values for python exceptions under AD7Metrics\…

### DIFF
--- a/Common/Product/SharedProject/ProvideDebugExceptionAttribute.cs
+++ b/Common/Product/SharedProject/ProvideDebugExceptionAttribute.cs
@@ -87,8 +87,15 @@ namespace Microsoft.VisualStudioTools {
             key.SetValue("Code", _code);
             key.SetValue("State", (int)_state);
 
-            string name = _path.LastOrDefault() ?? "*";
-            engineKey.SetValue(name, (int)(_state & DkmValidFlags));
+            // Debug engine load time can be improved by writing the exception category default 
+            // stop setting and exceptions to the default settings at the exception category reg 
+            // key node. This improves debug engine load time by getting necessary exception stop
+            // settings for the entire category without having to enumerate the entire category 
+            // hive structure when loading the debug engine.
+            string name = _path.LastOrDefault();
+            if (name == null || !BreakByDefault) {
+                engineKey.SetValue(name ?? "*", (int)(_state & DkmValidFlags));
+            }
         }
 
         public override void Unregister(RegistrationAttribute.RegistrationContext context) {


### PR DESCRIPTION
Fix redundant registry values for python exceptions under AD7Metrics\\Exception registry node. 

The ProvideDebugExceptionAttribute Register method was unnecessarily creating python exception default stop settings under the python exception category node, which is used to improve load times of debug engines. 

The intent of having exception stop settings under this node (as opposed to the traditional tree structure used as well) is to specify a default stop setting for the category and then add only the stop settings that are an exception to the category default. This way, when the debug engine loads, it only has to read the minimal number of registry values and does not have to traverse the entire registry hive tree under the exception category node.

This change limits writing exception stop settings to 1) the category default and 2) any exception to the category default.

This does not affect default exception settings shown in the Exception Settings window. Only affects exception settings read when debug engine initially loads (when the Exception Settings window has not loaded yet).

Built PythonTools and verified resultant pkgdef file matches expected value. 
Verified correct behavior by manually testing debugging a python app which raises exception. Debugger breaks on exception as expected.