### PR TITLE
Some minor fixes

### DIFF
--- a/Python/Product/Analysis/Interpreter/IPythonInterpreterFactoryWithDatabase.cs
+++ b/Python/Product/Analysis/Interpreter/IPythonInterpreterFactoryWithDatabase.cs
@@ -85,8 +85,8 @@ namespace Microsoft.PythonTools.Interpreter {
 
     public interface IPythonInterpreterFactoryWithDatabase2 : IPythonInterpreterFactoryWithDatabase {
         /// <summary>
-        /// Returns a list of module names that are causing the database to
-        /// appear out of date.
+        /// Returns a list of module names that appear to have current entries
+        /// in the database.
         /// </summary>
         IEnumerable<string> GetUpToDateModules();
     }

--- a/Python/Product/PythonTools/Dev14OrLater/source.extension.vsixmanifest
+++ b/Python/Product/PythonTools/Dev14OrLater/source.extension.vsixmanifest
@@ -19,8 +19,8 @@
   </Installation>
   <Dependencies>
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" Version="4.5" />
-    <Dependency Id="TestWindow.Microsoft.0771d463-d74d-4e95-aac2-39d3c7ec1f97" IsRequired="false" DisplayName="Test Explorer" Version="11.0" />
-    <Dependency Id="1F42C6D0-F876-4AF0-8185-1BEB0A325BB2" IsRequired="true" DisplayName="VisualStudio Interactive Components" Version="42.42.42.42" />
+    <Dependency IsRequired="false" Version="[14.0,15.0)" d:Source="Installed" Id="TestWindow.Microsoft.0771d463-d74d-4e95-aac2-39d3c7ec1f97" DisplayName="Test Explorer" />
+    <Dependency d:Source="Installed" Id="1F42C6D0-F876-4AF0-8185-1BEB0A325BB2" DisplayName="VisualStudio Interactive Components" Version="[1.0.0.50618,2.0)" />
   </Dependencies>
   <Assets>
     <Asset Type="Microsoft.VisualStudio.Package" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
@@ -28,6 +28,7 @@
     <Asset Type="Microsoft.VisualStudio.Assembly" Path="|Microsoft.PythonTools.Analysis;_GetTargetPath|" AssemblyName="|Microsoft.PythonTools.Analysis;_GetAssemblyName|" />
     <Asset Type="Microsoft.VisualStudio.Assembly" Path="|Microsoft.PythonTools.BuildTasks;_GetTargetPath|" AssemblyName="|Microsoft.PythonTools.BuildTasks;_GetAssemblyName|" />
     <Asset Type="Microsoft.VisualStudio.Assembly" Path="|Microsoft.PythonTools.Debugger;_GetTargetPath|" AssemblyName="|Microsoft.PythonTools.Debugger;_GetAssemblyName|" />
+    <Asset Type="Microsoft.VisualStudio.Assembly" Path="|Microsoft.PythonTools.EnvironmentsList;_GetTargetPath|" AssemblyName="|Microsoft.PythonTools.EnvironmentsList;_GetAssemblyName|" />
     <Asset Type="Microsoft.VisualStudio.Assembly" Path="|ImportWizard;_GetTargetPath|" AssemblyName="|ImportWizard;AssemblyName|" />
     <Asset Type="Microsoft.VisualStudio.Assembly" Path="|ProjectWizards;_GetTargetPath|" AssemblyName="|ProjectWizards;AssemblyName|" />
     <Asset Type="Microsoft.VisualStudio.Assembly" Path="|Microsoft.PythonTools.VSInterpreters;_GetTargetPath|" AssemblyName="|Microsoft.PythonTools.VSInterpreters;_GetAssemblyName|" />

--- a/Python/Product/PythonTools/PythonTools/Navigation/PythonLanguageInfo.cs
+++ b/Python/Product/PythonTools/PythonTools/Navigation/PythonLanguageInfo.cs
@@ -36,11 +36,9 @@ namespace Microsoft.PythonTools.Navigation {
     [Guid(GuidList.guidPythonLanguageService)]
     internal sealed class PythonLanguageInfo : IVsLanguageInfo, IVsLanguageDebugInfo {
         private readonly IServiceProvider _serviceProvider;
-        private readonly IComponentModel _componentModel;
 
         public PythonLanguageInfo(IServiceProvider serviceProvider) {
             _serviceProvider = serviceProvider;
-            _componentModel = serviceProvider.GetService(typeof(SComponentModel)) as IComponentModel;
         }
 
         public int GetCodeWindowManager(IVsCodeWindow pCodeWin, out IVsCodeWindowManager ppCodeWinMgr) {


### PR DESCRIPTION
Fixes API comment.
Fixes vsixmanifest.
Removes unnecessary reference to IComponentModel.

The last one has been triggering the MEF dialog on open. It'll be triggered by something eventually, but better that it isn't us, especially since we're loading on startup.