### PR TITLE
Environments window extensibility

### DIFF
--- a/Python/Product/EnvironmentsList/EnvironmentsList.csproj
+++ b/Python/Product/EnvironmentsList/EnvironmentsList.csproj
@@ -226,6 +226,7 @@
     <Compile Include="DBExtension.xaml.cs">
       <DependentUpon>DBExtension.xaml</DependentUpon>
     </Compile>
+    <Compile Include="IEnvironmentViewExtensionProvider.cs" />
     <Compile Include="Pep440Version.cs" />
     <Compile Include="PipExtension.xaml.cs">
       <DependentUpon>PipExtension.xaml</DependentUpon>

--- a/Python/Product/EnvironmentsList/IEnvironmentViewExtensionProvider.cs
+++ b/Python/Product/EnvironmentsList/IEnvironmentViewExtensionProvider.cs
@@ -1,0 +1,19 @@
+﻿/* ****************************************************************************
+ *
+ * Copyright (c) Microsoft Corporation. 
+ *
+ * This source code is subject to terms and conditions of the Apache License, Version 2.0. A 
+ * copy of the license can be found in the License.html file at the root of this distribution. If 
+ * you cannot locate the Apache License, Version 2.0, please send an email to 
+ * vspython@microsoft.com. By using this source code in any fashion, you are agreeing to be bound 
+ * by the terms of the Apache License, Version 2.0.
+ *
+ * You must not remove this notice, or any other, from this software.
+ *
+ * ***************************************************************************/
+
+namespace Microsoft.PythonTools.EnvironmentsList {
+    public interface IEnvironmentViewExtensionProvider {
+        IEnvironmentViewExtension CreateExtension(EnvironmentView view);
+    }
+}

--- a/Python/Product/PythonTools/Dev14OrLater/source.extension.vsixmanifest
+++ b/Python/Product/PythonTools/Dev14OrLater/source.extension.vsixmanifest
@@ -34,6 +34,7 @@
     <Asset Type="Microsoft.VisualStudio.MefComponent" Path="|%CurrentProject%;_GetTargetPath|" />
     <Asset Type="Microsoft.VisualStudio.MefComponent" Path="|Microsoft.PythonTools.Analysis;_GetTargetPath|" />
     <Asset Type="Microsoft.VisualStudio.MefComponent" Path="|Microsoft.PythonTools.Debugger;_GetTargetPath|" />
+    <Asset Type="Microsoft.VisualStudio.MefComponent" Path="|Microsoft.PythonTools.EnvironmentsList;_GetTargetPath|" />
     <Asset Type="Microsoft.VisualStudio.MefComponent" Path="|Microsoft.PythonTools.VSInterpreters;_GetTargetPath|" />
     <Asset Type="Microsoft.VisualStudio.MefComponent" Path="|TestAdapter;_GetTargetPath|" />
     <Asset Type="UnitTestExtension" Path="|TestAdapter;_GetTargetPath|" />

--- a/Python/Product/PythonTools/Properties/AssemblyInfo.cs
+++ b/Python/Product/PythonTools/Properties/AssemblyInfo.cs
@@ -17,6 +17,8 @@ using System.Reflection;
 using System.Resources;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using Microsoft.VisualStudio.Shell;
+
 
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
@@ -28,6 +30,10 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 [assembly: CLSCompliant(false)]
 [assembly: NeutralResourcesLanguage("en-US")]
+
+[assembly: ProvideCodeBase(AssemblyName = "Microsoft.PythonTools.Analysis", CodeBase = "Microsoft.PythonTools.Analysis.dll", Version = AssemblyVersionInfo.StableVersion)]
+[assembly: ProvideCodeBase(AssemblyName = "Microsoft.PythonTools.EnvironmentsList", CodeBase = "Microsoft.PythonTools.EnvironmentsList.dll", Version = AssemblyVersionInfo.StableVersion)]
+[assembly: ProvideCodeBase(AssemblyName = "Microsoft.PythonTools.VSInterpreters", CodeBase = "Microsoft.PythonTools.VSInterpreters.dll", Version = AssemblyVersionInfo.StableVersion)]
 
 [assembly: InternalsVisibleTo("Microsoft.PythonTools.TestAdapter, PublicKey=002400000480000094000000060200000024000052534131000400000100010007d1fa57c4aed9f0a32e84aa0faefd0de9e8fd6aec8f87fb03766c834c99921eb23be79ad9d5dcc1dd9ad236132102900b723cf980957fc4e177108fc607774f29e8320e92ea05ece4e821c0a5efe8f1645c4c0c93c1ab99285d622caa652c1dfad63d745d6f2de5f17e5eaf0fc4963d261c8a12436518206dc093344d5ad293")]
 

--- a/Python/Product/PythonTools/PythonTools.csproj
+++ b/Python/Product/PythonTools/PythonTools.csproj
@@ -76,6 +76,7 @@
       <Project>{b20e082b-4d3c-457d-b2bd-60420b434573}</Project>
       <Name>Microsoft.PythonTools.EnvironmentsList</Name>
       <IncludeInVSIX>True</IncludeInVSIX>
+      <Private>False</Private>
     </ProjectReference>
     <ProjectReference Include="..\VSInterpreters\VSInterpreters.csproj">
       <Project>{815db0cd-c0dd-4997-b43c-abee4dbeffe7}</Project>
@@ -1433,5 +1434,19 @@
         <Link>images\%(_ImageResources.Filename)%(_ImageResources.Extension)</Link>
       </Resource>
     </ItemGroup>
+  </Target>
+
+  <!-- We build these assemblies into separate folders to avoid incremental cleaning issues,
+       but then CreatePkgDef can't find them for the ProvideCodeBase attributes. So we copy
+       into the PythonTools output folder temporarily to generate the pkgdef file. -->
+  <Target Name="_CopyForCreatePkgDef" BeforeTargets="GeneratePkgDef">
+    <Copy SourceFiles="$(OutputPath)..\Analysis\Microsoft.PythonTools.Analysis.dll;
+                       $(OutputPath)..\EnvironmentsList\Microsoft.PythonTools.EnvironmentsList.dll;
+                       $(OutputPath)..\VSInterpreters\Microsoft.PythonTools.VSInterpreters.dll" DestinationFolder="$(OutputPath)">
+      <Output TaskParameter="CopiedFiles" ItemName="_CopiedForCreatePkgdef" />
+    </Copy>
+  </Target>
+  <Target Name="_DeleteAfterCreatePkgDef" AfterTargets="GeneratePkgDef">
+    <Delete Files="@(_CopiedForCreatePkgdef)" />
   </Target>
 </Project>

--- a/Python/Product/PythonTools/PythonTools/InterpreterList/InterpreterListToolWindow.cs
+++ b/Python/Product/PythonTools/PythonTools/InterpreterList/InterpreterListToolWindow.cs
@@ -125,6 +125,39 @@ namespace Microsoft.PythonTools.InterpreterList {
             if (_withDb != null) {
                 view.Extensions.Add(new DBExtensionProvider(_withDb));
             }
+
+            var model = _site.GetComponentModel();
+            if (model != null) {
+                try {
+                    foreach (var provider in model.GetExtensions<IEnvironmentViewExtensionProvider>()) {
+                        try {
+                            var ext = provider.CreateExtension(view);
+                            if (ext != null) {
+                                view.Extensions.Add(ext);
+                            }
+                        } catch (Exception ex) {
+                            LogLoadException(provider, ex);
+                        }
+                    }
+                } catch (Exception ex2) {
+                    LogLoadException(null, ex2);
+                }
+            }
+        }
+
+        private static void LogLoadException(IEnvironmentViewExtensionProvider provider, Exception ex) {
+            string message;
+            if (provider == null) {
+                message = SR.GetString(SR.ErrorLoadingEnvironmentViewExtensions, ex);
+            } else {
+                message = SR.GetString(SR.ErrorLoadingEnvironmentViewExtension, provider.GetType().FullName, ex);
+            }
+
+            Debug.Fail(message);
+            try {
+                ActivityLog.LogError(SR.ProductName, message);
+            } catch (InvalidOperationException) {
+            }
         }
 
         private void PipExtensionProvider_GetElevateSetting(object sender, ValueEventArgs<bool> e) {

--- a/Python/Product/PythonTools/PythonTools/InterpreterList/InterpreterListToolWindow.cs
+++ b/Python/Product/PythonTools/PythonTools/InterpreterList/InterpreterListToolWindow.cs
@@ -145,7 +145,7 @@ namespace Microsoft.PythonTools.InterpreterList {
             }
         }
 
-        private static void LogLoadException(IEnvironmentViewExtensionProvider provider, Exception ex) {
+        private void LogLoadException(IEnvironmentViewExtensionProvider provider, Exception ex) {
             string message;
             if (provider == null) {
                 message = SR.GetString(SR.ErrorLoadingEnvironmentViewExtensions, ex);
@@ -154,9 +154,13 @@ namespace Microsoft.PythonTools.InterpreterList {
             }
 
             Debug.Fail(message);
-            try {
-                ActivityLog.LogError(SR.ProductName, message);
-            } catch (InvalidOperationException) {
+            var log = _site.GetService(typeof(SVsActivityLog)) as IVsActivityLog;
+            if (log != null) {
+                log.LogEntry(
+                    (uint)__ACTIVITYLOG_ENTRYTYPE.ALE_ERROR,
+                    SR.ProductName,
+                    message
+                );
             }
         }
 

--- a/Python/Product/PythonTools/PythonTools/Project/ProjectResources.cs
+++ b/Python/Product/PythonTools/PythonTools/Project/ProjectResources.cs
@@ -185,6 +185,9 @@ namespace Microsoft.PythonTools.Project {
         public const string InsertSnippet = "InsertSnippet";
         public const string SurroundWith = "SurroundWith";
 
+        public const string ErrorLoadingEnvironmentViewExtensions = "ErrorLoadingEnvironmentViewExtensions";
+        public const string ErrorLoadingEnvironmentViewExtension = "ErrorLoadingEnvironmentViewExtension";
+
         private static readonly Lazy<ResourceManager> _manager = new Lazy<ResourceManager>(
             () => new System.Resources.ResourceManager("Microsoft.PythonTools.Resources", typeof(SR).Assembly),
             LazyThreadSafetyMode.ExecutionAndPublication

--- a/Python/Product/PythonTools/Resources.resx
+++ b/Python/Product/PythonTools/Resources.resx
@@ -576,4 +576,12 @@ Packages that cannot be installed using pip may prevent all listed packages from
   <data name="ImportWizardUwpProjectCustomization" xml:space="preserve">
     <value>Python UWP Project</value>
   </data>
+  <data name="ErrorLoadingEnvironmentViewExtension" xml:space="preserve">
+    <value>An error occurred loading '{0}' for the environments window.
+{1}</value>
+  </data>
+  <data name="ErrorLoadingEnvironmentViewExtensions" xml:space="preserve">
+    <value>An error occurred loading extensions for the environments window.
+{1}</value>
+  </data>
 </root>


### PR DESCRIPTION
Adds extensibility point to allow other VS extensions to provide panes in the environments list.

This may be used to provide conda or other package-related extensions independently of PTVS, simply by exposing a MEF component for `IEnvironmentViewExtensionProvider`.