### PR TITLE
Fixes #542 Microsoft ptvs and db completion doesn't work for python 3.4 64 bit

### DIFF
--- a/Python/Product/Analysis/Analyzer/FunctionAnalysisUnit.cs
+++ b/Python/Product/Analysis/Analyzer/FunctionAnalysisUnit.cs
@@ -150,8 +150,15 @@ namespace Microsoft.PythonTools.Analysis.Analyzer {
                                 nextExpr = _decoratorCalls[d] = new CallExpression(d, new[] { new Arg(expr) });
                             }
                             expr = nextExpr;
-                            var decorated = decorator.Call(expr, this, new[] { types }, ExpressionEvaluator.EmptyNames);
-
+                            var decorated = AnalysisSet.Empty;
+                            foreach (var ns in decorator) {
+                                var fd = ns as FunctionInfo;
+                                if (fd != null && Scope.EnumerateTowardsGlobal.Any(s => s.AnalysisValue == fd)) {
+                                    continue;
+                                }
+                                decorated = decorated.Union(ns.Call(expr, this, new[] { types }, ExpressionEvaluator.EmptyNames));
+                            }
+                            
                             // If processing decorators, update the current
                             // function type. Otherwise, we are acting as if
                             // each decorator returns the function unmodified.

--- a/Python/Product/AnalysisMemoryTester/AnalysisMemoryTester.csproj
+++ b/Python/Product/AnalysisMemoryTester/AnalysisMemoryTester.csproj
@@ -80,7 +80,17 @@
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>
-  <Target Name="AfterBuild">
-  </Target>
   -->
+  <Target Name="AfterBuild">
+    <MakeDir Directories="$(OutputPath)\CompletionDB" />
+
+    <ItemGroup>
+      <_CompletionDB Include="$(BuildRoot)Python\Product\Analyzer\CompletionDB\*.idb" />
+    </ItemGroup>
+    
+    <Copy SourceFiles="@(_CompletionDB)"
+          DestinationFolder="$(OutputPath)\CompletionDB"
+          OverwriteReadOnlyFiles="true"
+          SkipUnchangedFiles="true" />
+  </Target>
 </Project>

--- a/Python/Tests/Analysis/AnalysisTest.cs
+++ b/Python/Tests/Analysis/AnalysisTest.cs
@@ -6583,6 +6583,28 @@ async def f():
         }
 
 
+        [TestMethod, Priority(0)]
+        public void RecursiveDecorators() {
+            // See https://github.com/Microsoft/PTVS/issues/542
+            // Should not crash/OOM
+            var code = @"
+def f():
+    def d(fn):
+        @f()
+        def g(): pass
+
+    return d
+";
+
+            var cancelAt = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+            try {
+                var entry = ProcessText(code, cancel: cancelAt.Token);
+            } catch (OperationCanceledException) {
+            }
+            if (cancelAt.IsCancellationRequested) {
+                Assert.Fail("Failed to complete within 10 seconds");
+            }
+        }
 
         #endregion
 

--- a/Python/Tests/Analysis/BaseAnalysisTest.cs
+++ b/Python/Tests/Analysis/BaseAnalysisTest.cs
@@ -124,12 +124,17 @@ namespace AnalysisTests {
             return state;
         }
 
-        public ModuleAnalysis ProcessText(string text, PythonLanguageVersion version = PythonLanguageVersion.V27, string[] analysisDirs = null) {
+        public ModuleAnalysis ProcessText(
+            string text,
+            PythonLanguageVersion version = PythonLanguageVersion.V27,
+            string[] analysisDirs = null,
+            CancellationToken cancel = default(CancellationToken)
+        ) {
             var sourceUnit = GetSourceUnit(text, "fob");
             var state = CreateAnalyzer(version, analysisDirs);
             var entry = state.AddModule("fob", "fob", null);
             Prepare(entry, sourceUnit, version);
-            entry.Analyze(CancellationToken.None);
+            entry.Analyze(cancel);
 
             return entry.Analysis;
         }


### PR DESCRIPTION
Fixes #542 Microsoft ptvs and db completion doesn't work for python 3
Skips invoking decorators that are defined by outer functions.

Also improves AnalysisMemoryTester build.