### PR TITLE
Fixes #561 Hang stopping debugging

### DIFF
--- a/Python/Product/Debugger/Debugger/PythonProcess.cs
+++ b/Python/Product/Debugger/Debugger/PythonProcess.cs
@@ -209,6 +209,8 @@ namespace Microsoft.PythonTools.Debugger {
         }
 
         void _process_Exited(object sender, EventArgs e) {
+            // TODO: Abort all pending operations
+
             if (!_sentExited) {
                 _sentExited = true;
                 var exited = ProcessExited;


### PR DESCRIPTION
Fixes #561 Hang stopping debugging
Adds a timeout for getting breakpoint hit counts so that we don't freeze the UI for too long when stopping debugging.
Also adds a TODO for the post-2.2 fix.