### PR TITLE
Fixes #562 IndexOutOfRangeException in AnalysisDictionary

### DIFF
--- a/Python/Product/Analysis/AnalysisDictionary.cs
+++ b/Python/Product/Analysis/AnalysisDictionary.cs
@@ -224,6 +224,12 @@ namespace Microsoft.PythonTools.Analysis {
                 }
             }
 
+            Debug.Assert(
+                addIndex >= 0,
+                "addIndex was not found while scanning buckets. This normally indicates a race condition - " +
+                "AnalysisDictionary does not support simultaneous mutations."
+            );
+
             buckets[addIndex].HashCode = hc;
             buckets[addIndex].Value = value;
             Thread.MemoryBarrier();

--- a/Python/Product/Analysis/Values/ModuleInfo.cs
+++ b/Python/Product/Analysis/Values/ModuleInfo.cs
@@ -222,9 +222,13 @@ namespace Microsoft.PythonTools.Analysis.Values {
             // Must unconditionally call the base implementation of GetMember
             var ignored = base.GetMember(node, unit, name);
 
-            ModuleDefinition.AddDependency(unit);
-
-            return Scope.CreateEphemeralVariable(node, unit, name).Types;
+            if (unit.ForEval) {
+                VariableDef value;
+                return Scope.TryGetVariable(name, out value) ? value.Types : AnalysisSet.Empty;
+            } else {
+                ModuleDefinition.AddDependency(unit);
+                return Scope.CreateEphemeralVariable(node, unit, name).Types;
+            }
         }
 
         public override void SetMember(Node node, AnalysisUnit unit, string name, IAnalysisSet value) {


### PR DESCRIPTION
Fixes #562 IndexOutOfRangeException in AnalysisDictionary
Avoids mutating the module members dictionary from the UI thread.
Adds a debug assertion to identify this case sooner (shortly before crashing...).