### PR TITLE
Fixes #584 User prompts do not override IPython prompts

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Repl/BasePythonReplEvaluator.cs
+++ b/Python/Product/PythonTools/PythonTools/Repl/BasePythonReplEvaluator.cs
@@ -224,15 +224,26 @@ namespace Microsoft.PythonTools.Repl {
             internal string _userPrompt1, _userPrompt2;
 #endif
 
-            public CommandProcessorThread(BasePythonReplEvaluator evaluator, Stream stream, bool redirectOutput, Process process) {
+            private CommandProcessorThread(BasePythonReplEvaluator evaluator) {
                 _eval = evaluator;
+                var options = _eval._options;
+                if (options == null || options.UseInterpreterPrompts) {
+                    _userPrompt1 = _userPrompt2 = null;
+                } else {
+                    _userPrompt1 = options.PrimaryPrompt;
+                    _userPrompt2 = options.SecondaryPrompt;
+                }
+            }
+
+            public CommandProcessorThread(BasePythonReplEvaluator evaluator, Stream stream, bool redirectOutput, Process process)
+                : this(evaluator) {
                 _stream = stream;
                 _process = process;
                 StartOutputThread(redirectOutput);
             }
 
-            public CommandProcessorThread(BasePythonReplEvaluator evaluator, Socket listenerSocket, bool redirectOutput, Process process) {
-                _eval = evaluator;
+            public CommandProcessorThread(BasePythonReplEvaluator evaluator, Socket listenerSocket, bool redirectOutput, Process process)
+                : this(evaluator){
                 _listenerSocket = listenerSocket;
                 _process = process;
                 StartOutputThread(redirectOutput);

--- a/Python/Tests/ReplWindowUITests/ReplWindowPythonSmokeTests.cs
+++ b/Python/Tests/ReplWindowUITests/ReplWindowPythonSmokeTests.cs
@@ -50,12 +50,17 @@ namespace ReplWindowUITests {
             }
 
             if (enableAttach != s.EnableAttach) {
-                s = s.Clone();
+                s = object.ReferenceEquals(s, Settings) ? s.Clone() : s;
                 s.EnableAttach = enableAttach;
             }
             if (addNewLineAtEndOfFullyTypedWord != s.AddNewLineAtEndOfFullyTypedWord) {
-                s = s.Clone();
+                s = object.ReferenceEquals(s, Settings) ? s.Clone() : s;
                 s.AddNewLineAtEndOfFullyTypedWord = addNewLineAtEndOfFullyTypedWord;
+            }
+            if (useIPython) {
+                s = object.ReferenceEquals(s, Settings) ? s.Clone() : s;
+                s.PrimaryPrompt = ">>> ";
+                s.UseInterpreterPrompts = false;
             }
 
             return ReplWindowProxy.Prepare(s, useIPython: useIPython);


### PR DESCRIPTION
Fixes #584 User prompts do not override IPython prompts
Ensures prompt variables are initialized whenever a new command thread is created.