### PR TITLE
Fixes #616 Visual Studio runs out of memory

### DIFF
--- a/Common/Product/ReplWindow/Repl/OutputBuffer.cs
+++ b/Common/Product/ReplWindow/Repl/OutputBuffer.cs
@@ -195,10 +195,9 @@ namespace Microsoft.VisualStudio.Repl {
                             break;
                         }
                     }
-
-                    escape = text.IndexOf('\x1b', escape + 1);
                 }// else not an escape sequence, process as text
 
+                escape = text.IndexOf('\x1b', escape + 1);
             } while (escape != -1);
             if (start != text.Length) {
                 AppendText(text.Substring(start), kind, color);

--- a/Common/Tests/Utilities.UI/UI/ReplWindowProxy.cs
+++ b/Common/Tests/Utilities.UI/UI/ReplWindowProxy.cs
@@ -333,11 +333,19 @@ namespace TestUtilities.UI {
             // Resplit lines to handle cases where linebreaks are embedded in
             // a single string. This helps ensure the comparison is correct and
             // the output is sensible.
-            expected = expected.SelectMany(l => l.Split('\n')).Select(l => l.TrimEnd('\r', '\n')).ToList();
-            var lines = Window.TextView.TextBuffer.CurrentSnapshot.Lines;
+            expected = expected.SelectMany(l => l.Split('\n')).Select(l => l.TrimEnd('\r', '\n', ' ')).ToList();
+            var snapshot = Window.TextView.TextBuffer.CurrentSnapshot;
+            var lines = snapshot.Lines;
+            // Cap the number of lines we'll ever look at to avoid breaking here
+            // when tests get stuck in infinite loops
+            if (matchAtStart && !matchAtEnd) {
+                lines = lines.Take(expected.Count + 1);
+            } else if (!matchAtStart && matchAtEnd) {
+                lines = lines.Skip(snapshot.LineCount - expected.Count - 2);
+            }
             var actual = lines
                 .SelectMany(l => l.GetText().Split('\n'))
-                .Select(l => l.TrimEnd('\r', '\n'))
+                .Select(l => l.TrimEnd('\r', '\n', ' '))
                 .ToList();
 
             bool isMatch = true;

--- a/Common/Tests/Utilities/Mocks/MockReplWindow.cs
+++ b/Common/Tests/Utilities/Mocks/MockReplWindow.cs
@@ -242,10 +242,9 @@ namespace TestUtilities.Mocks {
                             break;
                         }
                     }
-
-                    escape = text.IndexOf('\x1b', escape + 1);
                 }// else not an escape sequence, process as text
 
+                escape = text.IndexOf('\x1b', escape + 1);
             } while (escape != -1);
             if (start != text.Length - 1) {
                 _output.Append(text.Substring(start));

--- a/Python/Product/PythonTools/PythonTools/Repl/BasePythonReplEvaluator.cs
+++ b/Python/Product/PythonTools/PythonTools/Repl/BasePythonReplEvaluator.cs
@@ -2035,9 +2035,9 @@ namespace Microsoft.PythonTools.Repl {
                             break;
                         }
                     }
-
-                    escape = text.IndexOf('\x1b', escape + 1);
                 }// else not an escape sequence, process as text
+
+                escape = text.IndexOf('\x1b', escape + 1);
             }
 
             if (start != text.Length) {

--- a/Python/Tests/ReplWindowUITests/ReplWindowPythonSmokeTests.cs
+++ b/Python/Tests/ReplWindowUITests/ReplWindowPythonSmokeTests.cs
@@ -12,6 +12,8 @@
  *
  * ***************************************************************************/
 
+using System;
+using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading;
 using Microsoft.PythonTools;
@@ -145,6 +147,20 @@ namespace ReplWindowUITests {
                 interactive.SubmitCode("42");
 
                 interactive.WaitForTextEnd(">42", "42", ">");
+            }
+        }
+
+        [TestMethod, Priority(0)]
+        [HostType("VSTestHost")]
+        public virtual void PrintAllCharacters() {
+            using (var interactive = Prepare()) {
+                interactive.SubmitCode("print(\"" +
+                    string.Join("", Enumerable.Range(0, 256).Select(i => string.Format("\\x{0:X2}", i))) +
+                    "\\nDONE\")",
+                    timeout: TimeSpan.FromSeconds(10.0)
+                );
+
+                interactive.WaitForTextEnd("DONE", ">");
             }
         }
 


### PR DESCRIPTION
Fixes #616 Visual Studio runs out of memory
Moves "escape" update outside of condition to ensure we always advance even when colour codes are invalid.
Adds test for printing all characters.