### PR TITLE
Fixes #603 IronPython: Must remove paths from "Search Paths" and put …

### DIFF
--- a/Python/Product/IronPython/Interpreter/IronPythonInterpreter.cs
+++ b/Python/Product/IronPython/Interpreter/IronPythonInterpreter.cs
@@ -158,6 +158,7 @@ namespace Microsoft.IronPythonTools.Interpreter {
 
             if (_state != null) {
                 _state.AnalysisDirectoriesChanged += AnalysisDirectoryChanged;
+                AnalysisDirectoryChanged(_state, EventArgs.Empty);
             }
         }
 

--- a/Python/Tests/TestData/AssemblyReference/PythonApplication/Program3.py
+++ b/Python/Tests/TestData/AssemblyReference/PythonApplication/Program3.py
@@ -1,0 +1,15 @@
+print('Hello World')
+import clr
+clr.AddReference('ClassLibrary3')
+
+from ClassLibrary1 import Class1
+a = Class1().X
+
+
+
+
+
+
+
+
+

--- a/Python/Tests/TestData/AssemblyReference/PythonApplication/PythonApplicationSearchPathReference.pyproj
+++ b/Python/Tests/TestData/AssemblyReference/PythonApplication/PythonApplicationSearchPathReference.pyproj
@@ -1,0 +1,42 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{7498888e-013b-4825-bd68-0b37e1d0e15c}</ProjectGuid>
+    <ProjectHome>.</ProjectHome>
+    <StartupFile>Program.py</StartupFile>
+    <SearchPath>Assemblies</SearchPath>
+    <WorkingDirectory>.</WorkingDirectory>
+    <OutputPath>.</OutputPath>
+    <Name>PythonApplication3</Name>
+    <RootNamespace>PythonApplication3</RootNamespace>
+    <IsWindowsApplication>False</IsWindowsApplication>
+    <InterpreterId>80659ab7-4d53-4e0c-8588-a766116cbd46</InterpreterId>
+    <InterpreterVersion>2.7</InterpreterVersion>
+    <LaunchProvider>Standard Python launcher</LaunchProvider>
+    <CommandLineArguments />
+    <InterpreterPath />
+    <InterpreterArguments />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
+    <DebugSymbols>true</DebugSymbols>
+    <EnableUnmanagedDebugging>false</EnableUnmanagedDebugging>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+    <DebugSymbols>true</DebugSymbols>
+    <EnableUnmanagedDebugging>false</EnableUnmanagedDebugging>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Program3.py" />
+  </ItemGroup>
+  <ItemGroup>
+    <InterpreterReference Include="{80659ab7-4d53-4e0c-8588-a766116cbd46}\2.7" />
+  </ItemGroup>
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
+    <PtvsTargetsFile>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\Python Tools\Microsoft.PythonTools.targets</PtvsTargetsFile>
+  </PropertyGroup>
+  <Import Condition="Exists($(PtvsTargetsFile))" Project="$(PtvsTargetsFile)" />
+  <Import Condition="!Exists($(PtvsTargetsFile))" Project="$(MSBuildToolsPath)\Microsoft.Common.targets" />
+</Project>

--- a/Python/Tests/TestData/AssemblyReference/SearchPathReference.sln
+++ b/Python/Tests/TestData/AssemblyReference/SearchPathReference.sln
@@ -1,0 +1,18 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 11.00
+# Visual Studio 2010
+Project("{888888A0-9F3D-457C-B088-3A5042F75D52}") = "PythonApplication", "PythonApplication\PythonApplicationSearchPathReference.pyproj", "{7498888e-013b-4825-bd68-0b37e1d0e15c}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{7498888e-013b-4825-bd68-0b37e1d0e15c}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7498888e-013b-4825-bd68-0b37e1d0e15c}.Release|Any CPU.ActiveCfg = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
Fixes #603 IronPython: Must remove paths from "Search Paths" and put them back for Intellisense to work
Triggers AnalysisDirectoryChanged in case search paths already exist.
Adds test