### PR TITLE
Fix #604: Breakpoint gets a new child bound breakpoint every time its When Hit action changes

### DIFF
--- a/Python/Product/Debugger/Debugger/DebugEngine/AD7MemoryAddress.cs
+++ b/Python/Product/Debugger/Debugger/DebugEngine/AD7MemoryAddress.cs
@@ -136,8 +136,8 @@ namespace Microsoft.PythonTools.Debugger.DebugEngine {
                 pinfo[0].dwFields |= enum_CONTEXT_INFO_FIELDS.CIF_ADDRESS;
             }
 
-            if ((dwFields & enum_CONTEXT_INFO_FIELDS.CIF_FUNCTION) != 0 && _frame != null) {
-                pinfo[0].bstrFunction = _frame.FunctionName;
+            if ((dwFields & enum_CONTEXT_INFO_FIELDS.CIF_FUNCTION) != 0) {
+                pinfo[0].bstrFunction = _frame != null ? _frame.FunctionName : "<unknown>";
                 pinfo[0].dwFields |= enum_CONTEXT_INFO_FIELDS.CIF_FUNCTION;
             }
 

--- a/Python/Tests/DebuggerUITests/DebugProject.cs
+++ b/Python/Tests/DebuggerUITests/DebugProject.cs
@@ -186,6 +186,37 @@ namespace DebuggerUITests {
                 bp = app.Dte.Debugger.Breakpoints.Add(File: "BreakpointInfo.py", Line: 7);
                 Assert.AreEqual("Python", bp.Item(1).Language);
                 //Assert.AreEqual("BreakpointInfo.f", bp.Item(1).FunctionName);
+
+                // https://github.com/Microsoft/PTVS/pull/630
+                // Make sure 
+            }
+        }
+
+        [TestMethod, Priority(0), TestCategory("Core")]
+        [HostType("VSTestHost")]
+        public void TestBoundBreakpoint() {
+            using (var app = new VisualStudioApp()) {
+                var project = OpenDebuggerProjectAndBreak(app, "BreakpointInfo.py", 2);
+
+                var pendingBp = (Breakpoint3)app.Dte.Debugger.Breakpoints.Item(1);
+                Assert.AreEqual(1, pendingBp.Children.Count);
+
+                var bp = (Breakpoint3)pendingBp.Children.Item(1);
+                Assert.AreEqual("Python", bp.Language);
+                Assert.AreEqual(TestData.GetPath(@"TestData\DebuggerProject\BreakpointInfo.py"), bp.File);
+                Assert.AreEqual(2, bp.FileLine);
+                Assert.AreEqual(1, bp.FileColumn);
+                Assert.AreEqual(true, bp.Enabled);
+                Assert.AreEqual(true, bp.BreakWhenHit);
+                Assert.AreEqual(1, bp.CurrentHits);
+                Assert.AreEqual(1, bp.HitCountTarget);
+                Assert.AreEqual(dbgHitCountType.dbgHitCountTypeNone, bp.HitCountType);
+
+                // https://github.com/Microsoft/PTVS/pull/630
+                pendingBp.BreakWhenHit = false; // causes rebind
+                Assert.AreEqual(1, pendingBp.Children.Count);
+                bp = (Breakpoint3)pendingBp.Children.Item(1);
+                Assert.AreEqual(false, bp.BreakWhenHit);
             }
         }
 


### PR DESCRIPTION
Always return some non-null, non-empty function name for IDebugCodeContext2, to enable debugger to correctly detect and clean up duplicate breakpoints (which it creates itself when "When Hit" action changes).