### PR TITLE
Fix mixed-mode debugging on VS 2015

### DIFF
--- a/Python/Product/DebuggerHelper/dllmain.cpp
+++ b/Python/Product/DebuggerHelper/dllmain.cpp
@@ -23,9 +23,7 @@ extern "C" {
     volatile char isInitialized;
 
     __declspec(dllexport) __declspec(noinline)
-    void OnInitialized() {
-        volatile char dummy = 0;
-    }
+    void OnInitialized() DUMMY_BREAKPOINT_FUNCTION
 }
 
 

--- a/Python/Product/DebuggerHelper/stdafx.h
+++ b/Python/Product/DebuggerHelper/stdafx.h
@@ -25,3 +25,6 @@
 #include "targetver.h"
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
+
+#define DUMMY_BREAKPOINT_FUNCTION \
+    { volatile char unique[] = __FUNCSIG__; while (*unique == 0) {} }

--- a/Python/Product/DebuggerHelper/trace.cpp
+++ b/Python/Product/DebuggerHelper/trace.cpp
@@ -348,27 +348,19 @@ bool StringEquals33(const DebuggerString* debuggerString, const void* pyString) 
 // and thus gets notifications when they're called.
 
 __declspec(dllexport) __declspec(noinline)
-void OnBreakpointHit() {
-    volatile char dummy = 0;
-}
+void OnBreakpointHit() DUMMY_BREAKPOINT_FUNCTION
 
 // Note that this is only reported for step in/over, not for step out - debugger handles the latter via native breakpoints.
 __declspec(dllexport) __declspec(noinline)
-void OnStepComplete() { 
-    volatile char dummy = 0;
-}
+void OnStepComplete() DUMMY_BREAKPOINT_FUNCTION
 
 // Stepping operation fell through the end of the frame on which it began - debugger should handle the rest of the step.
 __declspec(dllexport) __declspec(noinline)
-void OnStepFallThrough() {
-    volatile char dummy = 0;
-}
+void OnStepFallThrough() DUMMY_BREAKPOINT_FUNCTION
 
 // EvalLoop completed evaluation of input; evalLoopResult points at the resulting object if any, and evalLoopException points at exception if any.
 __declspec(dllexport) __declspec(noinline)
-void OnEvalComplete() {
-    volatile char dummy = 0;
-}
+void OnEvalComplete() DUMMY_BREAKPOINT_FUNCTION
 
 
 void EvalLoop(void (*bp)()) {


### PR DESCRIPTION
Work around compiler being more aggressive doing COMDAT folding on breakpoint-signal functions in the debugger helper DLL, which breaks mixed-mode debugging on VS 2015.