### PR TITLE
Correction of bug #676 - incorrect '.value'

### DIFF
--- a/Python/Product/PyKinect/PyKinect/pykinect/nui/structs.py
+++ b/Python/Product/PyKinect/PyKinect/pykinect/nui/structs.py
@@ -210,7 +210,7 @@ class PlanarImage(ctypes.c_voidp):
     def height(self):
         desc = _NuiSurfaceDesc()
         PlanarImage._GetLevelDesc(self, 0, ctypes.byref(desc))
-        return desc.height.value
+        return desc.height
         
     @property
     def bytes_per_pixel(self):


### PR DESCRIPTION
Correction of the bug #676: "Error getting the 'height' property of PlanarImage"

Removed the '.value' property from line 213.