### PR TITLE
Fixes #685 NullReferenceException in DjangoAnalyzer.GetArg

### DIFF
--- a/Python/Product/Analysis/Analyzer/ExpressionEvaluator.cs
+++ b/Python/Product/Analysis/Analyzer/ExpressionEvaluator.cs
@@ -312,6 +312,8 @@ namespace Microsoft.PythonTools.Analysis.Analyzer {
                     }
 
                     res[i - (args.Count - res.Length)] = (NameExpression)args[i].NameExpression;
+                } else if (res != null) {
+                    res[i - (args.Count - res.Length)] = NameExpression.Empty;
                 }
             }
             return res ?? EmptyNames;

--- a/Python/Product/Analysis/Parsing/Ast/NameExpression.cs
+++ b/Python/Product/Analysis/Parsing/Ast/NameExpression.cs
@@ -17,6 +17,7 @@ using System.Text;
 namespace Microsoft.PythonTools.Parsing.Ast {
     public class NameExpression : Expression {
         public static readonly NameExpression[] EmptyArray = new NameExpression[0];
+        public static readonly NameExpression Empty = new NameExpression("");
 
         private readonly string _name;
 

--- a/Python/Product/Analysis/PythonAnalyzer.Specializations.cs
+++ b/Python/Product/Analysis/PythonAnalyzer.Specializations.cs
@@ -192,7 +192,10 @@ namespace Microsoft.PythonTools.Analysis {
             for (int i = 0, j = args.Length - keywordArgNames.Length;
                 i < keywordArgNames.Length && j < args.Length;
                 ++i, ++j) {
-                if (keywordArgNames[i].Name == name) {
+                var kwArg = keywordArgNames[i];
+                if (kwArg == null) {
+                    Debug.Fail("Null keyword argument");
+                } else if (kwArg.Name == name) {
                     return args[j];
                 }
             }

--- a/Python/Product/Django/Project/DjangoAnalyzer.cs
+++ b/Python/Product/Django/Project/DjangoAnalyzer.cs
@@ -506,7 +506,10 @@ namespace Microsoft.PythonTools.Django.Project {
             for (int i = 0, j = args.Length - keywordArgNames.Length;
                 i < keywordArgNames.Length && j < args.Length;
                 ++i, ++j) {
-                if (keywordArgNames[i].Name == name) {
+                var kwArg = keywordArgNames[i];
+                if (kwArg == null) {
+                    Debug.Fail("Null keyword argument");
+                } else if (kwArg.Name == name) {
                     return args[j];
                 }
             }

--- a/Python/Tests/Analysis/AnalysisTest.cs
+++ b/Python/Tests/Analysis/AnalysisTest.cs
@@ -6606,6 +6606,34 @@ def f():
             }
         }
 
+        [TestMethod, Priority(0)]
+        public void NullNamedArgument() {
+            CallDelegate callable = (node, unit, args, keywordArgNames) => {
+                bool anyNull = false;
+                Console.WriteLine("fn({0})", string.Join(", ", keywordArgNames.Select(n => {
+                    if (n == null) {
+                        anyNull = true;
+                        return "(null)";
+                    } else {
+                        return n.Name + "=(value)";
+                    }
+                })));
+                Assert.IsFalse(anyNull, "Some arguments were null");
+                return AnalysisSet.Empty;
+            };
+
+            using (var state = CreateAnalyzer(PythonLanguageVersion.V27)) {
+                state.SpecializeFunction("NullNamedArgument", "fn", callable);
+
+                var entry1 = state.AddModule("NullNamedArgument", "NullNamedArgument.py");
+                Prepare(entry1, GetSourceUnit("def fn(**kwargs): pass", "NullNamedArgument"), state.LanguageVersion);
+                entry1.Analyze(CancellationToken.None);
+                var entry2 = state.AddModule("test", "test.py");
+                Prepare(entry2, GetSourceUnit("import NullNamedArgument; NullNamedArgument.fn(a=0, ]]])", "test"), state.LanguageVersion);
+                entry2.Analyze(CancellationToken.None);
+            }
+        }
+
         #endregion
 
         #region Helpers


### PR DESCRIPTION
Fixes #685 NullReferenceException in DjangoAnalyzer.GetArg
Adds assertion and safe fallbacks if null arguments appear in incorrect places in calls.
Adds test for null named arguments.