### PR TITLE
Fix #680: ExecuteInReplCommand does not validate filename

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Commands/ExecuteInReplCommand.cs
+++ b/Python/Product/PythonTools/PythonTools/Commands/ExecuteInReplCommand.cs
@@ -102,6 +102,7 @@ namespace Microsoft.PythonTools.Commands {
             var interpreterService = _serviceProvider.GetComponentModel().GetService<IInterpreterOptionsService>();
             string filename, dir;
             if (!PythonToolsPackage.TryGetStartupFileAndDirectory(_serviceProvider, out filename, out dir, out analyzer) ||
+                string.IsNullOrEmpty(filename) ||
                 interpreterService == null ||
                 interpreterService.NoInterpretersValue == analyzer.InterpreterFactory) {
                 // no interpreters installed, disable the command.
@@ -137,7 +138,9 @@ namespace Microsoft.PythonTools.Commands {
             VsProjectAnalyzer analyzer;
             string filename, dir;
             var pyProj = CommonPackage.GetStartupProject(_serviceProvider) as PythonProjectNode;
-            if (!PythonToolsPackage.TryGetStartupFileAndDirectory(_serviceProvider, out filename, out dir, out analyzer)) {
+            if (!PythonToolsPackage.TryGetStartupFileAndDirectory(_serviceProvider, out filename, out dir, out analyzer) ||
+                string.IsNullOrEmpty(filename)
+            ) {
                 // TODO: Error reporting
                 return;
             }


### PR DESCRIPTION
Disable command when filename is null or empty.