### PR TITLE
Tentatively fix #687: NullReferenceException in GetReplCommands caused by registry change

### DIFF
--- a/Python/Product/PythonTools/PythonToolsPackage.cs
+++ b/Python/Product/PythonTools/PythonToolsPackage.cs
@@ -663,7 +663,17 @@ You should uninstall IronPython 2.7 and re-install it with the ""Tools for Visua
 
         private List<OpenReplCommand> GetReplCommands() {
             var replCommands = new List<OpenReplCommand>();
+
+            var compModel = ComponentModel;
+            if (compModel == null) {
+                return replCommands;
+            }
+
             var interpreterService = ComponentModel.GetService<IInterpreterOptionsService>();
+            if (interpreterService == null) {
+                return replCommands;
+            }
+
             var factories = interpreterService.Interpreters.ToList();
             if (factories.Count == 0) {
                 return replCommands;

--- a/Python/Product/PythonTools/PythonToolsPackage.cs
+++ b/Python/Product/PythonTools/PythonToolsPackage.cs
@@ -669,7 +669,7 @@ You should uninstall IronPython 2.7 and re-install it with the ""Tools for Visua
                 return replCommands;
             }
 
-            var interpreterService = ComponentModel.GetService<IInterpreterOptionsService>();
+            var interpreterService = compModel.GetService<IInterpreterOptionsService>();
             if (interpreterService == null) {
                 return replCommands;
             }


### PR DESCRIPTION
Add null checks for SComponentModel and IInterpreterOptionsService (most likely it was the former).