### PR TITLE
Fix #705: Debugging unit tests in mixed mode skips breakpoints occasionally

### DIFF
--- a/Python/Product/Debugger/DkmDebugger/TraceManagerLocalHelper.cs
+++ b/Python/Product/Debugger/DkmDebugger/TraceManagerLocalHelper.cs
@@ -204,6 +204,7 @@ namespace Microsoft.PythonTools.DkmDebugger {
         private readonly PythonDllBreakpointHandlers _handlers;
         private readonly DkmNativeInstructionAddress _traceFunc;
         private readonly UInt32Proxy _pyTracingPossible;
+        private readonly ByteProxy _isTracing;
 
         // A step-in gate is a function inside the Python interpreter or one of the libaries that may call out
         // to native user code such that it may be a potential target of a step-in operation. For every gate,
@@ -245,6 +246,7 @@ namespace Microsoft.PythonTools.DkmDebugger {
             _pyrtInfo = process.GetPythonRuntimeInfo();
 
             _traceFunc = _pyrtInfo.DLLs.DebuggerHelper.GetExportedFunctionAddress("TraceFunc");
+            _isTracing = _pyrtInfo.DLLs.DebuggerHelper.GetExportedStaticVariable<ByteProxy>("isTracing");
             _pyTracingPossible = _pyrtInfo.DLLs.Python.GetStaticVariable<UInt32Proxy>("_Py_TracingPossible");
 
             if (kind == Kind.StepIn) {
@@ -307,8 +309,8 @@ namespace Microsoft.PythonTools.DkmDebugger {
         public unsafe void RegisterTracing(PyThreadState tstate) {
             tstate.use_tracing.Write(1);
             tstate.c_tracefunc.Write(_traceFunc.GetPointer());
-
             _pyTracingPossible.Write(_pyTracingPossible.Read() + 1);
+            _isTracing.Write(1);
         }
 
         public void OnBeginStepIn(DkmThread thread) {

--- a/Python/Product/DebuggerHelper/dllmain.cpp
+++ b/Python/Product/DebuggerHelper/dllmain.cpp
@@ -20,7 +20,7 @@
 // Used by debugger to detect when DLL is fully loaded and initialized and TraceFunc can be registered.
 extern "C" {
     __declspec(dllexport)
-    volatile char isInitialized;
+    volatile char isInitialized, isTracing;
 
     __declspec(dllexport) __declspec(noinline)
     void OnInitialized() {

--- a/Python/Product/TestAdapter/visualstudio_py_testlauncher.py
+++ b/Python/Product/TestAdapter/visualstudio_py_testlauncher.py
@@ -42,9 +42,18 @@ def main():
         # For mixed-mode attach, there's no ptvsd and hence no wait_for_attach(), 
         # so we have to use Win32 API in a loop to do the same thing.
         from time import sleep
-        from ctypes import windll
+        from ctypes import windll, c_char
         while True:
             if windll.kernel32.IsDebuggerPresent() != 0:
+                break
+            sleep(0.1)
+        try:
+            debugger_helper = windll['Microsoft.PythonTools.Debugger.Helper.x86.dll']
+        except WinError:
+            debugger_helper = windll['Microsoft.PythonTools.Debugger.Helper.x64.dll']
+        isTracing = c_char.in_dll(debugger_helper, "isTracing")
+        while True:
+            if isTracing.value != 0:
                 break
             sleep(0.1)
                 


### PR DESCRIPTION
Add a flag that test launcher now uses to detect when the debugger is actually tracing execution (and not just attached to the process).