### PR TITLE
Fixes #706: Should not detect unsupported interpreters

### DIFF
--- a/Python/Product/Analysis/Interpreter/PythonInterpreterFactoryWithDatabase.cs
+++ b/Python/Product/Analysis/Interpreter/PythonInterpreterFactoryWithDatabase.cs
@@ -22,6 +22,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.PythonTools.Analysis;
 using Microsoft.PythonTools.Interpreter.Default;
+using Microsoft.PythonTools.Parsing;
 using Microsoft.VisualStudioTools;
 
 namespace Microsoft.PythonTools.Interpreter {
@@ -67,6 +68,18 @@ namespace Microsoft.PythonTools.Interpreter {
             _description = description;
             _id = id;
             _config = config;
+
+            if (_config == null) {
+                throw new ArgumentNullException("config");
+            }
+
+            // Avoid creating a interpreter with an unsupported version.
+            // https://github.com/Microsoft/PTVS/issues/706
+            try {
+                var langVer = _config.Version.ToLanguageVersion();
+            } catch (InvalidOperationException ex) {
+                throw new ArgumentException(ex.Message, ex);
+            }
 
             if (watchLibraryForChanges && Directory.Exists(_config.LibraryPath)) {
                 _refreshIsCurrentTrigger = new Timer(RefreshIsCurrentTimer_Elapsed);

--- a/Python/Product/Analysis/Parsing/PythonLanguageVersion.cs
+++ b/Python/Product/Analysis/Parsing/PythonLanguageVersion.cs
@@ -53,6 +53,11 @@ namespace Microsoft.PythonTools.Parsing {
 
         public static PythonLanguageVersion ToLanguageVersion(this Version version) {
             switch (version.Major) {
+                case 0:
+                    switch (version.Minor) {
+                        case 0: return PythonLanguageVersion.None;
+                    }
+                    break;
                 case 2:
                     switch (version.Minor) {
                         case 4: return PythonLanguageVersion.V24;

--- a/Python/Product/PythonTools/PythonTools/Project/PythonProjectNode.cs
+++ b/Python/Product/PythonTools/PythonTools/Project/PythonProjectNode.cs
@@ -2161,7 +2161,13 @@ namespace Microsoft.PythonTools.Project {
                 throw Marshal.GetExceptionForHR(VSConstants.OLE_E_PROMPTSAVECANCELLED);
             }
 
-            var id = interpreters.CreateInterpreterFactory(options);
+            Guid id;
+            try {
+                id = interpreters.CreateInterpreterFactory(options);
+            } catch (ArgumentException ex) {
+                TaskDialog.ForException(Site, ex, issueTrackerUrl: IssueTrackerUrl).ShowModal();
+                return null;
+            }
             return interpreters.FindInterpreter(id, options.LanguageVersion);
         }
 

--- a/Python/Product/VSInterpreters/CPythonInterpreterFactoryProvider.cs
+++ b/Python/Product/VSInterpreters/CPythonInterpreterFactoryProvider.cs
@@ -209,19 +209,26 @@ namespace Microsoft.PythonTools.Interpreter {
                         }
 
                         if (!_interpreters.Any(f => f.Id == id && f.Configuration.Version == version)) {
-                            _interpreters.Add(InterpreterFactoryCreator.CreateInterpreterFactory(
-                                new InterpreterFactoryCreationOptions {
-                                    LanguageVersion = version,
-                                    Id = id,
-                                    Description = string.Format("{0} {1}", description, version),
-                                    InterpreterPath = Path.Combine(basePath, CPythonInterpreterFactoryConstants.ConsoleExecutable),
-                                    WindowInterpreterPath = Path.Combine(basePath, CPythonInterpreterFactoryConstants.WindowsExecutable),
-                                    LibraryPath = Path.Combine(basePath, CPythonInterpreterFactoryConstants.LibrarySubPath),
-                                    PathEnvironmentVariableName = CPythonInterpreterFactoryConstants.PathEnvironmentVariableName,
-                                    Architecture = actualArch ?? ProcessorArchitecture.None,
-                                    WatchLibraryForNewModules = true
-                                }
-                            ));
+                            IPythonInterpreterFactory fact;
+                            try {
+                                fact = InterpreterFactoryCreator.CreateInterpreterFactory(
+                                    new InterpreterFactoryCreationOptions {
+                                        LanguageVersion = version,
+                                        Id = id,
+                                        Description = string.Format("{0} {1}", description, version),
+                                        InterpreterPath = Path.Combine(basePath, CPythonInterpreterFactoryConstants.ConsoleExecutable),
+                                        WindowInterpreterPath = Path.Combine(basePath, CPythonInterpreterFactoryConstants.WindowsExecutable),
+                                        LibraryPath = Path.Combine(basePath, CPythonInterpreterFactoryConstants.LibrarySubPath),
+                                        PathEnvironmentVariableName = CPythonInterpreterFactoryConstants.PathEnvironmentVariableName,
+                                        Architecture = actualArch ?? ProcessorArchitecture.None,
+                                        WatchLibraryForNewModules = true
+                                    }
+                                );
+                            } catch (ArgumentException) {
+                                continue;
+                            }
+
+                            _interpreters.Add(fact);
                             anyAdded = true;
                         }
                     }


### PR DESCRIPTION
Fixes #706: Should not detect unsupported interpreters
Adds validation through PythonLanguageVersion when constructing.
Ensures callers handle or correctly propagate the new ArgumentException.
Makes "0.0" a supported version (implies PythonLanguageVersion.None)
Adds test
Removes invalid test

I will backport this to 2.1.1 and 2.2.1 after it's merged.