### PR TITLE
Fixes #712: Don't add Unicode BOM by default

### DIFF
--- a/Python/Product/Analysis/Parsing/Parser.cs
+++ b/Python/Product/Analysis/Parsing/Parser.cs
@@ -4831,7 +4831,7 @@ namespace Microsoft.PythonTools.Parsing {
         /// New in 1.1.
         /// </summary>
         public static Encoding GetEncodingFromStream(Stream stream) {
-            return GetStreamReaderWithEncoding(stream, Encoding.UTF8, ErrorSink.Null).CurrentEncoding;
+            return GetStreamReaderWithEncoding(stream, new UTF8Encoding(false), ErrorSink.Null).CurrentEncoding;
         }
 
         private static StreamReader/*!*/ GetStreamReaderWithEncoding(Stream/*!*/ stream, Encoding/*!*/ defaultEncoding, ErrorSink errors) {


### PR DESCRIPTION
Fixes #712: Don't add Unicode BOM by default
Changes default encoding to be UTF-8 without a signature.