### PR TITLE
Fixes #669 Log all unhandled exceptions to Event Log

### DIFF
--- a/Common/Product/SharedProject/ProjectResources.resx
+++ b/Common/Product/SharedProject/ProjectResources.resx
@@ -665,6 +665,6 @@ folder you are copying, do you want to replace the existing files?</value>
   <data name="SeeActivityLog" xml:space="preserve">
     <value>An unexpected error occurred.
 
-You can get more information by running Visual Studio with the /log parameter on the command line, and then examining the file '{0}'.</value>
+You can get more information by running Visual Studio with the /log parameter on the command line, and then examining the file '{0}', or by checking the Event Log.</value>
   </data>
 </root>

--- a/Python/Product/PythonTools/PythonTools/Project/AddVirtualEnvironment.xaml.cs
+++ b/Python/Product/PythonTools/PythonTools/Project/AddVirtualEnvironment.xaml.cs
@@ -67,7 +67,7 @@ namespace Microsoft.PythonTools.Project {
                     view.WillInstallRequirementsTxt = false;
                     await view.WaitForReady();
                     if (view.WillAddVirtualEnv) {
-                        await view.Create();
+                        await view.Create().HandleAllExceptions(SR.ProductName, typeof(AddVirtualEnvironment));
                         return;
                     }
 
@@ -119,7 +119,7 @@ namespace Microsoft.PythonTools.Project {
 
         private async void Save_Executed(object sender, ExecutedRoutedEventArgs e) {
             Debug.Assert(_currentOperation == null);
-            _currentOperation = _view.Create().HandleAllExceptions(SR.ProductName);
+            _currentOperation = _view.Create().HandleAllExceptions(SR.ProductName, GetType());
             
             await _currentOperation;
 

--- a/Python/Setup/PythonToolsInstaller/PythonToolsInstaller.wxs
+++ b/Python/Setup/PythonToolsInstaller/PythonToolsInstaller.wxs
@@ -86,6 +86,8 @@
             <util:RestartResource Path="[DEVENV_PATH]" />
             <util:RestartResource Path="[WDEXPRESS_PATH]" />
             <util:RestartResource Path="[VWDEXPRESS_PATH]" />
+            <util:EventSource Name="Python Tools for Visual Studio" Log="Application"
+                              EventMessageFile="%SystemRoot%\Microsoft.NET\Framework\v4.0.30319\EventLogMessages.dll" />
           </Component>
         </Directory>
       </Directory>


### PR DESCRIPTION
Fixes #669 Log all unhandled exceptions to Event Log
Creates an event source and writes errors to it.
Also handles errors better in code paths that I happened to be trying to test.