### PR TITLE
Fixes #725 PTVS 2.2 RTM can't profile Python 3.5.0rc1

### DIFF
--- a/Python/Product/Profiling/vspyprof.py
+++ b/Python/Product/Profiling/vspyprof.py
@@ -44,8 +44,11 @@ def profile(file, globals_obj, locals_obj, profdll):
     pyprofdll.CloseThread.argtypes = [ctypes.c_void_p]
     pyprofdll.CloseProfiler.argtypes = [ctypes.c_void_p]
     pyprofdll.InitProfiler.argtypes = [ctypes.c_void_p]
+    pyprofdll.InitProfiler.restype = ctypes.c_void_p
 
     profiler = pyprofdll.CreateProfiler(sys.dllhandle)
+    if not profiler:
+        raise NotImplementedError("Profiling is currently not supported for " + sys.version)
     handle = None
 
     try:

--- a/Python/Product/VsPyProf/PythonApi.cpp
+++ b/Python/Product/VsPyProf/PythonApi.cpp
@@ -90,7 +90,7 @@ VsPyProf* VsPyProf::Create(HMODULE pythonModule) {
                 }
 
                 if ((major == 2 && (minor >= 4 && minor <= 7)) ||
-                    (major == 3 && (minor >= 0 && minor <= 4))) {
+                    (major == 3 && (minor >= 0 && minor <= 5))) {
                         return new VsPyProf(pythonModule,
                             major,
                             minor,

--- a/Python/Product/VsPyProf/VsPyProf.cpp
+++ b/Python/Product/VsPyProf/VsPyProf.cpp
@@ -24,14 +24,16 @@ int TraceFunction(PyObject *obj, PyFrameObject *frame, int what, PyObject *arg) 
     return ((VsPyProfThread*)obj)->Trace(frame, what, arg);
 }
 
-extern "C" VSPYPROF_API VsPyProf* CreateProfiler(HMODULE module) 
-{
+extern "C" VSPYPROF_API VsPyProf* CreateProfiler(HMODULE module) {
     return VsPyProf::Create(module);
 }
 
 // This is an example of an exported function.
-extern "C" VSPYPROF_API VsPyProfThread* InitProfiler(VsPyProf* profiler)
-{    
+extern "C" VSPYPROF_API VsPyProfThread* InitProfiler(VsPyProf* profiler) {
+    if (!profiler) {
+        return nullptr;
+    }
+    
     auto thread = profiler->CreateThread();
 
     if (thread != nullptr) {
@@ -42,12 +44,16 @@ extern "C" VSPYPROF_API VsPyProfThread* InitProfiler(VsPyProf* profiler)
 }
 
 extern "C" VSPYPROF_API void CloseProfiler(VsPyProf* profiler) {
-    profiler->Release();
+    if (profiler) {
+        profiler->Release();
+    }
 }
 
 extern "C" VSPYPROF_API void CloseThread(VsPyProfThread* thread) {
-    thread->GetProfiler()->PyEval_SetProfile(nullptr, nullptr);    
-    delete thread;
+    if (thread) {
+        thread->GetProfiler()->PyEval_SetProfile(nullptr, nullptr);
+        delete thread;
+    }
 }
 
 // used for compat w/ Python 2.4 where we don't have ctypes.

--- a/Python/Product/VsPyProf/python.h
+++ b/Python/Product/VsPyProf/python.h
@@ -257,7 +257,10 @@ public:
     void* tp_print;
     void* tp_getattr;
     void* tp_setattr;
-    void* tp_compare;
+    union {
+        void* tp_compare; /* 2.4 - 3.4 */
+        void* tp_as_async; /* 3.5 */
+    };
     void* tp_repr;
 
     /* Method suites for standard classes */


### PR DESCRIPTION
Fixes #725 PTVS 2.2 RTM can't profile Python 3.5.0rc1
Changes version check to allow profiling 3.5
Improves handling when unable to profile
Adds basic profiling tests for more Python versions