### PR TITLE
Fixes #664 Excute File in Python Interactive -- wrong location and always appears

### DIFF
--- a/Python/Product/PythonTools/PythonTools.vsct
+++ b/Python/Product/PythonTools/PythonTools.vsct
@@ -904,7 +904,7 @@
       <Parent guid="guidPythonToolsCmdSet" id="CodeFileGroup2"/>
     </CommandPlacement>
 
-    <CommandPlacement guid="guidPythonToolsCmdSet" id="cmdidExecuteFileInRepl" priority="0x0300">
+    <CommandPlacement guid="guidPythonToolsCmdSet" id="cmdidExecuteFileInRepl" priority="0x0E7F">
       <Parent guid="guidVSDebugGroup" id="IDG_EXECUTION"/>
     </CommandPlacement>
 


### PR DESCRIPTION
Fixes #664 Excute File in Python Interactive -- wrong location and always appears
Moves command to near the bottom of the "execute" group.
Fixes logic to determine when command should be visible.

(Ping @Andrew-MSFT)
