### PR TITLE
#678 NullReferenceException in SaveSettingsToStorage

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Repl/BasePythonReplEvaluator.cs
+++ b/Python/Product/PythonTools/PythonTools/Repl/BasePythonReplEvaluator.cs
@@ -1901,14 +1901,22 @@ namespace Microsoft.PythonTools.Repl {
 
         public static void SetPrompts(this IInteractiveWindow window, string primary, string secondary) {
             var eval = window.Evaluator as BasePythonReplEvaluator;
-            eval.PrimaryPrompt = primary;
-            eval.SecondaryPrompt = secondary;
+            if (eval != null) {
+                eval.PrimaryPrompt = primary;
+                eval.SecondaryPrompt = secondary;
+            } else {
+                Debug.Fail("SetPrompts called on non-Python interactive window");
+            }
         }
 
         public static void UseInterpreterPrompts(this IInteractiveWindow window) {
             var eval = window.Evaluator as BasePythonReplEvaluator;
-            eval.PrimaryPrompt = null;
-            eval.SecondaryPrompt = null;
+            if (eval != null) {
+                eval.PrimaryPrompt = null;
+                eval.SecondaryPrompt = null;
+            } else {
+                Debug.Fail("SetPrompts called on non-Python interactive window");
+            }
         }
 
         public static void AppendEscapedText(this IInteractiveWindow window, string text, bool isError = false) {


### PR DESCRIPTION
#678 NullReferenceException in SaveSettingsToStorage
Skips trying to update debug interactive prompts, since they don't work anyway.
Fixes extension methods to test the cast before using the object.

Filed #765 for a full fix in 3.0