### PR TITLE
Fixes #784 Cannot have invalid module as startup file

### DIFF
--- a/Python/Product/BuildTasks/ConvertPathToModuleName.cs
+++ b/Python/Product/BuildTasks/ConvertPathToModuleName.cs
@@ -37,6 +37,11 @@ namespace Microsoft.PythonTools.BuildTasks {
         public string PathLimit { get; set; }
 
         /// <summary>
+        /// If true, does not log or fail because of invalid module names.
+        /// </summary>
+        public bool IgnoreErrors { get; set; }
+
+        /// <summary>
         /// The converted module names.
         /// </summary>
         [Output]
@@ -49,7 +54,10 @@ namespace Microsoft.PythonTools.BuildTasks {
                 try {
                     modules.Add(new TaskItem(ModulePath.FromFullPath(path.ItemSpec, PathLimit).ModuleName));
                 } catch (ArgumentException ex) {
-                    Log.LogErrorFromException(ex);
+                    modules.Add(new TaskItem(string.Empty));
+                    if (!IgnoreErrors) {
+                        Log.LogErrorFromException(ex);
+                    }
                 }
             }
 

--- a/Python/Product/BuildTasks/Microsoft.PythonTools.targets
+++ b/Python/Product/BuildTasks/Microsoft.PythonTools.targets
@@ -128,7 +128,7 @@
 
   <!-- Gets the full path module name of the startup file -->
   <Target Name="ResolveStartupModule" AfterTargets="_CheckForInvalidConfigurationAndPlatform" Condition="'$(StartupPath)' != ''">
-    <ConvertPathToModuleName Paths="$(StartupPath)" PathLimit="$(QualifiedProjectHome)">
+    <ConvertPathToModuleName Paths="$(StartupPath)" PathLimit="$(QualifiedProjectHome)" IgnoreErrors="true">
       <Output TaskParameter="ModuleNames" PropertyName="StartupModule" />
     </ConvertPathToModuleName>
     


### PR DESCRIPTION
Fixes #784 Cannot have invalid module as startup file
Allows creation of $(StartupModule) to fail silently and set an empty string.