### PR TITLE
Fixes #48 Move/rename the corresponding *.pyc file at the same time w…

### DIFF
--- a/Python/Tests/Core.UI/BasicProjectTests.cs
+++ b/Python/Tests/Core.UI/BasicProjectTests.cs
@@ -476,6 +476,11 @@ namespace PythonToolsUITests {
                 project.ProjectItems.Item(".fob").Name = "ProgramX.py";
                 AssertError<InvalidOperationException>(() => project.ProjectItems.Item("ProgramX.py").Name = "ProgramY.py");
 
+                var progXpyc = project.ProjectItems.Item("ProgramX.py").FileNames[0] + "c";
+                var progXpyo = project.ProjectItems.Item("ProgramX.py").FileNames[0] + "o";
+                Assert.IsTrue(File.Exists(progXpyc), "Expected " + progXpyc);
+                Assert.IsTrue(File.Exists(progXpyo), "Expected " + progXpyo);
+
                 project.ProjectItems.Item("ProgramX.py").Name = "PrOgRaMX.py";
                 project.ProjectItems.Item("ProgramX.py").Name = "ProgramX.py";
 
@@ -490,7 +495,17 @@ namespace PythonToolsUITests {
                 }
                 Assert.IsTrue(foundProg2);
 
+                Assert.IsFalse(File.Exists(progXpyc), "Did not expect " + progXpyc);
+                Assert.IsFalse(File.Exists(progXpyo), "Did not expect " + progXpyo);
+                var prog2pyc = project.ProjectItems.Item("Program2.py").FileNames[0] + "c";
+                var prog2pyo = project.ProjectItems.Item("Program2.py").FileNames[0] + "o";
+                Assert.IsTrue(File.Exists(prog2pyc), "Expected " + prog2pyc);
+                Assert.IsTrue(File.Exists(prog2pyo), "Expected " + prog2pyo);
+
+
                 // rename using a different method...
+                var progYpyc = project.ProjectItems.Item("ProgramY.py").FileNames[0] + "c";
+
                 project.ProjectItems.Item("ProgramY.py").Properties.Item("FileName").Value = "Program3.py";
                 bool foundProg3 = false;
                 foreach (ProjectItem item in project.ProjectItems) {
@@ -500,7 +515,14 @@ namespace PythonToolsUITests {
                     }
                 }
 
+                var prog3pyc = project.ProjectItems.Item("Program3.py").FileNames[0] + "c";
+
+                Assert.IsTrue(File.Exists(progYpyc), "Expected " + progYpyc);
+                Assert.IsTrue(File.Exists(prog3pyc), "Expected " + prog3pyc);
+                Assert.AreEqual("Program3.pyc", File.ReadAllText(prog3pyc), "Program3.pyc should not have changed");
+
                 project.ProjectItems.Item("Program3.py").Remove();
+                Assert.IsTrue(File.Exists(prog3pyc), "Expected " + prog3pyc);
 
                 Assert.IsTrue(foundProg3);
 
@@ -511,8 +533,7 @@ namespace PythonToolsUITests {
 
                 bool foundProgZ = false;
                 foreach (ProjectItem item in project.ProjectItems) {
-                    Debug.Assert(item.Name
-                        != "Program4.py");
+                    Debug.Assert(item.Name != "Program4.py");
                     if (item.Name == "ProgramZ.py") {
                         foundProgZ = true;
                     }
@@ -530,7 +551,12 @@ namespace PythonToolsUITests {
                 // rename something in a folder...
                 project.ProjectItems.Item("SubFolder").ProjectItems.Item("SubItem.py").Name = "NewSubItem.py";
 
+                var progDeletepyc = project.ProjectItems.Item("ProgramDelete.py").FileNames[0] + "c";
+                File.WriteAllText(progDeletepyc, "ProgramDelete.pyc");
+
                 project.ProjectItems.Item("ProgramDelete.py").Delete();
+
+                Assert.IsFalse(File.Exists(progDeletepyc), "Should have been deleted: " + progDeletepyc);
 
                 // rename the folder
                 project.ProjectItems.Item("SubFolder").Name = "SubFolderNew";

--- a/Python/Tests/TestData/RenameItemsTest/Program3.pyc
+++ b/Python/Tests/TestData/RenameItemsTest/Program3.pyc
@@ -1,0 +1,1 @@
+Program3.pyc

--- a/Python/Tests/TestData/RenameItemsTest/ProgramX.pyc
+++ b/Python/Tests/TestData/RenameItemsTest/ProgramX.pyc
@@ -1,0 +1,1 @@
+ProgramX.pyc

--- a/Python/Tests/TestData/RenameItemsTest/ProgramX.pyo
+++ b/Python/Tests/TestData/RenameItemsTest/ProgramX.pyo
@@ -1,0 +1,1 @@
+ProgramX.pyo

--- a/Python/Tests/TestData/RenameItemsTest/ProgramY.pyc
+++ b/Python/Tests/TestData/RenameItemsTest/ProgramY.pyc
@@ -1,0 +1,1 @@
+ProgramY.pyc


### PR DESCRIPTION
Fixes #48 Move/rename the corresponding *.pyc file at the same time when moving/renaming the *.py file
Attempts to remove or rename .pyc/.pyo files when moving the source.
We don't bother with __pycache__ folders because those aren't used to try and import files.
If a .pyc or .pyo file is in the project, we don't touch it, and if there is a conflicting file we also don't change anything.