### PR TITLE
fix build

### DIFF
--- a/Common/Tests/Utilities/TestUtilities.csproj
+++ b/Common/Tests/Utilities/TestUtilities.csproj
@@ -42,7 +42,7 @@
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Management.Automation, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="System.Management.Automation, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="System.Runtime.Remoting" />


### PR DESCRIPTION
Trying to build i got this error:

```
System.Management.Automation.PowerShell' does not contain a definition for 'HadErrors' and no extension method 'HadErrors' accepting a first argument of type 'System.Management.Automation.PowerShell' could be found
```

`PowerShell.HadErrors` property was added in powershell v3

Windows 7, no powershell 3 installed -> v 1.0.0.0 used.
After powershell 3 install the build work, because v 3.0.0.0 is used

I dont know, maybe is enough to add powershell v3 as prerequite in the documentation.
At least with this pr i see i need v3.0.0.0
