### PR TITLE
Fixes #831: Unhandled exception in PythonNavigateToItemProvider

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Navigation/NavigateTo/PythonNavigateToItemProvider.cs
+++ b/Python/Product/PythonTools/PythonTools/Navigation/NavigateTo/PythonNavigateToItemProvider.cs
@@ -159,7 +159,7 @@ namespace Microsoft.PythonTools.Navigation.NavigateTo {
                 } finally {
                     callback.Done();
                 }
-            }, _searchCts.Token).HandleAllExceptions(SR.ProductName, GetType()).DoNotWait();
+            }).HandleAllExceptions(SR.ProductName, GetType()).DoNotWait();
         }
 
         public void StopSearch() {


### PR DESCRIPTION
Fixes #831 Unhandled exception in PythonNavigateToItemProvider
Prevents TaskCanceledException being raised while stepping through the task.