### PR TITLE
Issue 663

### DIFF
--- a/Python/Product/Analysis/Interpreter/PythonInterpreterFactoryExtensions.cs
+++ b/Python/Product/Analysis/Interpreter/PythonInterpreterFactoryExtensions.cs
@@ -56,12 +56,6 @@ namespace Microsoft.PythonTools.Interpreter {
         /// <returns>The names of the modules that were found.</returns>
         public static async Task<HashSet<string>> FindModulesAsync(this IPythonInterpreterFactory factory, params string[] moduleNames) {
             var withDb = factory as PythonInterpreterFactoryWithDatabase;
-            if (withDb != null && withDb.IsCurrent) {
-                var db = withDb.GetCurrentDatabase();
-                var set = new HashSet<string>(moduleNames.Where(m => db.GetModule(m) != null));
-                return set;
-            }
-
             var expected = new HashSet<string>(moduleNames);
 
             if (withDb != null) {

--- a/Python/Product/Profiling/proflaun.py
+++ b/Python/Product/Profiling/proflaun.py
@@ -50,6 +50,8 @@ except:
         sys.stdout.write('Press any key to continue . . .')
         sys.stdout.flush()
         msvcrt.getch()
+    else:
+        raise
 else:
     import sys, msvcrt, os
     if 'VSPYPROF_WAIT_ON_NORMAL_EXIT' in os.environ:

--- a/Python/Product/Profiling/vspyprof.py
+++ b/Python/Product/Profiling/vspyprof.py
@@ -6,8 +6,31 @@ except:
 import sys
 import ctypes
 
+if sys.version_info[0] >= 3:
+    try:
+        from tokenize import open as srcopen
+    except ImportError:
+        from io import TextIOWrapper
+        from tokenize import detect_encoding
+
+        def srcopen(filename):
+            buff = open(filename, 'rb')
+            try:
+                encoding, lines = detect_encoding(buff.readline)
+                buff.seek(0)
+                if encoding == 'utf-8':
+                    if next(iter(buff.read(1)), -1) == 0xEF:
+                        encoding = 'utf-8-sig'
+                    buff.seek(0)
+                stream = TextIOWrapper(buff, encoding, line_buffering=True)
+                stream.mode = 'r'
+                return stream
+            except:
+                buff.close()
+                raise
+
 def hidden_frame(func, posargs, kwargs):
-    """this is just an extra method for new thread so"""
+    """this is just an extra method for new thread so """
     """we have the same # of extra frames (1) as the main thread"""
     func(*posargs, **kwargs)
 
@@ -55,8 +78,11 @@ def profile(file, globals_obj, locals_obj, profdll):
         if sys.version_info[0] >= 3:
             # execfile's not available, and we want to start profiling
             # after we've compiled the users code.
-            f = open(file, "r")
-            code = compile(f.read(), file, 'exec')
+            f = srcopen(file)
+            try:
+                code = compile(f.read(), file, 'exec')
+            finally:
+                f.close()
             handle = start_profiling()
             exec(code, globals_obj, locals_obj)
         else:

--- a/Python/Product/PythonTools/PythonTools/Project/AddVirtualEnvironmentOperation.cs
+++ b/Python/Product/PythonTools/PythonTools/Project/AddVirtualEnvironmentOperation.cs
@@ -62,13 +62,19 @@ namespace Microsoft.PythonTools.Project {
         public async Task Run() {
             var service = _project.Site.GetComponentModel().GetService<IInterpreterOptionsService>();
 
-            var factory = await _project.CreateOrAddVirtualEnvironment(
-                service,
-                _create,
-                _virtualEnvPath,
-                _baseInterpreter,
-                _useVEnv
-            );
+            IPythonInterpreterFactory factory = null;
+
+            try {
+                factory = await _project.CreateOrAddVirtualEnvironment(
+                    service,
+                    _create,
+                    _virtualEnvPath,
+                    _baseInterpreter,
+                    _useVEnv
+                );
+            } catch (InvalidOperationException ex) {
+                _output.WriteErrorLine(ex.ToString());
+            }
 
             if (factory == null) {
                 return;

--- a/Python/Product/PythonTools/PythonTools/Project/VirtualEnv.cs
+++ b/Python/Product/PythonTools/PythonTools/Project/VirtualEnv.cs
@@ -127,6 +127,7 @@ namespace Microsoft.PythonTools.Project {
             var modules = await factory.FindModulesAsync("pip", "virtualenv", "venv");
             bool hasPip = modules.Contains("pip");
             bool hasVirtualEnv = modules.Contains("virtualenv") || modules.Contains("venv");
+            bool useVEnv = modules.Contains("venv") && !modules.Contains("virtualenv");
 
             if (!hasVirtualEnv) {
                 if (!hasPip) {
@@ -138,7 +139,7 @@ namespace Microsoft.PythonTools.Project {
                 }
             }
 
-            await ContinueCreate(provider, factory, path, false, output);
+            await ContinueCreate(provider, factory, path, useVEnv, output);
         }
 
         public static InterpreterFactoryCreationOptions FindInterpreterOptions(

--- a/Python/Tests/TestData/ProfileTest/UTF8BOMProfile.py
+++ b/Python/Tests/TestData/ProfileTest/UTF8BOMProfile.py
@@ -1,0 +1,8 @@
+﻿import time
+
+def f():
+    print("φ and θ are Unicode")
+    for i in range(100):
+        time.sleep(0)
+
+f()

--- a/Python/Tests/TestData/ProfileTest/UTF8Profile.py
+++ b/Python/Tests/TestData/ProfileTest/UTF8Profile.py
@@ -1,0 +1,8 @@
+import time
+
+def f():
+    print("φ and θ are Unicode")
+    for i in range(100):
+        time.sleep(0)
+
+f()


### PR DESCRIPTION
Fixes #663 Profiler doesn't like UTF8 BOM
Switches to using tokenize.open or tokenize.detect_encoding for reading source files.

Also fixes unhandled error creating virtual environment. 