### PR TITLE
Fixes #802 VS crash with IronPython

### DIFF
--- a/Python/Product/Analysis/Values/BuiltinClassInfo.cs
+++ b/Python/Product/Analysis/Values/BuiltinClassInfo.cs
@@ -243,7 +243,7 @@ namespace Microsoft.PythonTools.Analysis.Values {
             get {
                 if (_doc == null) {
                     try {
-                        var doc = _type.Documentation;
+                        var doc = _type.Documentation ?? string.Empty;
                         _doc = Utils.StripDocumentation(doc.ToString());
                     } catch {
                         _doc = String.Empty;

--- a/Python/Product/IronPython/Interpreter/IronPythonBuiltinFunction.cs
+++ b/Python/Product/IronPython/Interpreter/IronPythonBuiltinFunction.cs
@@ -30,11 +30,17 @@ namespace Microsoft.IronPythonTools.Interpreter {
         #region IBuiltinFunction Members
 
         public string Name {
-            get { return Interpreter.Remote.GetBuiltinFunctionName(Value); }
+            get {
+                var ri = RemoteInterpreter;
+                return ri != null ? ri.GetBuiltinFunctionName(Value) : string.Empty;
+            }
         }
 
         public string Documentation {
-            get { return Interpreter.Remote.GetBuiltinFunctionDocumentation(Value); }
+            get {
+                var ri = RemoteInterpreter;
+                return ri != null ? ri.GetBuiltinFunctionDocumentation(Value) : string.Empty;
+            }
         }
 
         public IList<IPythonFunctionOverload> Overloads {
@@ -43,7 +49,8 @@ namespace Microsoft.IronPythonTools.Interpreter {
                 // object.Equals(Object_#1, object other))
 
                 if (_targets == null) {
-                    var overloads = Interpreter.Remote.GetBuiltinFunctionOverloads(Value);
+                    var ri = RemoteInterpreter;
+                    var overloads = ri != null ? ri.GetBuiltinFunctionOverloads(Value) : new ObjectIdentityHandle[0];
                     var result = new IronPythonBuiltinFunctionTarget[overloads.Length];
                     var decltype = (IronPythonType)DeclaringType;
                     for(int i = 0; i<overloads.Length; i++){
@@ -65,7 +72,8 @@ namespace Microsoft.IronPythonTools.Interpreter {
         public IPythonType DeclaringType {
             get {
                 if (_declaringType == null) {
-                    _declaringType = Interpreter.GetTypeFromType(Interpreter.Remote.GetBuiltinFunctionDeclaringPythonType(Value));
+                    var ri = RemoteInterpreter;
+                    _declaringType = ri != null ? Interpreter.GetTypeFromType(ri.GetBuiltinFunctionDeclaringPythonType(Value)) : null;
                 }
                 return _declaringType;
             }
@@ -86,7 +94,8 @@ namespace Microsoft.IronPythonTools.Interpreter {
         public IPythonModule DeclaringModule {
             get {
                 if (_declaringModule == null) {
-                    _declaringModule = Interpreter.GetModule(Interpreter.Remote.GetBuiltinFunctionModule(Value));
+                    var ri = RemoteInterpreter;
+                    _declaringModule = ri != null ? Interpreter.GetModule(ri.GetBuiltinFunctionModule(Value)) : null;
                 }
                 return _declaringModule;
             }

--- a/Python/Product/IronPython/Interpreter/IronPythonBuiltinFunctionTarget.cs
+++ b/Python/Product/IronPython/Interpreter/IronPythonBuiltinFunctionTarget.cs
@@ -12,6 +12,7 @@
  *
  * ***************************************************************************/
 
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Reflection;
@@ -20,6 +21,7 @@ using Microsoft.PythonTools.Interpreter;
 namespace Microsoft.IronPythonTools.Interpreter {
     class IronPythonBuiltinFunctionTarget : IPythonFunctionOverload {
         private readonly IronPythonInterpreter _interpreter;
+        private RemoteInterpreterProxy _remote;
         private readonly ObjectIdentityHandle _overload;
         private readonly IronPythonType _declaringType;
         private IParameterInfo[] _params;
@@ -28,8 +30,15 @@ namespace Microsoft.IronPythonTools.Interpreter {
         public IronPythonBuiltinFunctionTarget(IronPythonInterpreter interpreter, ObjectIdentityHandle overload, IronPythonType declType) {
             Debug.Assert(interpreter.Remote.TypeIs<MethodBase>(overload));
             _interpreter = interpreter;
+            _interpreter.UnloadingDomain += Interpreter_UnloadingDomain;
+            _remote = _interpreter.Remote;
             _overload = overload;
             _declaringType = declType;
+        }
+
+        private void Interpreter_UnloadingDomain(object sender, EventArgs e) {
+            _remote = null;
+            _interpreter.UnloadingDomain -= Interpreter_UnloadingDomain;
         }
 
         #region IBuiltinFunctionTarget Members
@@ -46,9 +55,10 @@ namespace Microsoft.IronPythonTools.Interpreter {
 
         public IParameterInfo[] GetParameters() {
             if (_params == null) {
-                bool isInstanceExtensionMethod = _interpreter.Remote.IsInstanceExtensionMethod(_overload, _declaringType.Value);
+                var ri = _remote;
+                bool isInstanceExtensionMethod = ri != null ? ri.IsInstanceExtensionMethod(_overload, _declaringType.Value) : false;
 
-                var parameters = _interpreter.Remote.GetParametersNoCodeContext(_overload);
+                var parameters = ri != null ? ri.GetParametersNoCodeContext(_overload) : new ObjectIdentityHandle[0];
                 var res = new List<IParameterInfo>(parameters.Length);
                 foreach (var param in parameters) {
                     if (res.Count == 0 && isInstanceExtensionMethod) {
@@ -69,7 +79,10 @@ namespace Microsoft.IronPythonTools.Interpreter {
             get {
                 if (_returnType == null) {
                     _returnType = new List<IPythonType>();
-                    _returnType.Add(_interpreter.GetTypeFromType(_interpreter.Remote.GetBuiltinFunctionOverloadReturnType(_overload)));
+                    var ri = _remote;
+                    if (ri != null) {
+                        _returnType.Add(_interpreter.GetTypeFromType(ri.GetBuiltinFunctionOverloadReturnType(_overload)));
+                    }
                 }
                 return _returnType;
             }

--- a/Python/Product/IronPython/Interpreter/IronPythonBuiltinMethodDescriptor.cs
+++ b/Python/Product/IronPython/Interpreter/IronPythonBuiltinMethodDescriptor.cs
@@ -29,9 +29,12 @@ namespace Microsoft.IronPythonTools.Interpreter {
         public IPythonFunction Function {
             get {
                 if (_function == null) {
-                    var func = Interpreter.Remote.GetBuiltinMethodDescriptorTemplate(Value);
+                    var ri = RemoteInterpreter;
+                    if (ri != null) {
+                        var func = ri.GetBuiltinMethodDescriptorTemplate(Value);
 
-                    _function = (IPythonFunction)Interpreter.MakeObject(func);
+                        _function = (IPythonFunction)Interpreter.MakeObject(func);
+                    }
                 }
                 return _function;
             }

--- a/Python/Product/IronPython/Interpreter/IronPythonConstant.cs
+++ b/Python/Product/IronPython/Interpreter/IronPythonConstant.cs
@@ -26,7 +26,8 @@ namespace Microsoft.IronPythonTools.Interpreter {
         public override PythonMemberType MemberType {
             get {
                 if (_memType == PythonMemberType.Unknown) {
-                    if (!Value.IsNull && Interpreter.Remote.IsEnumValue(Value)) {
+                    var ri = RemoteInterpreter;
+                    if (!Value.IsNull && ri != null && ri.IsEnumValue(Value)) {
                         _memType = PythonMemberType.EnumInstance;
                     } else {
                         _memType = PythonMemberType.Constant;
@@ -42,7 +43,8 @@ namespace Microsoft.IronPythonTools.Interpreter {
                     if (Value.IsNull) {
                         _type = Interpreter.GetBuiltinType(BuiltinTypeId.NoneType);
                     } else {
-                        _type = Interpreter.GetTypeFromType(Interpreter.Remote.GetObjectPythonType(Value));
+                        var ri = RemoteInterpreter;
+                        _type = ri != null ? Interpreter.GetTypeFromType(ri.GetObjectPythonType(Value)) : null;
                     }
                 }
                 return _type;

--- a/Python/Product/IronPython/Interpreter/IronPythonEvent.cs
+++ b/Python/Product/IronPython/Interpreter/IronPythonEvent.cs
@@ -13,7 +13,6 @@
  * ***************************************************************************/
 
 using System.Collections.Generic;
-using IronPython.Runtime.Types;
 using Microsoft.PythonTools.Interpreter;
 
 namespace Microsoft.IronPythonTools.Interpreter {
@@ -34,7 +33,8 @@ namespace Microsoft.IronPythonTools.Interpreter {
         public IPythonType EventHandlerType {
             get {
                 if (_eventHandlerType == null) {
-                    _eventHandlerType = Interpreter.GetTypeFromType(Interpreter.Remote.GetEventPythonType(Value));
+                    var ri = RemoteInterpreter;
+                    _eventHandlerType = ri != null ? Interpreter.GetTypeFromType(ri.GetEventPythonType(Value)) : null;
                 }
                 return _eventHandlerType;
             }
@@ -42,7 +42,8 @@ namespace Microsoft.IronPythonTools.Interpreter {
 
         public IList<IPythonType> GetEventParameterTypes() {
             if (_parameterTypes == null) {
-                var types = Interpreter.Remote.GetEventParameterPythonTypes(Value);
+                var ri = RemoteInterpreter;
+                var types = ri != null ? ri.GetEventParameterPythonTypes(Value) : new ObjectIdentityHandle[0];
 
                 var paramTypes = new IPythonType[types.Length];
                 for (int i = 0; i < paramTypes.Length; i++) {
@@ -55,7 +56,10 @@ namespace Microsoft.IronPythonTools.Interpreter {
         }
 
         public string Documentation {
-            get { return Interpreter.Remote.GetEventDocumentation(Value); }
+            get {
+                var ri = RemoteInterpreter;
+                return ri != null ? ri.GetEventDocumentation(Value) : string.Empty;
+            }
         }
 
         #endregion

--- a/Python/Product/IronPython/Interpreter/IronPythonExtensionProperty.cs
+++ b/Python/Product/IronPython/Interpreter/IronPythonExtensionProperty.cs
@@ -29,7 +29,8 @@ namespace Microsoft.IronPythonTools.Interpreter {
         public IPythonType Type {
             get {
                 if (_propertyType == null) {
-                    _propertyType = Interpreter.GetTypeFromType(Interpreter.Remote.GetExtensionPropertyType(Value));
+                    var ri = RemoteInterpreter;
+                    _propertyType = ri != null ? Interpreter.GetTypeFromType(ri.GetExtensionPropertyType(Value)) : null;
                 }
                 return _propertyType;
             }
@@ -42,7 +43,10 @@ namespace Microsoft.IronPythonTools.Interpreter {
         }
 
         public string Documentation {
-            get { return Interpreter.Remote.GetExtensionPropertyDocumentation(Value); }
+            get {
+                var ri = RemoteInterpreter;
+                return ri != null ? ri.GetExtensionPropertyDocumentation(Value) : string.Empty;
+            }
         }
 
         public string Description {

--- a/Python/Product/IronPython/Interpreter/IronPythonField.cs
+++ b/Python/Product/IronPython/Interpreter/IronPythonField.cs
@@ -29,7 +29,8 @@ namespace Microsoft.IronPythonTools.Interpreter {
         public IPythonType Type {
             get {
                 if (_fieldType == null) {
-                    _fieldType = (IPythonType)Interpreter.MakeObject(Interpreter.Remote.GetFieldType(Value));
+                    var ri = RemoteInterpreter;
+                    _fieldType = ri != null ? (IPythonType)Interpreter.MakeObject(ri.GetFieldType(Value)) : null;
                 }
                 return _fieldType;
             }
@@ -38,7 +39,8 @@ namespace Microsoft.IronPythonTools.Interpreter {
         public bool IsStatic {
             get {
                 if (_isStatic == null) {
-                    _isStatic = Interpreter.Remote.IsFieldStatic(Value);
+                    var ri = RemoteInterpreter;
+                    _isStatic = ri != null ? ri.IsFieldStatic(Value) : false;
                 }
 
                 return _isStatic.Value;
@@ -46,7 +48,10 @@ namespace Microsoft.IronPythonTools.Interpreter {
         }
 
         public string Documentation {
-            get { return Interpreter.Remote.GetFieldDocumentation(Value); }
+            get {
+                var ri = RemoteInterpreter;
+                return ri != null ? ri.GetFieldDocumentation(Value) : string.Empty;
+            }
         }
 
         public string Description {

--- a/Python/Product/IronPython/Interpreter/IronPythonInterpreter.cs
+++ b/Python/Product/IronPython/Interpreter/IronPythonInterpreter.cs
@@ -195,6 +195,11 @@ namespace Microsoft.IronPythonTools.Interpreter {
         private void ReloadRemoteDomain() {
             var oldUnloader = _unloader;
 
+            var evt = UnloadingDomain;
+            if (evt != null) {
+                evt(this, EventArgs.Empty);
+            }
+
             lock (this) {
                 _members.Clear();
                 _modules.Clear();
@@ -209,6 +214,8 @@ namespace Microsoft.IronPythonTools.Interpreter {
 
             oldUnloader.Dispose();
         }
+
+        public event EventHandler UnloadingDomain;
 
         private ObjectHandle LoadAssemblyByName(string name) {
             return Remote.LoadAssemblyByName(name);
@@ -534,6 +541,11 @@ namespace Microsoft.IronPythonTools.Interpreter {
         #region IDisposable Members
 
         public void Dispose() {
+            var evt = UnloadingDomain;
+            if (evt != null) {
+                evt(this, EventArgs.Empty);
+            }
+
             if (_factory != null) {
                 _factory.NewDatabaseAvailable -= OnNewDatabaseAvailable;
             }

--- a/Python/Product/IronPython/Interpreter/IronPythonModule.cs
+++ b/Python/Product/IronPython/Interpreter/IronPythonModule.cs
@@ -36,7 +36,8 @@ namespace Microsoft.IronPythonTools.Interpreter {
         public string Name {
             get {
                 if (_name == null) {
-                    _name = Interpreter.Remote.GetModuleName(Value);
+                    var ri = RemoteInterpreter;
+                    _name = ri != null ? ri.GetModuleName(Value) : string.Empty;
                 }
                 return _name; 
             }
@@ -55,7 +56,8 @@ namespace Microsoft.IronPythonTools.Interpreter {
         }
 
         private void AddWpfReferences() {
-            if (Interpreter.Remote.LoadWpf()) {
+            var ri = RemoteInterpreter;
+            if (ri != null && ri.LoadWpf()) {
                 Interpreter.RaiseModuleNamesChanged();
             }
         }
@@ -66,7 +68,8 @@ namespace Microsoft.IronPythonTools.Interpreter {
 
         public string Documentation {
             get {
-                return Interpreter.Remote.GetModuleDocumentation(Value);
+                var ri = RemoteInterpreter;
+                return ri != null ? ri.GetModuleDocumentation(Value) : string.Empty;
             }
         }
 

--- a/Python/Product/IronPython/Interpreter/IronPythonNamespace.cs
+++ b/Python/Product/IronPython/Interpreter/IronPythonNamespace.cs
@@ -13,6 +13,7 @@
  * ***************************************************************************/
 
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.PythonTools.Interpreter;
 using Microsoft.Scripting.Actions;
 
@@ -25,7 +26,10 @@ namespace Microsoft.IronPythonTools.Interpreter {
         #region IPythonModule Members
 
         public string Name {
-            get { return Interpreter.Remote.GetNamespaceName(Value); }
+            get {
+                var ri = RemoteInterpreter;
+                return ri != null ? ri.GetNamespaceName(Value) : string.Empty;
+            }
         }
 
         public void Imported(IModuleContext context) {
@@ -33,7 +37,8 @@ namespace Microsoft.IronPythonTools.Interpreter {
         }
 
         public IEnumerable<string> GetChildrenModules() {
-            return Interpreter.Remote.GetNamespaceChildren(Value);
+            var ri = RemoteInterpreter;
+            return ri != null ? ri.GetNamespaceChildren(Value) : Enumerable.Empty<string>();
         }
 
         public string Documentation {

--- a/Python/Product/IronPython/Interpreter/IronPythonProperty.cs
+++ b/Python/Product/IronPython/Interpreter/IronPythonProperty.cs
@@ -30,7 +30,8 @@ namespace Microsoft.IronPythonTools.Interpreter {
         public IPythonType Type {
             get {
                 if (_propertyType == null) {
-                    _propertyType = (IPythonType)Interpreter.MakeObject(Interpreter.Remote.GetPropertyType(Value));
+                    var ri = RemoteInterpreter;
+                    _propertyType = ri != null ? (IPythonType)Interpreter.MakeObject(ri.GetPropertyType(Value)) : null;
                 }
                 return _propertyType;
             }
@@ -39,7 +40,8 @@ namespace Microsoft.IronPythonTools.Interpreter {
         public bool IsStatic {
             get {
                 if (_isStatic == null) {
-                    _isStatic = Interpreter.Remote.IsPropertyStatic(Value);
+                    var ri = RemoteInterpreter;
+                    _isStatic = ri != null ? ri.IsPropertyStatic(Value) : false;
                 }
                 return _isStatic.Value;
             }
@@ -47,7 +49,8 @@ namespace Microsoft.IronPythonTools.Interpreter {
 
         public string Documentation {
             get {
-                return Interpreter.Remote.GetPropertyDocumentation(Value);
+                var ri = RemoteInterpreter;
+                return ri != null ? ri.GetPropertyDocumentation(Value) : string.Empty;
             }
         }
 

--- a/Python/Product/IronPython/Interpreter/IronPythonType.cs
+++ b/Python/Product/IronPython/Interpreter/IronPythonType.cs
@@ -38,7 +38,8 @@ namespace Microsoft.IronPythonTools.Interpreter {
 
         public IPythonFunction GetConstructors() {
             if (_ctors == null) {
-                if (!Interpreter.Remote.PythonTypeHasNewOrInitMethods(Value)) {
+                var ri = RemoteInterpreter;
+                if (ri != null && !ri.PythonTypeHasNewOrInitMethods(Value)) {
                     _ctors = GetClrOverloads();
                 }
 
@@ -53,7 +54,8 @@ namespace Microsoft.IronPythonTools.Interpreter {
         /// Returns the overloads for a normal .NET type
         /// </summary>
         private IPythonFunction GetClrOverloads() {
-            var ctors = Interpreter.Remote.GetPythonTypeConstructors(Value);
+            var ri = RemoteInterpreter;
+            var ctors = ri != null ? ri.GetPythonTypeConstructors(Value) : null;
             if (ctors != null) {
                 return new IronPythonConstructorFunction(Interpreter, ctors, this);
             }
@@ -63,7 +65,8 @@ namespace Microsoft.IronPythonTools.Interpreter {
         public override PythonMemberType MemberType {
             get {
                 if (_memberType == PythonMemberType.Unknown) {
-                    _memberType = Interpreter.Remote.GetPythonTypeMemberType(Value);
+                    var ri = RemoteInterpreter;
+                    _memberType = ri != null ? ri.GetPythonTypeMemberType(Value) : PythonMemberType.Unknown;
                 }
                 return _memberType;
             }
@@ -72,7 +75,8 @@ namespace Microsoft.IronPythonTools.Interpreter {
         public string Name {
             get {
                 if (_name == null) {
-                    _name = Interpreter.Remote.GetPythonTypeName(Value);
+                    var ri = RemoteInterpreter;
+                    _name = ri != null ? ri.GetPythonTypeName(Value) : string.Empty;
                 }
 
                 return _name; 
@@ -81,14 +85,16 @@ namespace Microsoft.IronPythonTools.Interpreter {
 
         public string Documentation {
             get {
-                return Interpreter.Remote.GetPythonTypeDocumentation(Value);
+                var ri = RemoteInterpreter;
+                return ri != null ? ri.GetPythonTypeDocumentation(Value) : string.Empty;
             }
         }
 
         public BuiltinTypeId TypeId {
             get {
                 if (_typeId == null) {
-                    _typeId = Interpreter.Remote.PythonTypeGetBuiltinTypeId(Value);
+                    var ri = RemoteInterpreter;
+                    _typeId = ri != null ? ri.PythonTypeGetBuiltinTypeId(Value) : BuiltinTypeId.Unknown;
                 }
                 return _typeId.Value;
             }
@@ -96,14 +102,16 @@ namespace Microsoft.IronPythonTools.Interpreter {
 
         public IPythonModule DeclaringModule {
             get {
-                return Interpreter.ImportModule(Interpreter.Remote.GetTypeDeclaringModule(Value));
+                var ri = RemoteInterpreter;
+                return ri != null ? Interpreter.ImportModule(ri.GetTypeDeclaringModule(Value)) : null;
             }
         }
 
         public IList<IPythonType> Mro {
             get {
                 if (_mro == null) {
-                    var types = Interpreter.Remote.GetPythonTypeMro(Value);
+                    var ri = RemoteInterpreter;
+                    var types = ri != null ? ri.GetPythonTypeMro(Value) : new ObjectIdentityHandle[0];
                     var mro = new IPythonType[types.Length];
                     for (int i = 0; i < types.Length; ++i) {
                         mro[i] = Interpreter.GetTypeFromType(types[i]);
@@ -128,17 +136,20 @@ namespace Microsoft.IronPythonTools.Interpreter {
 
         public bool IsArray {
             get {
-                return Interpreter.Remote.IsPythonTypeArray(Value);
+                var ri = RemoteInterpreter;
+                return ri != null ? ri.IsPythonTypeArray(Value) : false;
             }
         }
 
         public IPythonType GetElementType() {
-            return Interpreter.GetTypeFromType(Interpreter.Remote.GetPythonTypeElementType(Value));
+            var ri = RemoteInterpreter;
+            return ri != null ? Interpreter.GetTypeFromType(ri.GetPythonTypeElementType(Value)) : null;
         }
 
         public IList<IPythonType> GetTypesPropagatedOnCall() {
             if (_propagateOnCall == null) {
-                if (Interpreter.Remote.IsDelegateType(Value)) {
+                var ri = RemoteInterpreter;
+                if (ri != null && ri.IsDelegateType(Value)) {
                     _propagateOnCall = GetEventInvokeArgs();
                 } else {
                     _propagateOnCall = EmptyTypes;
@@ -151,7 +162,8 @@ namespace Microsoft.IronPythonTools.Interpreter {
         #endregion
 
         private IPythonType[] GetEventInvokeArgs() {
-            var types = Interpreter.Remote.GetEventInvokeArgs(Value);
+            var ri = RemoteInterpreter;
+            var types = ri != null ? ri.GetEventInvokeArgs(Value) : new ObjectIdentityHandle[0];
 
             var args = new IPythonType[types.Length];
             for (int i = 0; i < types.Length; i++) {
@@ -165,7 +177,8 @@ namespace Microsoft.IronPythonTools.Interpreter {
         public bool IsGenericTypeDefinition {
             get {
                 if (_genericTypeDefinition == null) {
-                    _genericTypeDefinition = Interpreter.Remote.IsPythonTypeGenericTypeDefinition(Value);
+                    var ri = RemoteInterpreter;
+                    _genericTypeDefinition = ri != null ? ri.IsPythonTypeGenericTypeDefinition(Value) : false;
                 }
                 return _genericTypeDefinition.Value;
             }
@@ -177,7 +190,8 @@ namespace Microsoft.IronPythonTools.Interpreter {
             for (int i = 0; i < types.Length; i++) {
                 types[i] = ((IronPythonType)indexTypes[i]).Value;
             }
-            return Interpreter.GetTypeFromType(Interpreter.Remote.PythonTypeMakeGenericType(Value, types));
+            var ri = RemoteInterpreter;
+            return ri != null ? Interpreter.GetTypeFromType(ri.PythonTypeMakeGenericType(Value, types)) : null;
         }
 
         #endregion

--- a/Python/Product/IronPython/Interpreter/IronPythonTypeGroup.cs
+++ b/Python/Product/IronPython/Interpreter/IronPythonTypeGroup.cs
@@ -33,7 +33,8 @@ namespace Microsoft.IronPythonTools.Interpreter {
 
         public IPythonFunction GetConstructors() {
             if (_ctors == null) {
-                if (!Interpreter.Remote.TypeGroupHasNewOrInitMethods(Value)) {
+                var ri = RemoteInterpreter;
+                if (ri != null && !ri.TypeGroupHasNewOrInitMethods(Value)) {
                     _ctors = GetClrOverloads();
                 }
 
@@ -54,30 +55,36 @@ namespace Microsoft.IronPythonTools.Interpreter {
         /// Returns the overloads for a normal .NET type
         /// </summary>
         private IPythonFunction GetClrOverloads() {
-            ObjectIdentityHandle declType;
-            var ctors = Interpreter.Remote.GetTypeGroupConstructors(Value, out declType);
+            ObjectIdentityHandle declType = default(ObjectIdentityHandle);
+            var ri = RemoteInterpreter;
+            var ctors = ri != null ? ri.GetTypeGroupConstructors(Value, out declType) : null;
             if (ctors != null) {
                 return new IronPythonConstructorFunction(Interpreter, ctors, Interpreter.GetTypeFromType(declType));
             }
-            return null;            
+            return null;
         }
 
         public override PythonMemberType MemberType {
             get {
                 if (_memberType == PythonMemberType.Unknown) {
-                    _memberType = Interpreter.Remote.GetTypeGroupMemberType(Value);
+                    var ri = RemoteInterpreter;
+                    _memberType = ri != null ? ri.GetTypeGroupMemberType(Value) : PythonMemberType.Unknown;
                 }
                 return _memberType;
             }
         }
 
         public string Name {
-            get { return Interpreter.Remote.GetTypeGroupName(Value); }
+            get {
+                var ri = RemoteInterpreter;
+                return ri != null ? ri.GetTypeGroupName(Value) : string.Empty;
+            }
         }
 
         public string Documentation {
             get {
-                return Interpreter.Remote.GetTypeGroupDocumentation(Value);
+                var ri = RemoteInterpreter;
+                return ri != null ? ri.GetTypeGroupDocumentation(Value) : string.Empty;
             }
         }
 
@@ -89,9 +96,8 @@ namespace Microsoft.IronPythonTools.Interpreter {
 
         public IPythonModule DeclaringModule {
             get {
-                return Interpreter.ImportModule(
-                    Interpreter.Remote.GetTypeGroupDeclaringModule(Value)
-                );
+                var ri = RemoteInterpreter;
+                return ri != null ? Interpreter.ImportModule(ri.GetTypeGroupDeclaringModule(Value)) : null;
             }
         }
 
@@ -128,7 +134,8 @@ namespace Microsoft.IronPythonTools.Interpreter {
 
         public IList<IPythonType> GetTypesPropagatedOnCall() {
             if (_eventInvokeArgs == null) {
-                var types = Interpreter.Remote.GetTypeGroupEventInvokeArgs(Value);
+                var ri = RemoteInterpreter;
+                var types = ri != null ? ri.GetTypeGroupEventInvokeArgs(Value) : null;
                 if (types == null) {
                     _eventInvokeArgs = IronPythonType.EmptyTypes;
                 } else {
@@ -150,7 +157,8 @@ namespace Microsoft.IronPythonTools.Interpreter {
         public bool IsGenericTypeDefinition {
             get {
                 if (_genericTypeDefinition == null) {
-                    _genericTypeDefinition = Interpreter.Remote.TypeGroupIsGenericTypeDefinition(Value);
+                    var ri = RemoteInterpreter;
+                    _genericTypeDefinition = ri != null ? ri.TypeGroupIsGenericTypeDefinition(Value) : false;
                 }
                 return _genericTypeDefinition.Value;
             }
@@ -163,7 +171,8 @@ namespace Microsoft.IronPythonTools.Interpreter {
                 types[i] = ((IronPythonType)indexTypes[i]).Value;
             }
 
-            return Interpreter.GetTypeFromType(Interpreter.Remote.TypeGroupMakeGenericType(Value, types));
+            var ri = RemoteInterpreter;
+            return ri != null ? Interpreter.GetTypeFromType(ri.TypeGroupMakeGenericType(Value, types)) : null;
         }
 
         #endregion

--- a/Python/Product/IronPython/Interpreter/RemoteInterpreterProxy.cs
+++ b/Python/Product/IronPython/Interpreter/RemoteInterpreterProxy.cs
@@ -29,7 +29,12 @@ namespace Microsoft.IronPythonTools.Interpreter {
         public RemoteInterpreterProxy() {
             AppDomain.CurrentDomain.AssemblyResolve += new ResolveEventHandler(CurrentDomain_AssemblyResolve);
             AppDomain.CurrentDomain.TypeResolve += new ResolveEventHandler(CurrentDomain_AssemblyResolve);
+            AppDomain.CurrentDomain.DomainUnload += CurrentDomain_Unload;
             _remoteInterpreter = new RemoteInterpreter();
+        }
+
+        private void CurrentDomain_Unload(object sender, EventArgs e) {
+            throw new NotImplementedException();
         }
 
         System.Reflection.Assembly CurrentDomain_AssemblyResolve(object sender, ResolveEventArgs args) {

--- a/Python/Product/IronPython/Interpreter/RemoteInterpreterProxy.cs
+++ b/Python/Product/IronPython/Interpreter/RemoteInterpreterProxy.cs
@@ -29,12 +29,7 @@ namespace Microsoft.IronPythonTools.Interpreter {
         public RemoteInterpreterProxy() {
             AppDomain.CurrentDomain.AssemblyResolve += new ResolveEventHandler(CurrentDomain_AssemblyResolve);
             AppDomain.CurrentDomain.TypeResolve += new ResolveEventHandler(CurrentDomain_AssemblyResolve);
-            AppDomain.CurrentDomain.DomainUnload += CurrentDomain_Unload;
             _remoteInterpreter = new RemoteInterpreter();
-        }
-
-        private void CurrentDomain_Unload(object sender, EventArgs e) {
-            throw new NotImplementedException();
         }
 
         System.Reflection.Assembly CurrentDomain_AssemblyResolve(object sender, ResolveEventArgs args) {


### PR DESCRIPTION
Fixes #802 VS crash with IronPython
Captures the remote interpreter proxy along with the object handle, and stops trying to call into the remote interpreter when we know it's been disposed.