### PR TITLE
Removes strict VSU1 build/runtime requirement.

### DIFF
--- a/Common/Setup/LaunchConditions.wxs
+++ b/Common/Setup/LaunchConditions.wxs
@@ -68,7 +68,7 @@
       <RegistrySearch Id="VSPrereleaseInstallDir" Root="HKLM" Key="Software\Microsoft\VisualStudio\$(var.VSTargetVersion)\Setup\VS" Name="ProductDir" Type="directory">
         <DirectorySearch Id="VSPrereleaseInstallDir_Common7_IDE" Path="Common7\IDE" Depth="1">
           <?if "$(var.VSTargetVersion)"="14.0" ?>
-          <FileSearch Id="VSPrerelease_Common7_IDE_msenv_dll" Name="msenv.dll" MinVersion="14.0.0.0" MaxVersion="14.0.24600.0"/>
+          <FileSearch Id="VSPrerelease_Common7_IDE_msenv_dll" Name="msenv.dll" MinVersion="14.0.0.0" MaxVersion="14.0.23102.0"/>
           <?elseif "$(var.VSTargetVersion)"="12.0" ?>
           <FileSearch Id="VSPrerelease_Common7_IDE_msenv_dll" Name="msenv.dll" MinVersion="12.0.0.0" MaxVersion="12.0.21004.0"/>
           <?endif ?>

--- a/Python/Product/PythonTools/PythonTools.csproj
+++ b/Python/Product/PythonTools/PythonTools.csproj
@@ -48,7 +48,6 @@
     <StartProgram>$(DevEnvDir)devenv.exe</StartProgram>
     <StartArguments>/rootSuffix Exp /Log</StartArguments>
     <DefineConstants>$(DefineConstants);$(SignedSym);SHAREDPROJECT_OLESERVICEPROVIDER</DefineConstants>
-    <DefineConstants Condition="$(FeatureInteractiveCommandsContentType)">$(DefineConstants);FEATURE_INTERACTIVE_COMMANDS_CONTENT_TYPE</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Platform)' == 'AnyCPU' ">

--- a/Python/Product/PythonTools/PythonTools/Repl/PythonDebugReplEvaluator.cs
+++ b/Python/Product/PythonTools/PythonTools/Repl/PythonDebugReplEvaluator.cs
@@ -45,9 +45,7 @@ using ReplRoleAttribute = Microsoft.PythonTools.Repl.InteractiveWindowRoleAttrib
 namespace Microsoft.PythonTools.Repl {
     [ReplRole("Debug")]
     [ContentType(PythonCoreConstants.ContentType)]
-#if FEATURE_INTERACTIVE_COMMANDS_CONTENT_TYPE
     [ContentType(PredefinedInteractiveCommandsContentTypes.InteractiveCommandContentTypeName)]
-#endif
     internal class PythonDebugReplEvaluator : IReplEvaluator, IMultipleScopeEvaluator, IPythonReplIntellisense {
         private IReplWindow _window;
         private PythonDebugProcessReplEvaluator _activeEvaluator;

--- a/Python/Product/PythonTools/PythonTools/Repl/PythonReplEvaluator.cs
+++ b/Python/Product/PythonTools/PythonTools/Repl/PythonReplEvaluator.cs
@@ -46,9 +46,7 @@ namespace Microsoft.PythonTools.Repl {
     [ReplRole("Execution")]
     [ReplRole("Reset")]
     [ContentType(PythonCoreConstants.ContentType)]
-#if FEATURE_INTERACTIVE_COMMANDS_CONTENT_TYPE
     [ContentType(PredefinedInteractiveCommandsContentTypes.InteractiveCommandContentTypeName)]
-#endif
     internal class PythonReplEvaluator : BasePythonReplEvaluator {
         private IPythonInterpreterFactory _interpreter;
         private readonly IInterpreterOptionsService _interpreterService;

--- a/Python/products.settings
+++ b/Python/products.settings
@@ -21,9 +21,5 @@
     <FeatureAzureRemoteDebug>$(ReleaseBuild)</FeatureAzureRemoteDebug>
     <FeatureAzureRemoteDebug Condition="$(VSMajorVersion) > 12 or ($(VSMajorVersion) == 12 and $(VSUpdateVersion) >= 30723)">true</FeatureAzureRemoteDebug>
     <FeatureAzureRemoteDebug Condition="'$(FeatureAzureRemoteDebug)' == ''">false</FeatureAzureRemoteDebug>
-    
-    <FeatureInteractiveCommandsContentType>false</FeatureInteractiveCommandsContentType>
-    <FeatureInteractiveCommandsContentType Condition="$(VSMajorVersion) > 14 or ($(VSMajorVersion) == 14 and $(VSUpdateVersion) > 24600)">true</FeatureInteractiveCommandsContentType>
-    <FeatureInteractiveCommandsContentType Condition="'$(FeatureInteractiveCommandsContentType)' == ''">false</FeatureInteractiveCommandsContentType>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Looks like there's enough info available to build without having to lock to VSU1, so trying a build with RTM and running against the update.