### PR TITLE
Issue 926

### DIFF
--- a/Python/Product/Analysis/Parsing/PythonAsciiEncoding.cs
+++ b/Python/Product/Analysis/Parsing/PythonAsciiEncoding.cs
@@ -294,7 +294,7 @@ namespace Microsoft.PythonTools.Parsing {
         public override char GetNextChar() {
             if (_fallbackLen > 0) {
                 _fallbackLen--;
-                return '\uFFFD';
+                return '?';
             }
             return '\0';
         }

--- a/Python/Product/Analysis/Parsing/PythonAsciiEncoding.cs
+++ b/Python/Product/Analysis/Parsing/PythonAsciiEncoding.cs
@@ -292,8 +292,11 @@ namespace Microsoft.PythonTools.Parsing {
         }
 
         public override char GetNextChar() {
-            _fallbackLen--;
-            return '?';
+            if (_fallbackLen > 0) {
+                _fallbackLen--;
+                return '\uFFFD';
+            }
+            return '\0';
         }
 
         public override bool MovePrevious() {

--- a/Python/Product/PythonTools/PythonTools/Intellisense/ProjectAnalyzer.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/ProjectAnalyzer.cs
@@ -963,6 +963,7 @@ namespace Microsoft.PythonTools.Intellisense {
                 try {
                     ast = parser.ParseFile();
                 } catch (BadSourceException) {
+                } catch (System.Text.EncoderFallbackException) {
                 } catch (Exception e) {
                     if (e.IsCriticalException()) {
                         throw;

--- a/Python/Product/PythonTools/PythonTools/Project/PythonEncodingDetector.cs
+++ b/Python/Product/PythonTools/PythonTools/Project/PythonEncodingDetector.cs
@@ -26,13 +26,7 @@ namespace Microsoft.PythonTools.Project {
     [Name("PythonEncodingDetector")]
     class PythonEncodingDetector : IEncodingDetector {
         public Encoding GetStreamEncoding(Stream stream) {
-            var res = Parser.GetEncodingFromStream(stream) ?? Parser.DefaultEncodingNoFallback;
-            if (res == Parser.DefaultEncoding) {
-                // return a version of the fallback buffer that doesn't throw exceptions, VS will detect the failure, and inform
-                // the user of the problem.
-                return Parser.DefaultEncodingNoFallback;
-            }
-            return res;
+            return Parser.GetEncodingFromStream(stream);
         }
     }
 }


### PR DESCRIPTION
Fixes #926 Cannot open file when coding comment does not match actual encoding
Makes fallback class only return correct number of substitution characters.
Changes default encoding to UTF-8 properly.
Makes GetEncodingFromStream() (only used for the editor detection) return non-throwing encodings.
