### PR TITLE
Fixing bug in PTVS for UWP python scenarios

### DIFF
--- a/Python/Product/Uwp/Project/PythonUwpProjectConfig.cs
+++ b/Python/Product/Uwp/Project/PythonUwpProjectConfig.cs
@@ -100,6 +100,12 @@ namespace Microsoft.PythonTools.Uwp.Project {
             const int attachRetryLimit = 10;
             int attachRetryCount = 0;
 
+            // Remove the port number if exist
+            int index = remoteMachine.IndexOf(':');
+            if (index != -1) {
+                remoteMachine = remoteMachine.Substring(0, index);
+            }
+
             var qualifierString = string.Format(
                 "tcp://{0}@{1}:{2}?{3}={4}&{5}={6}&{7}={8}",
                 secret,

--- a/Python/Product/Uwp/Templates/Projects/BackgroundService/PythonBackgroundService.pyproj
+++ b/Python/Product/Uwp/Templates/Projects/BackgroundService/PythonBackgroundService.pyproj
@@ -50,9 +50,9 @@
 
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
-    <PtvsVersion Condition="'$(PtvsVersion)' == ''">2.2</PtvsVersion>
-    <PtvsTargetsFile>$(LocalAppData)\Microsoft\VisualStudio\$(VisualStudioVersion)Exp\Extensions\Microsoft\Python Tools for Visual Studio - UWP\$(PtvsVersion)\Microsoft.PythonTools.Uwp.targets</PtvsTargetsFile>
-    <PtvsTargetsFile Condition="'$(PtvsTargetsFile)' == '' or !Exists('$(PtvsTargetsFile)')">$(MSBuildProgramFiles32)\Microsoft Visual Studio $(VisualStudioVersion)\Common7\IDE\Extensions\Microsoft\Python Tools for Visual Studio - UWP\$(PtvsVersion)\Microsoft.PythonTools.Uwp.targets</PtvsTargetsFile>
+    <PtvsVersion Condition="'$(PtvsVersion)' == ''">3.0</PtvsVersion>
+    <PtvsTargetsFile>$(LocalAppData)\Microsoft\VisualStudio\$(VisualStudioVersion)Exp\Extensions\Microsoft Corporation\Python Tools for Visual Studio - UWP\$(PtvsVersion)\Microsoft.PythonTools.Uwp.targets</PtvsTargetsFile>
+    <PtvsTargetsFile Condition="'$(PtvsTargetsFile)' == '' or !Exists('$(PtvsTargetsFile)')">$(MSBuildProgramFiles32)\Microsoft Visual Studio $(VisualStudioVersion)\Common7\IDE\Extensions\Microsoft Corporation\Python Tools for Visual Studio - UWP\$(PtvsVersion)\Microsoft.PythonTools.Uwp.targets</PtvsTargetsFile>
   </PropertyGroup>
 
   <Import Project="$(PtvsTargetsFile)" />


### PR DESCRIPTION
- Update PTVS version number and directory location
- Fixed an issue where the VS cannot attach the python debugger due to a malformated tcp string.

@zooba - For bug fixes in update 1?  Do I commit them in Master or v2.2.1 branch?  The first commit (Update PTVS version number and directory location) probably doesn't need to go into the v2.2.1 branch.