### PR TITLE
Fixes #960 REPL command aliases do not work

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Repl/DebugReplFrameDownCommand.cs
+++ b/Python/Product/PythonTools/PythonTools/Repl/DebugReplFrameDownCommand.cs
@@ -93,6 +93,9 @@ namespace Microsoft.PythonTools.Repl {
         public IEnumerable<string> Names {
             get {
                 yield return Command;
+                foreach (var a in Aliases) {
+                    yield return a;
+                }
             }
         }
 #endif

--- a/Python/Product/PythonTools/PythonTools/Repl/DebugReplFrameUpCommand.cs
+++ b/Python/Product/PythonTools/PythonTools/Repl/DebugReplFrameUpCommand.cs
@@ -93,6 +93,9 @@ namespace Microsoft.PythonTools.Repl {
         public IEnumerable<string> Names {
             get {
                 yield return Command;
+                foreach (var a in Aliases) {
+                    yield return a;
+                }
             }
         }
 #endif

--- a/Python/Product/PythonTools/PythonTools/Repl/DebugReplFramesCommand.cs
+++ b/Python/Product/PythonTools/PythonTools/Repl/DebugReplFramesCommand.cs
@@ -93,6 +93,9 @@ namespace Microsoft.PythonTools.Repl {
         public IEnumerable<string> Names {
             get {
                 yield return Command;
+                foreach (var a in Aliases) {
+                    yield return a;
+                }
             }
         }
 #endif

--- a/Python/Product/PythonTools/PythonTools/Repl/DebugReplGoCommand.cs
+++ b/Python/Product/PythonTools/PythonTools/Repl/DebugReplGoCommand.cs
@@ -95,6 +95,9 @@ namespace Microsoft.PythonTools.Repl {
         public IEnumerable<string> Names {
             get {
                 yield return Command;
+                foreach (var a in Aliases) {
+                    yield return a;
+                }
             }
         }
 #endif

--- a/Python/Product/PythonTools/PythonTools/Repl/DebugReplStepIntoCommand.cs
+++ b/Python/Product/PythonTools/PythonTools/Repl/DebugReplStepIntoCommand.cs
@@ -94,6 +94,9 @@ namespace Microsoft.PythonTools.Repl {
         public IEnumerable<string> Names {
             get {
                 yield return Command;
+                foreach (var a in Aliases) {
+                    yield return a;
+                }
             }
         }
 #endif

--- a/Python/Product/PythonTools/PythonTools/Repl/DebugReplStepOutCommand.cs
+++ b/Python/Product/PythonTools/PythonTools/Repl/DebugReplStepOutCommand.cs
@@ -94,6 +94,9 @@ namespace Microsoft.PythonTools.Repl {
         public IEnumerable<string> Names {
             get {
                 yield return Command;
+                foreach (var a in Aliases) {
+                    yield return a;
+                }
             }
         }
 #endif

--- a/Python/Product/PythonTools/PythonTools/Repl/DebugReplStepOverCommand.cs
+++ b/Python/Product/PythonTools/PythonTools/Repl/DebugReplStepOverCommand.cs
@@ -94,6 +94,9 @@ namespace Microsoft.PythonTools.Repl {
         public IEnumerable<string> Names {
             get {
                 yield return Command;
+                foreach (var a in Aliases) {
+                    yield return a;
+                }
             }
         }
 #endif


### PR DESCRIPTION
Fixes #960 REPL command aliases do not work
Adds aliases to list of names returned by Names.