### PR TITLE
Fixes #957 Debug REPL commands don't show up in help

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Repl/PythonDebugReplEvaluator.cs
+++ b/Python/Product/PythonTools/PythonTools/Repl/PythonDebugReplEvaluator.cs
@@ -595,6 +595,11 @@ namespace Microsoft.PythonTools.Repl {
 #endif
     }
 
+    [ReplRole("Debug")]
+    [ContentType(PythonCoreConstants.ContentType)]
+#if DEV14_OR_LATER
+    [ContentType(PredefinedInteractiveCommandsContentTypes.InteractiveCommandContentTypeName)]
+#endif
     internal class PythonDebugProcessReplEvaluator : BasePythonReplEvaluator {
         private readonly PythonProcess _process;
         private readonly IThreadIdMapper _threadIdMapper;


### PR DESCRIPTION
Fixes #957 Debug REPL commands don't show up in help
Adds role and content type to process evaluators so that correct commands are loaded.