### PR TITLE
Fixes #962 Django shell REPL input 2 characters for every character

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Intellisense/IntellisenseController.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/IntellisenseController.cs
@@ -253,7 +253,8 @@ namespace Microsoft.PythonTools.Intellisense {
         private bool ShouldTriggerIdentifierCompletionSession(out bool commitByDefault) {
             commitByDefault = true;
 
-            if (!_provider.PythonService.AdvancedOptions.AutoListIdentifiers ||
+            if (_bufferParser == null ||
+                !_provider.PythonService.AdvancedOptions.AutoListIdentifiers ||
                 !_provider.PythonService.AdvancedOptions.AutoListMembers) {
                 return false;
             }


### PR DESCRIPTION
Fixes #962 Django shell REPL input 2 characters for every character
Prevents an exception due to null buffer parser.