### PR TITLE
Fixes #965 Pasting into django shell causes activity log error

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Intellisense/IntellisenseController.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/IntellisenseController.cs
@@ -117,6 +117,10 @@ namespace Microsoft.PythonTools.Intellisense {
             PropagateAnalyzer(subjectBuffer);
 
             Debug.Assert(_bufferParser != null, "SetBufferParser has not been called");
+            if (_bufferParser == null) {
+                return;
+            }
+
             BufferParser existingParser;
             if (!subjectBuffer.Properties.TryGetProperty(typeof(BufferParser), out existingParser)) {
                 _bufferParser.AddBuffer(subjectBuffer);


### PR DESCRIPTION
Fixes #965 Pasting into django shell causes activity log error
Adds early-exit after assertion to avoid runtime exceptions.