### PR TITLE
Fixes #976 IPython REPL will not start

### DIFF
--- a/Python/Product/PythonTools/visualstudio_ipython_repl.py
+++ b/Python/Product/PythonTools/visualstudio_ipython_repl.py
@@ -17,6 +17,7 @@
 import re
 import sys
 from visualstudio_py_repl import BasicReplBackend, ReplBackend, UnsupportedReplException, _command_line_to_args_list
+from visualstudio_py_util import to_bytes
 try:
     import thread
 except:
@@ -288,7 +289,7 @@ class IPythonBackend(ReplBackend):
     def execute_file_as_main(self, filename, arg_string):
         f = open(filename, 'rb')
         try:
-            contents = f.read().replace("\r\n", "\n")
+            contents = f.read().replace(to_bytes("\r\n"), to_bytes("\n"))
         finally:
             f.close()
         args = [filename] + _command_line_to_args_list(arg_string)


### PR DESCRIPTION
Fixes #976 IPython REPL will not start
Adds missing str->bytes conversion for Python 3.x.