### PR TITLE
Should be WindowsError not WinError

### DIFF
--- a/Python/Product/TestAdapter/visualstudio_py_testlauncher.py
+++ b/Python/Product/TestAdapter/visualstudio_py_testlauncher.py
@@ -54,7 +54,7 @@ def main():
             sleep(0.1)
         try:
             debugger_helper = windll['Microsoft.PythonTools.Debugger.Helper.x86.dll']
-        except WinError:
+        except WindowsError:
             debugger_helper = windll['Microsoft.PythonTools.Debugger.Helper.x64.dll']
         isTracing = c_char.in_dll(debugger_helper, "isTracing")
         while True:


### PR DESCRIPTION
This fixes issue when trying to run unit tests on 64bit python in visual studio 2015.

https://docs.python.org/2/library/ctypes.html states that WinError is a wrapper that raises WindowsError which is the builtin python exception that is trying to be trapped.

I have opened a bug #1032, which this pull request should fix.