### PR TITLE
Fixing SCRIPT_NAME and PATH_INFO for non-root applications

### DIFF
--- a/Python/Product/WFastCgi/wfastcgi.py
+++ b/Python/Product/WFastCgi/wfastcgi.py
@@ -803,6 +803,13 @@ def main():
                     record.params['SCRIPT_NAME'] = ''
                     record.params['wsgi.script_name'] = wsgi_encode('')
 
+                # correct SCRIPT_NAME and PATH_INFO if we are told what our SCRIPT_NAME should be
+                if 'SCRIPT_NAME' in os.environ:
+                    record.params['SCRIPT_NAME'] = os.environ['SCRIPT_NAME']
+                    record.params['PATH_INFO'] = record.params['PATH_INFO'][len(record.params['SCRIPT_NAME']):]
+                    record.params['wsgi.script_name'] = wsgi_encode(record.params['SCRIPT_NAME'])
+                    record.params['wsgi.path_info'] = wsgi_encode(record.params['PATH_INFO'])
+
                 # Send each part of the response to FCGI_STDOUT.
                 # Exceptions raised in the handler will be logged by the context
                 # manager and we will then wait for the next record.

--- a/Python/Product/WFastCgi/wfastcgi.py
+++ b/Python/Product/WFastCgi/wfastcgi.py
@@ -804,7 +804,7 @@ def main():
                     record.params['wsgi.script_name'] = wsgi_encode('')
 
                 # correct SCRIPT_NAME and PATH_INFO if we are told what our SCRIPT_NAME should be
-                if 'SCRIPT_NAME' in os.environ:
+                if 'SCRIPT_NAME' in os.environ and record.params['PATH_INFO'].lower().startswith(os.environ['SCRIPT_NAME'].lower()):
                     record.params['SCRIPT_NAME'] = os.environ['SCRIPT_NAME']
                     record.params['PATH_INFO'] = record.params['PATH_INFO'][len(record.params['SCRIPT_NAME']):]
                     record.params['wsgi.script_name'] = wsgi_encode(record.params['SCRIPT_NAME'])


### PR DESCRIPTION
Django depends on SCRIPT_NAME and PATH_INFO adhering to PEP333 (http://www.python.org/dev/peps/pep-0333/)

See issue: #1029 