### PR TITLE
Build process fixes

### DIFF
--- a/.hgeol
+++ b/.hgeol
@@ -1,0 +1,3 @@
+[repository]
+# Do not change line endings of any files
+native = BIN

--- a/Build/BuildReleaseHelpers.psm1
+++ b/Build/BuildReleaseHelpers.psm1
@@ -97,13 +97,16 @@ function begin_sign_files {
             $job.Keywords = $jobKeywords
             
             if ($certificates -match "authenticode") {
-                $job.SelectCertificate("10006")  # Authenticode
+                $job.SelectCertificate("401")    # Authenticode for binaries
+            }
+            if ($certificates -match "msi") {
+                $job.SelectCertificate("400")    # Authenticode for MSI
             }
             if ($certificates -match "strongname") {
                 $job.SelectCertificate("67")     # StrongName key
             }
-            if ($certificates -match "opc") {
-                $job.SelectCertificate("160")     # Microsoft OPC Publisher (VSIX)
+            if ($certificates -match "vsix") {
+                $job.SelectCertificate("100040160") # Microsoft OPC Publisher (VSIX)
             }
             
             foreach ($approver in $approvers) {

--- a/Build/BuildReleaseMockHelpers.psm1
+++ b/Build/BuildReleaseMockHelpers.psm1
@@ -98,18 +98,25 @@ job.Keywords:     $jobKeywords"
     
     if ($certificates -match "authenticode") {
         $msg = "$msg
-job.SelectCertificate(10006)"
-        $job.SelectCertificate("10006")  # Authenticode
+job.SelectCertificate(401)"
+        $job.SelectCertificate("401")    # Authenticode for binaries
+    }
+    if ($certificates -match "msi") {
+        $msg = "$msg
+job.SelectCertificate(400)"
+        $job.SelectCertificate("400")    # Authenticode for MSI
     }
     if ($certificates -match "strongname") {
         $msg = "$msg
 job.SelectCertificate(67)"
         $job.SelectCertificate("67")     # StrongName key
     }
-    if ($certificates -match "opc") {
-        $job.SelectCertificate("160")     # Microsoft OPC Publisher (VSIX)
+    if ($certificates -match "vsix") {
+        $msg = "$msg
+job.SelectCertificate(100040160)"
+        $job.SelectCertificate("100040160") # Microsoft OPC Publisher (VSIX)
     }
-    
+
     foreach ($approver in $approvers) {
         $msg = "$msg
 job.AddApprover($approver)"

--- a/Python/Setup/BuildRelease.ps1
+++ b/Python/Setup/BuildRelease.ps1
@@ -279,7 +279,7 @@ $native_files = (
 
 $supported_vs_versions = (
     @{number="14.0"; name="VS 2015"; build_by_default=$true},
-    @{number="12.0"; name="VS 2013"; build_by_default=$true},
+    @{number="12.0"; name="VS 2013"; build_by_default=$false},
     @{number="11.0"; name="VS 2012"; build_by_default=$false},
     @{number="10.0"; name="VS 2010"; build_by_default=$false}
 )
@@ -593,7 +593,7 @@ try {
 
                     $jobs += begin_sign_files $msi_files $i.signed_msidir $approvers `
                         $project_name $project_url "$project_name $($i.VSName) - installer" $project_keywords `
-                        "authenticode"
+                        "msi"
                 }
 
 
@@ -607,7 +607,7 @@ try {
 
                     $jobs += begin_sign_files $vsix_files $i.signed_msidir $approvers `
                         $project_name $project_url "$project_name $($i.VSName) - VSIX" $project_keywords `
-                        "authenticode;opc"
+                        "vsix"
                 }
             }
 


### PR DESCRIPTION
Fixes signing certificates.
Disables default VS 2013 build.
Prevents hg users from changing line endings