### PR TITLE
Fixes #1097 Cannot add existing virtualenv when home has no trailing backslash

### DIFF
--- a/Python/Product/VSInterpreters/DerivedInterpreterFactory.cs
+++ b/Python/Product/VSInterpreters/DerivedInterpreterFactory.cs
@@ -298,7 +298,7 @@ namespace Microsoft.PythonTools.Interpreter {
                         .Where(m => m != null && m.Success)
                         .Select(m => m.Groups["path"])
                         .Where(g => g != null && g.Success)
-                        .Select(g => g.Value)
+                        .Select(g => g.Value.Trim())
                         .FirstOrDefault(CommonUtils.IsValidPath);
                 } catch (IOException) {
                 } catch (UnauthorizedAccessException) {
@@ -318,7 +318,7 @@ namespace Microsoft.PythonTools.Interpreter {
             if (basePath == null && File.Exists(prefixFile)) {
                 try {
                     var lines = File.ReadAllLines(prefixFile);
-                    basePath = lines.FirstOrDefault(CommonUtils.IsValidPath);
+                    basePath = (lines.FirstOrDefault(CommonUtils.IsValidPath) ?? string.Empty).Trim();
                 } catch (IOException) {
                 } catch (UnauthorizedAccessException) {
                 } catch (System.Security.SecurityException) {

--- a/Python/Product/VSInterpreters/DerivedInterpreterFactory.cs
+++ b/Python/Product/VSInterpreters/DerivedInterpreterFactory.cs
@@ -272,11 +272,11 @@ namespace Microsoft.PythonTools.Interpreter {
             string libPath,
             IInterpreterOptionsService service
         ) {
-            string basePath = GetOrigPrefixPath(prefixPath, libPath);
+            string basePath = CommonUtils.TrimEndSeparator(GetOrigPrefixPath(prefixPath, libPath));
 
             if (Directory.Exists(basePath)) {
                 return service.Interpreters.FirstOrDefault(interp =>
-                    CommonUtils.IsSamePath(interp.Configuration.PrefixPath, basePath)
+                    CommonUtils.IsSamePath(CommonUtils.TrimEndSeparator(interp.Configuration.PrefixPath), basePath)
                 );
             }
             return null;


### PR DESCRIPTION
Fixes #1097 Cannot add existing virtualenv when home has no trailing backslash
Ensures backslashes are trimmed from paths before comparing.