### PR TITLE
Fixes #1064 Debug-Attach to Python 3.5

### DIFF
--- a/Python/Product/Attacher/PyAttacher.cs
+++ b/Python/Product/Attacher/PyAttacher.cs
@@ -40,7 +40,7 @@ namespace Microsoft.PythonTools.Debugger {
 
         private static Process _checkProcess;
         private static readonly Regex _pythonModRegex = new Regex(
-            @".*python(2[5-7]|3[0-4])(_d)?\.dll$",
+            @".*python(2[5-7]|3[0-9])(_d)?\.dll$",
             RegexOptions.IgnoreCase | RegexOptions.IgnorePatternWhitespace | RegexOptions.CultureInvariant
         );
 

--- a/Python/Product/PyDebugAttach/dllmain.cpp
+++ b/Python/Product/PyDebugAttach/dllmain.cpp
@@ -22,20 +22,20 @@ void Detach();
 BOOL APIENTRY DllMain( HMODULE hModule,
                        DWORD  ul_reason_for_call,
                        LPVOID lpReserved
-					 )
+                     )
 {
-	switch (ul_reason_for_call)
-	{
-	case DLL_PROCESS_ATTACH:
+    switch (ul_reason_for_call)
+    {
+    case DLL_PROCESS_ATTACH:
         Attach();
-		break;
-	case DLL_PROCESS_DETACH:
+        break;
+    case DLL_PROCESS_DETACH:
         Detach();
         break;
-	case DLL_THREAD_ATTACH:
-	case DLL_THREAD_DETACH:
+    case DLL_THREAD_ATTACH:
+    case DLL_THREAD_DETACH:
         break;
-	}
-	return TRUE;
+    }
+    return TRUE;
 }
 


### PR DESCRIPTION
Fixes #1064 Debug-Attach to Python 3.5
Enables attaching to Python 3.5
Uses new _PyThreadState_UncheckedGet function in place of _PyThreadState_Current data when available.