### PR TITLE
Temporarily work around #1110 Can't create or load IronPython project

### DIFF
--- a/Python/Product/dirs.proj
+++ b/Python/Product/dirs.proj
@@ -24,9 +24,9 @@
 
     <ProjectFile Include="PythonTools\PythonTools.csproj"/>
 
-    <ProjectFile Include="IronPythonResolver\IronPythonResolver.csproj"/>
-    <ProjectFile Include="IronPython\IronPython.Interpreter.csproj"/>
-    <ProjectFile Include="IronPython\IronPython.csproj"/>
+    <ProjectFile Include="IronPythonResolver\IronPythonResolver.csproj" Condition="'$(IncludeIronPython)' == 'True'"/>
+    <ProjectFile Include="IronPython\IronPython.Interpreter.csproj" Condition="'$(IncludeIronPython)' == 'True'"/>
+    <ProjectFile Include="IronPython\IronPython.csproj" Condition="'$(IncludeIronPython)' == 'True'"/>
 
     <ProjectFile Include="VsPyProf\VsPyProf.vcxproj"/>
     <ProjectFile Include="VsPyProf\VsPyProfX86.vcxproj"/>
@@ -42,9 +42,9 @@
     <ProjectFile Include="AnalysisMemoryTester\AnalysisMemoryTester.csproj" Condition="$(VSTarget) != '15.0'" />
     <ProjectFile Include="EnvironmentsListHost\EnvironmentsListHost.csproj" Condition="$(VSTarget) != '15.0'" />
 
-    <ProjectFile Include="ML\ML.csproj" Condition="$(IncludeML)"/>
+    <ProjectFile Include="ML\ML.csproj" Condition="'$(IncludeML)' == 'True'"/>
     
-    <ProjectFile Include="Uwp\Uwp.csproj"/>
+    <ProjectFile Include="Uwp\Uwp.csproj" Condition="'$(IncludeUwp)' == 'True'"/>
   </ItemGroup>
 
   <Import Project="$(TargetsPath)\Common.Build.Traversal.targets" />

--- a/Python/Setup/PythonToolsInstaller/PythonToolsInstaller.wixproj
+++ b/Python/Setup/PythonToolsInstaller/PythonToolsInstaller.wixproj
@@ -11,9 +11,8 @@
     <DefineConstants>
       $(DefineConstants);
       IncludeVsLogger=$(IncludeVsLogger);
-      IncludeHpc=$(IncludeHpc);
       IncludeUwp=$(IncludeUwp);
-      IncludeReplWindow=$(IncludeReplWindow);
+      IncludeIronPython=$(IncludeIronPython);
     </DefineConstants>
     <DefineConstants Condition="$(VSTarget) == '14.0'">
       $(DefineConstants);
@@ -66,7 +65,7 @@
       <Name>PythonTools</Name>
       <Project>{0D7C4C3A-A08F-4B91-BD1C-C4C79C013484}</Project>
     </ProjectReference>
-    <ProjectReference Include="$(BuildRoot)\Python\Setup\IronPythonInterpreter\IronPythonInterpreter.wixproj">
+    <ProjectReference Include="$(BuildRoot)\Python\Setup\IronPythonInterpreter\IronPythonInterpreter.wixproj" Condition="'$(INcludeIronPython)' == 'True'">
       <Name>IronPythonInterpreterMsm</Name>
       <Project>{92851481-9141-480E-A85D-85120766949C}</Project>
     </ProjectReference>

--- a/Python/Setup/PythonToolsInstaller/PythonToolsInstaller.wxs
+++ b/Python/Setup/PythonToolsInstaller/PythonToolsInstaller.wxs
@@ -197,6 +197,7 @@
 
         <ConfigurationData Name="Config_StartMenuLocation" Value="Dir_StartMenu"/>
       </Merge>
+      <?if "$(var.IncludeIronPython)" ~= "True" ?>
       <Merge Id="Merge_IronPython" Language="1033" SourceFile="IronPython.msm" DiskId="1">
         <?foreach key in VS;WD;VWD?>
         <ConfigurationData Name="Config_$(var.key)ExtensionsParent" Value="Dir_$(var.key)Extensions" />
@@ -204,6 +205,7 @@
         <?endforeach?>
         <ConfigurationData Name="Config_MSBuildLocation" Value="Dir_MSBuildTargets"/>
       </Merge>
+      <?endif ?>
       <?if "$(var.IncludeVsLogger)" ~= "True" ?>
       <Merge Id="Merge_VsLogger" Language="1033" SourceFile="VsLogger.msm" DiskId="1">
         <?foreach key in VS;WD;VWD?>
@@ -239,9 +241,11 @@
       </Feature>
       <?endif?>
       
+      <?if "$(var.IncludeIronPython)" ~= "True" ?>
       <Feature Id="Feature_IronPython" AllowAdvertise="no" Level="1" Title="IronPython support" Description="IronPython support">
         <MergeRef Id="Merge_IronPython"/>
       </Feature>
+      <?endif?>
 
       <Feature Id="Feature_VsPyFile" AllowAdvertise="no" Level="1" Title="Register file associations" Description="Associates Python projects and source files with Visual Studio (existing source file associations are not modified).">
         <ComponentRef Id="Comp_VSPyFileProgId"/>

--- a/Python/Setup/setup.proj
+++ b/Python/Setup/setup.proj
@@ -9,8 +9,8 @@
 
   <ItemGroup>
     <ProjectFile Include="Django\Django.wixproj"/>
-    <ProjectFile Include="IronPythonInterpreter\IronPythonInterpreter.wixproj"/>
-    <ProjectFile Include="Uwp\Uwp.wixproj"/>
+    <ProjectFile Include="IronPythonInterpreter\IronPythonInterpreter.wixproj" Condition="'$(IncludeIronPython)' == 'True'"/>
+    <ProjectFile Include="Uwp\Uwp.wixproj" Condition="'$(IncludeUwp)' == 'True'"/>
     <ProjectFile Include="PythonTools\PythonTools.wixproj"/>
     <ProjectFile Include="PythonProfiling\PythonProfiling.wixproj"/>
     <ProjectFile Include="$(PTVSPRPath)VsLoggerSetup\VsLogger.wixproj" Condition="'$(IncludeVsLogger)' == 'True'"/>

--- a/Python/Tests/dirs.proj
+++ b/Python/Tests/dirs.proj
@@ -16,7 +16,7 @@
     <ProjectFile Include="ProfilingUITests\ProfilingUITests.csproj" />
     <ProjectFile Include="Core\PythonToolsTests.csproj" />
     <ProjectFile Include="Core.UI\PythonToolsUITests.csproj" />
-    <ProjectFile Include="IronPython\IronPythonTests.csproj" />
+    <ProjectFile Include="IronPython\IronPythonTests.csproj" Condition="'$(IncludeIronPython)' == 'True'" />
     <ProjectFile Include="ReplWindowUITests\ReplWindowUITests.csproj" />
     <ProjectFile Include="Utilities.Python\TestUtilities.Python.csproj" />
     <ProjectFile Include="PythonToolsMockTests\PythonToolsMockTests.csproj" />

--- a/Python/products.settings
+++ b/Python/products.settings
@@ -3,5 +3,9 @@
     <!-- Include ML by default, and force to false for VS "15" -->
     <IncludeML Condition="'$(IncludeML)' == ''">true</IncludeML>
     <IncludeML Condition="'$(VSTarget)' == '15.0'">false</IncludeML>
+    
+    <!-- Include IronPython by default, and force to false for VS "15" -->
+    <IncludeIronPython Condition="'$(IncludeIronPython)' == ''">true</IncludeIronPython>
+    <IncludeIronPython Condition="'$(VSTarget)' == '15.0'">false</IncludeIronPython>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Temporarily work around #1110 Can't create or load IronPython project
Exclude IronPython support from builds.
Fixes inconsistencies with other exclusions.