### PR TITLE
Fixes #1161 Cannot find Python install dir when profiling

### DIFF
--- a/Python/Product/Common/Infrastructure/PythonToolsInstallPath.cs
+++ b/Python/Product/Common/Infrastructure/PythonToolsInstallPath.cs
@@ -63,8 +63,8 @@ namespace Microsoft.PythonTools.Infrastructure {
             return string.Empty;
         }
 
-        public static string TryGetFile(string filename) {
-            string path = GetFromAssembly(typeof(PythonToolsInstallPath).Assembly, filename);
+        public static string TryGetFile(string filename, Assembly assembly = null) {
+            string path = GetFromAssembly(assembly ?? typeof(PythonToolsInstallPath).Assembly, filename);
 
             if (string.IsNullOrEmpty(path)) {
                 path = GetFromRegistry(filename);
@@ -73,8 +73,8 @@ namespace Microsoft.PythonTools.Infrastructure {
             return path;
         }
 
-        public static string GetFile(string filename) {
-            var path = TryGetFile(filename);
+        public static string GetFile(string filename, Assembly assembly = null) {
+            var path = TryGetFile(filename, assembly);
 
 #if DEBUG
             if (string.IsNullOrEmpty(path)) {

--- a/Python/Product/Profiling/Profiling/ProfiledProcess.cs
+++ b/Python/Product/Profiling/Profiling/ProfiledProcess.cs
@@ -48,7 +48,7 @@ namespace Microsoft.PythonTools.Profiling {
             _arch = arch;
 
             ProcessStartInfo processInfo;
-            string pythonInstallDir = Path.GetDirectoryName(PythonToolsInstallPath.GetFile("VsPyProf.dll"));
+            string pythonInstallDir = Path.GetDirectoryName(PythonToolsInstallPath.GetFile("VsPyProf.dll", typeof(ProfiledProcess).Assembly));
             string dll = _arch == ProcessorArchitecture.Amd64 ? "VsPyProf.dll" : "VsPyProfX86.dll";
             string arguments = "\"" + Path.Combine(pythonInstallDir, "proflaun.py") + "\" " +
                 "\"" + Path.Combine(pythonInstallDir, dll) + "\" " +


### PR DESCRIPTION
Fixes #1161 Cannot find Python install dir when profiling
Allows callers to PythonToolsInstallPath.GetFile to override the assembly used for locating files.