### PR TITLE
Fixes #1166 Crash opening diagnostic info

### DIFF
--- a/Python/Product/Analysis/Interpreter/PythonInterpreterFactoryWithDatabase.cs
+++ b/Python/Product/Analysis/Interpreter/PythonInterpreterFactoryWithDatabase.cs
@@ -341,8 +341,13 @@ namespace Microsoft.PythonTools.Interpreter {
             if (File.Exists(analysisLog)) {
                 try {
                     return File.ReadAllText(analysisLog);
-                } catch (Exception e) {
-                    return string.Format(culture, "Error reading: {0}", e);
+                } catch (Exception ex) {
+                    return string.Format(
+                        culture,
+                        "Error reading {0}. Please let analysis complete and try again.",
+                        analysisLog,
+                        ex
+                    );
                 }
             }
             return null;


### PR DESCRIPTION
Fixes #1166 Crash opening diagnostic info
Improves exception handling when generating diagnostic info
Also improves output when some errors occur getting logs.