### PR TITLE
Fixes #590 NullReferenceException reinitializing modules

### DIFF
--- a/Python/Tests/Analysis/AnalysisTests.csproj
+++ b/Python/Tests/Analysis/AnalysisTests.csproj
@@ -70,6 +70,7 @@
     <Compile Include="DeserializationTests.cs" />
     <Compile Include="DotNetAnalysis\Generics.cs" />
     <Compile Include="ModulePathTests.cs" />
+    <Compile Include="ModuleTableTests.cs" />
     <Compile Include="ProcessOutputTests.cs" />
     <Compile Include="MutateStdLibTest.cs" />
     <Compile Include="TestExpressions.cs" />

--- a/Python/Tests/Analysis/ModuleTableTests.cs
+++ b/Python/Tests/Analysis/ModuleTableTests.cs
@@ -1,0 +1,67 @@
+﻿// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABLITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+extern alias analysis;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.PythonTools.Analysis;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using TestUtilities;
+using TestUtilities.Python;
+using analysis::Microsoft.PythonTools.Interpreter;
+
+namespace AnalysisTests {
+    [TestClass]
+    public class ModuleTableTests {
+        class MockPythonModule : IPythonModule {
+            private readonly string _name;
+
+            public MockPythonModule(string name) {
+                _name = name;
+            }
+
+            public string Documentation => "";
+            public PythonMemberType MemberType => PythonMemberType.Module;
+            public string Name => _name;
+            public IEnumerable<string> GetChildrenModules() => Enumerable.Empty<string>();
+            public IMember GetMember(IModuleContext context, string name) => null;
+            public IEnumerable<string> GetMemberNames(IModuleContext moduleContext) => Enumerable.Empty<string>();
+            public void Imported(IModuleContext context) { }
+        }
+
+        [TestMethod]
+        public void RemovedModule() {
+            var config = new InterpreterConfiguration(new Version(3, 5));
+            var fact = new MockPythonInterpreterFactory(Guid.NewGuid(), "Test Factory", config);
+            var interp = new MockPythonInterpreter(fact);
+            var modules = new ModuleTable(null, interp);
+
+            var orig = modules.Select(kv => kv.Key).ToSet();
+
+            interp.AddModule("test", new MockPythonModule("test"));
+
+            ModuleReference modref;
+            Assert.IsTrue(modules.TryImport("test", out modref));
+
+            interp.RemoveModule("test", retainName: true);
+
+            modules.ReInit();
+            Assert.IsFalse(modules.TryImport("test", out modref));
+        }
+    }
+}


### PR DESCRIPTION
Fixes #590 NullReferenceException reinitializing modules
Fixes handling where ReInit() encounters a module that is listed in module names but cannot be imported.
Adds test.