### PR TITLE
Fixes #1117 Auto indent default is block

### DIFF
--- a/Python/Product/PythonTools/PythonToolsPackage.cs
+++ b/Python/Product/PythonTools/PythonToolsPackage.cs
@@ -90,8 +90,8 @@ namespace Microsoft.PythonTools {
 #else
     [ProvideMenuResource(1000, 1)]
 #endif
-    [ProvideAutoLoad(Microsoft.VisualStudio.Shell.Interop.UIContextGuids.NoSolution)]
-    [ProvideAutoLoad(Microsoft.VisualStudio.Shell.Interop.UIContextGuids.SolutionExists)]
+    [ProvideUIContextRule(AutoLoadContextGuidString, "PTVS AutoLoad", "ShellInitialized", new[] { "ShellInitialized" }, new[] { VSConstants.UICONTEXT.ShellInitialized_string })]
+    [ProvideAutoLoad(AutoLoadContextGuidString)]
     [Description("Python Tools Package")]
     [ProvideAutomationObject("VsPython")]
     [ProvideLanguageEditorOptionPage(typeof(PythonAdvancedEditorOptionsPage), PythonConstants.LanguageName, "", "Advanced", "113")]
@@ -214,6 +214,8 @@ namespace Microsoft.PythonTools {
         private PackageContainer _packageContainer;
         internal const string PythonExpressionEvaluatorGuid = "{D67D5DB8-3D44-4105-B4B8-47AB1BA66180}";
         internal PythonToolsService _pyService;
+
+        private const string AutoLoadContextGuidString = "{C9970999-7979-4CF1-944C-8DA89F4CBA64}";
 
         /// <summary>
         /// Default constructor of the package.


### PR DESCRIPTION
Delays package load until after the shell is initialized.

(I'll actually merge this into a new `v2.x` branch - so don't hit Merge yet.)