### PR TITLE
Fix #1236: Crash in PyDebugAttach.dll when attaching to Blender

### DIFF
--- a/Python/Product/PyDebugAttach/PyDebugAttach.cpp
+++ b/Python/Product/PyDebugAttach/PyDebugAttach.cpp
@@ -129,7 +129,8 @@ public:
         IsDebug(debug),
         SetTrace(nullptr),
         PyThreadState_New(nullptr),
-        ThreadState_Swap(nullptr) {
+        ThreadState_Swap(nullptr),
+		Thread_UncheckedGet(nullptr) {
     }
 
     ~InterpreterInfo() {


### PR DESCRIPTION
Fixes #1236.