### PR TITLE
Fixes #1247 unable to load solution using vs2015

### DIFF
--- a/Build/Common.Build.VSSDK.targets
+++ b/Build/Common.Build.VSSDK.targets
@@ -80,7 +80,7 @@
   </PropertyGroup>
   
   <!-- Import the VS SDK headers -->
-  <Import Project="$(VSSDKTargets)" />
+  <Import Project="$(VSSDKTargets)" Condition="Exists($(VSSDKTargets))" />
 
   <!-- For non-debug builds, don't copy debug symbols -->
   <Target Name="_ClearVSIXSourceItemLocalOnly"

--- a/Build/MicroBuild.props
+++ b/Build/MicroBuild.props
@@ -1,3 +1,3 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(PackagesPath)MicroBuild.Core\build\MicroBuild.Core.props" />
+  <Import Project="$(PackagesPath)MicroBuild.Core\build\MicroBuild.Core.props" Condition="Exists('$(PackagesPath)MicroBuild.Core\build\MicroBuild.Core.props')" />
 </Project>

--- a/Build/MicroBuild.targets
+++ b/Build/MicroBuild.targets
@@ -1,3 +1,3 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(PackagesPath)MicroBuild.Core\build\MicroBuild.Core.targets" />
+  <Import Project="$(PackagesPath)MicroBuild.Core\build\MicroBuild.Core.targets" Condition="Exists('$(PackagesPath)MicroBuild.Core\build\MicroBuild.Core.targets')" />
 </Project>


### PR DESCRIPTION
Fixes #1247 unable to load solution using vs2015
Makes imports optional. The code to automatically install dependencies already exists and works correctly from within VS.