### PR TITLE
Explicitly sets IpyToolsPackage GUID so that the value is visible within sources

### DIFF
--- a/Python/Product/IronPython/IpyToolsPackage.cs
+++ b/Python/Product/IronPython/IpyToolsPackage.cs
@@ -15,14 +15,18 @@
 // permissions and limitations under the License.
 
 using System.ComponentModel;
+using System.Runtime.InteropServices;
 using Microsoft.IronPythonTools.Interpreter;
 using Microsoft.PythonTools;
 using Microsoft.VisualStudio.Shell;
 
 namespace Microsoft.IronPythonTools {
     [PackageRegistration(UseManagedResourcesOnly = true)]
+    [Guid(IpyToolsPackageGuid)]
     [Description("Python Tools IronPython Interpreter")]
     class IpyToolsPackage : Package {
+        public const string IpyToolsPackageGuid = "af7eaf4b-5af3-3622-b39a-7ae7ed25e7b2";
+
         public IpyToolsPackage() {
         }
     }


### PR DESCRIPTION
Previously we were implicitly generating this GUID, which means it's hard to find out what it is from looking at source.

This does not change the GUID from our previous release - it just puts it into source.