### PR TITLE
Fixes #1272 Ctrl+C, Ctrl+V on empty line pastes in the middle of the line

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Navigation/EditFilter.cs
+++ b/Python/Product/PythonTools/PythonTools/Navigation/EditFilter.cs
@@ -633,12 +633,20 @@ namespace Microsoft.PythonTools.Language {
             if (pguidCmdGroup == VSConstants.GUID_VSStandardCommandSet97) {
                 switch ((VSConstants.VSStd97CmdID)nCmdID) {
                     case VSConstants.VSStd97CmdID.Paste:
-                        string updated = RemoveReplPrompts(_pyService, Clipboard.GetText(), _textView.Options.GetNewLineCharacter());
+                        string updated = RemoveReplPrompts(
+                            _pyService,
+                            Clipboard.GetText(),
+                            _textView.Options.GetNewLineCharacter()
+                        );
+
+                        if (IsSingleLineWithNewline(updated) && string.IsNullOrEmpty(_editorOps.SelectedText)) {
+                            _editorOps.MoveToStartOfLine(false);
+                        }
+
                         if (updated != null) {
                             _editorOps.ReplaceSelection(updated);
-                            return VSConstants.S_OK;
                         }
-                        break;
+                        return VSConstants.S_OK;
                     case VSConstants.VSStd97CmdID.GotoDefn: GotoDefinition(); return VSConstants.S_OK;
                     case VSConstants.VSStd97CmdID.FindReferences: FindAllReferences(); return VSConstants.S_OK;
                 }
@@ -748,6 +756,18 @@ namespace Microsoft.PythonTools.Language {
             return _next.Exec(pguidCmdGroup, nCmdID, nCmdexecopt, pvaIn, pvaOut);
         }
 
+        private static bool IsSingleLineWithNewline(string text) {
+            if (string.IsNullOrEmpty(text)) {
+                return false;
+            }
+
+            if (text.EndsWith("\r\n")) {
+                // Ensure there are no newlines before the last one
+                return text.IndexOf('\r') == text.Length - 2 && text.IndexOf('\n') == text.Length - 1;
+            }
+
+            return text.IndexOfAny(new[] { '\r', '\n' }) == text.Length - 1;
+        }
 
         private void ExtractMethod() {
             new MethodExtractor(_serviceProvider, _textView).ExtractMethod(new ExtractMethodUserInput(_serviceProvider)).DoNotWait();
@@ -909,12 +929,8 @@ namespace Microsoft.PythonTools.Language {
             string text,
             string newline
         ) {
-            if (string.IsNullOrEmpty(text)) {
+            if (string.IsNullOrEmpty(text) || !pyService.AdvancedOptions.PasteRemovesReplPrompts) {
                 return text;
-            }
-
-            if (!pyService.AdvancedOptions.PasteRemovesReplPrompts) {
-                return null;
             }
 
             string[] lines = text.Replace("\r\n", "\n").Split('\n');


### PR DESCRIPTION
Fixes #1272 Ctrl+C, Ctrl+V on empty line pastes in the middle of the line
Check whether we are pasting a complete line with no selection, and if so move to the start of the line before pasting.