### PR TITLE
Fixes #1268 Crash in ReverseExpressionParser

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Intellisense/IntellisenseController.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/IntellisenseController.cs
@@ -161,11 +161,11 @@ namespace Microsoft.PythonTools.Intellisense {
             if (analyzer != null) {
                 analyzer.MonitorTextBufferAsync(subjectBuffer, isTemporaryFile).ContinueWith(task => {
                     var newParser = task.Result;
-                    // store the analysis entry so that we can detach it (the file path is lost
-                    // when we close the view)
-                    subjectBuffer.Properties[_intellisenseAnalysisEntry] = newParser.AnalysisEntry;
-
                     if (newParser != null) {
+                        // store the analysis entry so that we can detach it (the file path is lost
+                        // when we close the view)
+                        subjectBuffer.Properties[_intellisenseAnalysisEntry] = newParser.AnalysisEntry;
+
                         lock(newParser) {
                             newParser.AttachedViews++;
                         }

--- a/Python/Product/PythonTools/PythonTools/Intellisense/ReverseExpressionParser.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/ReverseExpressionParser.cs
@@ -320,7 +320,7 @@ namespace Microsoft.PythonTools.Intellisense {
                                 return null;
                             }
                             if (text == "*" || text == "**") {
-                                if (enumerator.MoveNext()) {
+                                if (MoveNextSkipExplicitNewLines(enumerator)) {
                                     if (enumerator.Current.ClassificationType == Classifier.Provider.CommaClassification) {
                                         isParameterName = IsParameterNameComma(enumerator);
                                     } else if (enumerator.Current.IsOpenGrouping() && enumerator.Current.Span.GetText() == "(") {


### PR DESCRIPTION
Fixes #1268 Crash in ReverseExpressionParser
Handles * and ** appearing first on a line.
Also fixes a potential null reference when monitoring a new buffer.