### PR TITLE
Fix #1275 and improve editing files w/ odd extensions

### DIFF
--- a/Python/Product/Analyzer/Intellisense/AnalysisProtocol.cs
+++ b/Python/Product/Analyzer/Intellisense/AnalysisProtocol.cs
@@ -398,6 +398,7 @@ namespace Microsoft.PythonTools.Intellisense {
 #if DEBUG
             public Dictionary<int, string> newCode;
 #endif
+            public bool? failed;
         }
 
         public sealed class UnresolvedImportsRequest : Request<UnresolvedImportsResponse> {

--- a/Python/Product/PythonTools/PythonTools/Extensions.cs
+++ b/Python/Product/PythonTools/PythonTools/Extensions.cs
@@ -316,6 +316,10 @@ namespace Microsoft.PythonTools {
             return false;
         }
 
+        internal static AnalysisEntry GetAnalysisEntry(this FileNode node) {
+            return ((PythonProjectNode)node.ProjectMgr).GetAnalyzer().GetAnalysisEntryFromPath(node.Url);
+        }
+
         /// <summary>
         /// Gets the best analyzer for this text view, accounting for things like REPL windows and
         /// difference windows.

--- a/Python/Product/PythonTools/PythonTools/Intellisense/BufferParser.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/BufferParser.cs
@@ -179,13 +179,10 @@ namespace Microsoft.PythonTools.Intellisense {
 
         public void StopMonitoring() {
             foreach (var buffer in _buffers) {
-                buffer.ChangedLowPriority -= BufferChangedLowPriority;
-                if (_document != null) {
-                    _document.EncodingChanged -= EncodingChanged;
-                    _document = null;
-                }
+                UninitBuffer(buffer);
             }
             _timer.Dispose();
+            AnalysisEntry.BufferParser = null;
         }
 
         public ITextBuffer[] Buffers {

--- a/Python/Product/PythonTools/PythonTools/Intellisense/IntellisenseController.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/IntellisenseController.cs
@@ -161,11 +161,12 @@ namespace Microsoft.PythonTools.Intellisense {
             if (analyzer != null) {
                 analyzer.MonitorTextBufferAsync(subjectBuffer, isTemporaryFile).ContinueWith(task => {
                     var newParser = task.Result;
-                    // store the analysis entry so that we can detach it (the file path is lost
-                    // when we close the view)
-                    subjectBuffer.Properties[_intellisenseAnalysisEntry] = newParser.AnalysisEntry;
 
                     if (newParser != null) {
+                        // store the analysis entry so that we can detach it (the file path is lost
+                        // when we close the view)
+                        subjectBuffer.Properties[_intellisenseAnalysisEntry] = newParser.AnalysisEntry;
+
                         lock(newParser) {
                             newParser.AttachedViews++;
                         }

--- a/Python/Product/PythonTools/PythonTools/Intellisense/ProjectAnalyzer.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/ProjectAnalyzer.cs
@@ -577,7 +577,7 @@ namespace Microsoft.PythonTools.Intellisense {
                         path = path
                     }).ConfigureAwait(false);
 
-                if (res != null) {
+                if (res != null && res.fileId != -1) {
                     OnAnalysisStarted();
 
                     var id = res.fileId;

--- a/Python/Product/PythonTools/PythonTools/Navigation/EditFilter.cs
+++ b/Python/Product/PythonTools/PythonTools/Navigation/EditFilter.cs
@@ -894,8 +894,8 @@ namespace Microsoft.PythonTools.Language {
         }
 
         private void QueryStatusRename(OLECMD[] prgCmds, int i) {
-            IWpfTextView activeView = CommonPackage.GetActiveTextView(_serviceProvider);
-            if (activeView != null && activeView.GetPythonBufferAtCaret() != null) {
+            var analyzer = _textView.GetAnalyzerAtCaret(_serviceProvider);
+            if (analyzer != null && _textView.GetPythonBufferAtCaret() != null) {
                 prgCmds[i].cmdf = (uint)(OLECMDF.OLECMDF_ENABLED | OLECMDF.OLECMDF_SUPPORTED);
             } else {
                 prgCmds[i].cmdf = (uint)(OLECMDF.OLECMDF_INVISIBLE);

--- a/Python/Product/PythonTools/PythonTools/Navigation/PythonFileLibraryNode.cs
+++ b/Python/Product/PythonTools/PythonTools/Navigation/PythonFileLibraryNode.cs
@@ -33,7 +33,7 @@ namespace Microsoft.PythonTools.Navigation {
     class PythonFileLibraryNode : LibraryNode {
         private readonly HierarchyNode _hierarchy;
         public PythonFileLibraryNode(LibraryNode parent, HierarchyNode hierarchy, string name, string filename)
-            : base(parent, name, filename, LibraryNodeType.Namespaces, children: new PythonFileChildren((PythonFileNode)hierarchy)) {
+            : base(parent, name, filename, LibraryNodeType.Namespaces, children: new PythonFileChildren((FileNode)hierarchy)) {
             _hierarchy = hierarchy;
 
             ((PythonFileChildren)Children)._parent = this;
@@ -100,10 +100,10 @@ namespace Microsoft.PythonTools.Navigation {
 
     abstract class ObjectBrowserChildren : IList<LibraryNode> {
         private LibraryNode[] _children;
-        protected readonly PythonFileNode _hierarchy;
+        protected readonly FileNode _hierarchy;
         internal LibraryNode _parent;
 
-        public ObjectBrowserChildren(PythonFileNode hierarchy) {
+        public ObjectBrowserChildren(FileNode hierarchy) {
             _hierarchy = hierarchy;
         }
 
@@ -200,7 +200,7 @@ namespace Microsoft.PythonTools.Navigation {
     }
 
     class PythonFileChildren : ObjectBrowserChildren {
-        public PythonFileChildren(PythonFileNode hierarchy) : base(hierarchy) {
+        public PythonFileChildren(FileNode hierarchy) : base(hierarchy) {
         }
 
         protected override IEnumerable<CompletionResult> GetChildren() {
@@ -221,7 +221,7 @@ namespace Microsoft.PythonTools.Navigation {
     class MemberChildren : ObjectBrowserChildren {
         private readonly string _member;
 
-        public MemberChildren(PythonFileNode hierarchy, string member) : base(hierarchy) {
+        public MemberChildren(FileNode hierarchy, string member) : base(hierarchy) {
             _member = member;
         }
 


### PR DESCRIPTION
Fix #1275 - we just need to null out of the buffer parser when we stop monitoring
Also improves some error handling w/ the out of proc analyzer, and improves the experience when opening a file with the Python editor that aren't .py files.