### PR TITLE
Fixes #1285 BreaksExistingExtensionException

### DIFF
--- a/Python/Product/PythonTools/source.extension.vsixmanifest
+++ b/Python/Product/PythonTools/source.extension.vsixmanifest
@@ -21,7 +21,7 @@
   <Dependencies>
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" Version="4.6" />
     <Dependency IsRequired="false" Version="[14.0,16.0)" d:Source="Installed" Id="TestWindow.Microsoft.0771d463-d74d-4e95-aac2-39d3c7ec1f97" DisplayName="Test Explorer" />
-    <Dependency d:Source="Installed" Id="1F42C6D0-F876-4AF0-8185-1BEB0A325BB2" DisplayName="VisualStudio Interactive Components" Version="[1.0.0.50618,2.0)" />
+    <Dependency d:Source="Installed" Id="1F42C6D0-F876-4AF0-8185-1BEB0A325BB2" DisplayName="VisualStudio Interactive Components" Version="1.0.0.0" />
   </Dependencies>
   <Assets>
     <Asset Type="Microsoft.VisualStudio.Package" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />


### PR DESCRIPTION
Fixes #1285 BreaksExistingExtensionException when attempting to install new Roslyn vsix on Dev 15 Preview

Changes version specifier for interactive components.