### PR TITLE
Fixes #268 In Python 2.7 True and False show up in the Autos window. …

### DIFF
--- a/Python/Product/Analyzer/Intellisense/ProximityExpressionWalker.cs
+++ b/Python/Product/Analyzer/Intellisense/ProximityExpressionWalker.cs
@@ -80,6 +80,13 @@ namespace Microsoft.PythonTools.Intellisense {
 
         public override void PostWalk(NameExpression node) {
             if (IsInRange(node)) {
+                if(_ast.LanguageVersion.Is2x()) {
+                    // In 2.7 True and False are constants, we made an exception to not show them Autos window.
+                    if(node.Name == "True" || node.Name == "False") {
+                        return;
+                    }
+                }
+
                 _expressions.Add(node, null);
             }
 

--- a/Python/Tests/Core/ProximityExpressionWalkerTests.cs
+++ b/Python/Tests/Core/ProximityExpressionWalkerTests.cs
@@ -110,6 +110,16 @@ a.b
             ProximityTest(code, "a.b");
         }
 
+
+        [TestMethod, Priority(1)]
+        public void AutosNoTrueFalseInV27() {
+            string code = @"
+a = True
+b = False
+";
+            ProximityTest(PythonLanguageVersion.V27, code, 0, int.MaxValue, "a", "b");
+        }
+
         private void ProximityTest(string code, params string[] exprs) {
             ProximityTest(PythonLanguageVersion.V34, code, 0, int.MaxValue, exprs);
         }


### PR DESCRIPTION
…This fix excludes them from showing up.