### PR TITLE
Fixes #1297 File Cut/Past null reference exception with data loss

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Project/PythonFileNode.cs
+++ b/Python/Product/PythonTools/PythonTools/Project/PythonFileNode.cs
@@ -234,7 +234,7 @@ namespace Microsoft.PythonTools.Project {
 
                 var textBuffer = GetTextBuffer(false);
 
-                BufferParser parser = analysis.BufferParser;
+                BufferParser parser = analysis?.BufferParser;
                 if (parser != null) {
                     analyzer.ReAnalyzeTextBuffers(parser);
                 }


### PR DESCRIPTION
Fixes #1297 File Cut/Past null reference exception with data loss
Allows analysis to be null when renaming a file.