### PR TITLE
Fixes #1269 Removing calls to GetZipFileName, and GetPathInZipFile. 

### DIFF
--- a/Python/Product/Analyzer/Intellisense/OutOfProcProjectAnalyzer.cs
+++ b/Python/Product/Analyzer/Intellisense/OutOfProcProjectAnalyzer.cs
@@ -1981,9 +1981,6 @@ namespace Microsoft.PythonTools.Intellisense {
             IPythonProjectEntry pyEntry;
             IExternalProjectEntry externalEntry;
 
-            string zipFileName = GetZipFileName(entry);
-            string pathInZipFile = GetPathInZipFile(entry);
-
             SortedDictionary<int, ParseResult> parseResults = new SortedDictionary<int, ParseResult>();
 
             if ((pyEntry = entry as IPythonProjectEntry) != null) {


### PR DESCRIPTION
Fixes #1269 Removing calls to GetZipFileName, and GetPathInZipFile. They were called but the return value was never used.