### PR TITLE
Fixes command prompt not including global environment variables.

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Project/PythonProjectNode.cs
+++ b/Python/Product/PythonTools/PythonTools/Project/PythonProjectNode.cs
@@ -1570,7 +1570,11 @@ namespace Microsoft.PythonTools.Project {
             }
 
             var env = PathUtils.MergeEnvironments(
-                config.GetEnvironmentVariables(),
+                PathUtils.MergeEnvironments(
+                    Environment.GetEnvironmentVariables().AsEnumerable<string, string>(),
+                    config.GetEnvironmentVariables(),
+                    "PATH"
+                ),
                 new KeyValuePair<string, string>[] {
                     new KeyValuePair<string, string>("PATH", paths),
                 },


### PR DESCRIPTION
Fixes command prompt not including global environment variables.

(Most critically, it blanks out `PATH`, which breaks many commands.)