### PR TITLE
Fixes #1251 No completions in virtual env REPL

### DIFF
--- a/Python/Product/Analysis/Interpreter/IInterpreterRegistryService.cs
+++ b/Python/Product/Analysis/Interpreter/IInterpreterRegistryService.cs
@@ -45,6 +45,8 @@ namespace Microsoft.PythonTools.Interpreter {
 
         InterpreterConfiguration FindConfiguration(string id);
 
+        string FindAssociatedProjectMoniker(string id);
+
         /// <summary>
         /// Raised when the set of interpreters changes. This is not raised when
         /// the set is first initialized.

--- a/Python/Product/Analysis/Interpreter/IInterpreterRegistryService.cs
+++ b/Python/Product/Analysis/Interpreter/IInterpreterRegistryService.cs
@@ -45,7 +45,16 @@ namespace Microsoft.PythonTools.Interpreter {
 
         InterpreterConfiguration FindConfiguration(string id);
 
-        string FindAssociatedProjectMoniker(string id);
+        /// <summary>
+        /// Gets a property value relating to a specific interpreter.
+        /// 
+        /// If the property is not set, returns <c>null</c>.
+        /// </summary>
+        /// <param name="id">The interpreter identifier.</param>
+        /// <param name="propName">A case-sensitive string identifying the
+        /// property. Values will be compared by ordinal.</param>
+        /// <returns>The property value, or <c>null</c> if not set.</returns>
+        object GetProperty(string id, string propName);
 
         /// <summary>
         /// Raised when the set of interpreters changes. This is not raised when

--- a/Python/Product/Analysis/Interpreter/IPythonInterpreterFactoryProvider.cs
+++ b/Python/Product/Analysis/Interpreter/IPythonInterpreterFactoryProvider.cs
@@ -48,9 +48,15 @@ namespace Microsoft.PythonTools.Interpreter {
         IPythonInterpreterFactory GetInterpreterFactory(string id);
 
         /// <summary>
-        /// Gets the associated project moniker, if any.
+        /// Gets a property value associated with the specified interpreter. If
+        /// the property is not set or available, return <c>null</c>.
+        /// 
+        /// Property values should not change over the process lifetime.
         /// </summary>
-        string GetAssociatedProjectMoniker(string id);
+        /// <param name="id">The interpreter id.</param>
+        /// <param name="propName">A case-sensitive string identifying the name
+        /// of the property. Values will be compared by ordinal.</param>
+        object GetProperty(string id, string propName);
     }
 
     public static class PythonInterpreterExtensions {

--- a/Python/Product/Analysis/Interpreter/IPythonInterpreterFactoryProvider.cs
+++ b/Python/Product/Analysis/Interpreter/IPythonInterpreterFactoryProvider.cs
@@ -46,6 +46,11 @@ namespace Microsoft.PythonTools.Interpreter {
         /// Gets a specific configured interpreter
         /// </summary>
         IPythonInterpreterFactory GetInterpreterFactory(string id);
+
+        /// <summary>
+        /// Gets the associated project moniker, if any.
+        /// </summary>
+        string GetAssociatedProjectMoniker(string id);
     }
 
     public static class PythonInterpreterExtensions {

--- a/Python/Product/Analysis/Interpreter/InterpreterRegistryService.cs
+++ b/Python/Product/Analysis/Interpreter/InterpreterRegistryService.cs
@@ -361,6 +361,11 @@ namespace Microsoft.PythonTools.Interpreter {
             return null;
         }
 
+        public string FindAssociatedProjectMoniker(string id) {
+            var factoryProvider = GetFactoryProvider(id);
+            return factoryProvider?.GetAssociatedProjectMoniker(id);
+        }
+
         private IPythonInterpreterFactoryProvider GetFactoryProvider(string id) {
             var interpAndId = id.Split(new[] { '|' }, 2);
             if (interpAndId.Length == 2) {

--- a/Python/Product/Analysis/Interpreter/InterpreterRegistryService.cs
+++ b/Python/Product/Analysis/Interpreter/InterpreterRegistryService.cs
@@ -361,9 +361,9 @@ namespace Microsoft.PythonTools.Interpreter {
             return null;
         }
 
-        public string FindAssociatedProjectMoniker(string id) {
+        public object GetProperty(string id, string propName) {
             var factoryProvider = GetFactoryProvider(id);
-            return factoryProvider?.GetAssociatedProjectMoniker(id);
+            return factoryProvider?.GetProperty(id, propName);
         }
 
         private IPythonInterpreterFactoryProvider GetFactoryProvider(string id) {

--- a/Python/Product/CanopyInterpreter/CanopyInterpreterFactoryProvider.cs
+++ b/Python/Product/CanopyInterpreter/CanopyInterpreterFactoryProvider.cs
@@ -230,6 +230,8 @@ namespace CanopyInterpreter {
                 .FirstOrDefault();
         }
 
+        public string GetAssociatedProjectMoniker(string id) => null;
+
         public event EventHandler InterpreterFactoriesChanged;
 
         private void OnInterpreterFactoriesChanged() {

--- a/Python/Product/CanopyInterpreter/CanopyInterpreterFactoryProvider.cs
+++ b/Python/Product/CanopyInterpreter/CanopyInterpreterFactoryProvider.cs
@@ -230,7 +230,7 @@ namespace CanopyInterpreter {
                 .FirstOrDefault();
         }
 
-        public string GetAssociatedProjectMoniker(string id) => null;
+        public object GetProperty(string id, string propName) => null;
 
         public event EventHandler InterpreterFactoriesChanged;
 

--- a/Python/Product/IronPython/Interpreter/IronPythonInterpreterFactoryProvider.cs
+++ b/Python/Product/IronPython/Interpreter/IronPythonInterpreterFactoryProvider.cs
@@ -171,7 +171,7 @@ namespace Microsoft.IronPythonTools.Interpreter {
 
         public event EventHandler InterpreterFactoriesChanged;
 
-        public string GetAssociatedProjectMoniker(string id) => null;
+        public object GetProperty(string id, string propName) => null;
 
         #endregion
 

--- a/Python/Product/IronPython/Interpreter/IronPythonInterpreterFactoryProvider.cs
+++ b/Python/Product/IronPython/Interpreter/IronPythonInterpreterFactoryProvider.cs
@@ -171,6 +171,7 @@ namespace Microsoft.IronPythonTools.Interpreter {
 
         public event EventHandler InterpreterFactoriesChanged;
 
+        public string GetAssociatedProjectMoniker(string id) => null;
 
         #endregion
 

--- a/Python/Product/PythonTools/PythonTools/Repl/PythonInteractiveEvaluator.cs
+++ b/Python/Product/PythonTools/PythonTools/Repl/PythonInteractiveEvaluator.cs
@@ -136,7 +136,7 @@ namespace Microsoft.PythonTools.Repl {
                 } else {
                     Build.Evaluation.Project projectFile = null;
                     var moniker = ProjectMoniker ??
-                        interpreterService.FindAssociatedProjectMoniker(config.Interpreter.Id);
+                        interpreterService.GetProperty(config.Interpreter.Id, "ProjectMoniker") as string;
                     if (!string.IsNullOrEmpty(moniker)) {
                         projectFile = _serviceProvider.GetProjectFromFile(moniker)?.BuildProject;
                     }
@@ -363,7 +363,7 @@ namespace Microsoft.PythonTools.Repl {
             var interpreter = Configuration?.Interpreter;
             if (interpreter != null && string.IsNullOrEmpty(moniker)) {
                 var interpreterService = _serviceProvider.GetComponentModel().GetService<IInterpreterRegistryService>();
-                moniker = interpreterService?.FindAssociatedProjectMoniker(Configuration.Interpreter.Id);
+                moniker = interpreterService?.GetProperty(Configuration.Interpreter.Id, "ProjectMoniker") as string;
             }
 
             if (string.IsNullOrEmpty(moniker)) {

--- a/Python/Product/Uwp.Interpreter/PythonUwpInterpreterFactoryProvider.cs
+++ b/Python/Product/Uwp.Interpreter/PythonUwpInterpreterFactoryProvider.cs
@@ -120,5 +120,7 @@ namespace Microsoft.PythonTools.Uwp.Interpreter {
                 .Where(x => x.Configuration.Id == id)
                 .FirstOrDefault();
         }
+
+        public string GetAssociatedProjectMoniker(string id) => null;
     }
 }

--- a/Python/Product/Uwp.Interpreter/PythonUwpInterpreterFactoryProvider.cs
+++ b/Python/Product/Uwp.Interpreter/PythonUwpInterpreterFactoryProvider.cs
@@ -121,6 +121,6 @@ namespace Microsoft.PythonTools.Uwp.Interpreter {
                 .FirstOrDefault();
         }
 
-        public string GetAssociatedProjectMoniker(string id) => null;
+        public object GetProperty(string id, string propName) => null;
     }
 }

--- a/Python/Product/VSInterpreters/CPythonInterpreterFactoryProvider.cs
+++ b/Python/Product/VSInterpreters/CPythonInterpreterFactoryProvider.cs
@@ -361,7 +361,7 @@ namespace Microsoft.PythonTools.Interpreter {
             _interpFactoriesChanged?.Invoke(this, EventArgs.Empty);
         }
 
-        public string GetAssociatedProjectMoniker(string id) => null;
+        public object GetProperty(string id, string propName) => null;
 
         #endregion
 

--- a/Python/Product/VSInterpreters/CPythonInterpreterFactoryProvider.cs
+++ b/Python/Product/VSInterpreters/CPythonInterpreterFactoryProvider.cs
@@ -24,6 +24,7 @@ using System.Reflection;
 using System.Text.RegularExpressions;
 using System.Threading;
 using Microsoft.PythonTools.Infrastructure;
+using Microsoft.PythonTools.Parsing;
 using Microsoft.Win32;
 
 namespace Microsoft.PythonTools.Interpreter {
@@ -178,6 +179,13 @@ namespace Microsoft.PythonTools.Interpreter {
                 if ((versionValue == null || !Version.TryParse(versionValue, out version)) &&
                     !TryParsePythonVersion(key, out version, out arch2, ref id)) {
                     version = new Version(2, 7);
+                }
+
+                try {
+                    var langVer = version.ToLanguageVersion();
+                } catch (InvalidOperationException) {
+                    // Version is not currently supported
+                    return;
                 }
 
                 var archStr = interpKey.GetValue("Architecture") as string;
@@ -352,6 +360,8 @@ namespace Microsoft.PythonTools.Interpreter {
         private void OnInterpreterFactoriesChanged() {
             _interpFactoriesChanged?.Invoke(this, EventArgs.Empty);
         }
+
+        public string GetAssociatedProjectMoniker(string id) => null;
 
         #endregion
 

--- a/Python/Product/VSInterpreters/MSBuildProjectInterpreterFactoryProvider.cs
+++ b/Python/Product/VSInterpreters/MSBuildProjectInterpreterFactoryProvider.cs
@@ -129,9 +129,12 @@ namespace Microsoft.PythonTools.Interpreter {
             return null;
         }
 
-        public string GetAssociatedProjectMoniker(string id) {
-            var moniker = id.Substring(id.LastIndexOf('|') + 1);
-            return PathUtils.IsValidPath(moniker) ? moniker : null;
+        public object GetProperty(string id, string propName) {
+            if (propName == "ProjectMoniker") {
+                var moniker = id.Substring(id.LastIndexOf('|') + 1);
+                return PathUtils.IsValidPath(moniker) ? moniker : null;
+            }
+            return null;
         }
 
         public static string GetInterpreterId(string file, string id) {

--- a/Python/Product/VSInterpreters/MSBuildProjectInterpreterFactoryProvider.cs
+++ b/Python/Product/VSInterpreters/MSBuildProjectInterpreterFactoryProvider.cs
@@ -129,6 +129,11 @@ namespace Microsoft.PythonTools.Interpreter {
             return null;
         }
 
+        public string GetAssociatedProjectMoniker(string id) {
+            var moniker = id.Substring(id.LastIndexOf('|') + 1);
+            return PathUtils.IsValidPath(moniker) ? moniker : null;
+        }
+
         public static string GetInterpreterId(string file, string id) {
             return String.Join("|", MSBuildProviderName, id, file);
         }

--- a/Python/Tests/Core/ReplEvaluatorTests.cs
+++ b/Python/Tests/Core/ReplEvaluatorTests.cs
@@ -235,7 +235,7 @@ g()",
                     .FirstOrDefault();
             }
 
-            public string GetAssociatedProjectMoniker(string id) => null;
+            public object GetProperty(string id, string propName) => null;
 
             public event EventHandler InterpreterFactoriesChanged { add { } remove { } }
         }

--- a/Python/Tests/Core/ReplEvaluatorTests.cs
+++ b/Python/Tests/Core/ReplEvaluatorTests.cs
@@ -235,6 +235,8 @@ g()",
                     .FirstOrDefault();
             }
 
+            public string GetAssociatedProjectMoniker(string id) => null;
+
             public event EventHandler InterpreterFactoriesChanged { add { } remove { } }
         }
 

--- a/Python/Tests/Utilities.Python.Analysis/MockInterpreterOptionsService.cs
+++ b/Python/Tests/Utilities.Python.Analysis/MockInterpreterOptionsService.cs
@@ -166,7 +166,7 @@ namespace TestUtilities.Python {
             throw new NotImplementedException();
         }
 
-        public string FindAssociatedProjectMoniker(string id) {
+        public object GetProperty(string id, string propName) {
             throw new NotImplementedException();
         }
     }

--- a/Python/Tests/Utilities.Python.Analysis/MockInterpreterOptionsService.cs
+++ b/Python/Tests/Utilities.Python.Analysis/MockInterpreterOptionsService.cs
@@ -165,5 +165,9 @@ namespace TestUtilities.Python {
         public string AddConfigurableInterpreter(string name, InterpreterConfiguration config) {
             throw new NotImplementedException();
         }
+
+        public string FindAssociatedProjectMoniker(string id) {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/Python/Tests/Utilities.Python.Analysis/MockPythonInterpreterFactoryProvider.cs
+++ b/Python/Tests/Utilities.Python.Analysis/MockPythonInterpreterFactoryProvider.cs
@@ -90,7 +90,7 @@ namespace TestUtilities.Python {
                 .FirstOrDefault();
         }
 
-        public string GetAssociatedProjectMoniker(string id) => null;
+        public object GetProperty(string id, string propName) => null;
 
         public event EventHandler InterpreterFactoriesChanged;
     }

--- a/Python/Tests/Utilities.Python.Analysis/MockPythonInterpreterFactoryProvider.cs
+++ b/Python/Tests/Utilities.Python.Analysis/MockPythonInterpreterFactoryProvider.cs
@@ -90,6 +90,8 @@ namespace TestUtilities.Python {
                 .FirstOrDefault();
         }
 
+        public string GetAssociatedProjectMoniker(string id) => null;
+
         public event EventHandler InterpreterFactoriesChanged;
     }
 }


### PR DESCRIPTION
Fixes #1251 No completions in virtual env REPL
Enables getting the project associated with an interpreter ID so that we can flow settings through to the interactive window.

Also fixes a potential crash on VS shutdown.