### PR TITLE
Allow to modify PythonProjectNodeProperties.CommandLineArguments

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Project/PythonProjectNodeProperties.cs
+++ b/Python/Product/PythonTools/PythonTools/Project/PythonProjectNodeProperties.cs
@@ -53,6 +53,9 @@ namespace Microsoft.PythonTools.Project {
             get {
                 return this.Node.ProjectMgr.GetProjectProperty(CommonConstants.CommandLineArguments, true);
             }
+            set {
+                this.Node.ProjectMgr.SetProjectProperty(CommonConstants.CommandLineArguments, value);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Added a set method on the PythonProjectNodeProperties.CommandLineArguments to allow extensions to modify this property.

I wanted to add support to Python Projects for https://github.com/MBulli/SmartCommandlineArgs/issues/9.
However, I couldn't find an easy way to modify the CommandLineArguments property without messing with your internal objects.

I don't know if there was a good reason not to put the `set` method, but I figured it might just be because there was no need before.

Closes #1078 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/ptvs/1335)
<!-- Reviewable:end -->
