### PR TITLE
Adds triple-quotes around exception message so that copy-pasting into…

### DIFF
--- a/Python/Product/VSCommon/Infrastructure/TaskDialog.cs
+++ b/Python/Product/VSCommon/Infrastructure/TaskDialog.cs
@@ -58,7 +58,7 @@ namespace Microsoft.PythonTools.Infrastructure {
                 EnableHyperlinks = true,
                 CollapsedControlText = "Show &details",
                 ExpandedControlText = "Hide &details",
-                ExpandedInformation = exception.ToString()
+                ExpandedInformation = "```{0}{1}{0}```".FormatUI(Environment.NewLine, exception)
             };
             td.Buttons.Add(TaskDialogButton.Close);
             if (!string.IsNullOrEmpty(issueTrackerUrl)) {


### PR DESCRIPTION
Adds triple-quotes around exception message so that copy-pasting into github looks nicer.