### PR TITLE
Fixes #1363 Crash reformatting code

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Intellisense/LocationTracker.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/LocationTracker.cs
@@ -43,7 +43,7 @@ namespace Microsoft.PythonTools.Intellisense {
             // prevents us from holding onto every version in the world.
             Debug.Assert(fromVersion >= lastAnalysisVersion.VersionNumber);
 
-            while (lastAnalysisVersion.VersionNumber != fromVersion) {
+            while (lastAnalysisVersion.Next != null && lastAnalysisVersion.VersionNumber != fromVersion) {
                 lastAnalysisVersion = lastAnalysisVersion.Next;
             }
 


### PR DESCRIPTION
Fixes #1363 Crash reformatting code
The only way to get a null reference error in that function is when the fromVersion is not in the chain. To prevent it, we'll stop at the earlier available version.