### PR TITLE
Fixes #88 Support code cells

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Commands/SendToReplCommand.cs
+++ b/Python/Product/PythonTools/PythonTools/Commands/SendToReplCommand.cs
@@ -53,7 +53,7 @@ namespace Microsoft.PythonTools.Commands {
         }
 
         private static bool IsCellMarker(ITextSnapshotLine line) {
-            return line.GetText().Trim(' ', '\t').StartsWith("#%%");
+            return OutliningTaggerProvider.OutliningTagger._codeCellRegex.IsMatch(line.GetText());
         }
 
         public override async void DoCommand(object sender, EventArgs args) {

--- a/Python/Product/PythonTools/PythonTools/Extensions.cs
+++ b/Python/Product/PythonTools/PythonTools/Extensions.cs
@@ -628,7 +628,15 @@ namespace Microsoft.PythonTools {
             // this case too, but mostly it will succeed (and then assert).
             serviceProvider.GetUIThread().MustBeCalledFromUIThread();
 #endif
+            return serviceProvider.GetPythonToolsService_NotThreadSafe();
+        }
 
+        /// <summary>
+        /// Gets the current Python Tools service without validating that we are
+        /// on the UI thread. This may return null or crash at (somewhat) random
+        /// but is necessary for some tests.
+        /// </summary>
+        internal static PythonToolsService GetPythonToolsService_NotThreadSafe(this IServiceProvider serviceProvider) {
             var pyService = (PythonToolsService)serviceProvider.GetService(typeof(PythonToolsService));
             if (pyService == null) {
                 var shell = (IVsShell)serviceProvider.GetService(typeof(SVsShell));

--- a/Python/Product/PythonTools/PythonTools/Intellisense/BufferParser.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/BufferParser.cs
@@ -366,8 +366,10 @@ namespace Microsoft.PythonTools.Intellisense {
                 );
 
                 if (res != null) {
+                    Debug.Assert(res.failed != false);
                     _parser.OnAnalysisStarted();
 #if DEBUG
+                    Debug.Assert(res.newCode != null, "FileId={0}, Path={1}".FormatUI(entry.FileId, entry.Path));
                     for (int i = 0; i < bufferInfos.Length; i++) {
                         var snapshot = snapshots[i];
                         var buffer = bufferInfos[i];

--- a/Python/Product/PythonTools/PythonTools/Intellisense/PythonSuggestedActionsSource.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/PythonSuggestedActionsSource.cs
@@ -34,6 +34,7 @@ namespace Microsoft.PythonTools.Intellisense {
         private readonly object _currentLock = new object();
         private IEnumerable<SuggestedActionSet> _current;
         private SnapshotSpan _currentSpan;
+        private readonly UIThreadBase _uiThread;
 
         public PythonSuggestedActionsSource(
             IServiceProvider provider,
@@ -44,6 +45,7 @@ namespace Microsoft.PythonTools.Intellisense {
             _view = textView;
             _textBuffer = textBuffer;
             _textBuffer.RegisterForNewAnalysis(OnNewAnalysisEntry);
+            _uiThread = provider.GetUIThread();
         }
 
         private void OnNewAnalysisEntry(AnalysisEntry obj) {
@@ -81,7 +83,7 @@ namespace Microsoft.PythonTools.Intellisense {
                 SpanTrackingMode.EdgePositive,
                 TrackingFidelityMode.Forward
             );
-            var imports = await VsProjectAnalyzer.GetMissingImportsAsync(_provider, _view, textBuffer.CurrentSnapshot, span);
+            var imports = await _uiThread.InvokeTask(() => VsProjectAnalyzer.GetMissingImportsAsync(_provider, _view, textBuffer.CurrentSnapshot, span));
 
             if (imports == MissingImportAnalysis.Empty) {
                 return false;

--- a/Python/Product/PythonTools/PythonTools/OutliningTaggerProvider.cs
+++ b/Python/Product/PythonTools/PythonTools/OutliningTaggerProvider.cs
@@ -59,7 +59,7 @@ namespace Microsoft.PythonTools {
             private bool _enabled;
             private static readonly Regex _openingRegionRegex = new Regex(@"^\s*#\s*region($|\s+.*$)");
             private static readonly Regex _closingRegionRegex = new Regex(@"^\s*#\s*endregion($|\s+.*$)");
-            private static readonly Regex _codeCellRegex = new Regex(@"^\s*#%%(.*)$");
+            internal static readonly Regex _codeCellRegex = new Regex(@"^\s*#%%(.*)$");
 
             public OutliningTagger(PythonToolsService pyService, ITextBuffer buffer) {
                 _pyService = pyService;

--- a/Python/Product/PythonTools/PythonTools/OutliningTaggerProvider.cs
+++ b/Python/Product/PythonTools/PythonTools/OutliningTaggerProvider.cs
@@ -59,6 +59,7 @@ namespace Microsoft.PythonTools {
             private bool _enabled;
             private static readonly Regex _openingRegionRegex = new Regex(@"^\s*#\s*region($|\s+.*$)");
             private static readonly Regex _closingRegionRegex = new Regex(@"^\s*#\s*endregion($|\s+.*$)");
+            private static readonly Regex _codeCellRegex = new Regex(@"^\s*#%%(.*)$");
 
             public OutliningTagger(PythonToolsService pyService, ITextBuffer buffer) {
                 _pyService = pyService;
@@ -103,7 +104,10 @@ namespace Microsoft.PythonTools {
                 
                 var tags = await entry.Analyzer.GetOutliningTagsAsync(snapshot);
                 if (tags != null) {
-                    _tags = tags.Concat(ProcessRegionTags(_buffer.CurrentSnapshot)).ToArray();
+                    _tags = tags
+                        .Concat(ProcessRegionTags(_buffer.CurrentSnapshot))
+                        .Concat(ProcessCellTags(_buffer.CurrentSnapshot))
+                        .ToArray();
 
                     TagsChanged?.Invoke(
                         this,
@@ -125,6 +129,27 @@ namespace Microsoft.PythonTools {
 
                         yield return outline;
                     }
+                }
+            }
+
+            internal static IEnumerable<TagSpan> ProcessCellTags(ITextSnapshot snapshot) {
+                ITextSnapshotLine region = null, lastNonBlankLine = null;
+                // Walk lines and attempt to find '#%%' tags
+                foreach (var line in snapshot.Lines) {
+                    var lineText = line.GetText();
+                    if (_codeCellRegex.IsMatch(lineText)) {
+                        if (region != null && lastNonBlankLine != null && lastNonBlankLine.LineNumber > region.LineNumber) {
+                            yield return GetTagSpan(snapshot, region.Start, lastNonBlankLine.End);
+                        }
+                        region = line;
+                    }
+                    if (!string.IsNullOrWhiteSpace(lineText) || lastNonBlankLine == null) {
+                        lastNonBlankLine = line;
+                    }
+                }
+
+                if (region != null && lastNonBlankLine != null && lastNonBlankLine.LineNumber > region.LineNumber) {
+                    yield return GetTagSpan(snapshot, region.Start, lastNonBlankLine.End);
                 }
             }
 

--- a/Python/Tests/Core/EditorTests.cs
+++ b/Python/Tests/Core/EditorTests.cs
@@ -76,6 +76,33 @@ class someClass:
 
         #endregion Outlining Regions
 
+        #region Outlining Cells
+
+        [TestMethod, Priority(0)]
+        public void OutlineCells() {
+            string content = @"pass
+#%% cell 1
+pass
+
+#%% empty cell
+#%%cell2
+
+pass
+
+#%% lastcell
+pass
+
+";
+
+            SnapshotCellTest(content,
+                new ExpectedTag(16, 22, "\r\npass"),
+                new ExpectedTag(50, 58, "\r\n\r\npass"),
+                new ExpectedTag(74, 80, "\r\npass")
+            );
+        }
+
+        #endregion
+
         #region Outline Compound Statements
 
         [TestMethod, Priority(0)]
@@ -367,6 +394,13 @@ string'''";
             var snapshot = new TestUtilities.Mocks.MockTextSnapshot(new TestUtilities.Mocks.MockTextBuffer(fileContents), fileContents);
             var ast = Parser.CreateParser(new TextSnapshotToTextReader(snapshot), PythonLanguageVersion.V34).ParseFile();
             var tags = Microsoft.PythonTools.OutliningTaggerProvider.OutliningTagger.ProcessRegionTags(snapshot);
+            VerifyTags(snapshot, tags, expected);
+        }
+
+        private void SnapshotCellTest(string fileContents, params ExpectedTag[] expected) {
+            var snapshot = new TestUtilities.Mocks.MockTextSnapshot(new TestUtilities.Mocks.MockTextBuffer(fileContents), fileContents);
+            var ast = Parser.CreateParser(new TextSnapshotToTextReader(snapshot), PythonLanguageVersion.V34).ParseFile();
+            var tags = Microsoft.PythonTools.OutliningTaggerProvider.OutliningTagger.ProcessCellTags(snapshot);
             VerifyTags(snapshot, tags, expected);
         }
 

--- a/Python/Tests/ReplWindowUITests/SendToReplTests.cs
+++ b/Python/Tests/ReplWindowUITests/SendToReplTests.cs
@@ -63,6 +63,32 @@ namespace ReplWindowUITests {
         }
 
         /// <summary>
+        /// Simple line-by-line tests which verify we submit when we get to
+        /// the next statement.
+        /// </summary>
+        [TestMethod, Priority(1)]
+        [HostType("VSTestHost"), TestCategory("Installed")]
+        public virtual void SendToInteractiveCellByCell() {
+            RunOne("Cells.py",
+                Input(@"#%% cell 1
+... x = 1
+... 
+>>> y = 2").Complete,
+                Input(@"#%% cell 2
+... x = 3
+... 
+>>> y = 4").Complete,
+                Input(@"#%% cell 3
+... if x > y:
+...     print(x ** y)
+... else:
+...     print(y ** x)
+... ").Complete.Outputs("64"),
+                EndOfInput
+            );
+        }
+
+        /// <summary>
         /// Line-by-line tests that verify we work with buffering code
         /// while it's executing.
         /// </summary>

--- a/Python/Tests/TestData/SendToInteractive/Cells.py
+++ b/Python/Tests/TestData/SendToInteractive/Cells.py
@@ -1,0 +1,13 @@
+#%% cell 1
+x = 1
+y = 2
+
+#%% cell 2
+x = 3
+y = 4
+
+#%% cell 3
+if x > y:
+    print(x ** y)
+else:
+    print(y ** x)

--- a/Python/Tests/TestData/SendToInteractive/SendToInteractive.pyproj
+++ b/Python/Tests/TestData/SendToInteractive/SendToInteractive.pyproj
@@ -27,6 +27,7 @@
   <ItemGroup>
     <None Include="Program.py" />
     <None Include="Delayed.py" />
+    <None Include="Cells.py" />
   </ItemGroup>
   <ItemGroup>
     <InterpreterReference Include="Global|PythonCore|3.5|x86" />

--- a/Python/Tests/Utilities.Python/PythonVisualStudioApp.cs
+++ b/Python/Tests/Utilities.Python/PythonVisualStudioApp.cs
@@ -49,9 +49,9 @@ namespace TestUtilities.UI.Python {
         public PythonVisualStudioApp(DTE dte = null)
             : base(dte) {
 
-            var service = ServiceProvider.GetPythonToolsService();
+            var service = ServiceProvider.GetPythonToolsService_NotThreadSafe();
             Assert.IsNotNull(service, "Failed to get PythonToolsService");
-            
+
             // Disable AutoListIdentifiers for tests
             var ao = service.AdvancedOptions;
             Assert.IsNotNull(ao, "Failed to get AdvancedOptions");


### PR DESCRIPTION
Fixes #88 Support code cells
Adds support for marking code cells with "#%%", including collapsing them and sending the entire cell to the REPL when pressing Ctrl+Enter on the cell header.
Also fixes some threading issues.

See #88 for a screenshot of how it looks.