### PR TITLE
Fixes #1249 Highlighting for async is wrong when a decorator is used

### DIFF
--- a/Python/Product/Analysis/Parsing/Ast/FunctionDefinition.cs
+++ b/Python/Product/Analysis/Parsing/Ast/FunctionDefinition.cs
@@ -34,6 +34,7 @@ namespace Microsoft.PythonTools.Parsing.Ast {
         internal PythonVariable _nameVariable;          // the variable that refers to the global __name__
         internal bool _hasReturn;
         private int _headerIndex;
+        private int _defIndex;
 
         internal static readonly object WhitespaceAfterAsync = new object();
 
@@ -86,6 +87,11 @@ namespace Microsoft.PythonTools.Parsing.Ast {
         public int HeaderIndex {
             get { return _headerIndex; }
             set { _headerIndex = value; }
+        }
+
+        public int DefIndex {
+            get { return _defIndex; }
+            set { _defIndex = value; }
         }
 
         public override string/*!*/ Name {

--- a/Python/Product/Analysis/Parsing/Parser.cs
+++ b/Python/Product/Analysis/Parsing/Parser.cs
@@ -1794,8 +1794,9 @@ namespace Microsoft.PythonTools.Parsing {
             if (isCoroutine) {
                 preWhitespace = _tokenWhiteSpace;
             }
+
             Eat(TokenKind.KeywordDef);
-            
+
             if (isCoroutine) {
                 afterAsyncWhitespace = _tokenWhiteSpace;
             } else {
@@ -1868,6 +1869,9 @@ namespace Microsoft.PythonTools.Parsing {
 
             ret.SetBody(body);
             ret.ReturnAnnotation = returnAnnotation;
+            // StartIndex may be adjusted later, but we want to keep the def (or
+            // async) index.
+            ret.DefIndex = start;
             ret.HeaderIndex = mid;
             if (_verbatim) {
                 AddPreceedingWhiteSpace(ret, preWhitespace);
@@ -2262,7 +2266,7 @@ namespace Microsoft.PythonTools.Parsing {
 
             FunctionDefinition func = new FunctionDefinition(null, parameters ?? new Parameter[0]); // new Parameter[0] for error handling of incomplete lambda
             func.HeaderIndex = mid;
-            func.StartIndex = start;
+            func.DefIndex = func.StartIndex = start;
 
             // Push the lambda function on the stack so that it's available for any yield expressions to mark it as a generator.
             PushFunction(func);

--- a/Python/Product/Analyzer/Intellisense/ClassifierWalker.cs
+++ b/Python/Product/Analyzer/Intellisense/ClassifierWalker.cs
@@ -240,7 +240,7 @@ namespace Microsoft.PythonTools.Intellisense {
 
         public override bool Walk(FunctionDefinition node) {
             if (node.IsCoroutine) {
-                AddSpan(Tuple.Create("", new Span(node.StartIndex, 5)), Classifications.Keyword);
+                AddSpan(Tuple.Create("", new Span(node.DefIndex, 5)), Classifications.Keyword);
             }
 
             Debug.Assert(_head != null);

--- a/Python/Tests/PythonToolsMockTests/ClassifierTests.cs
+++ b/Python/Tests/PythonToolsMockTests/ClassifierTests.cs
@@ -207,12 +207,15 @@ async def f():
 class F:
     async def f(self): pass
 
+@F
+async def f():
+    pass
 ";
 
             using (var helper = new ClassifierHelper(code, PythonLanguageVersion.V35)) {
-                helper.CheckAstClassifierSpans("ii i+i iki:k ikiki:k iki(): ii iki:k ikiki:k ki: iki(i): k");
+                helper.CheckAstClassifierSpans("ii i+i iki:k ikiki:k iki(): ii iki:k ikiki:k ki: iki(i): k @iiki():k");
                 // "await f" does not highlight "f", but "await + f" does
-                helper.CheckAnalysisClassifierSpans("fff k<async>f k<await>f k<async>f k<async>f c<F> k<async>fp");
+                helper.CheckAnalysisClassifierSpans("fff k<async>f k<await>f k<async>f k<async>f c<F> k<async>fp c<F>k<async>f");
             }
         }
 
@@ -330,6 +333,7 @@ def f() -> int:
                 { '+', PythonPredefinedClassificationTypeNames.Operator },
                 { ':', PythonPredefinedClassificationTypeNames.Operator },
                 { '=', PythonPredefinedClassificationTypeNames.Operator },
+                { '@', PythonPredefinedClassificationTypeNames.Operator },
                 { ',', PythonPredefinedClassificationTypeNames.Comma },
                 { '.', PythonPredefinedClassificationTypeNames.Dot },
             };


### PR DESCRIPTION
Fixes #1249 Highlighting for async is wrong when a decorator is used
Preserves the original start index of a function so it can be used even if a decorator later changes it.