### PR TITLE
Fixes #1473 Directory/File IntelliSense on multi level folder

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Extensions.cs
+++ b/Python/Product/PythonTools/PythonTools/Extensions.cs
@@ -155,7 +155,13 @@ namespace Microsoft.PythonTools {
             }
 
             if (position > lastToken.Span.Start) {
-                if (lastToken.CanComplete()) {
+                if (lastToken.ClassificationType.IsOfType(PredefinedClassificationTypeNames.String)) {
+                    // Handle "'contents of strin|g"
+                    var text = lastToken.Span.GetText();
+                    var span = StringLiteralCompletionList.GetStringContentSpan(text, lastToken.Span.Start) ?? lastToken.Span;
+
+                    return snapshot.CreateTrackingSpan(span, SpanTrackingMode.EdgeInclusive);
+                } else if (lastToken.CanComplete()) {
                     // Handle "fo|o"
                     return snapshot.CreateTrackingSpan(lastToken.Span, SpanTrackingMode.EdgeInclusive);
                 } else {

--- a/Python/Tests/Core/EditorTests.cs
+++ b/Python/Tests/Core/EditorTests.cs
@@ -414,7 +414,7 @@ string'''";
             var realIsFile = isFile ?? !string.IsNullOrEmpty(Path.GetExtension(filename));
             return new StringLiteralCompletionList.EntryInfo {
                 Tooltip = fullpath ?? Path.Combine(rootpath, filename),
-                InsertionText = insertionText ?? ("r\"" + Path.Combine(rootpath, filename) + (realIsFile ? "\"" : "\\\"")),
+                InsertionText = insertionText ?? (Path.Combine(rootpath, filename) + (realIsFile ? "" : "\\")),
                 Caption = filename,
                 IsFile = realIsFile
             };
@@ -425,51 +425,49 @@ string'''";
             var cwd = TestData.GetPath("TestData");
             var user = TestData.GetPath("TestData\\Databases");
 
-            foreach (var quotePrefix in new[] { "\"", "'", "r\"", "r'" }) {
-                AssertUtil.ContainsAtLeast(
-                    StringLiteralCompletionList.GetEntryInfo(quotePrefix + cwd + "\\AbsolutePaths", cwd, user),
-                    MakeEntryInfo(cwd, "AbsolutePath"),
-                    MakeEntryInfo(cwd, "AbsolutePath.sln"),
-                    MakeEntryInfo(cwd, "HelloWorld"),
-                    MakeEntryInfo(cwd, "HelloWorld.sln")
-                );
-                AssertUtil.ContainsAtLeast(
-                    StringLiteralCompletionList.GetEntryInfo(quotePrefix + cwd + "\\AbsolutePath\\", cwd, user),
-                    MakeEntryInfo(cwd + "\\AbsolutePath", "AbsolutePath.pyproj")
-                );
-                AssertUtil.ContainsAtLeast(
-                    StringLiteralCompletionList.GetEntryInfo(quotePrefix + "./AbsolutePaths", cwd, user),
-                    MakeEntryInfo(cwd, "AbsolutePath", "r\".\\AbsolutePath\\\""),
-                    MakeEntryInfo(cwd, "AbsolutePath.sln", "r\".\\AbsolutePath.sln\""),
-                    MakeEntryInfo(cwd, "HelloWorld", "r\".\\HelloWorld\\\""),
-                    MakeEntryInfo(cwd, "HelloWorld.sln", "r\".\\HelloWorld.sln\"")
-                );
-                AssertUtil.ContainsAtLeast(
-                    StringLiteralCompletionList.GetEntryInfo(quotePrefix + ".\\Ab", cwd, user),
-                    MakeEntryInfo(cwd, "AbsolutePath", "r\".\\AbsolutePath\\\""),
-                    MakeEntryInfo(cwd, "AbsolutePath.sln", "r\".\\AbsolutePath.sln\""),
-                    MakeEntryInfo(cwd, "HelloWorld", "r\".\\HelloWorld\\\""),
-                    MakeEntryInfo(cwd, "HelloWorld.sln", "r\".\\HelloWorld.sln\"")
-                );
-                AssertUtil.ContainsAtLeast(
-                    StringLiteralCompletionList.GetEntryInfo(quotePrefix + "~/Ab", cwd, user),
-                    MakeEntryInfo(user, "V27", "r\"~\\V27\\\""),
-                    MakeEntryInfo(user, "Readme.txt", "r\"~\\Readme.txt\"")
-                );
-                AssertUtil.ContainsAtLeast(
-                    StringLiteralCompletionList.GetEntryInfo(quotePrefix + "~\\Ab", cwd, user),
-                    MakeEntryInfo(user, "V27", "r\"~\\V27\\\""),
-                    MakeEntryInfo(user, "Readme.txt", "r\"~\\Readme.txt\"")
-                );
-                AssertUtil.ContainsAtLeast(
-                    StringLiteralCompletionList.GetEntryInfo(quotePrefix + "~\\V27\\", cwd, user),
-                    MakeEntryInfo(user + "\\V27", "ntpath.idb", "r\"~\\V27\\ntpath.idb\""),
-                    MakeEntryInfo(user + "\\V27", "os.idb", "r\"~\\V27\\os.idb\"")
-                );
-                AssertUtil.ContainsAtLeast(
-                    StringLiteralCompletionList.GetEntryInfo(quotePrefix + "Ab", cwd, user)
-                );
-            }
+            AssertUtil.ContainsAtLeast(
+                StringLiteralCompletionList.GetEntryInfo(cwd + "\\AbsolutePaths", cwd, user),
+                MakeEntryInfo(cwd, "AbsolutePath"),
+                MakeEntryInfo(cwd, "AbsolutePath.sln"),
+                MakeEntryInfo(cwd, "HelloWorld"),
+                MakeEntryInfo(cwd, "HelloWorld.sln")
+            );
+            AssertUtil.ContainsAtLeast(
+                StringLiteralCompletionList.GetEntryInfo(cwd + "\\AbsolutePath\\", cwd, user),
+                MakeEntryInfo(cwd + "\\AbsolutePath", "AbsolutePath.pyproj")
+            );
+            AssertUtil.ContainsAtLeast(
+                StringLiteralCompletionList.GetEntryInfo("./AbsolutePaths", cwd, user),
+                MakeEntryInfo(cwd, "AbsolutePath", ".\\AbsolutePath\\"),
+                MakeEntryInfo(cwd, "AbsolutePath.sln", ".\\AbsolutePath.sln"),
+                MakeEntryInfo(cwd, "HelloWorld", ".\\HelloWorld\\"),
+                MakeEntryInfo(cwd, "HelloWorld.sln", ".\\HelloWorld.sln")
+            );
+            AssertUtil.ContainsAtLeast(
+                StringLiteralCompletionList.GetEntryInfo(".\\Ab", cwd, user),
+                MakeEntryInfo(cwd, "AbsolutePath", ".\\AbsolutePath\\"),
+                MakeEntryInfo(cwd, "AbsolutePath.sln", ".\\AbsolutePath.sln"),
+                MakeEntryInfo(cwd, "HelloWorld", ".\\HelloWorld\\"),
+                MakeEntryInfo(cwd, "HelloWorld.sln", ".\\HelloWorld.sln")
+            );
+            AssertUtil.ContainsAtLeast(
+                StringLiteralCompletionList.GetEntryInfo("~/Ab", cwd, user),
+                MakeEntryInfo(user, "V27", "~\\V27\\"),
+                MakeEntryInfo(user, "Readme.txt", "~\\Readme.txt")
+            );
+            AssertUtil.ContainsAtLeast(
+                StringLiteralCompletionList.GetEntryInfo("~\\Ab", cwd, user),
+                MakeEntryInfo(user, "V27", "~\\V27\\"),
+                MakeEntryInfo(user, "Readme.txt", "~\\Readme.txt")
+            );
+            AssertUtil.ContainsAtLeast(
+                StringLiteralCompletionList.GetEntryInfo("~\\V27\\", cwd, user),
+                MakeEntryInfo(user + "\\V27", "ntpath.idb", "~\\V27\\ntpath.idb"),
+                MakeEntryInfo(user + "\\V27", "os.idb", "~\\V27\\os.idb")
+            );
+            AssertUtil.ContainsAtLeast(
+                StringLiteralCompletionList.GetEntryInfo("Ab", cwd, user)
+            );
         }
 
         #endregion Test Cases


### PR DESCRIPTION
Fixes #1473 Directory/File IntelliSense on multi level folder
Updates string literal completions to only operate on string contents
Specialized completion triggering for filenames.