### PR TITLE
Fixes #1360 Error loading web project

### DIFF
--- a/Common/Product/SharedProject/CommonProjectNodeProperties.cs
+++ b/Common/Product/SharedProject/CommonProjectNodeProperties.cs
@@ -16,10 +16,11 @@
 
 using System;
 using System.ComponentModel;
-using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
 using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudioTools.Infrastructure;
 using Microsoft.VisualStudioTools.Project.Automation;
 
 namespace Microsoft.VisualStudioTools.Project {
@@ -42,11 +43,16 @@ namespace Microsoft.VisualStudioTools.Project {
         public string StartupFile {
             get {
                 return Node.Site.GetUIThread().Invoke(() => {
-                    var res = Node.ProjectMgr.GetProjectProperty(CommonConstants.StartupFile, true);
-                    if (res != null && !Path.IsPathRooted(res)) {
-                        res = CommonUtils.GetAbsoluteFilePath(Node.ProjectMgr.ProjectHome, res);
+                    try {
+                        var res = Node.ProjectMgr.GetProjectProperty(CommonConstants.StartupFile, true);
+                        if (res != null && !Path.IsPathRooted(res)) {
+                            res = CommonUtils.GetAbsoluteFilePath(Node.ProjectMgr.ProjectHome, res);
+                        }
+                        return res;
+                    } catch (Exception ex) when (!ex.IsCriticalException()) {
+                        Debug.Fail(ex.ToString());
+                        return "(unknown)";
                     }
-                    return res;
                 });
             }
             set {
@@ -71,7 +77,12 @@ namespace Microsoft.VisualStudioTools.Project {
         public string WorkingDirectory {
             get {
                 return Node.Site.GetUIThread().Invoke(() => {
-                    return this.Node.ProjectMgr.GetProjectProperty(CommonConstants.WorkingDirectory, true);
+                    try {
+                        return this.Node.ProjectMgr.GetProjectProperty(CommonConstants.WorkingDirectory, true);
+                    } catch (Exception ex) when (!ex.IsCriticalException()) {
+                        Debug.Fail(ex.ToString());
+                        return "(unknown)";
+                    }
                 });
             }
             set {
@@ -88,7 +99,12 @@ namespace Microsoft.VisualStudioTools.Project {
         public string PublishUrl {
             get {
                 return Node.Site.GetUIThread().Invoke(() => {
-                    return this.Node.ProjectMgr.GetProjectProperty(CommonConstants.PublishUrl, true);
+                    try {
+                        return this.Node.ProjectMgr.GetProjectProperty(CommonConstants.PublishUrl, true);
+                    } catch (Exception ex) when (!ex.IsCriticalException()) {
+                        Debug.Fail(ex.ToString());
+                        return "(unknown)";
+                    }
                 });
             }
             set {

--- a/Python/Product/Common/Strings.Designer.cs
+++ b/Python/Product/Common/Strings.Designer.cs
@@ -1911,7 +1911,7 @@ namespace Microsoft.PythonTools {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The web browser URL property has been set a a default value. It may be modified through Project Properties..
+        ///   Looks up a localized string similar to The web browser URL property has been set to a default value. It may be modified through Project Properties..
         /// </summary>
         public static string UpgradedWebBrowserUrlProperty {
             get {

--- a/Python/Product/Common/Strings.Designer.cs
+++ b/Python/Product/Common/Strings.Designer.cs
@@ -1911,6 +1911,15 @@ namespace Microsoft.PythonTools {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The web browser URL property has been set a a default value. It may be modified through Project Properties..
+        /// </summary>
+        public static string UpgradedWebBrowserUrlProperty {
+            get {
+                return ResourceManager.GetString("UpgradedWebBrowserUrlProperty", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Failed to create or add the virtual environment. See the Output window for details..
         /// </summary>
         public static string VirtualEnvAddFailed {

--- a/Python/Product/Common/Strings.resx
+++ b/Python/Product/Common/Strings.resx
@@ -809,6 +809,6 @@ modified from these scripts.</value>
     <value>Administrator privileges may be required to install or update this package.</value>
   </data>
   <data name="UpgradedWebBrowserUrlProperty" xml:space="preserve">
-    <value>The web browser URL property has been set a a default value. It may be modified through Project Properties.</value>
+    <value>The web browser URL property has been set to a default value. It may be modified through Project Properties.</value>
   </data>
 </root>

--- a/Python/Product/Common/Strings.resx
+++ b/Python/Product/Common/Strings.resx
@@ -808,4 +808,7 @@ modified from these scripts.</value>
   <data name="ElevateForInstallPackage_MainInstruction" xml:space="preserve">
     <value>Administrator privileges may be required to install or update this package.</value>
   </data>
+  <data name="UpgradedWebBrowserUrlProperty" xml:space="preserve">
+    <value>The web browser URL property has been set a a default value. It may be modified through Project Properties.</value>
+  </data>
 </root>

--- a/Python/Product/PythonTools/PythonTools/Project/PythonProjectFactory.cs
+++ b/Python/Product/PythonTools/PythonTools/Project/PythonProjectFactory.cs
@@ -214,13 +214,11 @@ namespace Microsoft.PythonTools.Project {
 
         private static void ProcessMissingWebBrowserUrl(ProjectRootElement projectXml, Action<__VSUL_ERRORLEVEL, string> log) {
             var launcher = projectXml.Properties.LastOrDefault(p => p.Name == "LaunchProvider");
-            if (launcher == null ||
-                launcher.Value != "Web launcher" ||
-                launcher.Value != "Django launcher") {
+            if (launcher?.Value != "Web launcher" && launcher?.Value != "Django launcher") {
                 return;
             }
 
-            //<WebBrowserUrl>http://localhost</WebBrowserUrl>
+            // <WebBrowserUrl>http://localhost</WebBrowserUrl>
             var prop = projectXml.CreatePropertyElement("WebBrowserUrl");
             prop.Value = "http://localhost";
             launcher.Parent.InsertAfterChild(launcher, prop);

--- a/Python/Product/PythonTools/PythonTools/Project/PythonProjectNode.cs
+++ b/Python/Product/PythonTools/PythonTools/Project/PythonProjectNode.cs
@@ -82,9 +82,6 @@ namespace Microsoft.PythonTools.Project {
         private readonly PythonProject _pythonProject;
 
         public PythonProjectNode(IServiceProvider serviceProvider) : base(serviceProvider, null) {
-            // This will ensure that our package is loaded
-            var pyService = serviceProvider.GetPythonToolsService();
-
             Type projectNodePropsType = typeof(PythonProjectNodeProperties);
             AddCATIDMapping(projectNodePropsType, projectNodePropsType.GUID);
             ActiveInterpreterChanged += OnActiveInterpreterChanged;

--- a/Python/Product/PythonTools/PythonTools/Project/PythonProjectPackage.cs
+++ b/Python/Product/PythonTools/PythonTools/Project/PythonProjectPackage.cs
@@ -57,6 +57,11 @@ namespace Microsoft.PythonTools.Project {
     public class PythonProjectPackage : CommonProjectPackage {
         internal const string PythonFileFilter = "Python Project Files (*.pyproj);*.pyproj";
 
+        protected override void Initialize() {
+            base.Initialize();
+            RegisterProjectFactory(new PythonWebProjectFactory(this));
+        }
+
         public override ProjectFactory CreateProjectFactory() {
             return new PythonProjectFactory(this);
         }

--- a/Python/Product/PythonTools/PythonTools/WebProject/PythonWebProject.cs
+++ b/Python/Product/PythonTools/PythonTools/WebProject/PythonWebProject.cs
@@ -37,25 +37,15 @@ namespace Microsoft.PythonTools.Project.Web {
         IVsProject,
         IVsFilterAddProjectItemDlg
     {
-        private PythonToolsPackage _package;
+        private readonly IServiceProvider _site;
         internal IVsProject _innerProject;
         internal IVsProject3 _innerProject3;
         private IVsProjectFlavorCfgProvider _innerVsProjectFlavorCfgProvider;
         private static Guid PythonProjectGuid = new Guid(PythonConstants.ProjectFactoryGuid);
         private IOleCommandTarget _menuService;
 
-        public PythonWebProject() {
-        }
-
-        internal PythonToolsPackage Package {
-            get { return _package; }
-            set {
-                Debug.Assert(_package == null);
-                if (_package != null) {
-                    throw new InvalidOperationException("PythonWebProject.Package must only be set once");
-                }
-                _package = value;
-            }
+        public PythonWebProject(IServiceProvider site) {
+            _site = site;
         }
 
         #region IVsAggregatableProject
@@ -107,9 +97,8 @@ namespace Microsoft.PythonTools.Project.Web {
             _innerProject3 = inner as IVsProject3;
             _innerVsHierarchy = inner as IVsHierarchy;
 
-            // Ensure we have a service provider as this is required for menu items to work
-            if (this.serviceProvider == null) {
-                this.serviceProvider = (IServiceProvider)Package;
+            if (serviceProvider == null) {
+                serviceProvider = _site;
             }
 
             // Now let the base implementation set the inner object
@@ -241,7 +230,7 @@ namespace Microsoft.PythonTools.Project.Web {
                 dlgOwner = IntPtr.Zero;
             }
 
-            var fullTemplate = ((EnvDTE80.Solution2)_package.DTE.Solution).GetProjectItemTemplate(
+            var fullTemplate = ((EnvDTE80.Solution2)this.GetDTE().Solution).GetProjectItemTemplate(
                 "AzureCSWebRole.zip",
                 PythonConstants.LanguageName
             );

--- a/Python/Product/PythonTools/PythonTools/WebProject/PythonWebProjectFactory.cs
+++ b/Python/Product/PythonTools/PythonTools/WebProject/PythonWebProjectFactory.cs
@@ -16,21 +16,19 @@
 
 using System;
 using System.Runtime.InteropServices;
-using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Shell.Flavor;
-using Microsoft.VisualStudio.Shell.Interop;
 
 namespace Microsoft.PythonTools.Project.Web {
     [Guid(PythonConstants.WebProjectFactoryGuid)]
     internal class PythonWebProjectFactory : FlavoredProjectFactoryBase {
-        private PythonToolsPackage _package;
+        private readonly IServiceProvider _site;
 
-        internal PythonWebProjectFactory(PythonToolsPackage package) {
-            _package = package;
+        internal PythonWebProjectFactory(IServiceProvider site) {
+            _site = site;
         }
 
         protected override object PreCreateForOuter(IntPtr outerProjectIUnknown) {
-            return new PythonWebProject { Package = _package };
+            return new PythonWebProject(_site);
         }
     }
 }

--- a/Python/Product/PythonTools/PythonToolsPackage.cs
+++ b/Python/Product/PythonTools/PythonToolsPackage.cs
@@ -495,8 +495,6 @@ You should uninstall IronPython 2.7 and re-install it with the ""Tools for Visua
             }, GuidList.guidPythonToolsCmdSet);
 
 
-            RegisterProjectFactory(new PythonWebProjectFactory(this));
-
             // Enable the Python debugger UI context
             UIContext.FromUIContextGuid(AD7Engine.DebugEngineGuid).IsActive = true;
 

--- a/Python/Templates/Django/ProjectTemplates/Python/Web/DjangoProject/DjangoApp.pyproj
+++ b/Python/Templates/Django/ProjectTemplates/Python/Web/DjangoProject/DjangoApp.pyproj
@@ -13,6 +13,7 @@
     <WorkingDirectory>.</WorkingDirectory>
     <LaunchProvider>Django launcher</LaunchProvider>
     <DjangoSettingsModule>$safeprojectname$.settings</DjangoSettingsModule>
+    <WebBrowserUrl>http://localhost</WebBrowserUrl>
     <OutputPath>.</OutputPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/Python/Templates/Django/ProjectTemplates/Python/Web/StarterDjangoProject/StarterDjangoProject.pyproj
+++ b/Python/Templates/Django/ProjectTemplates/Python/Web/StarterDjangoProject/StarterDjangoProject.pyproj
@@ -13,6 +13,7 @@
     <SearchPath>
     </SearchPath>
     <WorkingDirectory>.</WorkingDirectory>
+    <WebBrowserUrl>http://localhost</WebBrowserUrl>
     <LaunchProvider>Django launcher</LaunchProvider>
     <OutputPath>.</OutputPath>
   </PropertyGroup>

--- a/Python/Templates/Django/ProjectTemplates/Python/Web/WebRoleDjango/DjangoWebRole.pyproj
+++ b/Python/Templates/Django/ProjectTemplates/Python/Web/WebRoleDjango/DjangoWebRole.pyproj
@@ -13,6 +13,7 @@
     <WorkingDirectory>.</WorkingDirectory>
     <LaunchProvider>Django launcher</LaunchProvider>
     <DjangoSettingsModule>$safeprojectname$.settings</DjangoSettingsModule>
+    <WebBrowserUrl>http://localhost</WebBrowserUrl>
     <OutputPath>.</OutputPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/Python/Templates/Samples/ProjectTemplates/Python/Samples/PollsBottle/PollsBottle.pyproj
+++ b/Python/Templates/Samples/ProjectTemplates/Python/Samples/PollsBottle/PollsBottle.pyproj
@@ -10,6 +10,7 @@
     <StartupFile>app.py</StartupFile>
     <WorkingDirectory>.</WorkingDirectory>
     <LaunchProvider>Web launcher</LaunchProvider>
+    <WebBrowserUrl>http://localhost</WebBrowserUrl>
     <OutputPath>.</OutputPath>
     <StaticUriPattern>^/static/.*</StaticUriPattern>
     <PythonDebugWebServerCommandArguments>--debug $(CommandLineArguments)</PythonDebugWebServerCommandArguments>

--- a/Python/Templates/Samples/ProjectTemplates/Python/Samples/PollsDjango/PollsDjango.pyproj
+++ b/Python/Templates/Samples/ProjectTemplates/Python/Samples/PollsDjango/PollsDjango.pyproj
@@ -15,6 +15,7 @@
     </SearchPath>
     <WorkingDirectory>.</WorkingDirectory>
     <LaunchProvider>Django launcher</LaunchProvider>
+    <WebBrowserUrl>http://localhost</WebBrowserUrl>
     <OutputPath>.</OutputPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/Python/Templates/Samples/ProjectTemplates/Python/Samples/PollsFlask/PollsFlask.pyproj
+++ b/Python/Templates/Samples/ProjectTemplates/Python/Samples/PollsFlask/PollsFlask.pyproj
@@ -10,6 +10,7 @@
     <StartupFile>runserver.py</StartupFile>
     <WorkingDirectory>.</WorkingDirectory>
     <LaunchProvider>Web launcher</LaunchProvider>
+    <WebBrowserUrl>http://localhost</WebBrowserUrl>
     <OutputPath>.</OutputPath>
     <StaticUriPattern>^/static/.*</StaticUriPattern>
     <StaticUriRewrite>^/$(MSBuildProjectName)/static/.*</StaticUriRewrite>

--- a/Python/Templates/Samples/ProjectTemplates/Python/Samples/PollsFlaskJade/PollsFlaskJade.pyproj
+++ b/Python/Templates/Samples/ProjectTemplates/Python/Samples/PollsFlaskJade/PollsFlaskJade.pyproj
@@ -10,6 +10,7 @@
     <StartupFile>runserver.py</StartupFile>
     <WorkingDirectory>.</WorkingDirectory>
     <LaunchProvider>Web launcher</LaunchProvider>
+    <WebBrowserUrl>http://localhost</WebBrowserUrl>
     <OutputPath>.</OutputPath>
     <StaticUriPattern>^/static/.*</StaticUriPattern>
     <StaticUriRewrite>^/$(MSBuildProjectName)/static/.*</StaticUriRewrite>

--- a/Python/Templates/Web/ProjectTemplates/Python/Web/StarterBottleProject/StarterBottleProject.pyproj
+++ b/Python/Templates/Web/ProjectTemplates/Python/Web/StarterBottleProject/StarterBottleProject.pyproj
@@ -13,6 +13,7 @@
     <WorkingDirectory>.</WorkingDirectory>
     <LaunchProvider>Web launcher</LaunchProvider>
     <OutputPath>.</OutputPath>
+    <WebBrowserUrl>http://localhost</WebBrowserUrl>
     <StaticUriPattern>^/static/.*</StaticUriPattern>
     <PythonDebugWebServerCommandArguments>--debug $(CommandLineArguments)</PythonDebugWebServerCommandArguments>
     <PythonWsgiHandler>{StartupModule}.wsgi_app()</PythonWsgiHandler>

--- a/Python/Templates/Web/ProjectTemplates/Python/Web/StarterFlaskJadeProject/StarterFlaskJadeProject.pyproj
+++ b/Python/Templates/Web/ProjectTemplates/Python/Web/StarterFlaskJadeProject/StarterFlaskJadeProject.pyproj
@@ -12,6 +12,7 @@
     </SearchPath>
     <WorkingDirectory>.</WorkingDirectory>
     <LaunchProvider>Web launcher</LaunchProvider>
+    <WebBrowserUrl>http://localhost</WebBrowserUrl>
     <OutputPath>.</OutputPath>
     <StaticUriPattern>^/static/.*</StaticUriPattern>
     <StaticUriRewrite>^/$(MSBuildProjectName)/static/.*</StaticUriRewrite>

--- a/Python/Templates/Web/ProjectTemplates/Python/Web/StarterFlaskProject/StarterFlaskProject.pyproj
+++ b/Python/Templates/Web/ProjectTemplates/Python/Web/StarterFlaskProject/StarterFlaskProject.pyproj
@@ -12,6 +12,7 @@
     </SearchPath>
     <WorkingDirectory>.</WorkingDirectory>
     <LaunchProvider>Web launcher</LaunchProvider>
+    <WebBrowserUrl>http://localhost</WebBrowserUrl>
     <OutputPath>.</OutputPath>
     <StaticUriPattern>^/static/.*</StaticUriPattern>
     <StaticUriRewrite>^/$(MSBuildProjectName)/static/.*</StaticUriRewrite>

--- a/Python/Templates/Web/ProjectTemplates/Python/Web/WebProjectBottle/WebProjectBottle.pyproj
+++ b/Python/Templates/Web/ProjectTemplates/Python/Web/WebProjectBottle/WebProjectBottle.pyproj
@@ -10,6 +10,7 @@
     <SearchPath></SearchPath>
     <WorkingDirectory>.</WorkingDirectory>
     <LaunchProvider>Web launcher</LaunchProvider>
+    <WebBrowserUrl>http://localhost</WebBrowserUrl>
     <OutputPath>.</OutputPath>
     <PythonDebugWebServerCommandArguments>--debug $(CommandLineArguments)</PythonDebugWebServerCommandArguments>
     <PythonWsgiHandler>{StartupModule}.wsgi_app()</PythonWsgiHandler>

--- a/Python/Templates/Web/ProjectTemplates/Python/Web/WebProjectEmpty/EmptyWebProject.pyproj
+++ b/Python/Templates/Web/ProjectTemplates/Python/Web/WebProjectEmpty/EmptyWebProject.pyproj
@@ -10,6 +10,7 @@
     <SearchPath></SearchPath>
     <WorkingDirectory>.</WorkingDirectory>
     <LaunchProvider>Web launcher</LaunchProvider>
+    <WebBrowserUrl>http://localhost</WebBrowserUrl>
     <OutputPath>.</OutputPath>
     <PythonWsgiHandler>app.wsgi_app</PythonWsgiHandler>
   </PropertyGroup>

--- a/Python/Templates/Web/ProjectTemplates/Python/Web/WebProjectFlask/WebProjectFlask.pyproj
+++ b/Python/Templates/Web/ProjectTemplates/Python/Web/WebProjectFlask/WebProjectFlask.pyproj
@@ -10,6 +10,7 @@
     <SearchPath></SearchPath>
     <WorkingDirectory>.</WorkingDirectory>
     <LaunchProvider>Web launcher</LaunchProvider>
+    <WebBrowserUrl>http://localhost</WebBrowserUrl>
     <OutputPath>.</OutputPath>
     <PythonWsgiHandler>{StartupModule}.wsgi_app</PythonWsgiHandler>
   </PropertyGroup>

--- a/Python/Templates/Web/ProjectTemplates/Python/Web/WebRoleBottle/WebRoleBottle.pyproj
+++ b/Python/Templates/Web/ProjectTemplates/Python/Web/WebRoleBottle/WebRoleBottle.pyproj
@@ -10,6 +10,7 @@
     <SearchPath></SearchPath>
     <WorkingDirectory>.</WorkingDirectory>
     <LaunchProvider>Web launcher</LaunchProvider>
+    <WebBrowserUrl>http://localhost</WebBrowserUrl>
     <OutputPath>.</OutputPath>
     <PythonDebugWebServerCommandArguments>--debug $(CommandLineArguments)</PythonDebugWebServerCommandArguments>
     <PythonWsgiHandler>{StartupModule}.wsgi_app()</PythonWsgiHandler>

--- a/Python/Templates/Web/ProjectTemplates/Python/Web/WebRoleEmpty/EmptyWebRole.pyproj
+++ b/Python/Templates/Web/ProjectTemplates/Python/Web/WebRoleEmpty/EmptyWebRole.pyproj
@@ -10,6 +10,7 @@
     <SearchPath></SearchPath>
     <WorkingDirectory>.</WorkingDirectory>
     <LaunchProvider>Web launcher</LaunchProvider>
+    <WebBrowserUrl>http://localhost</WebBrowserUrl>
     <OutputPath>.</OutputPath>
     <PythonWsgiHandler>app.wsgi_app</PythonWsgiHandler>
   </PropertyGroup>

--- a/Python/Templates/Web/ProjectTemplates/Python/Web/WebRoleFlask/WebRoleFlask.pyproj
+++ b/Python/Templates/Web/ProjectTemplates/Python/Web/WebRoleFlask/WebRoleFlask.pyproj
@@ -10,6 +10,7 @@
     <SearchPath></SearchPath>
     <WorkingDirectory>.</WorkingDirectory>
     <LaunchProvider>Web launcher</LaunchProvider>
+    <WebBrowserUrl>http://localhost</WebBrowserUrl>
     <OutputPath>.</OutputPath>
     <PythonWsgiHandler>{StartupModule}.wsgi_app</PythonWsgiHandler>
   </PropertyGroup>

--- a/Python/Tests/TestData/CloudProject/WebRole1/WebRole1.pyproj
+++ b/Python/Tests/TestData/CloudProject/WebRole1/WebRole1.pyproj
@@ -13,6 +13,7 @@
     </SearchPath>
     <WorkingDirectory>.</WorkingDirectory>
     <LaunchProvider>Web launcher</LaunchProvider>
+    <WebBrowserUrl></WebBrowserUrl>
     <OutputPath>.</OutputPath>
     <PythonWsgiHandler>app.wsgi_app</PythonWsgiHandler>
     <Name>WebRole1</Name>

--- a/Python/Tests/TestData/DjangoAnalysisTestApp/DjangoAnalysisTestApp.pyproj
+++ b/Python/Tests/TestData/DjangoAnalysisTestApp/DjangoAnalysisTestApp.pyproj
@@ -16,6 +16,7 @@
     </SearchPath>
     <WorkingDirectory>.</WorkingDirectory>
     <LaunchProvider>Django launcher</LaunchProvider>
+    <WebBrowserUrl></WebBrowserUrl>
     <OutputPath>.</OutputPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/Python/Tests/TestData/DjangoApplication1/DjangoApplication1.pyproj
+++ b/Python/Tests/TestData/DjangoApplication1/DjangoApplication1.pyproj
@@ -24,6 +24,7 @@
     </SearchPath>
     <WorkingDirectory>.</WorkingDirectory>
     <LaunchProvider>Django launcher</LaunchProvider>
+    <WebBrowserUrl></WebBrowserUrl>
     <OutputPath>.</OutputPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/Python/Tests/TestData/DjangoDebugProject/DjangoDebugProject.pyproj
+++ b/Python/Tests/TestData/DjangoDebugProject/DjangoDebugProject.pyproj
@@ -11,6 +11,7 @@
     </SearchPath>
     <WorkingDirectory>.</WorkingDirectory>
     <LaunchProvider>Django launcher</LaunchProvider>
+    <WebBrowserUrl></WebBrowserUrl>
     <OutputPath>.</OutputPath>
     <Name>DjangoDebugProject</Name>
     <RootNamespace>DjangoDebugProject</RootNamespace>

--- a/Python/Tests/TestData/DjangoEditProject/DjangoEditProject.pyproj
+++ b/Python/Tests/TestData/DjangoEditProject/DjangoEditProject.pyproj
@@ -15,8 +15,7 @@
     <RootNamespace>DebuggerProject</RootNamespace>
     <OutputPath>.</OutputPath>
     <UseIISExpress>false</UseIISExpress>
-    <InterpreterId>2af0f10d-7135-4994-9156-5d01c9c11b7e</InterpreterId>
-    <InterpreterVersion>2.7</InterpreterVersion>    
+    <InterpreterId>Global|PythonCore|2.7|x86</InterpreterId>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Python/Tests/TestData/DjangoProject/DjangoProject.pyproj
+++ b/Python/Tests/TestData/DjangoProject/DjangoProject.pyproj
@@ -11,6 +11,7 @@
     </SearchPath>
     <WorkingDirectory>.</WorkingDirectory>
     <LaunchProvider>Django launcher</LaunchProvider>
+    <WebBrowserUrl></WebBrowserUrl>
     <OutputPath>.</OutputPath>
     <Name>DjangoApplication1</Name>
     <RootNamespace>DjangoApplication1</RootNamespace>

--- a/Python/Tests/TestData/DjangoProjectWithSubDirectory/DjangoProjectWithSubDirectory.pyproj
+++ b/Python/Tests/TestData/DjangoProjectWithSubDirectory/DjangoProjectWithSubDirectory.pyproj
@@ -24,6 +24,7 @@
     </SearchPath>
     <WorkingDirectory>project</WorkingDirectory>
     <LaunchProvider>Django launcher</LaunchProvider>
+    <WebBrowserUrl></WebBrowserUrl>
     <OutputPath>.</OutputPath>
     <DjangoSettingsModule>config.settings</DjangoSettingsModule>
   </PropertyGroup>

--- a/Python/Tests/TestData/DjangoTemplateCodeIntelligence/DjangoTemplateCodeIntelligence.pyproj
+++ b/Python/Tests/TestData/DjangoTemplateCodeIntelligence/DjangoTemplateCodeIntelligence.pyproj
@@ -11,6 +11,7 @@
     </SearchPath>
     <WorkingDirectory>.</WorkingDirectory>
     <LaunchProvider>Django launcher</LaunchProvider>
+    <WebBrowserUrl></WebBrowserUrl>
     <OutputPath>.</OutputPath>
     <Name>DjangoTemplateCodeIntelligence</Name>
     <RootNamespace>DjangoTemplateCodeIntelligence</RootNamespace>

--- a/Python/Tests/TestData/DjangoTestApp/DjangoTestApp.pyproj
+++ b/Python/Tests/TestData/DjangoTestApp/DjangoTestApp.pyproj
@@ -11,6 +11,7 @@
     </SearchPath>
     <WorkingDirectory>.</WorkingDirectory>
     <LaunchProvider>Django launcher</LaunchProvider>
+    <WebBrowserUrl></WebBrowserUrl>
     <OutputPath>.</OutputPath>
     <Name>DjangoTestApp</Name>
     <RootNamespace>DjangoTestApp</RootNamespace>

--- a/Python/Tests/TestData/ProjectUpgrade/OldBottleProject.pyproj
+++ b/Python/Tests/TestData/ProjectUpgrade/OldBottleProject.pyproj
@@ -9,6 +9,7 @@
     <SearchPath></SearchPath>
     <WorkingDirectory>.</WorkingDirectory>
     <LaunchProvider>Web launcher</LaunchProvider>
+    <WebBrowserUrl></WebBrowserUrl>
     <OutputPath>.</OutputPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/Python/Tests/TestData/ProjectUpgrade/OldFlaskProject.pyproj
+++ b/Python/Tests/TestData/ProjectUpgrade/OldFlaskProject.pyproj
@@ -9,6 +9,7 @@
     <SearchPath></SearchPath>
     <WorkingDirectory>.</WorkingDirectory>
     <LaunchProvider>Web launcher</LaunchProvider>
+    <WebBrowserUrl></WebBrowserUrl>
     <OutputPath>.</OutputPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/Python/Tests/TestData/WFastCgi/DjangoTestApp/DjangoTestApp.pyproj
+++ b/Python/Tests/TestData/WFastCgi/DjangoTestApp/DjangoTestApp.pyproj
@@ -11,6 +11,7 @@
     </SearchPath>
     <WorkingDirectory>.</WorkingDirectory>
     <LaunchProvider>Django launcher</LaunchProvider>
+    <WebBrowserUrl></WebBrowserUrl>
     <OutputPath>.</OutputPath>
     <Name>DjangoTestApp</Name>
     <RootNamespace>DjangoTestApp</RootNamespace>

--- a/Python/Tests/TestData/WebProject/CheckCommandLineArgs.pyproj
+++ b/Python/Tests/TestData/WebProject/CheckCommandLineArgs.pyproj
@@ -15,6 +15,7 @@
     <InterpreterId></InterpreterId>
     <InterpreterVersion></InterpreterVersion>
     <LaunchProvider>Web launcher</LaunchProvider>
+    <WebBrowserUrl></WebBrowserUrl>
     <OutputPath>.</OutputPath>
     <PythonWebFramework></PythonWebFramework>
   </PropertyGroup>

--- a/Python/Tests/TestData/WebProject/CheckEnvironment.pyproj
+++ b/Python/Tests/TestData/WebProject/CheckEnvironment.pyproj
@@ -12,6 +12,7 @@
     </SearchPath>
     <WorkingDirectory>.</WorkingDirectory>
     <LaunchProvider>Web launcher</LaunchProvider>
+    <WebBrowserUrl></WebBrowserUrl>
     <OutputPath>.</OutputPath>
     <PythonWsgiHandler>app.wsgi_app</PythonWsgiHandler>
     <Name>CheckEnvironment</Name>

--- a/Python/Tests/TestData/WebProject/EmptyWebProject.pyproj
+++ b/Python/Tests/TestData/WebProject/EmptyWebProject.pyproj
@@ -15,6 +15,7 @@
     <InterpreterId></InterpreterId>
     <InterpreterVersion></InterpreterVersion>
     <LaunchProvider>Web launcher</LaunchProvider>
+    <WebBrowserUrl></WebBrowserUrl>
     <OutputPath>.</OutputPath>
     <PythonWebFramework></PythonWebFramework>
   </PropertyGroup>


### PR DESCRIPTION
Fixes #1360 Error loading web project
Moves project factory registration to the project package to ensure the web flavor is active after loading the package containing the base project type.

Fixes #1480 Web browser no longer launches for web projects
Adds upgrade step to ensure all web projects have a WebBrowserUrl property
Updates templates and test data
(Note that the experimental hive can't upgrade projects for some reason, so you'll need to manually add the property for any existing projects)