### PR TITLE
Fixes #1463 Non-Python files are tokenized as Python files after swit…

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Project/PythonProjectNode.cs
+++ b/Python/Product/PythonTools/PythonTools/Project/PythonProjectNode.cs
@@ -1503,7 +1503,7 @@ namespace Microsoft.PythonTools.Project {
         }
 
         private async void Reanalyze(VsProjectAnalyzer newAnalyzer) {
-            foreach (var child in AllVisibleDescendants.OfType<FileNode>()) {
+            foreach (var child in AllVisibleDescendants.OfType<PythonFileNode>()) {
                 await newAnalyzer.AnalyzeFileAsync(child.Url);
             }
 


### PR DESCRIPTION
Fixes #1463 Non-Python files are tokenized as Python files after switching environment
Filters file nodes to those that are Python code files.