### PR TITLE
Ensures text manager is not loaded before the shell is initialized.

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Navigation/CodeWindowManager.cs
+++ b/Python/Product/PythonTools/PythonTools/Navigation/CodeWindowManager.cs
@@ -60,7 +60,7 @@ namespace Microsoft.PythonTools.Navigation {
                 ((IVsCodeWindowEvents)this).OnNewView(textView);
             }
 
-            AddDropDownBarAsync(_pyService).DoNotWait();
+            AddDropDownBarAsync(_pyService).SilenceException<OperationCanceledException>().DoNotWait();
 
             return VSConstants.S_OK;
         }

--- a/Python/Product/PythonTools/PythonTools/Navigation/CodeWindowManager.cs
+++ b/Python/Product/PythonTools/PythonTools/Navigation/CodeWindowManager.cs
@@ -15,24 +15,20 @@
 // permissions and limitations under the License.
 
 using System;
-using System.Collections.Generic;
-using System.Runtime.InteropServices;
-using Microsoft.PythonTools.Analysis;
+using Microsoft.PythonTools.Infrastructure;
 using Microsoft.PythonTools.Intellisense;
 using Microsoft.PythonTools.Language;
-using Microsoft.PythonTools.Repl;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.Editor;
-using Microsoft.PythonTools.InteractiveWindow;
 using Microsoft.VisualStudio.OLE.Interop;
 using Microsoft.VisualStudio.Shell;
-using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Text.Operations;
 using Microsoft.VisualStudio.TextManager.Interop;
 using Microsoft.VisualStudioTools;
 using IServiceProvider = System.IServiceProvider;
+using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.PythonTools.Navigation {
     class CodeWindowManager : IVsCodeWindowManager, IVsCodeWindowEvents {
@@ -64,11 +60,16 @@ namespace Microsoft.PythonTools.Navigation {
                 ((IVsCodeWindowEvents)this).OnNewView(textView);
             }
 
-            if (_pyService.LangPrefs.NavigationBar) {
-                return AddDropDownBar();
-            }
+            AddDropDownBarAsync(_pyService).DoNotWait();
 
             return VSConstants.S_OK;
+        }
+
+        private async Task AddDropDownBarAsync(PythonToolsService service) {
+            var prefs = await _pyService.GetLangPrefsAsync();
+            if (prefs.NavigationBar) {
+                AddDropDownBar();
+            }
         }
 
         private int AddDropDownBar() {

--- a/Python/Product/PythonTools/PythonTools/Options/GlobalInterpreterOptions.cs
+++ b/Python/Product/PythonTools/PythonTools/Options/GlobalInterpreterOptions.cs
@@ -32,6 +32,7 @@ namespace Microsoft.PythonTools.Options {
             _pyService = pyService;
             _interpreters = interpreters;
             _interpreterOptions = interpreterOptions;
+            Load();
         }
 
         internal string DefaultInterpreter {

--- a/Python/Product/PythonTools/PythonTools/Options/PythonInteractiveOptions.cs
+++ b/Python/Product/PythonTools/PythonTools/Options/PythonInteractiveOptions.cs
@@ -41,6 +41,7 @@ namespace Microsoft.PythonTools.Options {
             _completionMode = ReplIntellisenseMode.DontEvaluateCalls;
             _smartHistory = true;
             _scripts = string.Empty;
+            Load();
         }
 
         internal ReplIntellisenseMode CompletionMode {

--- a/Python/Product/PythonTools/PythonTools/Options/PythonToolsOptionsService.cs
+++ b/Python/Product/PythonTools/PythonTools/Options/PythonToolsOptionsService.cs
@@ -15,15 +15,24 @@
 // permissions and limitations under the License.
 
 using System;
+using System.ComponentModel.Design;
 using Microsoft.VisualStudio.Settings;
+using Microsoft.VisualStudioTools;
 
 namespace Microsoft.PythonTools.Options {
     class PythonToolsOptionsService : IPythonToolsOptionsService {
         private const string _optionsKey = "Options";
         private readonly WritableSettingsStore _settingsStore;
 
-        public PythonToolsOptionsService(IServiceProvider serviceProvider) {
-            var settingsManager = PythonToolsPackage.GetSettings(serviceProvider);
+        public static object CreateService(IServiceContainer container, Type serviceType) {
+            if (serviceType.IsEquivalentTo(typeof(IPythonToolsOptionsService))) {
+                return new PythonToolsOptionsService(container);
+            }
+            return null;
+        }
+
+        private PythonToolsOptionsService(IServiceProvider serviceProvider) {
+            var settingsManager = SettingsManagerCreator.GetSettingsManager(serviceProvider);
             _settingsStore = settingsManager.GetWritableSettingsStore(SettingsScope.UserSettings);
         }
 

--- a/Python/Product/PythonTools/PythonToolsPackage.cs
+++ b/Python/Product/PythonTools/PythonToolsPackage.cs
@@ -413,10 +413,6 @@ You should uninstall IronPython 2.7 and re-install it with the ""Tools for Visua
             }
         }
 
-        internal static SettingsManager GetSettings(System.IServiceProvider serviceProvider) {
-            return SettingsManagerCreator.GetSettingsManager(serviceProvider);
-        }
-
         /////////////////////////////////////////////////////////////////////////////
         // Overriden Package Implementation
 
@@ -431,8 +427,7 @@ You should uninstall IronPython 2.7 and re-install it with the ""Tools for Visua
             var services = (IServiceContainer)this;
 
             // register our options service which provides registry access for various options
-            var optionsService = new PythonToolsOptionsService(this);
-            services.AddService(typeof(IPythonToolsOptionsService), optionsService, promote: true);
+            services.AddService(typeof(IPythonToolsOptionsService), PythonToolsOptionsService.CreateService, promote: true);
 
             services.AddService(typeof(IClipboardService), new ClipboardService(), promote: true);
 

--- a/Python/Product/PythonTools/PythonToolsService.cs
+++ b/Python/Product/PythonTools/PythonToolsService.cs
@@ -563,6 +563,15 @@ namespace Microsoft.PythonTools {
 
         internal LanguagePreferences LangPrefs => _langPrefs.Value;
 
+        /// <summary>
+        /// Ensures the shell is loaded before returning language preferences,
+        /// as obtaining them while the shell is initializing can corrupt
+        /// settings.
+        /// </summary>
+        /// <remarks>
+        /// Should only be called from the UI thread, and you must not
+        /// synchronously wait on the returned task.
+        /// </remarks>
         internal async Task<LanguagePreferences> GetLangPrefsAsync() {
             if (_langPrefs.IsValueCreated) {
                 return _langPrefs.Value;


### PR DESCRIPTION
Ensures text manager is not loaded before the shell is initialized. (This helps prevent the Tab setting from being incorrect)
Switches to correct parsing of Unicode identifiers.