### PR TITLE
Adds missing Microsoft.PythonTools.Uwp.Wizards.dll to signing script

### DIFF
--- a/Python/Setup/signlayout.proj
+++ b/Python/Setup/signlayout.proj
@@ -47,6 +47,7 @@
     <ManagedFiles Include="
         Microsoft.PythonTools.Uwp.dll;
         Microsoft.PythonTools.Uwp.Interpreter.dll;
+        Microsoft.PythonTools.Uwp.Wizards.dll;
     " Condition="$(IncludeUwp)" />
 
     <UnmanagedFiles Include="


### PR DESCRIPTION
FYI @alanch-ms - I missed it as well, so hopefully next time we add a new assembly we'll remember between us.