### PR TITLE
Fixes #1070 Cannot debug script that uses colorama

### DIFF
--- a/Python/Product/PythonTools/visualstudio_py_repl.py
+++ b/Python/Product/PythonTools/visualstudio_py_repl.py
@@ -1169,6 +1169,7 @@ class DebugReplBackend(BasicReplBackend):
 class _ReplOutput(object):
     """file like object which redirects output to the repl window."""
     errors = None
+    closed = False
 
     def __init__(self, backend, is_stdout, old_out = None):
         self.name = "<stdout>" if is_stdout else "<stderr>"


### PR DESCRIPTION
Fixes #1070 Cannot debug script that uses colorama
Adds closed attribute to repl output.

This has been in 3.0 for a while, but wasn't backported.