### PR TITLE
Fixes #17 Debugger ignores some try except statements

### DIFF
--- a/Python/Product/Analysis/Analyzer/OverviewWalker.cs
+++ b/Python/Product/Analysis/Analyzer/OverviewWalker.cs
@@ -524,6 +524,10 @@ namespace Microsoft.PythonTools.Analysis.Analyzer {
             // recursively walk the statements in the suite
             if (node.Statements != null) {
                 foreach (var innerNode in node.Statements) {
+                    var doc = ((innerNode as ExpressionStatement)?.Expression as ConstantExpression)?.Value as string;
+                    if (!string.IsNullOrEmpty(doc)) {
+                        
+                    }
                     innerNode.Walk(this);
                 }
             }

--- a/Python/Product/Analysis/Analyzer/OverviewWalker.cs
+++ b/Python/Product/Analysis/Analyzer/OverviewWalker.cs
@@ -524,10 +524,6 @@ namespace Microsoft.PythonTools.Analysis.Analyzer {
             // recursively walk the statements in the suite
             if (node.Statements != null) {
                 foreach (var innerNode in node.Statements) {
-                    var doc = ((innerNode as ExpressionStatement)?.Expression as ConstantExpression)?.Value as string;
-                    if (!string.IsNullOrEmpty(doc)) {
-                        
-                    }
                     innerNode.Walk(this);
                 }
             }

--- a/Python/Product/Debugger/Debugger/PythonProcess.cs
+++ b/Python/Product/Debugger/Debugger/PythonProcess.cs
@@ -486,25 +486,6 @@ namespace Microsoft.PythonTools.Debugger {
             }
         }
 
-        private static string ToDottedNameString(Expression expr, PythonAst ast) {
-            NameExpression name;
-            MemberExpression member;
-            ParenthesisExpression paren;
-            if ((name = expr as NameExpression) != null) {
-                return name.Name;
-            } else if ((member = expr as MemberExpression) != null) {
-                while (member.Target is MemberExpression) {
-                    member = (MemberExpression)member.Target;
-                }
-                if (member.Target is NameExpression) {
-                    return expr.ToCodeString(ast);
-                }
-            } else if ((paren = expr as ParenthesisExpression) != null) {
-                return ToDottedNameString(paren.Expression, ast);
-            }
-            return null;
-        }
-
         internal IList<PythonThread> GetThreads() {
             List<PythonThread> threads = new List<PythonThread>();
             foreach (var thread in _threads.Values) {
@@ -541,72 +522,22 @@ namespace Microsoft.PythonTools.Debugger {
 
         internal IList<Tuple<int, int, IList<string>>> GetHandledExceptionRanges(string filename) {
             PythonAst ast;
-            TryHandlerWalker walker = new TryHandlerWalker();
-            var statements = new List<Tuple<int, int, IList<string>>>();
+            TryHandlerWalker walker;
 
             try {
                 ast = GetAst(filename);
-                if (ast == null) {
-                    return statements;
+                if (ast != null) {
+                    walker = new TryHandlerWalker(ast);
+                    ast.Walk(walker);
+                    return walker.Statements;
                 }
-                ast.Walk(walker);
             } catch (Exception ex) {
                 Debug.WriteLine("Exception in GetHandledExceptionRanges:");
                 Debug.WriteLine(string.Format("Filename: {0}", filename));
                 Debug.WriteLine(ex);
-                return statements;
             }
 
-            foreach (var statement in walker.Statements) {
-                int start = statement.GetStart(ast).Line;
-                int end = statement.Body.GetEnd(ast).Line + 1;
-                var expressions = new List<string>();
-
-                if (statement.Handlers == null) {
-                    if (statement.Finally != null) {
-                        // This is a try/finally block without an except, which
-                        // means that no exceptions are handled.
-                        continue;
-                    } else {
-                        // If Handlers and Finally are null, there was probably
-                        // a parser error. We assume all exceptions are handled
-                        // by default, to avoid bothering the user too much, so
-                        // handle everything here since we can't be more
-                        // accurate.
-                        expressions.Add("*");
-                    }
-                } else {
-                    foreach (var handler in statement.Handlers) {
-                        Expression expr = handler.Test;
-                        TupleExpression tuple;
-                        if (expr == null) {
-                            expressions.Clear();
-                            expressions.Add("*");
-                            break;
-                        } else if ((tuple = handler.Test as TupleExpression) != null) {
-                            foreach (var e in tuple.Items) {
-                                var text = ToDottedNameString(e, ast);
-                                if (text != null) {
-                                    expressions.Add(text);
-                                }
-                            }
-                        
-                        } else {
-                            var text = ToDottedNameString(expr, ast);
-                            if (text != null) {
-                                expressions.Add(text);
-                            }
-                        }
-                    }
-                }
-
-                if (expressions.Count > 0) {
-                    statements.Add(new Tuple<int, int, IList<string>>(start, end, expressions));
-                }
-            }
-
-
-            return statements;
+            return new List<Tuple<int, int, IList<string>>>();
         }
 
         private void HandleRequestHandlers(Stream stream) {

--- a/Python/Product/Debugger/Debugger/TryHandlerWalker.cs
+++ b/Python/Product/Debugger/Debugger/TryHandlerWalker.cs
@@ -16,7 +16,8 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.PythonTools.Analysis.Values;
+using System.Linq;
+using Microsoft.PythonTools.Infrastructure;
 using Microsoft.PythonTools.Parsing.Ast;
 
 namespace Microsoft.PythonTools.Debugger {
@@ -25,20 +26,106 @@ namespace Microsoft.PythonTools.Debugger {
     /// handlers.
     /// </summary>
     class TryHandlerWalker : PythonWalker {
-        private List<TryStatement> _statements;
+        private readonly PythonAst _ast;
+        private List<Tuple<int, int, IList<string>>> _statements;
 
-        public TryHandlerWalker() {
-            _statements = new List<TryStatement>();
+        public TryHandlerWalker(PythonAst ast) {
+            _ast = ast;
+            _statements = new List<Tuple<int, int, IList<string>>>();
         }
 
-        public ICollection<TryStatement> Statements {
-            get {
-                return _statements;
+        public IList<Tuple<int, int, IList<string>>> Statements => _statements;
+
+        private string ToDottedNameString(Expression expr) {
+            NameExpression name;
+            MemberExpression member;
+            ParenthesisExpression paren;
+            if ((name = expr as NameExpression) != null) {
+                return name.Name;
+            } else if ((member = expr as MemberExpression) != null) {
+                while (member.Target is MemberExpression) {
+                    member = (MemberExpression)member.Target;
+                }
+                if (member.Target is NameExpression) {
+                    return expr.ToCodeString(_ast);
+                }
+            } else if ((paren = expr as ParenthesisExpression) != null) {
+                return ToDottedNameString(paren.Expression);
+            }
+            return null;
+        }
+
+        private void Add(Statement block, Statement statement, IEnumerable<string> exceptions) {
+            int start = block.GetStart(_ast).Line;
+            int end = statement.GetEnd(_ast).Line + 1;
+            var exc = exceptions.ToList();
+            if (exc.Any()) {
+                _statements.Add(new Tuple<int, int, IList<string>>(start, end, exc));
             }
         }
 
         public override bool Walk(TryStatement node) {
-            _statements.Add(node);
+            var expressions = new List<string>();
+            foreach (var handler in node.Handlers.MaybeEnumerate()) {
+                Expression expr = handler.Test;
+                TupleExpression tuple;
+                if (expr == null) {
+                    expressions.Clear();
+                    expressions.Add("*");
+                    break;
+                } else if ((tuple = handler.Test as TupleExpression) != null) {
+                    foreach (var e in tuple.Items) {
+                        var text = ToDottedNameString(e);
+                        if (text != null) {
+                            expressions.Add(text);
+                        }
+                    }
+
+                } else {
+                    var text = ToDottedNameString(expr);
+                    if (text != null) {
+                        expressions.Add(text);
+                    }
+                }
+            }
+
+            if (node.Handlers == null && node.Finally == null) {
+                // If Handlers and Finally are null, there was probably
+                // a parser error. We assume all exceptions are handled
+                // by default, to avoid bothering the user too much, so
+                // handle everything here since we can't be more
+                // accurate.
+                expressions.Clear();
+                expressions.Add("*");
+            }
+            Add(node, node.Body, expressions);
+
+            return base.Walk(node);
+        }
+
+        private static bool IsFullOrPartialName(Expression expr, string modName, string name) {
+            var ne = expr as NameExpression;
+            if (ne != null) {
+                return ne.Name == name;
+            }
+            var me = expr as MemberExpression;
+            ne = me?.Target as NameExpression;
+            if (me != null && ne != null) {
+                return me.Name == name && ne.Name == modName;
+            }
+
+            return false;
+        }
+
+        public override bool Walk(WithStatement node) {
+            foreach (var item in node.Items.MaybeEnumerate()) {
+                var cm = item.ContextManager as CallExpression;
+                if (!IsFullOrPartialName(cm?.Target, "contextlib", "ignored")) {
+                    continue;
+                }
+
+                Add(node, node.Body, cm.Args.Select(a => ToDottedNameString(a.Expression)).Where(n => !string.IsNullOrEmpty(n)));
+            }
             return base.Walk(node);
         }
     }

--- a/Python/Tests/TestData/DebuggerProject/ExceptionHandlers.py
+++ b/Python/Tests/TestData/DebuggerProject/ExceptionHandlers.py
@@ -174,3 +174,6 @@ except is_included: pass
 except also.included: pass
 except this.one.too.despite.having.lots.of.dots: pass
 except but().not_me: pass
+
+with ignored(ValueError, not_me(), socket.error, or_().me):
+    pass


### PR DESCRIPTION
Fixes #17 Debugger ignores some try except statements
Adds support for "with ignored(exc_name)" blocks.

I don't think we're going to be able to generally deal with exceptions handled out-of-line, so we may need another approach. This will also affect async code.
