### PR TITLE
Fixes #1576 PythonCore default description does not match 3.6 description

### DIFF
--- a/Python/Product/VSInterpreters/PythonRegistrySearch.cs
+++ b/Python/Product/VSInterpreters/PythonRegistrySearch.cs
@@ -184,7 +184,7 @@ namespace Microsoft.PythonTools.Interpreter {
             var description = tagKey.GetValue("DisplayName") as string;
             if (string.IsNullOrEmpty(description)) {
                 if (pythonCoreCompatibility) {
-                    description = "Python {0} {1}".FormatUI(arch, version);
+                    description = "Python {0}{1: ()}".FormatUI(version, arch);
                 } else {
                     description = "{0} {1}".FormatUI(company, tag);
                 }


### PR DESCRIPTION
Fixes #1576 PythonCore default description does not match 3.6 description
Updates default description format.