### PR TITLE
Fixes #1572 pip install shows double spacing within output

### DIFF
--- a/Python/Product/Common/Infrastructure/StringExtensions.cs
+++ b/Python/Product/Common/Infrastructure/StringExtensions.cs
@@ -79,5 +79,19 @@ namespace Microsoft.PythonTools.Infrastructure {
                 (bool.TryParse(str, out asBool) && asBool)
             );
         }
+
+        public static string TrimEndNewline(this string str) {
+            if (string.IsNullOrEmpty(str)) {
+                return string.Empty;
+            }
+
+            if (str[str.Length - 1] == '\n') {
+                if (str.Length >= 2 && str[str.Length - 2] == '\r') {
+                    return str.Remove(str.Length - 2);
+                }
+                return str.Remove(str.Length - 1);
+            }
+            return str;
+        }
     }
 }

--- a/Python/Product/PythonTools/PythonTools/InterpreterList/InterpreterListToolWindow.cs
+++ b/Python/Product/PythonTools/PythonTools/InterpreterList/InterpreterListToolWindow.cs
@@ -323,7 +323,6 @@ namespace Microsoft.PythonTools.InterpreterList {
         }
 
         private void PipExtensionProvider_OperationStarted(object sender, OutputEventArgs e) {
-            _outputWindow.WriteLine(e.Data);
             if (_statusBar != null) {
                 _statusBar.SetText(e.Data);
             }
@@ -333,11 +332,11 @@ namespace Microsoft.PythonTools.InterpreterList {
         }
 
         private void PipExtensionProvider_OutputTextReceived(object sender, OutputEventArgs e) {
-            _outputWindow.WriteLine(e.Data);
+            _outputWindow.WriteLine(e.Data.TrimEndNewline());
         }
 
         private void PipExtensionProvider_ErrorTextReceived(object sender, OutputEventArgs e) {
-            _outputWindow.WriteErrorLine(e.Data);
+            _outputWindow.WriteErrorLine(e.Data.TrimEndNewline());
         }
 
         private void PipExtensionProvider_OperationFinished(object sender, OperationFinishedEventArgs e) {

--- a/Python/Product/PythonTools/PythonTools/Project/AddVirtualEnvironmentOperation.cs
+++ b/Python/Product/PythonTools/PythonTools/Project/AddVirtualEnvironmentOperation.cs
@@ -107,11 +107,11 @@ namespace Microsoft.PythonTools.Project {
         }
 
         void IPackageManagerUI.OnOutputTextReceived(string text) {
-            _output.WriteLine(text.TrimEnd('\r', '\n'));
+            _output.WriteLine(text.TrimEndNewline());
         }
 
         void IPackageManagerUI.OnErrorTextReceived(string text) {
-            _output.WriteErrorLine(text.TrimEnd('\r', '\n'));
+            _output.WriteErrorLine(text.TrimEndNewline());
         }
 
         void IPackageManagerUI.OnOperationStarted(string operation) { }

--- a/Python/Product/PythonTools/PythonTools/Project/VsPackageManagerUI.cs
+++ b/Python/Product/PythonTools/PythonTools/Project/VsPackageManagerUI.cs
@@ -32,22 +32,8 @@ namespace Microsoft.PythonTools.Project {
             _alwaysElevate = alwaysElevate;
         }
 
-        private static string RemoveLastNewline(string text) {
-            if (string.IsNullOrEmpty(text)) {
-                return string.Empty;
-            }
-
-            if (text[text.Length - 1] == '\n') {
-                if (text.Length >= 2 && text[text.Length - 2] == '\r') {
-                    return text.Remove(text.Length - 2);
-                }
-                return text.Remove(text.Length - 1);
-            }
-            return text;
-        }
-
         public void OnErrorTextReceived(string text) {
-            _outputWindow.WriteErrorLine(RemoveLastNewline(text));
+            _outputWindow.WriteErrorLine(text.TrimEndNewline());
         }
 
         public void OnOperationFinished(string operation, bool success) {
@@ -63,7 +49,7 @@ namespace Microsoft.PythonTools.Project {
         }
 
         public void OnOutputTextReceived(string text) {
-            _outputWindow.WriteLine(RemoveLastNewline(text));
+            _outputWindow.WriteLine(text.TrimEndNewline());
         }
 
         public Task<bool> ShouldElevateAsync(string operation) {


### PR DESCRIPTION
Fixes #1572 pip install shows double spacing within output
Moves TrimEndNewline into StringExtensions
Trims newline in PipExtensionProvider.
Removes output for operation started event.