### PR TITLE
fix "Cannot add duplicate collection entry" error

### DIFF
--- a/Python/Templates/SharedFiles/ConfigureCloudService.ps1
+++ b/Python/Templates/SharedFiles/ConfigureCloudService.ps1
@@ -220,7 +220,7 @@ if ($is_web) {
         $max_requests = 1000
     }
 
-    iex "appcmd $appcmdargs set config /section:system.webServer/fastCGI ""/-[fullPath='$interp',arguments='\""""$wfastcgi\""""',instanceMaxRequests='$max_requests',signalBeforeTerminateSeconds='30']"""
+    iex "appcmd $appcmdargs set config /section:system.webServer/fastCGI ""/-[fullPath='$interp',arguments='\""""$wfastcgi\""""',instanceMaxRequests='$max_requests',signalBeforeTerminateSeconds='30']"" | Out-Null"
     iex "appcmd $appcmdargs set config /section:system.webServer/fastCGI ""/+[fullPath='$interp',arguments='\""""$wfastcgi\""""',instanceMaxRequests='$max_requests',signalBeforeTerminateSeconds='30']"""
 
     if ($is_emulated) {

--- a/Python/Templates/SharedFiles/ConfigureCloudService.ps1
+++ b/Python/Templates/SharedFiles/ConfigureCloudService.ps1
@@ -220,6 +220,7 @@ if ($is_web) {
         $max_requests = 1000
     }
 
+    iex "appcmd $appcmdargs set config /section:system.webServer/fastCGI ""/-[fullPath='$interp',arguments='\""""$wfastcgi\""""',instanceMaxRequests='$max_requests',signalBeforeTerminateSeconds='30']"""
     iex "appcmd $appcmdargs set config /section:system.webServer/fastCGI ""/+[fullPath='$interp',arguments='\""""$wfastcgi\""""',instanceMaxRequests='$max_requests',signalBeforeTerminateSeconds='30']"""
 
     if ($is_emulated) {


### PR DESCRIPTION
When this script runs multiple times, it throws error as below.

> ERROR ( message:New application object missing required attributes. Cannot add duplicate collection entry of type 'application' with combined key attributes 'fullPath, arguments' respectively set to 'D:\\Python27\\\\python.exe, "F:\\sitesroot\\0\\bin\\wfastcgi.py"'. )

So, I added a line to remove previous config by following similar solution; http://stackoverflow.com/a/35506641/361100
It tested in Azure Web Role + Flask project.