### PR TITLE
Fix 1608 Cookiecutter post-gen file copy creates duplicate files

### DIFF
--- a/Python/Product/Cookiecutter/Model/CookiecutterClient.cs
+++ b/Python/Product/Cookiecutter/Model/CookiecutterClient.cs
@@ -157,7 +157,7 @@ namespace Microsoft.CookiecutterTools.Model {
         private void CopyFiles(string sourceFolderPath, string targetFolderPath) {
             Directory.CreateDirectory(targetFolderPath);
 
-            foreach (var sourceFilePath in PathUtils.EnumerateFiles(sourceFolderPath)) {
+            foreach (var sourceFilePath in PathUtils.EnumerateFiles(sourceFolderPath, recurse: false, fullPaths: true)) {
                 var fileName = PathUtils.GetFileOrDirectoryName(sourceFilePath);
                 var targetFilePath = Path.Combine(targetFolderPath, fileName);
                 File.Copy(sourceFilePath, targetFilePath, true);

--- a/Python/Tests/CookiecutterTests/CookiecutterIntegrationTests.cs
+++ b/Python/Tests/CookiecutterTests/CookiecutterIntegrationTests.cs
@@ -274,6 +274,11 @@ namespace CookiecutterTests {
             Assert.IsFalse(_vm.IsCreatingError);
 
             Assert.IsTrue(Directory.Exists(Path.Combine(_vm.OutputFolderPath, "static_files")));
+            Assert.IsTrue(Directory.Exists(Path.Combine(_vm.OutputFolderPath, "post-deployment")));
+            Assert.IsTrue(File.Exists(Path.Combine(_vm.OutputFolderPath, "web.config")));
+            Assert.IsTrue(File.Exists(Path.Combine(_vm.OutputFolderPath, "static_files", "web.config")));
+            Assert.IsTrue(File.Exists(Path.Combine(_vm.OutputFolderPath, "post-deployment", "install-requirements.ps1")));
+            Assert.IsFalse(File.Exists(Path.Combine(_vm.OutputFolderPath, "install-requirements.ps1")));
         }
 
         private static void PrintResults(ObservableCollection<object> items) {


### PR DESCRIPTION
https://github.com/Microsoft/PTVS/issues/1608
Fixes copying of files after generating them in temp folder. I forgot that the default value for recursion on PathUtils.EnumerateFiles is true.

Without this fix, the root of the output folder contains all the files from all the subfolders.