### PR TITLE
Fix 1612 - cookiecutter should make it more obvious when it doesn't create a subdirectory

### DIFF
--- a/Python/Product/Cookiecutter/Model/GitClient.cs
+++ b/Python/Product/Cookiecutter/Model/GitClient.cs
@@ -169,6 +169,7 @@ namespace Microsoft.CookiecutterTools.Model {
             try {
                 ProcessStartInfo info = new ProcessStartInfo("where", executable);
                 info.UseShellExecute = false;
+                info.CreateNoWindow = true;
                 var process = Process.Start(info);
                 process.WaitForExit();
                 return process.ExitCode == 0;

--- a/Python/Product/Cookiecutter/Strings.Designer.cs
+++ b/Python/Product/Cookiecutter/Strings.Designer.cs
@@ -200,7 +200,7 @@ namespace Microsoft.CookiecutterTools {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Please enter a valid output folder path..
+        ///   Looks up a localized string similar to Please enter a valid output folder in the &apos;Create To&apos; field..
         /// </summary>
         internal static string InvalidOutputFolder {
             get {

--- a/Python/Product/Cookiecutter/Strings.resx
+++ b/Python/Product/Cookiecutter/Strings.resx
@@ -142,7 +142,7 @@
 You can get more information by running Visual Studio with the /log parameter on the command line, and then examining the file '{0}', or by checking the Event Log.</value>
   </data>
   <data name="InvalidOutputFolder" xml:space="preserve">
-    <value>Please enter a valid output folder path.</value>
+    <value>Please enter a valid output folder in the 'Create To' field.</value>
   </data>
   <data name="FeedLoadError" xml:space="preserve">
     <value>Could not retrieve results from feed</value>

--- a/Python/Product/Cookiecutter/View/CookiecutterControl.xaml.cs
+++ b/Python/Product/Cookiecutter/View/CookiecutterControl.xaml.cs
@@ -62,7 +62,7 @@ namespace Microsoft.CookiecutterTools.View {
             );
 
             ViewModel.UserConfigFilePath = CookiecutterViewModel.GetUserConfigPath();
-            ViewModel.OutputFolderPath = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
+            ViewModel.OutputFolderPath = string.Empty; // leaving this empty for now, force user to enter one
             ViewModel.SearchAsync().DoNotWait();
             ViewModel.ContextLoaded += ViewModel_ContextLoaded;
             ViewModel.HomeClicked += ViewModel_HomeClicked;

--- a/Python/Product/Cookiecutter/View/CookiecutterOptionsPage.xaml.cs
+++ b/Python/Product/Cookiecutter/View/CookiecutterOptionsPage.xaml.cs
@@ -56,7 +56,7 @@ namespace Microsoft.CookiecutterTools.View {
 
         private void CreateFiles_Executed(object sender, ExecutedRoutedEventArgs e) {
             if (!PathUtils.IsValidPath(ViewModel.OutputFolderPath)) {
-                MessageBox.Show(Strings.InvalidOutputFolder, Strings.ProductTitle, MessageBoxButton.OKCancel, MessageBoxImage.Error);
+                MessageBox.Show(Strings.InvalidOutputFolder, Strings.ProductTitle, MessageBoxButton.OK, MessageBoxImage.Error);
                 return;
             }
 


### PR DESCRIPTION
Don't prepopulate the output folder, as to not mislead the user into generating templates in their documents folder.

We'll need to decide on a better policy later on.  I suspect that if cookiecutter is invoked from Add -> From Cookiecutter on an existing project/folder, we'll want to prepopulate it with that folder path.

Hide the process window that detects git that was showing up on dev14.