### PR TITLE
Fix 1620: cookiecutter templates failing to clone

### DIFF
--- a/Python/Product/Cookiecutter/Model/CookiecutterClient.cs
+++ b/Python/Product/Cookiecutter/Model/CookiecutterClient.cs
@@ -119,12 +119,14 @@ namespace Microsoft.CookiecutterTools.Model {
                 await output;
 
                 var r = new ProcessOutputResult() {
+                    ExeFileName = interpreterPath,
                     ExitCode = output.ExitCode,
                     StandardOutputLines = output.StandardOutputLines.ToArray(),
                     StandardErrorLines = output.StandardErrorLines.ToArray(),
                 };
 
-                if (r.ExitCode < 0) {
+                // All our python scripts will return 0 if successful
+                if (r.ExitCode != 0) {
                     throw new ProcessException(r);
                 }
 

--- a/Python/Product/Cookiecutter/Model/GitClient.cs
+++ b/Python/Product/Cookiecutter/Model/GitClient.cs
@@ -63,8 +63,10 @@ namespace Microsoft.CookiecutterTools.Model {
                     using (var key = Registry.LocalMachine.OpenSubKey(@"Software\\Microsoft\VisualStudio\SxS\VS7")) {
                         var installRoot = (string)key.GetValue(AssemblyVersionInfo.VSVersion);
                         if (installRoot != null) {
+                            // git.exe is in a folder path with a symlink to the actual extension dir with random name
                             var gitFolder = Path.Combine(installRoot, @"Common7\IDE\CommonExtensions\Microsoft\TeamFoundation\Team Explorer\Git\cmd");
-                            var gitExe = Path.Combine(gitFolder, GitExecutableName);
+                            var finalGitFolder = PathUtils.GetFinalPathName(gitFolder);
+                            var gitExe = Path.Combine(finalGitFolder, GitExecutableName);
                             return gitExe;
                         }
                     }
@@ -90,6 +92,7 @@ namespace Microsoft.CookiecutterTools.Model {
                 await output;
 
                 var r = new ProcessOutputResult() {
+                    ExeFileName = _gitExeFilePath,
                     ExitCode = output.ExitCode,
                     StandardOutputLines = output.StandardOutputLines.ToArray(),
                     StandardErrorLines = output.StandardErrorLines.ToArray(),

--- a/Python/Product/Cookiecutter/Model/ProcessOutputResult.cs
+++ b/Python/Product/Cookiecutter/Model/ProcessOutputResult.cs
@@ -19,6 +19,7 @@ using System.Threading.Tasks;
 
 namespace Microsoft.CookiecutterTools.Model {
     struct ProcessOutputResult {
+        public string ExeFileName;
         public int? ExitCode;
         public string[] StandardOutputLines;
         public string[] StandardErrorLines;

--- a/Python/Product/Cookiecutter/Shared/Infrastructure/NativeMethods.cs
+++ b/Python/Product/Cookiecutter/Shared/Infrastructure/NativeMethods.cs
@@ -14,8 +14,11 @@
 // See the Apache Version 2.0 License for specific language governing
 // permissions and limitations under the License.
 
+using System;
 using System.Reflection;
 using System.Runtime.InteropServices;
+using System.Text;
+using Microsoft.Win32.SafeHandles;
 
 namespace Microsoft.CookiecutterTools.Infrastructure {
     public static partial class NativeMethods {
@@ -53,5 +56,52 @@ namespace Microsoft.CookiecutterTools.Infrastructure {
 
             return ProcessorArchitecture.None;
         }
+
+        public const int MAX_PATH = 260; // windef.h	
+        public const int MAX_FOLDER_PATH = MAX_PATH - 12;   // folders need to allow 8.3 filenames, so MAX_PATH - 12
+
+        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        public static extern uint GetFinalPathNameByHandle(
+            SafeHandle hFile,
+            [Out]StringBuilder lpszFilePath,
+            uint cchFilePath,
+            uint dwFlags
+        );
+
+        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        public static extern SafeFileHandle CreateFile(
+            string lpFileName,
+            FileDesiredAccess dwDesiredAccess,
+            FileShareFlags dwShareMode,
+            IntPtr lpSecurityAttributes,
+            FileCreationDisposition dwCreationDisposition,
+            FileFlagsAndAttributes dwFlagsAndAttributes,
+            IntPtr hTemplateFile
+        );
+
+        [Flags]
+        public enum FileDesiredAccess : uint {
+            FILE_LIST_DIRECTORY = 1
+        }
+
+        [Flags]
+        public enum FileShareFlags : uint {
+            FILE_SHARE_READ = 0x00000001,
+            FILE_SHARE_WRITE = 0x00000002,
+            FILE_SHARE_DELETE = 0x00000004
+        }
+
+        [Flags]
+        public enum FileCreationDisposition : uint {
+            OPEN_EXISTING = 3
+        }
+
+        [Flags]
+        public enum FileFlagsAndAttributes : uint {
+            FILE_FLAG_BACKUP_SEMANTICS = 0x02000000
+        }
+
+        public static IntPtr INVALID_FILE_HANDLE = new IntPtr(-1);
+        public static IntPtr INVALID_HANDLE_VALUE = new IntPtr(-1);
     }
 }

--- a/Python/Product/Cookiecutter/Strings.Designer.cs
+++ b/Python/Product/Cookiecutter/Strings.Designer.cs
@@ -263,6 +263,15 @@ namespace Microsoft.CookiecutterTools {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to {0} returned an exit code of {1}..
+        /// </summary>
+        internal static string ProcessExitCodeMessage {
+            get {
+                return ResourceManager.GetString("ProcessExitCodeMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Cookiecutter.
         /// </summary>
         internal static string ProductTitle {

--- a/Python/Product/Cookiecutter/Strings.resx
+++ b/Python/Product/Cookiecutter/Strings.resx
@@ -223,4 +223,7 @@ Please delete the installed template and try again.</value>
   <data name="OpenInSolutionExplorerQuestion" xml:space="preserve">
     <value>Would you like to open the generated folder in Solution Explorer?</value>
   </data>
+  <data name="ProcessExitCodeMessage" xml:space="preserve">
+    <value>{0} returned an exit code of {1}.</value>
+  </data>
 </root>

--- a/Python/Product/Cookiecutter/ViewModel/CookiecutterViewModel.cs
+++ b/Python/Product/Cookiecutter/ViewModel/CookiecutterViewModel.cs
@@ -472,6 +472,7 @@ namespace Microsoft.CookiecutterTools.ViewModel {
                     IsCloningSuccess = false;
                     IsCloningError = true;
 
+                    _outputWindow.WriteLine(string.Format(CultureInfo.CurrentUICulture, Strings.ProcessExitCodeMessage, ex.Result.ExeFileName, ex.Result.ExitCode));
                     _outputWindow.WriteLine(string.Join(Environment.NewLine, ex.Result.StandardOutputLines));
                     _outputWindow.WriteErrorLine(string.Join(Environment.NewLine, ex.Result.StandardErrorLines));
 
@@ -559,6 +560,7 @@ namespace Microsoft.CookiecutterTools.ViewModel {
                 IsCreatingSuccess = false;
                 IsCreatingError = true;
 
+                _outputWindow.WriteLine(string.Format(CultureInfo.CurrentUICulture, Strings.ProcessExitCodeMessage, ex.Result.ExeFileName, ex.Result.ExitCode));
                 _outputWindow.WriteLine(string.Join(Environment.NewLine, ex.Result.StandardOutputLines));
                 _outputWindow.WriteErrorLine(string.Join(Environment.NewLine, ex.Result.StandardErrorLines));
 
@@ -693,6 +695,7 @@ namespace Microsoft.CookiecutterTools.ViewModel {
                 IsLoadingSuccess = false;
                 IsLoadingError = true;
 
+                _outputWindow.WriteLine(string.Format(CultureInfo.CurrentUICulture, Strings.ProcessExitCodeMessage, ex.Result.ExeFileName, ex.Result.ExitCode));
                 _outputWindow.WriteLine(string.Join(Environment.NewLine, ex.Result.StandardOutputLines));
                 _outputWindow.WriteErrorLine(string.Join(Environment.NewLine, ex.Result.StandardErrorLines));
 


### PR DESCRIPTION
Resolve symbolic link in the git folder path.

In case of a process error, always print out the executable and exit code.

Check strictly for exit code 0 for our python scripts. Cookiecutter will return positive value for error. We now have much better error reporting for iknite/cookiecutter-ansible-role template which fails during post hook, and other templates now report errors when they were ignored before.
