### PR TITLE
Improves logging when analyzer process does not start.

### DIFF
--- a/Python/Product/Analyzer/PyLibAnalyzer.cs
+++ b/Python/Product/Analyzer/PyLibAnalyzer.cs
@@ -162,7 +162,7 @@ namespace Microsoft.PythonTools.Analysis {
                     Console.Error.WriteLine("This interpreter is already being analyzed.");
                     return PythonTypeDatabase.AlreadyGeneratingExitCode;
                 } catch (Exception e) {
-                    Console.WriteLine("Error during analysis: {0}{1}", Environment.NewLine, e.ToString());
+                    Console.Error.WriteLine("Error during analysis: {0}{1}", Environment.NewLine, e.ToString());
                     LogToGlobal("FAIL_STDLIB" + Environment.NewLine + e.ToString());
                     TraceError("Analysis failed{0}{1}", Environment.NewLine, e.ToString());
                     return -10;


### PR DESCRIPTION
Improves logging when analyzer process does not start.
Ensures messages are not missed because of races between process exit and event hookup.
Ensures messages are sent to stderr and so not misinterpreted as packages.
Ensures messages on stdout are not misinterpreted as a series of invalid headers.