### PR TITLE
Fix 1619 - github buttons are always active in cookiecutter window

### DIFF
--- a/Python/Product/Cookiecutter/Commands/GitHubHomeCommand.cs
+++ b/Python/Product/Cookiecutter/Commands/GitHubHomeCommand.cs
@@ -40,6 +40,15 @@ namespace Microsoft.CookiecutterTools.Commands {
             }
         }
 
+        public override EventHandler BeforeQueryStatus {
+            get {
+                return (sender, args) => {
+                    var oleMenuCmd = (Microsoft.VisualStudio.Shell.OleMenuCommand)sender;
+                    oleMenuCmd.Enabled = (_window.CanNavigateToGitHub());
+                };
+            }
+        }
+
         public override int CommandId {
             get { return _commandId; }
         }

--- a/Python/Product/Cookiecutter/CookiecutterToolWindow.cs
+++ b/Python/Product/Cookiecutter/CookiecutterToolWindow.cs
@@ -243,6 +243,10 @@ namespace Microsoft.CookiecutterTools {
             }
         }
 
+        internal bool CanNavigateToGitHub() {
+            return _cookiecutterControl != null ? _cookiecutterControl.CanNavigateToGitHub() : false;
+        }
+
         internal void Home() {
             _cookiecutterControl?.Home();
         }

--- a/Python/Product/Cookiecutter/View/CookiecutterControl.xaml.cs
+++ b/Python/Product/Cookiecutter/View/CookiecutterControl.xaml.cs
@@ -147,6 +147,10 @@ namespace Microsoft.CookiecutterTools.View {
             return PageSequence.CurrentPosition == 0 && Directory.Exists(ViewModel.SelectedTemplate?.ClonedPath);
         }
 
+        internal bool CanNavigateToGitHub() {
+            return PageSequence.CurrentPosition == 0 && !string.IsNullOrEmpty(ViewModel.SelectedTemplate?.GitHubHomeUrl);
+        }
+
         internal void DeleteSelection() {
             if (!CanDeleteSelection()) {
                 return;

--- a/Python/Product/Cookiecutter/View/CookiecutterSearchPage.xaml.cs
+++ b/Python/Product/Cookiecutter/View/CookiecutterSearchPage.xaml.cs
@@ -86,9 +86,7 @@ namespace Microsoft.CookiecutterTools.View {
 
         private void TreeView_SelectedItemChanged(object sender, RoutedPropertyChangedEventArgs<object> e) {
             var val = e.NewValue as TemplateViewModel;
-            if (val != null) {
-                ViewModel.SelectTemplate(val).DoNotWait();
-            }
+            ViewModel.SelectTemplate(val).DoNotWait();
 
             SelectedTemplateChanged?.Invoke(this, EventArgs.Empty);
         }


### PR DESCRIPTION
Fixes https://github.com/Microsoft/PTVS/issues/1619

More importantly, the selection is now correctly updated to match the selection. Before, if you selected a template, did a search, didn't select a template, you'd still be able to click Next (or other toolbar buttons). It would use whatever you had selected before the search.