### PR TITLE
Fixes #1601: async for/with not formatted correctly

### DIFF
--- a/Python/Product/Analysis/Parsing/Ast/ForStatement.cs
+++ b/Python/Product/Analysis/Parsing/Ast/ForStatement.cs
@@ -89,6 +89,10 @@ namespace Microsoft.PythonTools.Parsing.Ast {
 
         internal override void AppendCodeStringStmt(StringBuilder res, PythonAst ast, CodeFormattingOptions format) {
             format.ReflowComment(res, this.GetProceedingWhiteSpace(ast));
+            if (IsAsync) {
+                res.Append("async");
+                res.Append(this.GetFourthWhiteSpace(ast));
+            }
             res.Append("for");
             _left.AppendCodeString(res, ast, format);
             if (!this.IsIncompleteNode(ast)) {

--- a/Python/Product/Analysis/Parsing/Ast/WithStatement.cs
+++ b/Python/Product/Analysis/Parsing/Ast/WithStatement.cs
@@ -68,6 +68,10 @@ namespace Microsoft.PythonTools.Parsing.Ast {
 
         internal override void AppendCodeStringStmt(StringBuilder res, PythonAst ast, CodeFormattingOptions format) {
             format.ReflowComment(res, this.GetProceedingWhiteSpace(ast));
+            if (IsAsync) {
+                res.Append("async");
+                res.Append(this.GetSecondWhiteSpace(ast));
+            }
             res.Append("with");
             var itemWhiteSpace = this.GetListWhiteSpace(ast);
             int whiteSpaceIndex = 0;

--- a/Python/Product/Analysis/Parsing/Parser.cs
+++ b/Python/Product/Analysis/Parsing/Parser.cs
@@ -2338,6 +2338,7 @@ namespace Microsoft.PythonTools.Parsing {
         //with_item: test ['as' expr]
         private WithStatement ParseWithStmt(bool isAsync) {
             var start = isAsync ? GetStart() : 0;
+            var asyncWhiteSpace = isAsync ? _tokenWhiteSpace : null;
             Eat(TokenKind.KeywordWith);
             if (!isAsync) {
                 start = GetStart();
@@ -2361,7 +2362,8 @@ namespace Microsoft.PythonTools.Parsing {
 
             WithStatement ret = new WithStatement(items.ToArray(), body, isAsync);
             if (_verbatim) {
-                AddPreceedingWhiteSpace(ret, withWhiteSpace);
+                AddPreceedingWhiteSpace(ret, isAsync ? asyncWhiteSpace : withWhiteSpace);
+                AddSecondPreceedingWhiteSpace(ret, isAsync ? withWhiteSpace : null);
                 AddListWhiteSpace(ret, itemWhiteSpace.ToArray());
             }
             ret.SetLoc(start, body.EndIndex);
@@ -2387,6 +2389,7 @@ namespace Microsoft.PythonTools.Parsing {
         //for_stmt: 'for' target_list 'in' expression_list ':' suite ['else' ':' suite]
         private Statement ParseForStmt(bool isAsync) {
             var start = isAsync ? GetStart() : 0;
+            var asyncWhiteSpace = isAsync ? _tokenWhiteSpace : null;
             Eat(TokenKind.KeywordFor);
             if (!isAsync) {
                 start = GetStart();
@@ -2439,7 +2442,8 @@ namespace Microsoft.PythonTools.Parsing {
 
             ForStatement ret = new ForStatement(lhs, list, body, else_, isAsync);
             if (_verbatim) {
-                AddPreceedingWhiteSpace(ret, forWhiteSpace);
+                AddPreceedingWhiteSpace(ret, isAsync ? asyncWhiteSpace : forWhiteSpace);
+                AddFourthPreceedingWhiteSpace(ret, isAsync ? forWhiteSpace : null);
                 if (inWhiteSpace != null) {
                     AddSecondPreceedingWhiteSpace(ret, inWhiteSpace);
                 }

--- a/Python/Tests/Analysis/ParserRoundTripTest.cs
+++ b/Python/Tests/Analysis/ParserRoundTripTest.cs
@@ -1250,7 +1250,12 @@ def f(): pass");
             TestOneString(PythonLanguageVersion.V27, "for  (((i), (j)))   in    x.items()     :      print(i, j)");
             TestOneString(PythonLanguageVersion.V27, "for  [i, j]   in    x.items()     :      print(i, j)");
             TestOneString(PythonLanguageVersion.V27, "for  [[i], [j]]   in    x.items()     :      print(i, j)");
-            
+
+            TestOneString(PythonLanguageVersion.V35, "async def f():\r\n    async for i in xrange(10): pass");
+            TestOneString(PythonLanguageVersion.V35, "async def f():\r\n    async  for i in xrange(10):\r\n        pass\r\n        pass");
+            TestOneString(PythonLanguageVersion.V35, "async def f():\r\n    async  for  i in xrange(10):\r\n\r\n        pass\r\n        pass");
+            TestOneString(PythonLanguageVersion.V35, "async def f():\r\n    async for  i  in xrange(10):\r\n        break\r\nelse:\r\n        pass");
+
             // While Statement
             TestOneString(PythonLanguageVersion.V27, "while True: break");
             TestOneString(PythonLanguageVersion.V27, "while True: break\r\nelse: pass");
@@ -1302,7 +1307,12 @@ def f(): pass");
             TestOneString(PythonLanguageVersion.V27, "with  abc   as    oar     :  \r\n    pass");
             TestOneString(PythonLanguageVersion.V27, "with  fob   ,    oar     :  \r\n    pass");
             TestOneString(PythonLanguageVersion.V27, "with  fob   as    f     ,       oar       as       b        :  \r\n    pass");
-            
+
+            TestOneString(PythonLanguageVersion.V35, "async def f():\r\n    async with abc: pass");
+            TestOneString(PythonLanguageVersion.V35, "async def f():\r\n    async  with  abc   :\r\n        pass");
+            TestOneString(PythonLanguageVersion.V35, "async def f():\r\n    async   with  fob   ,    oar     :\r\n          pass");
+            TestOneString(PythonLanguageVersion.V35, "async def f():\r\n    async  with  fob   ,    oar     :  \r\n        pass");
+
             // Try Statement
             TestOneString(PythonLanguageVersion.V27, "try: pass\r\nexcept: pass");
             TestOneString(PythonLanguageVersion.V27, "try: pass\r\nexcept Exception: pass");
@@ -1490,6 +1500,11 @@ def f(): pass");
 
             TestOneString(PythonLanguageVersion.V27, "class C:\r\n    @property\r\n    def fob(self): return 42");
 
+            TestOneString(PythonLanguageVersion.V35, "async def f(): pass");
+            TestOneString(PythonLanguageVersion.V35, "@fob\r\n\r\nasync def f(): pass");
+            TestOneString(PythonLanguageVersion.V35, "@fob(2)\r\nasync \\\r\ndef f(): pass");
+
+            TestOneString(PythonLanguageVersion.V35, "");
         }
 
         [TestMethod, Priority(1)]

--- a/Python/Tests/TestData/FormattingTests/FormattingTests.pyproj
+++ b/Python/Tests/TestData/FormattingTests/FormattingTests.pyproj
@@ -30,6 +30,7 @@
     <EnableUnmanagedDebugging>false</EnableUnmanagedDebugging>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="async.py" />
     <Compile Include="document.py" />
     <Compile Include="selection.py" />
     <Compile Include="selection2.py" />

--- a/Python/Tests/TestData/FormattingTests/async.py
+++ b/Python/Tests/TestData/FormattingTests/async.py
@@ -1,0 +1,6 @@
+async  def f(x):
+    async  for  i in await  x:
+        pass
+    # comment before
+    async   with x:
+        pass


### PR DESCRIPTION
Fixes #1601: async for/with not formatted correctly
Enables round-tripping of async for/with statements
Adds tests