### PR TITLE
Django urls intellisense - mini fix

### DIFF
--- a/Python/Product/Django.Analysis/DjangoAnalyzer.cs
+++ b/Python/Product/Django.Analysis/DjangoAnalyzer.cs
@@ -349,11 +349,13 @@ namespace Microsoft.PythonTools.Django.Analysis {
                 return AnalysisSet.Empty;
             }
 
-            IAnalysisSet urlNames = GetArg(args, keywordArgNames, "name", 0);
+            IAnalysisSet urlNames = GetArg(args, keywordArgNames, "name", -1);
+            if (urlNames == null) { // The kwargs do not contain a name arg
+                return AnalysisSet.Empty;
+            }
 
             string urlName = urlNames.First().GetConstantValueAsString();
             string urlRegex = args.First().First().GetConstantValueAsString();
-
             _urls.Add(new DjangoUrl(urlName, urlRegex));
 
             return AnalysisSet.Empty;


### PR DESCRIPTION
Hi,

Just adding a tiny condition, avoiding _url()_ calls without _name_ in the keyword arguments to be displayed during completion of a url django template block.

Cheers,
David