### PR TITLE
Install cookiecutter on demand

### DIFF
--- a/Python/Product/Cookiecutter/CookiecutterFeed.txt
+++ b/Python/Product/Cookiecutter/CookiecutterFeed.txt
@@ -1,6 +1,1 @@
 ﻿https://github.com/brettcannon/python-azure-web-app-cookiecutter
-https://github.com/pydanny/cookiecutter-django
-https://github.com/sloria/cookiecutter-flask
-https://github.com/pydanny/cookiecutter-djangopackage
-https://github.com/marcofucci/cookiecutter-simple-django
-https://github.com/agconti/cookiecutter-django-rest

--- a/Python/Product/Cookiecutter/CookiecutterToolWindow.cs
+++ b/Python/Product/Cookiecutter/CookiecutterToolWindow.cs
@@ -47,7 +47,6 @@ namespace Microsoft.CookiecutterTools {
         private bool _missingDependencies;
         private bool _missingGit;
         private bool _missingPython;
-        private bool _missingCookiecutter;
 
         private readonly object _commandsLock = new object();
         private readonly Dictionary<Command, MenuCommand> _commands = new Dictionary<Command, MenuCommand>();
@@ -77,7 +76,7 @@ namespace Microsoft.CookiecutterTools {
             _infoBarFactory = _site.GetService(typeof(SVsInfoBarUIFactory)) as IVsInfoBarUIFactory;
 
             object control = null;
-            _missingDependencies = CheckDependencies(out _missingGit, out _missingPython, out _missingCookiecutter);
+            _missingDependencies = CheckDependencies(out _missingGit, out _missingPython);
             if (_missingDependencies) {
                 control = new MissingDependencies();
             } else {
@@ -140,7 +139,6 @@ namespace Microsoft.CookiecutterTools {
             Action showHelp = () => Process.Start(UrlConstants.HelpUrl);
             Action installGit = () => Process.Start(UrlConstants.InstallGitUrl);
             Action installPython = () => Process.Start(UrlConstants.InstallPythonUrl);
-            Action installCookiecutter = () => Process.Start(UrlConstants.InstallCookiecutterUrl);
 
             var messages = new List<IVsInfoBarTextSpan>();
             var actions = new List<InfoBarActionItem>();
@@ -161,10 +159,6 @@ namespace Microsoft.CookiecutterTools {
 
             if (_missingPython) {
                 actions.Add(new InfoBarHyperlink(Strings.InstallPythonInfoBarLink, installPython));
-            }
-
-            if (_missingCookiecutter) {
-                actions.Add(new InfoBarHyperlink(Strings.InstallCookiecutterInfoBarLink, installCookiecutter));
             }
 
             var image =  _missingDependencies ? KnownMonikers.StatusError : KnownMonikers.StatusInformation;
@@ -280,18 +274,15 @@ namespace Microsoft.CookiecutterTools {
             );
         }
 
-        private static bool CheckDependencies(out bool missingGit, out bool missingPython, out bool missingCookiecutter) {
+        private static bool CheckDependencies(out bool missingGit, out bool missingPython) {
             missingGit = true;
-            missingPython = true;
-            missingCookiecutter = true;
-
-            new CookiecutterClientProvider().CheckDependencies(out missingPython, out missingCookiecutter);
+            missingPython = !new CookiecutterClientProvider().CompatiblePythonAvailable();
 
             if (!string.IsNullOrEmpty(GitClient.RecommendedGitFilePath)) {
                 missingGit = false;
             }
 
-            return missingGit || missingPython || missingCookiecutter;
+            return missingGit || missingPython;
         }
     }
 }

--- a/Python/Product/Cookiecutter/CookiecutterToolWindow.cs
+++ b/Python/Product/Cookiecutter/CookiecutterToolWindow.cs
@@ -44,10 +44,6 @@ namespace Microsoft.CookiecutterTools {
         private IVsInfoBar _infoBarModel;
         private uint _infoBarAdviseCookie;
 
-        private bool _missingDependencies;
-        private bool _missingGit;
-        private bool _missingPython;
-
         private readonly object _commandsLock = new object();
         private readonly Dictionary<Command, MenuCommand> _commands = new Dictionary<Command, MenuCommand>();
 
@@ -76,8 +72,8 @@ namespace Microsoft.CookiecutterTools {
             _infoBarFactory = _site.GetService(typeof(SVsInfoBarUIFactory)) as IVsInfoBarUIFactory;
 
             object control = null;
-            _missingDependencies = CheckDependencies(out _missingGit, out _missingPython);
-            if (_missingDependencies) {
+
+            if (!CookiecutterClientProvider.IsCompatiblePythonAvailable()) {
                 control = new MissingDependencies();
             } else {
                 string feedUrl = CookiecutterPackage.Instance.RecommendedFeed;
@@ -108,7 +104,7 @@ namespace Microsoft.CookiecutterTools {
 
             OleMenuCommandService mcs = GetService(typeof(IMenuCommandService)) as OleMenuCommandService;
 
-            if (CookiecutterPackage.Instance.ShowHelp || _missingDependencies) {
+            if (CookiecutterPackage.Instance.ShowHelp) {
                 AddInfoBar();
             }
         }
@@ -120,10 +116,8 @@ namespace Microsoft.CookiecutterTools {
                     _infoBarAdviseCookie = 0;
                 }
 
-                if (!_missingDependencies) {
-                    // Save this for later time
-                    CookiecutterPackage.Instance.ShowHelp = false;
-                }
+                // Remember this for next time
+                CookiecutterPackage.Instance.ShowHelp = false;
 
                 RemoveInfoBar(_infoBar);
                 _infoBar.Close();
@@ -137,32 +131,14 @@ namespace Microsoft.CookiecutterTools {
 
         private void AddInfoBar() {
             Action showHelp = () => Process.Start(UrlConstants.HelpUrl);
-            Action installGit = () => Process.Start(UrlConstants.InstallGitUrl);
-            Action installPython = () => Process.Start(UrlConstants.InstallPythonUrl);
 
             var messages = new List<IVsInfoBarTextSpan>();
             var actions = new List<InfoBarActionItem>();
 
-            if (_missingDependencies) {
-                messages.Add(new InfoBarTextSpan(Strings.MissingDependenciesInfoBarMessage));
-            } else {
-                messages.Add(new InfoBarTextSpan(Strings.InfoBarMessage));
-            }
+            messages.Add(new InfoBarTextSpan(Strings.InfoBarMessage));
+            actions.Add(new InfoBarHyperlink(Strings.InfoBarMessageLink, showHelp));
 
-            if (!_missingDependencies) {
-                actions.Add(new InfoBarHyperlink(Strings.InfoBarMessageLink, showHelp));
-            }
-
-            if (_missingGit) {
-                actions.Add(new InfoBarHyperlink(Strings.InstallGitInfoBarLink, installGit));
-            }
-
-            if (_missingPython) {
-                actions.Add(new InfoBarHyperlink(Strings.InstallPythonInfoBarLink, installPython));
-            }
-
-            var image =  _missingDependencies ? KnownMonikers.StatusError : KnownMonikers.StatusInformation;
-            _infoBarModel = new InfoBarModel(messages, actions, image, isCloseButtonVisible: true);
+            _infoBarModel = new InfoBarModel(messages, actions, KnownMonikers.StatusInformation, isCloseButtonVisible: true);
             _infoBar = _infoBarFactory.CreateInfoBar(_infoBarModel);
             AddInfoBar(_infoBar);
             _infoBar.Advise(this, out _infoBarAdviseCookie);
@@ -272,17 +248,6 @@ namespace Microsoft.CookiecutterTools {
                 (int)point.Y,
                 this
             );
-        }
-
-        private static bool CheckDependencies(out bool missingGit, out bool missingPython) {
-            missingGit = true;
-            missingPython = !new CookiecutterClientProvider().CompatiblePythonAvailable();
-
-            if (!string.IsNullOrEmpty(GitClient.RecommendedGitFilePath)) {
-                missingGit = false;
-            }
-
-            return missingGit || missingPython;
         }
     }
 }

--- a/Python/Product/Cookiecutter/Model/CookiecutterClientProvider.cs
+++ b/Python/Product/Cookiecutter/Model/CookiecutterClientProvider.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using Microsoft.CookiecutterTools.Interpreters;
 
@@ -36,7 +37,10 @@ namespace Microsoft.CookiecutterTools.Model {
 
         private static CookiecutterPythonInterpreter FindCompatibleInterpreter() {
             var interpreters = PythonRegistrySearch.PerformDefaultSearch();
-            var compatible = interpreters.Where(interp => interp.Configuration.Version >= new Version(3, 3)).FirstOrDefault();
+            var compatible = interpreters
+                .Where(x => File.Exists(x.Configuration.InterpreterPath))
+                .OrderByDescending(x => x.Configuration.Version)
+                .FirstOrDefault(x => x.Configuration.Version >= new Version(3, 3));
             return compatible != null ? new CookiecutterPythonInterpreter(compatible.Configuration.InterpreterPath) : null;
         }
     }

--- a/Python/Product/Cookiecutter/Model/ICookiecutterClient.cs
+++ b/Python/Product/Cookiecutter/Model/ICookiecutterClient.cs
@@ -19,6 +19,10 @@ using System.Threading.Tasks;
 
 namespace Microsoft.CookiecutterTools.Model {
     interface ICookiecutterClient {
+        bool CookiecutterInstalled { get; }
+        Task<bool> IsCookiecutterInstalled();
+        Task<ProcessOutputResult> CreateCookiecutterEnv();
+        Task<ProcessOutputResult> InstallPackage();
         Task<Tuple<ContextItem[], ProcessOutputResult>> LoadContextAsync(string localTemplateFolder, string userConfigFilePath);
         Task<ProcessOutputResult> GenerateProjectAsync(string localTemplateFolder, string userConfigFilePath, string contextFilePath, string outputFolderPath);
     }

--- a/Python/Product/Cookiecutter/Strings.Designer.cs
+++ b/Python/Product/Cookiecutter/Strings.Designer.cs
@@ -173,15 +173,6 @@ namespace Microsoft.CookiecutterTools {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Install cookiecutter package.
-        /// </summary>
-        internal static string InstallCookiecutterInfoBarLink {
-            get {
-                return ResourceManager.GetString("InstallCookiecutterInfoBarLink", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Install Git.
         /// </summary>
         internal static string InstallGitInfoBarLink {
@@ -191,7 +182,34 @@ namespace Microsoft.CookiecutterTools {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Install Python.
+        ///   Looks up a localized string similar to ----- Failed to install cookiecutter -----.
+        /// </summary>
+        internal static string InstallingCookiecutterFailed {
+            get {
+                return ResourceManager.GetString("InstallingCookiecutterFailed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to ----- Installing cookiecutter -----.
+        /// </summary>
+        internal static string InstallingCookiecutterStarted {
+            get {
+                return ResourceManager.GetString("InstallingCookiecutterStarted", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to ----- Successfully installed cookiecutter -----.
+        /// </summary>
+        internal static string InstallingCookiecutterSuccess {
+            get {
+                return ResourceManager.GetString("InstallingCookiecutterSuccess", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Install Python 3.
         /// </summary>
         internal static string InstallPythonInfoBarLink {
             get {

--- a/Python/Product/Cookiecutter/Strings.resx
+++ b/Python/Product/Cookiecutter/Strings.resx
@@ -150,14 +150,11 @@ You can get more information by running Visual Studio with the /log parameter on
   <data name="GitHubSearchError" xml:space="preserve">
     <value>Could not retrieve results from GitHub</value>
   </data>
-  <data name="InstallCookiecutterInfoBarLink" xml:space="preserve">
-    <value>Install cookiecutter package</value>
-  </data>
   <data name="InstallGitInfoBarLink" xml:space="preserve">
     <value>Install Git</value>
   </data>
   <data name="InstallPythonInfoBarLink" xml:space="preserve">
-    <value>Install Python</value>
+    <value>Install Python 3</value>
   </data>
   <data name="MissingDependenciesInfoBarMessage" xml:space="preserve">
     <value>Some external dependencies are missing. Click the links to install them.</value>
@@ -171,6 +168,15 @@ You can get more information by running Visual Studio with the /log parameter on
     <value>A different template with the name '{0}' already exists in '{1}'.
 
 Please delete the installed template and try again.</value>
+  </data>
+  <data name="InstallingCookiecutterStarted" xml:space="preserve">
+    <value>----- Installing cookiecutter -----</value>
+  </data>
+  <data name="InstallingCookiecutterSuccess" xml:space="preserve">
+    <value>----- Successfully installed cookiecutter -----</value>
+  </data>
+  <data name="InstallingCookiecutterFailed" xml:space="preserve">
+    <value>----- Failed to install cookiecutter -----</value>
   </data>
   <data name="CloningTemplateStarted" xml:space="preserve">
     <value>----- Cloning template '{0}' -----</value>

--- a/Python/Product/Cookiecutter/UrlConstants.cs
+++ b/Python/Product/Cookiecutter/UrlConstants.cs
@@ -18,7 +18,6 @@ namespace Microsoft.CookiecutterTools {
     internal static class UrlConstants {
         public const string DefaultRecommendedFeed = "http://go.microsoft.com/fwlink/?LinkID=823051";
         public const string HelpUrl = "http://go.microsoft.com/fwlink/?LinkID=827351";
-        public const string InstallGitUrl = "http://go.microsoft.com/fwlink/?LinkID=827352";
         public const string InstallPythonUrl = "http://go.microsoft.com/fwlink/?LinkID=827353";
     }
 }

--- a/Python/Product/Cookiecutter/UrlConstants.cs
+++ b/Python/Product/Cookiecutter/UrlConstants.cs
@@ -20,6 +20,5 @@ namespace Microsoft.CookiecutterTools {
         public const string HelpUrl = "http://go.microsoft.com/fwlink/?LinkID=827351";
         public const string InstallGitUrl = "http://go.microsoft.com/fwlink/?LinkID=827352";
         public const string InstallPythonUrl = "http://go.microsoft.com/fwlink/?LinkID=827353";
-        public const string InstallCookiecutterUrl = "http://go.microsoft.com/fwlink/?LinkID=827354";
     }
 }

--- a/Python/Product/Cookiecutter/View/CookiecutterControl.xaml.cs
+++ b/Python/Product/Cookiecutter/View/CookiecutterControl.xaml.cs
@@ -51,7 +51,7 @@ namespace Microsoft.CookiecutterTools.View {
             var gitClient = new GitClient(gitExeFilePath);
             var gitHubClient = new GitHubClient();
             ViewModel = new CookiecutterViewModel(
-                new CookiecutterClientProvider().Create(),
+                CookiecutterClientProvider.Create(),
                 gitHubClient,
                 gitClient,
                 outputWindow,

--- a/Python/Product/Cookiecutter/View/CookiecutterControl.xaml.cs
+++ b/Python/Product/Cookiecutter/View/CookiecutterControl.xaml.cs
@@ -51,7 +51,7 @@ namespace Microsoft.CookiecutterTools.View {
             var gitClient = new GitClient(gitExeFilePath);
             var gitHubClient = new GitHubClient();
             ViewModel = new CookiecutterViewModel(
-                new CookiecutterClientProvider().Create(false),
+                new CookiecutterClientProvider().Create(),
                 gitHubClient,
                 gitClient,
                 outputWindow,

--- a/Python/Product/Cookiecutter/View/CookiecutterSearchPage.xaml
+++ b/Python/Product/Cookiecutter/View/CookiecutterSearchPage.xaml
@@ -207,6 +207,21 @@
 
             <StackPanel Margin="4 4 4 8"
                         Orientation="Vertical"
+                        Visibility="{Binding Path=IsInstalling, Converter={StaticResource BoolToVisibleOrCollapsed}}">
+                <Separator/>
+                <TextBlock Text="Installing cookiecutter..."/>
+                <ProgressBar Margin="4" IsIndeterminate="True"/>
+            </StackPanel>
+
+            <StackPanel Margin="4 4 4 8"
+                        Orientation="Horizontal"
+                        Visibility="{Binding Path=IsInstallingError, Converter={StaticResource BoolToVisibleOrCollapsed}}">
+                <imaging:CrispImage Width="16" Height="16" Moniker="{x:Static imagecatalog:KnownMonikers.StatusError}"/>
+                <TextBlock Margin="4 0 0 0" TextWrapping="Wrap" Text="Error installing cookiecutter. See output window for details."/>
+            </StackPanel>
+
+            <StackPanel Margin="4 4 4 8"
+                        Orientation="Vertical"
                         Visibility="{Binding Path=IsCloning, Converter={StaticResource BoolToVisibleOrCollapsed}}">
                 <Separator/>
                 <TextBlock Text="Cloning repository..."/>

--- a/Python/Product/Cookiecutter/View/MissingDependencies.xaml
+++ b/Python/Product/Cookiecutter/View/MissingDependencies.xaml
@@ -7,7 +7,27 @@
              xmlns:local="clr-namespace:Microsoft.CookiecutterTools.View"
              mc:Ignorable="d" 
              d:DesignHeight="300" d:DesignWidth="300">
-    <Grid>
-        <TextBlock Margin="4" TextWrapping="Wrap" Text="This feature requires external dependencies that are not installed." VerticalAlignment="Center" HorizontalAlignment="Center"/>
-    </Grid>
+    <UserControl.CommandBindings>
+        <CommandBinding Command="{x:Static local:MissingDependencies.InstallPython}"
+                    CanExecute="InstallPython_CanExecute"
+                    Executed="InstallPython_Executed" />
+    </UserControl.CommandBindings>
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="CookiecutterDictionary.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </UserControl.Resources>
+    <StackPanel Orientation="Vertical" VerticalAlignment="Center">
+        <TextBlock Margin="8"
+                    TextWrapping="Wrap"
+                    Text="Please install Python 3.3 or later to use this feature (requires VS restart)."
+                    VerticalAlignment="Center"
+                    HorizontalAlignment="Center"/>
+        <Button Margin="8"
+                Command="{x:Static local:MissingDependencies.InstallPython}"
+                HorizontalAlignment="Center"
+                Style="{StaticResource NavigationButton}">Help me install Python</Button>
+    </StackPanel>
 </UserControl>

--- a/Python/Product/Cookiecutter/View/MissingDependencies.xaml.cs
+++ b/Python/Product/Cookiecutter/View/MissingDependencies.xaml.cs
@@ -14,15 +14,30 @@
 // See the Apache Version 2.0 License for specific language governing
 // permissions and limitations under the License.
 
+using System.Diagnostics;
 using System.Windows.Controls;
+using System.Windows.Input;
 
 namespace Microsoft.CookiecutterTools.View {
     /// <summary>
     /// Interaction logic for MissingDependencies.xaml
     /// </summary>
     internal partial class MissingDependencies : UserControl {
+        public static readonly ICommand InstallPython = new RoutedCommand();
+
         public MissingDependencies() {
             InitializeComponent();
+        }
+
+        private void InstallPython_CanExecute(object sender, CanExecuteRoutedEventArgs e) {
+            var url = (string)e.Parameter;
+            e.CanExecute = true;
+            e.Handled = true;
+        }
+
+        private void InstallPython_Executed(object sender, ExecutedRoutedEventArgs e) {
+            var url = (string)e.Parameter;
+            Process.Start(UrlConstants.InstallPythonUrl)?.Dispose();
         }
     }
 }

--- a/Python/Product/Cookiecutter/ViewModel/CookiecutterViewModel.cs
+++ b/Python/Product/Cookiecutter/ViewModel/CookiecutterViewModel.cs
@@ -168,15 +168,12 @@ namespace Microsoft.CookiecutterTools.ViewModel {
             }
         }
 
-        public bool IsInstalling
-        {
-            get
-            {
+        public bool IsInstalling {
+            get {
                 return _isInstalling;
             }
 
-            set
-            {
+            set {
                 if (value != _isInstalling) {
                     _isInstalling = value;
                     PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsInstalling)));
@@ -184,15 +181,12 @@ namespace Microsoft.CookiecutterTools.ViewModel {
             }
         }
 
-        public bool IsInstallingSuccess
-        {
-            get
-            {
+        public bool IsInstallingSuccess {
+            get {
                 return _isInstallingSuccess;
             }
 
-            set
-            {
+            set {
                 if (value != _isInstallingSuccess) {
                     _isInstallingSuccess = value;
                     PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsInstallingSuccess)));
@@ -200,15 +194,12 @@ namespace Microsoft.CookiecutterTools.ViewModel {
             }
         }
 
-        public bool IsInstallingError
-        {
-            get
-            {
+        public bool IsInstallingError {
+            get {
                 return _isInstallingError;
             }
 
-            set
-            {
+            set {
                 if (value != _isInstallingError) {
                     _isInstallingError = value;
                     PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsInstallingError)));

--- a/Python/Tests/CookiecutterTests/CookiecutterClientTests.cs
+++ b/Python/Tests/CookiecutterTests/CookiecutterClientTests.cs
@@ -74,13 +74,21 @@ namespace CookiecutterTests {
 
         [TestInitialize]
         public void SetupTest() {
-            var provider = new CookiecutterClientProvider();
-            _client = provider.Create();
+            _client = CookiecutterClientProvider.Create();
             Assert.IsNotNull(_client, "The system doesn't have any compatible Python interpreters.");
+        }
+
+        private async Task EnsureCookiecutterInstalledAsync() {
+            if (!_client.CookiecutterInstalled) {
+                await _client.CreateCookiecutterEnv();
+                await _client.InstallPackage();
+            }
         }
 
         [TestMethod]
         public async Task LoadContextNoUserConfig() {
+            await EnsureCookiecutterInstalledAsync();
+
             var actual = await _client.LoadContextAsync(LocalTemplatePath, NoUserConfigFilePath);
 
             CollectionAssert.AreEqual(LocalTemplateNoUserConfigContextItems, actual.Item1, new ContextItemComparer());
@@ -88,6 +96,8 @@ namespace CookiecutterTests {
 
         [TestMethod]
         public async Task LoadContextWithUserConfig() {
+            await EnsureCookiecutterInstalledAsync();
+
             var actual = await _client.LoadContextAsync(LocalTemplatePath, UserConfigFilePath);
 
             CollectionAssert.AreEqual(LocalTemplateWithUserConfigContextItems, actual.Item1, new ContextItemComparer());
@@ -95,6 +105,8 @@ namespace CookiecutterTests {
 
         [TestMethod]
         public async Task GenerateWithoutUserConfig() {
+            await EnsureCookiecutterInstalledAsync();
+
             Dictionary<string, string> actual = await GenerateFromLocalTemplate(NoUserConfigFilePath);
 
             var expected = new Dictionary<string, string>() {
@@ -114,6 +126,8 @@ namespace CookiecutterTests {
 
         [TestMethod]
         public async Task GenerateWithUserConfig() {
+            await EnsureCookiecutterInstalledAsync();
+
             Dictionary<string, string> actual = await GenerateFromLocalTemplate(UserConfigFilePath);
 
             var expected = new Dictionary<string, string>() {

--- a/Python/Tests/CookiecutterTests/CookiecutterClientTests.cs
+++ b/Python/Tests/CookiecutterTests/CookiecutterClientTests.cs
@@ -75,10 +75,8 @@ namespace CookiecutterTests {
         [TestInitialize]
         public void SetupTest() {
             var provider = new CookiecutterClientProvider();
-            _client = provider.Create(false);
-            if (_client == null) {
-                Assert.Inconclusive("The Cookiecutter package is not installed in any of the registered interpreters.");
-            }
+            _client = provider.Create();
+            Assert.IsNotNull(_client, "The system doesn't have any compatible Python interpreters.");
         }
 
         [TestMethod]

--- a/Python/Tests/CookiecutterTests/CookiecutterIntegrationTests.cs
+++ b/Python/Tests/CookiecutterTests/CookiecutterIntegrationTests.cs
@@ -88,7 +88,7 @@ namespace CookiecutterTests {
 
             _gitClient = new GitClient(GitClient.RecommendedGitFilePath);
             _gitHubClient = new GitHubClient();
-            _cutterClient = new CookiecutterClientProvider().Create(false);
+            _cutterClient = new CookiecutterClientProvider().Create();
             _installedTemplateSource = new LocalTemplateSource(installedPath, _gitClient);
             _gitHubTemplateSource = new GitHubTemplateSource(_gitHubClient);
             _feedTemplateSource = new FeedTemplateSource(feedUrl);

--- a/Python/Tests/CookiecutterTests/CookiecutterIntegrationTests.cs
+++ b/Python/Tests/CookiecutterTests/CookiecutterIntegrationTests.cs
@@ -88,7 +88,7 @@ namespace CookiecutterTests {
 
             _gitClient = new GitClient(GitClient.RecommendedGitFilePath);
             _gitHubClient = new GitHubClient();
-            _cutterClient = new CookiecutterClientProvider().Create();
+            _cutterClient = CookiecutterClientProvider.Create();
             _installedTemplateSource = new LocalTemplateSource(installedPath, _gitClient);
             _gitHubTemplateSource = new GitHubTemplateSource(_gitHubClient);
             _feedTemplateSource = new FeedTemplateSource(feedUrl);
@@ -202,6 +202,8 @@ namespace CookiecutterTests {
 
         [TestMethod]
         public async Task CreateFromLocalTemplate() {
+            await EnsureCookiecutterInstalledAsync();
+
             _vm.SearchTerm = TestLocalTemplatePath;
             await _vm.SearchAsync();
 
@@ -249,6 +251,8 @@ namespace CookiecutterTests {
 
         [TestMethod]
         public async Task CreateFromOnlineTemplate() {
+            await EnsureCookiecutterInstalledAsync();
+
             _vm.SearchTerm = OnlineTemplateUrl;
             await _vm.SearchAsync();
 
@@ -279,6 +283,13 @@ namespace CookiecutterTests {
             Assert.IsTrue(File.Exists(Path.Combine(_vm.OutputFolderPath, "static_files", "web.config")));
             Assert.IsTrue(File.Exists(Path.Combine(_vm.OutputFolderPath, "post-deployment", "install-requirements.ps1")));
             Assert.IsFalse(File.Exists(Path.Combine(_vm.OutputFolderPath, "install-requirements.ps1")));
+        }
+
+        private async Task EnsureCookiecutterInstalledAsync() {
+            if (!_cutterClient.CookiecutterInstalled) {
+                await _cutterClient.CreateCookiecutterEnv();
+                await _cutterClient.InstallPackage();
+            }
         }
 
         private static void PrintResults(ObservableCollection<object> items) {

--- a/Python/Tests/CookiecutterTests/MockCookiecutterClient.cs
+++ b/Python/Tests/CookiecutterTests/MockCookiecutterClient.cs
@@ -24,7 +24,27 @@ using Microsoft.CookiecutterTools.Model;
 
 namespace CookiecutterTests {
     class MockCookiecutterClient : ICookiecutterClient {
+        public bool CookiecutterInstalled
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public Task<ProcessOutputResult> CreateCookiecutterEnv() {
+            throw new NotImplementedException();
+        }
+
         public Task<ProcessOutputResult> GenerateProjectAsync(string localTemplateFolder, string userConfigFilePath, string contextFilePath, string outputFolderPath) {
+            throw new NotImplementedException();
+        }
+
+        public Task<ProcessOutputResult> InstallPackage() {
+            throw new NotImplementedException();
+        }
+
+        public Task<bool> IsCookiecutterInstalled() {
             throw new NotImplementedException();
         }
 

--- a/Python/Tests/CookiecutterTests/MockCookiecutterClient.cs
+++ b/Python/Tests/CookiecutterTests/MockCookiecutterClient.cs
@@ -24,10 +24,8 @@ using Microsoft.CookiecutterTools.Model;
 
 namespace CookiecutterTests {
     class MockCookiecutterClient : ICookiecutterClient {
-        public bool CookiecutterInstalled
-        {
-            get
-            {
+        public bool CookiecutterInstalled {
+            get {
                 throw new NotImplementedException();
             }
         }


### PR DESCRIPTION
Our only external requirement is Python 3.3 or later.
Don't bother notifying for missing git, we know it's installed. In rare error case (like dev14), message in output window will be sufficient.
Virtual environment + cookiecutter package go in  %localappdata%/Microsoft/CookiecutterTools/env

Please check the strings/messages in missing dependencies xaml, and in strings.resx, I'm open to more detailed or better strings.

I've updated the feed so we don't recommend third party templates we haven't really tested.