### PR TITLE
Fixes #1672 Double backslash in Python environments prevent from open…

### DIFF
--- a/Python/Product/Common/Infrastructure/PathUtils.cs
+++ b/Python/Product/Common/Infrastructure/PathUtils.cs
@@ -73,7 +73,6 @@ namespace Microsoft.PythonTools.Infrastructure {
 
             var root = EnsureEndSeparator(Path.GetPathRoot(path));
             var parts = path.Substring(root.Length).Split(DirectorySeparators);
-            bool isAbs = parts[0].EndsWith(":");
             bool isDir = string.IsNullOrWhiteSpace(parts[parts.Length - 1]);
 
             for (int i = 0; i < parts.Length; ++i) {
@@ -90,12 +89,17 @@ namespace Microsoft.PythonTools.Infrastructure {
                 }
 
                 if (parts[i] == "..") {
-                    for (int j = i - 1; j > 0; --j) {
+                    bool found = false;
+                    for (int j = i - 1; j >= 0; --j) {
                         if (!string.IsNullOrEmpty(parts[j])) {
                             parts[i] = null;
                             parts[j] = null;
+                            found = true;
                             break;
                         }
+                    }
+                    if (!found && !string.IsNullOrEmpty(root)) {
+                        parts[i] = null;
                     }
                     continue;
                 }

--- a/Python/Product/Common/Infrastructure/PathUtils.cs
+++ b/Python/Product/Common/Infrastructure/PathUtils.cs
@@ -62,19 +62,52 @@ namespace Microsoft.PythonTools.Infrastructure {
         /// </summary>
         public static string NormalizePath(string path) {
             if (string.IsNullOrEmpty(path)) {
-                return null;
+                return string.Empty;
             }
 
-            var uri = MakeUri(path, false, UriKind.RelativeOrAbsolute);
-            if (uri.IsAbsoluteUri) {
-                if (uri.IsFile) {
-                    return uri.LocalPath;
-                } else {
-                    return uri.AbsoluteUri.Replace(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-                }
-            } else {
-                return Uri.UnescapeDataString(uri.ToString()).Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
+            Uri uri;
+            if (TryMakeUri(path, false, UriKind.Absolute, out uri) &&
+                uri.Scheme != Uri.UriSchemeFile) {
+                return uri.AbsoluteUri;
             }
+
+            var root = EnsureEndSeparator(Path.GetPathRoot(path));
+            var parts = path.Substring(root.Length).Split(DirectorySeparators);
+            bool isAbs = parts[0].EndsWith(":");
+            bool isDir = string.IsNullOrWhiteSpace(parts[parts.Length - 1]);
+
+            for (int i = 0; i < parts.Length; ++i) {
+                if (string.IsNullOrEmpty(parts[i])) {
+                    if (i > 0) {
+                        parts[i] = null;
+                    }
+                    continue;
+                }
+
+                if (parts[i] == ".") {
+                    parts[i] = null;
+                    continue;
+                }
+
+                if (parts[i] == "..") {
+                    for (int j = i - 1; j > 0; --j) {
+                        if (!string.IsNullOrEmpty(parts[j])) {
+                            parts[i] = null;
+                            parts[j] = null;
+                            break;
+                        }
+                    }
+                    continue;
+                }
+
+                parts[i] = parts[i].TrimEnd(' ', '.');
+            }
+
+            var newPath = root + string.Join(
+                Path.DirectorySeparatorChar.ToString(),
+                parts.Where(s => s != null)
+            );
+            return isDir ? EnsureEndSeparator(newPath) : newPath;
         }
 
         /// <summary>
@@ -82,20 +115,13 @@ namespace Microsoft.PythonTools.Infrastructure {
         /// ending with '/'.
         /// </summary>
         public static string NormalizeDirectoryPath(string path) {
-            if (string.IsNullOrEmpty(path)) {
-                return null;
+            Uri uri;
+            if (TryMakeUri(path, true, UriKind.Absolute, out uri) &&
+                uri.Scheme != Uri.UriSchemeFile) {
+                return uri.AbsoluteUri;
             }
 
-            var uri = MakeUri(path, true, UriKind.RelativeOrAbsolute);
-            if (uri.IsAbsoluteUri) {
-                if (uri.IsFile) {
-                    return uri.LocalPath;
-                } else {
-                    return uri.AbsoluteUri.Replace(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-                }
-            } else {
-                return Uri.UnescapeDataString(uri.ToString()).Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
-            }
+            return EnsureEndSeparator(NormalizePath(path));
         }
 
         /// <summary>

--- a/Python/Product/VSInterpreters/PythonRegistrySearch.cs
+++ b/Python/Product/VSInterpreters/PythonRegistrySearch.cs
@@ -122,9 +122,9 @@ namespace Microsoft.PythonTools.Interpreter {
                 return null;
             }
 
-            var prefixPath = installKey.GetValue(null) as string;
-            var exePath = installKey.GetValue("ExecutablePath") as string;
-            var exewPath = installKey.GetValue("WindowedExecutablePath") as string;
+            var prefixPath = PathUtils.NormalizePath(installKey.GetValue(null) as string);
+            var exePath = PathUtils.NormalizePath(installKey.GetValue("ExecutablePath") as string);
+            var exewPath = PathUtils.NormalizePath(installKey.GetValue("WindowedExecutablePath") as string);
             if (pythonCoreCompatibility && !string.IsNullOrEmpty(prefixPath)) {
                 if (string.IsNullOrEmpty(exePath)) {
                     exePath = PathUtils.GetAbsoluteFilePath(prefixPath, CPythonInterpreterFactoryConstants.ConsoleExecutable);

--- a/Python/Tests/Core/PathUtilsTests.cs
+++ b/Python/Tests/Core/PathUtilsTests.cs
@@ -374,11 +374,12 @@ namespace PythonToolsTests {
         public void TestNormalizeDirectoryPath() {
             foreach (var testCase in Pairs(
                 @"a\b\c", @"a\b\c\",
-                @"a\b\.\c", @"a\b\.\c\",
-                @"a\b\d\..\c", @"a\b\d\..\c\"
+                @"a\b\.\c", @"a\b\c\",
+                @"a\b\d\..\c", @"a\b\c\",
+                @"a\b\\c", @"a\b\c\"
                 )) {
                 foreach (var root in new[] { "", @".\", @"..\", @"\" }) {
-                    var expected = root + testCase.Item2;
+                    var expected = (root == @".\" ? "" : root) + testCase.Item2;
                     var actual = PathUtils.NormalizeDirectoryPath(root + testCase.Item1);
 
                     Assert.AreEqual(expected, actual);
@@ -410,11 +411,13 @@ namespace PythonToolsTests {
         public void TestNormalizePath() {
             foreach (var testCase in Pairs(
                 @"a\b\c", @"a\b\c",
-                @"a\b\.\c", @"a\b\.\c",
-                @"a\b\d\..\c", @"a\b\d\..\c"
+                @"a\b\.\c", @"a\b\c",
+                @"a\b\d\..\c", @"a\b\c",
+                @"a\b\\c", @"a\b\c",
+                @".\..\a", @"..\a"
                 )) {
                 foreach (var root in new[] { "", @".\", @"..\", @"\" }) {
-                    var expected = root + testCase.Item2;
+                    var expected = (root == @".\" ? "" : root) + testCase.Item2;
                     var actual = PathUtils.NormalizePath(root + testCase.Item1);
 
                     Assert.AreEqual(expected, actual);

--- a/Python/Tests/Core/PathUtilsTests.cs
+++ b/Python/Tests/Core/PathUtilsTests.cs
@@ -377,7 +377,7 @@ namespace PythonToolsTests {
                 @"a\b\.\c", @"a\b\c\",
                 @"a\b\d\..\c", @"a\b\c\",
                 @"a\b\\c", @"a\b\c\"
-                )) {
+            )) {
                 foreach (var root in new[] { "", @".\", @"..\", @"\" }) {
                     var expected = (root == @".\" ? "" : root) + testCase.Item2;
                     var actual = PathUtils.NormalizeDirectoryPath(root + testCase.Item1);
@@ -389,8 +389,9 @@ namespace PythonToolsTests {
             foreach (var testCase in Pairs(
                 @"a\b\c", @"a\b\c\",
                 @"a\b\.\c", @"a\b\c\",
-                @"a\b\d\..\c", @"a\b\c\"
-                )) {
+                @"a\b\d\..\c", @"a\b\c\",
+                @"a\..\..\b", @"b\"
+            )) {
                 foreach (var root in new[] { @"C:\", @"\\pc\share\", @"ftp://me@example.com/" }) {
                     var expected = root + testCase.Item2;
                     var actual = PathUtils.NormalizeDirectoryPath(root + testCase.Item1);
@@ -413,9 +414,8 @@ namespace PythonToolsTests {
                 @"a\b\c", @"a\b\c",
                 @"a\b\.\c", @"a\b\c",
                 @"a\b\d\..\c", @"a\b\c",
-                @"a\b\\c", @"a\b\c",
-                @".\..\a", @"..\a"
-                )) {
+                @"a\b\\c", @"a\b\c"
+            )) {
                 foreach (var root in new[] { "", @".\", @"..\", @"\" }) {
                     var expected = (root == @".\" ? "" : root) + testCase.Item2;
                     var actual = PathUtils.NormalizePath(root + testCase.Item1);
@@ -432,8 +432,9 @@ namespace PythonToolsTests {
             foreach (var testCase in Pairs(
                 @"a\b\c", @"a\b\c",
                 @"a\b\.\c", @"a\b\c",
-                @"a\b\d\..\c", @"a\b\c"
-                )) {
+                @"a\b\d\..\c", @"a\b\c",
+                @"a\..\..\b", @"b"
+            )) {
                 foreach (var root in new[] { @"C:\", @"\\pc\share\", @"ftp://me@example.com/" }) {
                     var expected = root + testCase.Item2;
                     var actual = PathUtils.NormalizePath(root + testCase.Item1);


### PR DESCRIPTION
Fixes #1672 Double backslash in Python environments prevent from opening interpreter folder

Normalise paths when reading from registry.