### PR TITLE
Profiler issues

### DIFF
--- a/Python/Product/Profiling/Profiling/ProfiledProcess.cs
+++ b/Python/Product/Profiling/Profiling/ProfiledProcess.cs
@@ -113,6 +113,10 @@ namespace Microsoft.PythonTools.Profiling {
 
             string perfMonPath = Path.Combine(perfToolsPath, "VSPerfMon.exe");
 
+            if (!File.Exists(perfMonPath)) {
+                throw new InvalidOperationException("Cannot locate performance tools.");
+            }
+
             var psi = new ProcessStartInfo(perfMonPath, "/trace /output:" + ProcessOutput.QuoteSingleArgument(filename));
             psi.CreateNoWindow = true;
             psi.UseShellExecute = false;

--- a/Python/Product/Profiling/Profiling/ProfiledProcess.cs
+++ b/Python/Product/Profiling/Profiling/ProfiledProcess.cs
@@ -172,7 +172,7 @@ namespace Microsoft.PythonTools.Profiling {
                     }
                 }
 
-                using (var key = baseKey.OpenSubKey(@"SOFTWARE\Microsoft\VisualStudio\RemoteTools\{0}\DiagnosticsHub".FormatUI(AssemblyVersionInfo.VSVersion))) {
+                using (var key = baseKey.OpenSubKey(@"SOFTWARE\Microsoft\VisualStudio\RemoteTools\{0}\DiagnosticsHub".FormatInvariant(AssemblyVersionInfo.VSVersion))) {
                     var path = PathUtils.GetParent(key?.GetValue("VSPerfPath") as string);
                     if (!string.IsNullOrEmpty(path)) {
                         if (_arch == ProcessorArchitecture.Amd64) {


### PR DESCRIPTION
Fixes search for profiler tools and improves the error message when they aren't found.

We still need to properly handle the case where it is not found - the call logic is crazy and handling the exception in the right place for all entry points is not trivial.