### PR TITLE
Fixes #1585 All .pyd files are listed in Intellisense view for venvs

### DIFF
--- a/Python/Product/Analysis/Analysis.csproj
+++ b/Python/Product/Analysis/Analysis.csproj
@@ -375,6 +375,13 @@
       <Name>Microsoft.PythonTools.Common</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <Content Include="get_search_paths.py">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <IncludeInVSIX>true</IncludeInVSIX>
+      <VSIXSubPath>.</VSIXSubPath>
+    </Content>
+  </ItemGroup>
   <Import Project="..\ProjectAfter.settings" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Python/Product/Analysis/get_search_paths.py
+++ b/Python/Product/Analysis/get_search_paths.py
@@ -1,0 +1,48 @@
+﻿import sys
+
+if 'site' in sys.modules:
+    raise RuntimeError('script must be run with -S')
+
+BEFORE_SITE = list(sys.path)
+import site
+try:
+    site.main()
+except:
+    import traceback
+    traceback.print_exc(file=sys.stderr)
+AFTER_SITE = list(sys.path)
+
+import os
+def clean(path):
+    if path:
+        return os.path.normcase(os.path.abspath(path).rstrip('/\\'))
+    return None
+
+BEFORE_SITE = set(clean(p) for p in BEFORE_SITE)
+AFTER_SITE = set(clean(p) for p in AFTER_SITE)
+
+for prefix in [
+    sys.prefix,
+    sys.exec_prefix,
+    getattr(sys, 'real_prefix', ''),
+    getattr(sys, 'base_prefix', '')
+]:
+    if not prefix:
+        continue
+
+    BEFORE_SITE.add(clean(prefix))
+    
+    for subdir in ['DLLs', 'Lib', 'Scripts']:
+        d = clean(os.path.join(prefix, subdir))
+        BEFORE_SITE.add(d)
+
+BEFORE_SITE.discard(None)
+AFTER_SITE.discard(None)
+
+for p in sorted(BEFORE_SITE):
+    if os.path.isdir(p):
+        print("%s|stdlib|" % p)
+
+for p in sorted(AFTER_SITE - BEFORE_SITE):
+    if os.path.isdir(p):
+        print("%s||" % p)

--- a/Python/Product/VSInterpreters/PipPackageManager.cs
+++ b/Python/Product/VSInterpreters/PipPackageManager.cs
@@ -429,7 +429,7 @@ namespace Microsoft.PythonTools.Interpreter {
                         // Pip failed, so return a directory listing
                         var paths = await PythonTypeDatabase.GetDatabaseSearchPathsAsync(_factory);
 
-                        packages = await Task.Run(() => paths.Where(p => !p.IsStandardLibrary)
+                        packages = await Task.Run(() => paths.Where(p => !p.IsStandardLibrary && Directory.Exists(p.Path))
                             .SelectMany(p => PathUtils.EnumerateDirectories(p.Path, recurse: false))
                             .Select(path => Path.GetFileName(path))
                             .Select(name => PackageNameRegex.Match(name))
@@ -561,7 +561,10 @@ namespace Microsoft.PythonTools.Interpreter {
                 return;
             }
 
-            paths = paths.OrderBy(p => p.Path.Length).ToList();
+            paths = paths
+                .Where(p => Directory.Exists(p.Path))
+                .OrderBy(p => p.Path.Length)
+                .ToList();
 
             var watching = new List<string>();
             var watchers = new List<FileSystemWatcher>();

--- a/Python/Tests/Analysis/AnalyzerTests.cs
+++ b/Python/Tests/Analysis/AnalyzerTests.cs
@@ -22,6 +22,7 @@ using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Microsoft.PythonTools.Analysis;
+using Microsoft.PythonTools.Infrastructure;
 using Microsoft.PythonTools.Interpreter;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using TestUtilities;
@@ -422,6 +423,184 @@ namespace AnalysisTests {
                     Assert.AreEqual(4, analyzer._analyzeFileGroups.Count);
                 }
             }
+        }
+
+        [TestMethod, Priority(1)]
+        public async Task GetDatabasePaths() {
+            foreach (var version in PythonPaths.Versions) {
+                var paths = await PythonTypeDatabase.GetUncachedDatabaseSearchPathsAsync(version.InterpreterPath);
+                AssertUtil.ContainsAtLeast(
+                    paths.Where(p => p.IsStandardLibrary).Select(p => p.Path),
+                    new[] {
+                        PathUtils.TrimEndSeparator(version.PrefixPath.ToLowerInvariant()),
+                        Path.Combine(version.PrefixPath, "Lib").ToLowerInvariant()
+                    }
+                );
+                AssertUtil.ContainsAtLeast(
+                    paths.Where(p => !p.IsStandardLibrary).Select(p => p.Path),
+                    new[] {
+                        Path.Combine(version.PrefixPath, "Lib", "site-packages").ToLowerInvariant()
+                    }
+                );
+            }
+        }
+
+        [TestMethod, Priority(1)]
+        [TestCategory("10s")]
+        public async Task GetVirtualEnvDatabasePaths() {
+            var version = PythonPaths.Python27 ?? PythonPaths.Python27_x64;
+
+            var env = Path.Combine(TestData.GetTempPath(randomSubPath: true), "env");
+
+            using (var p = ProcessOutput.RunHiddenAndCapture(version.InterpreterPath, "-m", "virtualenv", env)) {
+                if ((await p) != 0) {
+                    Assert.Fail("Could not create virtualenv{0}{1}{0}{2}",
+                        Environment.NewLine,
+                        string.Join(Environment.NewLine, p.StandardOutputLines),
+                        string.Join(Environment.NewLine, p.StandardErrorLines)
+                    );
+                    return;
+                }
+            }
+
+            var interpreter = Path.Combine(env, "Scripts", "python.exe");
+            var paths = await PythonTypeDatabase.GetUncachedDatabaseSearchPathsAsync(interpreter);
+            AssertUtil.ContainsAtLeast(
+                paths.Where(p => p.IsStandardLibrary).Select(p => p.Path),
+                new[] {
+                    Path.Combine(env, "Scripts").ToLowerInvariant(),
+                    PathUtils.TrimEndSeparator(env.ToLowerInvariant()),
+                    PathUtils.TrimEndSeparator(version.PrefixPath.ToLowerInvariant()),
+                    Path.Combine(version.PrefixPath, "Lib").ToLowerInvariant()
+                }
+            );
+            AssertUtil.ContainsAtLeast(
+                paths.Where(p => !p.IsStandardLibrary).Select(p => p.Path),
+                new[] {
+                    Path.Combine(env, "Lib", "site-packages").ToLowerInvariant()
+                }
+            );
+            AssertUtil.DoesntContain(
+                paths.Select(p => p.Path),
+                Path.Combine(version.PrefixPath, "Lib", "site-packages").ToLowerInvariant()
+            );
+        }
+
+        [TestMethod, Priority(1)]
+        [TestCategory("10s")]
+        public async Task GetVirtualEnvDatabasePathsWithSystemSitePackages() {
+            var version = PythonPaths.Python27 ?? PythonPaths.Python27_x64;
+
+            var env = Path.Combine(TestData.GetTempPath(randomSubPath: true), "env");
+
+            using (var p = ProcessOutput.RunHiddenAndCapture(version.InterpreterPath, "-m", "virtualenv", "--system-site-packages", env)) {
+                if ((await p) != 0) {
+                    Assert.Fail("Could not create virtualenv{0}{1}{0}{2}",
+                        Environment.NewLine,
+                        string.Join(Environment.NewLine, p.StandardOutputLines),
+                        string.Join(Environment.NewLine, p.StandardErrorLines)
+                    );
+                    return;
+                }
+            }
+
+            var interpreter = Path.Combine(env, "Scripts", "python.exe");
+            var paths = await PythonTypeDatabase.GetUncachedDatabaseSearchPathsAsync(interpreter);
+            AssertUtil.ContainsAtLeast(
+                paths.Where(p => p.IsStandardLibrary).Select(p => p.Path),
+                new[] {
+                    Path.Combine(env, "Scripts").ToLowerInvariant(),
+                    PathUtils.TrimEndSeparator(env.ToLowerInvariant()),
+                    PathUtils.TrimEndSeparator(version.PrefixPath.ToLowerInvariant()),
+                    Path.Combine(version.PrefixPath, "Lib").ToLowerInvariant()
+                }
+            );
+            AssertUtil.ContainsAtLeast(
+                paths.Where(p => !p.IsStandardLibrary).Select(p => p.Path),
+                new[] {
+                    Path.Combine(env, "Lib", "site-packages").ToLowerInvariant(),
+                    Path.Combine(version.PrefixPath, "Lib", "site-packages").ToLowerInvariant()
+                }
+            );
+        }
+
+        [TestMethod, Priority(1)]
+        [TestCategory("10s")]
+        public async Task GetVEnvDatabasePaths() {
+            var version = PythonPaths.Python35 ?? PythonPaths.Python35_x64;
+
+            var env = Path.Combine(TestData.GetTempPath(randomSubPath: true), "env");
+
+            using (var p = ProcessOutput.RunHiddenAndCapture(version.InterpreterPath, "-m", "venv", env)) {
+                if ((await p) != 0) {
+                    Assert.Fail("Could not create venv{0}{1}{0}{2}",
+                        Environment.NewLine,
+                        string.Join(Environment.NewLine, p.StandardOutputLines),
+                        string.Join(Environment.NewLine, p.StandardErrorLines)
+                    );
+                    return;
+                }
+            }
+
+            var interpreter = Path.Combine(env, "Scripts", "python.exe");
+            var paths = await PythonTypeDatabase.GetUncachedDatabaseSearchPathsAsync(interpreter);
+            AssertUtil.ContainsAtLeast(
+                paths.Where(p => p.IsStandardLibrary).Select(p => p.Path),
+                new[] {
+                    Path.Combine(env, "Scripts").ToLowerInvariant(),
+                    PathUtils.TrimEndSeparator(env.ToLowerInvariant()),
+                    PathUtils.TrimEndSeparator(version.PrefixPath.ToLowerInvariant()),
+                    Path.Combine(version.PrefixPath, "Lib").ToLowerInvariant()
+                }
+            );
+            AssertUtil.ContainsAtLeast(
+                paths.Where(p => !p.IsStandardLibrary).Select(p => p.Path),
+                new[] {
+                    Path.Combine(env, "Lib", "site-packages").ToLowerInvariant()
+                }
+            );
+            AssertUtil.DoesntContain(
+                paths.Select(p => p.Path),
+                Path.Combine(version.PrefixPath, "Lib", "site-packages").ToLowerInvariant()
+            );
+        }
+
+        [TestMethod, Priority(1)]
+        [TestCategory("10s")]
+        public async Task GetVEnvDatabasePathsWithSystemSitePackage() {
+            var version = PythonPaths.Python35 ?? PythonPaths.Python35_x64;
+
+            var env = Path.Combine(TestData.GetTempPath(randomSubPath: true), "env");
+
+            using (var p = ProcessOutput.RunHiddenAndCapture(version.InterpreterPath, "-m", "venv", "--system-site-packages", env)) {
+                if ((await p) != 0) {
+                    Assert.Fail("Could not create venv{0}{1}{0}{2}",
+                        Environment.NewLine,
+                        string.Join(Environment.NewLine, p.StandardOutputLines),
+                        string.Join(Environment.NewLine, p.StandardErrorLines)
+                    );
+                    return;
+                }
+            }
+
+            var interpreter = Path.Combine(env, "Scripts", "python.exe");
+            var paths = await PythonTypeDatabase.GetUncachedDatabaseSearchPathsAsync(interpreter);
+            AssertUtil.ContainsAtLeast(
+                paths.Where(p => p.IsStandardLibrary).Select(p => p.Path),
+                new[] {
+                    Path.Combine(env, "Scripts").ToLowerInvariant(),
+                    PathUtils.TrimEndSeparator(env.ToLowerInvariant()),
+                    PathUtils.TrimEndSeparator(version.PrefixPath.ToLowerInvariant()),
+                    Path.Combine(version.PrefixPath, "Lib").ToLowerInvariant()
+                }
+            );
+            AssertUtil.ContainsAtLeast(
+                paths.Where(p => !p.IsStandardLibrary).Select(p => p.Path),
+                new[] {
+                    Path.Combine(env, "Lib", "site-packages").ToLowerInvariant(),
+                    Path.Combine(version.PrefixPath, "Lib", "site-packages").ToLowerInvariant()
+                }
+            );
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #1585 All .pyd files are listed in Intellisense view for venvs
Correctly marks paths that are used for DB generation as stdlib.