### PR TITLE
Use default framework version for BuildTasks project.

### DIFF
--- a/Common/Tools/BuildTasks/BuildTasks.csproj
+++ b/Common/Tools/BuildTasks/BuildTasks.csproj
@@ -14,9 +14,6 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Microsoft.VisualStudioTools.BuildTasks</RootNamespace>
     <AssemblyName>Microsoft.VisualStudioTools.BuildTasks</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-    <TargetFrameworkProfile>
-    </TargetFrameworkProfile>
     <FileAlignment>512</FileAlignment>
     <SignAssembly>false</SignAssembly>
     <RunCodeAnalysis>false</RunCodeAnalysis>


### PR DESCRIPTION
The imported `Common.Build.settings` file sets it to 4.6, and this project was overwriting it with 4.5.

This was the reason I was getting these build errors:
`MSB3030: Could not copy file "C:\program Files (x86)\Reference Assemblies\Microsoft\.NETFramework\v4.5\norm*.nlp" because it was not found `

I was getting them only on Dev 15 Preview 5, but starting today I am also seeing the error on Dev 14 Update 3.

