### PR TITLE
Cookiecutter template updating

### DIFF
--- a/Python/Product/Cookiecutter/Commands/CheckForUpdatesCommand.cs
+++ b/Python/Product/Cookiecutter/Commands/CheckForUpdatesCommand.cs
@@ -1,0 +1,53 @@
+// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABLITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System;
+using Microsoft.CookiecutterTools.Infrastructure;
+
+namespace Microsoft.CookiecutterTools.Commands {
+    /// <summary>
+    /// Provides the command for opening the cookiecutter window.
+    /// </summary>
+    class CheckForUpdatesCommand : Command {
+        private CookiecutterToolWindow _window;
+
+        public CheckForUpdatesCommand(CookiecutterToolWindow window) {
+            _window = window;
+        }
+
+        public override void DoCommand(object sender, EventArgs args) {
+            _window.CheckForUpdates();
+        }
+
+        public string Description {
+            get {
+                return "Cookiecutter";
+            }
+        }
+        public override EventHandler BeforeQueryStatus {
+            get {
+                return (sender, args) => {
+                    var oleMenuCmd = (Microsoft.VisualStudio.Shell.OleMenuCommand)sender;
+                    oleMenuCmd.Enabled = (_window.CanCheckForUpdates());
+                };
+            }
+        }
+
+        public override int CommandId {
+            get { return (int)PackageIds.cmdidCheckForUpdates; }
+        }
+    }
+}

--- a/Python/Product/Cookiecutter/Commands/UpdateCommand.cs
+++ b/Python/Product/Cookiecutter/Commands/UpdateCommand.cs
@@ -1,0 +1,54 @@
+// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABLITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System;
+using Microsoft.CookiecutterTools.Infrastructure;
+
+namespace Microsoft.CookiecutterTools.Commands {
+    /// <summary>
+    /// Provides the command for opening the cookiecutter window.
+    /// </summary>
+    class UpdateCommand : Command {
+        private CookiecutterToolWindow _window;
+
+        public UpdateCommand(CookiecutterToolWindow window) {
+            _window = window;
+        }
+
+        public override void DoCommand(object sender, EventArgs args) {
+            _window.UpdateSelection();
+        }
+
+        public string Description {
+            get {
+                return "Cookiecutter";
+            }
+        }
+
+        public override EventHandler BeforeQueryStatus {
+            get {
+                return (sender, args) => {
+                    var oleMenuCmd = (Microsoft.VisualStudio.Shell.OleMenuCommand)sender;
+                    oleMenuCmd.Enabled = (_window.CanUpdateSelection());
+                };
+            }
+        }
+
+        public override int CommandId {
+            get { return (int)PackageIds.cmdidUpdateTemplate; }
+        }
+    }
+}

--- a/Python/Product/Cookiecutter/Cookiecutter.cs
+++ b/Python/Product/Cookiecutter/Cookiecutter.cs
@@ -32,6 +32,8 @@ namespace Microsoft.CookiecutterTools
         public const int cmdidLinkGitHubWiki = 0x1006;
         public const int cmdidCreateFromCookiecutter = 0x1007;
         public const int cmdidAddFromCookiecutter = 0x1008;
+        public const int cmdidUpdateTemplate = 0x1009;
+        public const int cmdidCheckForUpdates = 0x1010;
         public const int ContextMenu = 0x0065;
         public const int WindowToolBarId = 0x2000;
         public const int ToolbarNavGroup = 0x3000;

--- a/Python/Product/Cookiecutter/Cookiecutter.cs
+++ b/Python/Product/Cookiecutter/Cookiecutter.cs
@@ -33,7 +33,7 @@ namespace Microsoft.CookiecutterTools
         public const int cmdidCreateFromCookiecutter = 0x1007;
         public const int cmdidAddFromCookiecutter = 0x1008;
         public const int cmdidUpdateTemplate = 0x1009;
-        public const int cmdidCheckForUpdates = 0x1010;
+        public const int cmdidCheckForUpdates = 0x100A;
         public const int ContextMenu = 0x0065;
         public const int WindowToolBarId = 0x2000;
         public const int ToolbarNavGroup = 0x3000;

--- a/Python/Product/Cookiecutter/Cookiecutter.csproj
+++ b/Python/Product/Cookiecutter/Cookiecutter.csproj
@@ -146,6 +146,9 @@
     <Compile Include="Commands\DeleteInstalledTemplateCommand.cs" />
     <Compile Include="Commands\GitHubHomeCommand.cs" />
     <Compile Include="Commands\RunCommand.cs" />
+    <Compile Include="Commands\CheckForUpdatesCommand.cs" />
+    <Compile Include="Commands\UpdateCommand.cs" />
+    <Compile Include="Model\ILocalTemplateSource.cs" />
     <Compile Include="Telemetry\DictionaryExtension.cs" />
     <Compile Include="Telemetry\ITelemetryRecorder.cs" />
     <Compile Include="Telemetry\ITelemetryService.cs" />
@@ -179,6 +182,7 @@
     <Compile Include="Telemetry\VsTelemetryService.cs" />
     <Compile Include="UrlConstants.cs" />
     <Compile Include="ViewModel\ContinuationViewModel.cs" />
+    <Compile Include="ViewModel\OperationStatus.cs" />
     <Compile Include="ViewModel\LoadingViewModel.cs" />
     <Compile Include="ViewModel\ErrorViewModel.cs" />
     <Compile Include="Model\GitHubTemplateSource.cs" />

--- a/Python/Product/Cookiecutter/Cookiecutter.vsct
+++ b/Python/Product/Cookiecutter/Cookiecutter.vsct
@@ -129,6 +129,26 @@
         </Strings>
       </Button>
 
+      <Button guid="guidCookiecutterCmdSet" id="cmdidCheckForUpdates" priority="0x0300" type="Button">
+        <Icon guid="ImageCatalogGuid" id="RunUpdate"/>
+        <CommandFlag>DefaultDisabled</CommandFlag>
+        <CommandFlag>IconIsMoniker</CommandFlag>
+        <Strings>
+          <ButtonText>Check for Updates</ButtonText>
+          <MenuText>&amp;Check for Updates</MenuText>
+        </Strings>
+      </Button>
+
+      <Button guid="guidCookiecutterCmdSet" id="cmdidUpdateTemplate" priority="0x0400" type="Button">
+        <Icon guid="ImageCatalogGuid" id="Download"/>
+        <CommandFlag>DefaultDisabled</CommandFlag>
+        <CommandFlag>IconIsMoniker</CommandFlag>
+        <Strings>
+          <ButtonText>Update</ButtonText>
+          <MenuText>&amp;Update</MenuText>
+        </Strings>
+      </Button>
+
       <Button guid="guidCookiecutterCmdSet" id="cmdidLinkGitHubHome" priority="0x0100" type="Button">
         <Icon guid="ImageCatalogGuid" id="BrowserLink"/>
         <CommandFlag>DefaultDisabled</CommandFlag>
@@ -176,6 +196,12 @@
     <CommandPlacement guid="guidVSStd97" id="cmdidDelete" priority="0x300">
       <Parent guid="guidCookiecutterCmdSet" id="ToolbarNavGroup"/>
     </CommandPlacement>
+    <CommandPlacement guid="guidCookiecutterCmdSet" id="cmdidCheckForUpdates" priority="0x400">
+      <Parent guid="guidCookiecutterCmdSet" id="ToolbarNavGroup"/>
+    </CommandPlacement>
+    <CommandPlacement guid="guidCookiecutterCmdSet" id="cmdidUpdateTemplate" priority="0x500">
+      <Parent guid="guidCookiecutterCmdSet" id="ToolbarNavGroup"/>
+    </CommandPlacement>
     <CommandPlacement guid="guidCookiecutterCmdSet" id="cmdidLinkGitHubHome" priority="0x100">
         <Parent guid="guidCookiecutterCmdSet" id="ToolbarLinksGroup"/>
     </CommandPlacement>
@@ -193,6 +219,12 @@
       <Parent guid="guidCookiecutterCmdSet" id="ContextNavGroup"/>
     </CommandPlacement>
     <CommandPlacement guid="guidVSStd97" id="cmdidDelete" priority="0x300">
+      <Parent guid="guidCookiecutterCmdSet" id="ContextNavGroup"/>
+    </CommandPlacement>
+    <CommandPlacement guid="guidCookiecutterCmdSet" id="cmdidCheckForUpdates" priority="0x400">
+      <Parent guid="guidCookiecutterCmdSet" id="ContextNavGroup"/>
+    </CommandPlacement>
+    <CommandPlacement guid="guidCookiecutterCmdSet" id="cmdidUpdateTemplate" priority="0x500">
       <Parent guid="guidCookiecutterCmdSet" id="ContextNavGroup"/>
     </CommandPlacement>
     <CommandPlacement guid="guidCookiecutterCmdSet" id="cmdidLinkGitHubHome" priority="0x100">
@@ -239,6 +271,8 @@
       <IDSymbol name="cmdidLinkGitHubWiki" value="0x1006" />
       <IDSymbol name="cmdidCreateFromCookiecutter" value ="0x1007"/>
       <IDSymbol name="cmdidAddFromCookiecutter" value ="0x1008"/>
+      <IDSymbol name="cmdidUpdateTemplate" value ="0x1009"/>
+      <IDSymbol name="cmdidCheckForUpdates" value ="0x1010"/>
 
       <!-- Context Menus -->
       <IDSymbol name="ContextMenu" value="101"/>

--- a/Python/Product/Cookiecutter/Cookiecutter.vsct
+++ b/Python/Product/Cookiecutter/Cookiecutter.vsct
@@ -272,7 +272,7 @@
       <IDSymbol name="cmdidCreateFromCookiecutter" value ="0x1007"/>
       <IDSymbol name="cmdidAddFromCookiecutter" value ="0x1008"/>
       <IDSymbol name="cmdidUpdateTemplate" value ="0x1009"/>
-      <IDSymbol name="cmdidCheckForUpdates" value ="0x1010"/>
+      <IDSymbol name="cmdidCheckForUpdates" value ="0x100a"/>
 
       <!-- Context Menus -->
       <IDSymbol name="ContextMenu" value="101"/>

--- a/Python/Product/Cookiecutter/CookiecutterOptionPage.cs
+++ b/Python/Product/Cookiecutter/CookiecutterOptionPage.cs
@@ -15,18 +15,15 @@
 // permissions and limitations under the License.
 
 using System;
-using System.Collections.Generic;
 using System.ComponentModel;
-using System.Linq;
 using System.Runtime.InteropServices;
-using System.Text;
-using System.Threading.Tasks;
 using Microsoft.VisualStudio.Shell;
 
 namespace Microsoft.CookiecutterTools {
     [Guid("BDB4E0B1-4869-4A6F-AD55-5230B768261D")]
     public class CookiecutterOptionPage : DialogPage {
         private bool _showHelp = true;
+        private bool _checkForTemplateUpdate = true;
         private string _feedUrl = UrlConstants.DefaultRecommendedFeed;
 
         public CookiecutterOptionPage() {
@@ -46,6 +43,14 @@ namespace Microsoft.CookiecutterTools {
         public string FeedUrl {
             get { return _feedUrl; }
             set { _feedUrl = value; }
+        }
+
+        [Category("General")]
+        [DisplayName("Check for Template Update")]
+        [Description("Automatically check online for updates to installed templates.")]
+        public bool CheckForTemplateUpdate {
+            get { return _checkForTemplateUpdate; }
+            set { _checkForTemplateUpdate = value; }
         }
     }
 }

--- a/Python/Product/Cookiecutter/CookiecutterPackage.cs
+++ b/Python/Product/Cookiecutter/CookiecutterPackage.cs
@@ -172,5 +172,18 @@ namespace Microsoft.CookiecutterTools {
                 page.SaveSettingsToStorage();
             }
         }
+
+        internal bool CheckForTemplateUpdate {
+            get {
+                var page = (CookiecutterOptionPage)GetDialogPage(typeof(CookiecutterOptionPage));
+                return page.CheckForTemplateUpdate;
+            }
+
+            set {
+                var page = (CookiecutterOptionPage)GetDialogPage(typeof(CookiecutterOptionPage));
+                page.CheckForTemplateUpdate = value;
+                page.SaveSettingsToStorage();
+            }
+        }
     }
 }

--- a/Python/Product/Cookiecutter/CookiecutterToolWindow.cs
+++ b/Python/Product/Cookiecutter/CookiecutterToolWindow.cs
@@ -84,7 +84,7 @@ namespace Microsoft.CookiecutterTools {
                 _cookiecutterControl = new CookiecutterControl(_outputWindow, CookiecutterTelemetry.Current, new Uri(feedUrl), OpenGeneratedFolder, UpdateCommandUI);
                 _cookiecutterControl.ContextMenuRequested += OnContextMenuRequested;
                 control = _cookiecutterControl;
-                _cookiecutterControl.InitializeAsync(CookiecutterPackage.Instance.CheckForTemplateUpdate).DoNotWait();
+                _cookiecutterControl.InitializeAsync(CookiecutterPackage.Instance.CheckForTemplateUpdate).HandleAllExceptions(this, GetType()).DoNotWait();
             }
 
             Content = control;

--- a/Python/Product/Cookiecutter/CookiecutterToolWindow.cs
+++ b/Python/Product/Cookiecutter/CookiecutterToolWindow.cs
@@ -84,6 +84,7 @@ namespace Microsoft.CookiecutterTools {
                 _cookiecutterControl = new CookiecutterControl(_outputWindow, CookiecutterTelemetry.Current, new Uri(feedUrl), OpenGeneratedFolder, UpdateCommandUI);
                 _cookiecutterControl.ContextMenuRequested += OnContextMenuRequested;
                 control = _cookiecutterControl;
+                _cookiecutterControl.InitializeAsync(CookiecutterPackage.Instance.CheckForTemplateUpdate).DoNotWait();
             }
 
             Content = control;

--- a/Python/Product/Cookiecutter/CookiecutterToolWindow.cs
+++ b/Python/Product/Cookiecutter/CookiecutterToolWindow.cs
@@ -33,11 +33,11 @@ using Microsoft.VisualStudio.Shell.Interop;
 namespace Microsoft.CookiecutterTools {
     [Guid("AC207EBF-16F8-4AA4-A0A8-70AF37308FCD")]
     sealed class CookiecutterToolWindow : ToolWindowPane, IVsInfoBarUIEvents {
-        private IServiceProvider _site;
         private Redirector _outputWindow;
         private IVsStatusbar _statusBar;
         private IVsUIShell _uiShell;
         private EnvDTE.DTE _dte;
+
         private CookiecutterControl _cookiecutterControl;
         private IVsInfoBarUIFactory _infoBarFactory;
         private IVsInfoBarUIElement _infoBar;
@@ -62,14 +62,12 @@ namespace Microsoft.CookiecutterTools {
         }
 
         protected override void OnCreate() {
-            _site = (IServiceProvider)this;
-
-            _outputWindow = OutputWindowRedirector.GetGeneral(CookiecutterPackage.Instance);
+            _outputWindow = OutputWindowRedirector.GetGeneral(this);
             Debug.Assert(_outputWindow != null);
-            _statusBar = _site.GetService(typeof(SVsStatusbar)) as IVsStatusbar;
-            _uiShell = _site.GetService(typeof(SVsUIShell)) as IVsUIShell;
-            _dte = _site.GetService(typeof(EnvDTE.DTE)) as EnvDTE.DTE;
-            _infoBarFactory = _site.GetService(typeof(SVsInfoBarUIFactory)) as IVsInfoBarUIFactory;
+            _statusBar = GetService(typeof(SVsStatusbar)) as IVsStatusbar;
+            _uiShell = GetService(typeof(SVsUIShell)) as IVsUIShell;
+            _dte = GetService(typeof(EnvDTE.DTE)) as EnvDTE.DTE;
+            _infoBarFactory = GetService(typeof(SVsInfoBarUIFactory)) as IVsInfoBarUIFactory;
 
             object control = null;
 
@@ -93,6 +91,8 @@ namespace Microsoft.CookiecutterTools {
             RegisterCommands(new Command[] {
                 new HomeCommand(this),
                 new RunCommand(this),
+                new UpdateCommand(this),
+                new CheckForUpdatesCommand(this),
                 new GitHubCommand(this, PackageIds.cmdidLinkGitHubHome),
                 new GitHubCommand(this, PackageIds.cmdidLinkGitHubIssues),
                 new GitHubCommand(this, PackageIds.cmdidLinkGitHubWiki),
@@ -232,6 +232,22 @@ namespace Microsoft.CookiecutterTools {
 
         internal bool CanRunSelection() {
             return _cookiecutterControl != null ? _cookiecutterControl.CanRunSelection() : false;
+        }
+
+        internal void CheckForUpdates() {
+            _cookiecutterControl?.CheckForUpdates();
+        }
+
+        internal bool CanCheckForUpdates() {
+            return _cookiecutterControl != null ? _cookiecutterControl.CanCheckForUpdates() : false;
+        }
+
+        internal void UpdateSelection() {
+            _cookiecutterControl?.UpdateSelection();
+        }
+
+        internal bool CanUpdateSelection() {
+            return _cookiecutterControl != null ? _cookiecutterControl.CanUpdateSelection() : false;
         }
 
         private void OnContextMenuRequested(object sender, PointEventArgs e) {

--- a/Python/Product/Cookiecutter/Model/CookiecutterClient.cs
+++ b/Python/Product/Cookiecutter/Model/CookiecutterClient.cs
@@ -176,6 +176,8 @@ namespace Microsoft.CookiecutterTools.Model {
                 var r = new ProcessOutputResult() {
                     ExeFileName = interpreterPath,
                     ExitCode = output.ExitCode,
+                    StandardOutputLines = output.StandardOutputLines?.ToArray(),
+                    StandardErrorLines = output.StandardErrorLines?.ToArray(),
                 };
 
                 // All our python scripts will return 0 if successful

--- a/Python/Product/Cookiecutter/Model/CookiecutterClient.cs
+++ b/Python/Product/Cookiecutter/Model/CookiecutterClient.cs
@@ -21,7 +21,6 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.CookiecutterTools.Infrastructure;
-using Microsoft.VisualStudio.Shell;
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.CookiecutterTools.Model {
@@ -29,6 +28,7 @@ namespace Microsoft.CookiecutterTools.Model {
         private readonly CookiecutterPythonInterpreter _interpreter;
         private readonly string _envFolderPath;
         private readonly string _envInterpreterPath;
+        private readonly Redirector _redirector;
 
         public bool CookiecutterInstalled {
             get {
@@ -40,11 +40,12 @@ namespace Microsoft.CookiecutterTools.Model {
             }
         }
 
-        public CookiecutterClient(CookiecutterPythonInterpreter interpreter) {
+        public CookiecutterClient(CookiecutterPythonInterpreter interpreter, Redirector redirector) {
             _interpreter = interpreter;
             var localAppDataFolderPath = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
             _envFolderPath = Path.Combine(localAppDataFolderPath, "Microsoft", "CookiecutterTools", "env");
             _envInterpreterPath = Path.Combine(_envFolderPath, "scripts", "python.exe");
+            _redirector = redirector;
         }
 
         public async Task<bool> IsCookiecutterInstalled() {
@@ -61,29 +62,29 @@ namespace Microsoft.CookiecutterTools.Model {
             }
         }
 
-        public async Task<ProcessOutputResult> CreateCookiecutterEnv() {
+        public async Task CreateCookiecutterEnv() {
             // Create a virtual environment using the global interpreter
             var interpreterPath = _interpreter.InterpreterExecutablePath;
             var output = ProcessOutput.RunHiddenAndCapture(interpreterPath, "-m", "venv", _envFolderPath);
 
-            return await WaitForOutput(interpreterPath, output);
+            await WaitForOutput(interpreterPath, output);
         }
 
-        public async Task<ProcessOutputResult> InstallPackage() {
+        public async Task InstallPackage() {
             // Install the package into the virtual environment
             var output = ProcessOutput.RunHiddenAndCapture(_envInterpreterPath, "-m", "pip", "install", "cookiecutter<1.5");
 
-            return await WaitForOutput(_envInterpreterPath, output);
+            await WaitForOutput(_envInterpreterPath, output);
         }
 
-        public async Task<Tuple<ContextItem[], ProcessOutputResult>> LoadContextAsync(string localTemplateFolder, string userConfigFilePath) {
+        public async Task<ContextItem[]> LoadContextAsync(string localTemplateFolder, string userConfigFilePath) {
             if (localTemplateFolder == null) {
                 throw new ArgumentNullException(nameof(localTemplateFolder));
             }
 
             var items = new List<ContextItem>();
 
-            var result = await RunGenerateContextScript(_envInterpreterPath, localTemplateFolder, userConfigFilePath);
+            var result = await RunGenerateContextScript(_redirector, _envInterpreterPath, localTemplateFolder, userConfigFilePath);
             var contextJson = string.Join(Environment.NewLine, result.StandardOutputLines);
             var context = (JToken)JObject.Parse(contextJson).SelectToken("cookiecutter");
             if (context != null) {
@@ -107,10 +108,10 @@ namespace Microsoft.CookiecutterTools.Model {
                 }
             }
 
-            return Tuple.Create(items.ToArray(), result);
+            return items.ToArray();
         }
 
-        public async Task<ProcessOutputResult> GenerateProjectAsync(string localTemplateFolder, string userConfigFilePath, string contextFilePath, string outputFolderPath) {
+        public async Task GenerateProjectAsync(string localTemplateFolder, string userConfigFilePath, string contextFilePath, string outputFolderPath) {
             if (localTemplateFolder == null) {
                 throw new ArgumentNullException(nameof(localTemplateFolder));
             }
@@ -126,15 +127,13 @@ namespace Microsoft.CookiecutterTools.Model {
             string tempFolder = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
             Directory.CreateDirectory(tempFolder);
 
-            var result = await RunRunScript(_envInterpreterPath, localTemplateFolder, userConfigFilePath, tempFolder, contextFilePath);
+            var result = await RunRunScript(_redirector, _envInterpreterPath, localTemplateFolder, userConfigFilePath, tempFolder, contextFilePath);
             MoveToDesiredFolder(outputFolderPath, tempFolder);
-
-            return result;
         }
 
-        private static async Task<ProcessOutputResult> RunGenerateContextScript(string interpreterPath, string templateFolderPath, string userConfigFilePath) {
+        private static async Task<ProcessOutputResult> RunGenerateContextScript(Redirector redirector, string interpreterPath, string templateFolderPath, string userConfigFilePath) {
             var scriptPath = PythonToolsInstallPath.GetFile("cookiecutter_load.py");
-            return await RunPythonScript(interpreterPath, scriptPath, string.Format("\"{0}\" \"{1}\"", templateFolderPath, userConfigFilePath));
+            return await RunPythonScript(redirector, interpreterPath, scriptPath, string.Format("\"{0}\" \"{1}\"", templateFolderPath, userConfigFilePath));
         }
 
         private static async Task<ProcessOutputResult> RunCheckScript(string interpreterPath) {
@@ -143,25 +142,31 @@ namespace Microsoft.CookiecutterTools.Model {
             return await WaitForOutput(interpreterPath, output);
         }
 
-        private static async Task<ProcessOutputResult> RunRunScript(string interpreterPath, string templateFolderPath, string userConfigFilePath, string outputFolderPath, string contextPath) {
+        private static async Task<ProcessOutputResult> RunRunScript(Redirector redirector, string interpreterPath, string templateFolderPath, string userConfigFilePath, string outputFolderPath, string contextPath) {
             var scriptPath = PythonToolsInstallPath.GetFile("cookiecutter_run.py");
-            return await RunPythonScript(interpreterPath, scriptPath, GetRunArguments(templateFolderPath, userConfigFilePath, outputFolderPath, contextPath));
+            return await RunPythonScript(redirector, interpreterPath, scriptPath, GetRunArguments(templateFolderPath, userConfigFilePath, outputFolderPath, contextPath));
         }
 
         private static string GetRunArguments(string templateFolderPath, string userConfigFilePath, string outputFolderPath, string contextFilePath) {
             return string.Format("\"{0}\" \"{1}\" \"{2}\" \"{3}\"", contextFilePath, templateFolderPath, outputFolderPath, userConfigFilePath);
         }
 
-        private static async Task<ProcessOutputResult> RunPythonScript(string interpreterPath, string script, string parameters, bool showWindow = false) {
+        private static async Task<ProcessOutputResult> RunPythonScript(Redirector redirector, string interpreterPath, string script, string parameters) {
+            var outputLines = new List<string>();
+            var errorLines = new List<string>();
+
             ProcessOutput output = null;
             var arguments = string.Format("\"{0}\" {1}", script, parameters);
-            if (showWindow) {
-                output = ProcessOutput.RunVisible(interpreterPath, arguments);
-            } else {
-                output = ProcessOutput.RunHiddenAndCapture(interpreterPath, arguments);
-            }
+            var listRedirector = new ListRedirector(outputLines, errorLines);
+            var outerRedirector = new TeeRedirector(redirector, listRedirector);
 
-            return await WaitForOutput(interpreterPath, output);
+            output = ProcessOutput.Run(interpreterPath, new string[] { arguments }, null, null, false, outerRedirector);
+
+            var result = await WaitForOutput(interpreterPath, output);
+            result.StandardOutputLines = outputLines.ToArray();
+            result.StandardErrorLines = errorLines.ToArray();
+
+            return result;
         }
 
         private static async Task<ProcessOutputResult> WaitForOutput(string interpreterPath, ProcessOutput output) {
@@ -171,8 +176,6 @@ namespace Microsoft.CookiecutterTools.Model {
                 var r = new ProcessOutputResult() {
                     ExeFileName = interpreterPath,
                     ExitCode = output.ExitCode,
-                    StandardOutputLines = output.StandardOutputLines.ToArray(),
-                    StandardErrorLines = output.StandardErrorLines.ToArray(),
                 };
 
                 // All our python scripts will return 0 if successful

--- a/Python/Product/Cookiecutter/Model/CookiecutterClientProvider.cs
+++ b/Python/Product/Cookiecutter/Model/CookiecutterClientProvider.cs
@@ -18,14 +18,15 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using Microsoft.CookiecutterTools.Infrastructure;
 using Microsoft.CookiecutterTools.Interpreters;
 
 namespace Microsoft.CookiecutterTools.Model {
     static class CookiecutterClientProvider {
-        public static ICookiecutterClient Create() {
+        public static ICookiecutterClient Create(Redirector redirector) {
             var interpreter = FindCompatibleInterpreter();
             if (interpreter != null) {
-                return new CookiecutterClient(interpreter);
+                return new CookiecutterClient(interpreter, redirector);
             }
 
             return null;

--- a/Python/Product/Cookiecutter/Model/GitClient.cs
+++ b/Python/Product/Cookiecutter/Model/GitClient.cs
@@ -87,8 +87,7 @@ namespace Microsoft.CookiecutterTools.Model {
             }
 
             var arguments = new string[] { "clone", repoUrl };
-            var output = ProcessOutput.Run(_gitExeFilePath, arguments, targetParentFolderPath, null, false, _redirector);
-            using (output) {
+            using (var output = ProcessOutput.Run(_gitExeFilePath, arguments, targetParentFolderPath, null, false, _redirector)) {
                 await output;
 
                 var r = new ProcessOutputResult() {
@@ -110,8 +109,7 @@ namespace Microsoft.CookiecutterTools.Model {
 
         public async Task<string> GetRemoteOriginAsync(string repoFolderPath) {
             var arguments = new string[] { "remote", "-v" };
-            var output = ProcessOutput.Run(_gitExeFilePath, arguments, repoFolderPath, null, false, null);
-            using (output) {
+            using (var output = ProcessOutput.Run(_gitExeFilePath, arguments, repoFolderPath, null, false, null)) {
                 await output;
                 foreach (var remote in output.StandardOutputLines) {
                     string origin;
@@ -129,8 +127,7 @@ namespace Microsoft.CookiecutterTools.Model {
                 arguments.Add(branch);
             }
 
-            var output = ProcessOutput.Run(_gitExeFilePath, arguments, repoFolderPath, null, false, null);
-            using (output) {
+            using (var output = ProcessOutput.Run(_gitExeFilePath, arguments, repoFolderPath, null, false, null)) {
                 await output;
                 foreach (var line in output.StandardOutputLines) {
                     // Line with date starts with 'Date'. Example:
@@ -150,10 +147,8 @@ namespace Microsoft.CookiecutterTools.Model {
 
         public async Task FetchAsync(string repoFolderPath) {
             var arguments = new string[] { "fetch" };
-            var output = ProcessOutput.Run(_gitExeFilePath, arguments, repoFolderPath, null, false, _redirector);
-            using (output) {
-                await output;
-                if (output.ExitCode < 0) {
+            using (var output = ProcessOutput.Run(_gitExeFilePath, arguments, repoFolderPath, null, false, _redirector)) {
+                if (await output < 0) {
                     throw new ProcessException(new ProcessOutputResult() {
                         ExeFileName = _gitExeFilePath,
                         ExitCode = output.ExitCode,
@@ -164,10 +159,8 @@ namespace Microsoft.CookiecutterTools.Model {
 
         public async Task MergeAsync(string repoFolderPath) {
             var arguments = new string[] { "merge" };
-            var output = ProcessOutput.Run(_gitExeFilePath, arguments, repoFolderPath, null, false, _redirector);
-            using (output) {
-                await output;
-                if (output.ExitCode < 0) {
+            using (var output = ProcessOutput.Run(_gitExeFilePath, arguments, repoFolderPath, null, false, _redirector)) {
+                if (await output < 0) {
                     throw new ProcessException(new ProcessOutputResult() {
                         ExeFileName = _gitExeFilePath,
                         ExitCode = output.ExitCode,

--- a/Python/Product/Cookiecutter/Model/ICookiecutterClient.cs
+++ b/Python/Product/Cookiecutter/Model/ICookiecutterClient.cs
@@ -16,14 +16,15 @@
 
 using System;
 using System.Threading.Tasks;
+using Microsoft.CookiecutterTools.Infrastructure;
 
 namespace Microsoft.CookiecutterTools.Model {
     interface ICookiecutterClient {
         bool CookiecutterInstalled { get; }
         Task<bool> IsCookiecutterInstalled();
-        Task<ProcessOutputResult> CreateCookiecutterEnv();
-        Task<ProcessOutputResult> InstallPackage();
-        Task<Tuple<ContextItem[], ProcessOutputResult>> LoadContextAsync(string localTemplateFolder, string userConfigFilePath);
-        Task<ProcessOutputResult> GenerateProjectAsync(string localTemplateFolder, string userConfigFilePath, string contextFilePath, string outputFolderPath);
+        Task CreateCookiecutterEnv();
+        Task InstallPackage();
+        Task<ContextItem[]> LoadContextAsync(string localTemplateFolder, string userConfigFilePath);
+        Task GenerateProjectAsync(string localTemplateFolder, string userConfigFilePath, string contextFilePath, string outputFolderPath);
     }
 }

--- a/Python/Product/Cookiecutter/Model/IGitClient.cs
+++ b/Python/Product/Cookiecutter/Model/IGitClient.cs
@@ -16,13 +16,14 @@
 
 using System;
 using System.Threading.Tasks;
+using Microsoft.CookiecutterTools.Infrastructure;
 
 namespace Microsoft.CookiecutterTools.Model {
     interface IGitClient {
-        Task<Tuple<string, ProcessOutputResult>> CloneAsync(string repoUrl, string targetParentFolderPath);
+        Task<string> CloneAsync(string repoUrl, string targetParentFolderPath);
         Task<string> GetRemoteOriginAsync(string repoFolderPath);
         Task<DateTime?> GetLastCommitDateAsync(string repoFolderPath, string branch = null);
-        Task<ProcessOutputResult> FetchAsync(string repoFolderPath);
-        Task<ProcessOutputResult> MergeAsync(string repoFolderPath);
+        Task FetchAsync(string repoFolderPath);
+        Task MergeAsync(string repoFolderPath);
     }
 }

--- a/Python/Product/Cookiecutter/Model/ILocalTemplateSource.cs
+++ b/Python/Product/Cookiecutter/Model/ILocalTemplateSource.cs
@@ -17,11 +17,12 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CookiecutterTools.Infrastructure;
 
 namespace Microsoft.CookiecutterTools.Model {
     interface ILocalTemplateSource : ITemplateSource {
         Task DeleteTemplateAsync(string repoPath);
-        Task<Tuple<bool?, ProcessOutputResult>> CheckForUpdateAsync(string repoPath);
-        Task<ProcessOutputResult> UpdateTemplateAsync(string repoPath);
+        Task<bool?> CheckForUpdateAsync(string repoPath);
+        Task UpdateTemplateAsync(string repoPath);
     }
 }

--- a/Python/Product/Cookiecutter/Model/ILocalTemplateSource.cs
+++ b/Python/Product/Cookiecutter/Model/ILocalTemplateSource.cs
@@ -24,5 +24,6 @@ namespace Microsoft.CookiecutterTools.Model {
         Task DeleteTemplateAsync(string repoPath);
         Task<bool?> CheckForUpdateAsync(string repoPath);
         Task UpdateTemplateAsync(string repoPath);
+        Task AddTemplateAsync(string repoPath);
     }
 }

--- a/Python/Product/Cookiecutter/Model/ILocalTemplateSource.cs
+++ b/Python/Product/Cookiecutter/Model/ILocalTemplateSource.cs
@@ -15,14 +15,13 @@
 // permissions and limitations under the License.
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.CookiecutterTools.Model {
-    interface IGitClient {
-        Task<Tuple<string, ProcessOutputResult>> CloneAsync(string repoUrl, string targetParentFolderPath);
-        Task<string> GetRemoteOriginAsync(string repoFolderPath);
-        Task<DateTime?> GetLastCommitDateAsync(string repoFolderPath, string branch = null);
-        Task<ProcessOutputResult> FetchAsync(string repoFolderPath);
-        Task<ProcessOutputResult> MergeAsync(string repoFolderPath);
+    interface ILocalTemplateSource : ITemplateSource {
+        Task DeleteTemplateAsync(string repoPath);
+        Task<Tuple<bool?, ProcessOutputResult>> CheckForUpdateAsync(string repoPath);
+        Task<ProcessOutputResult> UpdateTemplateAsync(string repoPath);
     }
 }

--- a/Python/Product/Cookiecutter/Model/ITemplateSource.cs
+++ b/Python/Product/Cookiecutter/Model/ITemplateSource.cs
@@ -20,6 +20,5 @@ using System.Threading.Tasks;
 namespace Microsoft.CookiecutterTools.Model {
     interface ITemplateSource {
         Task<TemplateEnumerationResult> GetTemplatesAsync(string filter, string continuationToken, CancellationToken cancellationToken);
-        void InvalidateCache();
     }
 }

--- a/Python/Product/Cookiecutter/Model/LocalTemplateSource.cs
+++ b/Python/Product/Cookiecutter/Model/LocalTemplateSource.cs
@@ -52,19 +52,29 @@ namespace Microsoft.CookiecutterTools.Model {
             return new TemplateEnumerationResult(templates.OrderBy(t => t.Name).ToList());
         }
 
-        public Task DeleteTemplateAsync(string repoPath) {
+        public async Task DeleteTemplateAsync(string repoPath) {
+            if (_cache == null) {
+                await BuildCacheAsync();
+            }
+
             ShellUtils.DeleteDirectory(repoPath);
 
             _cache.RemoveAll(t => t.LocalFolderPath == repoPath);
-
-            return Task.CompletedTask;
         }
 
         public async Task AddTemplateAsync(string repoPath) {
-            await AddFolderToCache(repoPath);
+            if (_cache == null) {
+                await BuildCacheAsync();
+            } else {
+                await AddFolderToCache(repoPath);
+            }
         }
 
         public async Task UpdateTemplateAsync(string repoPath) {
+            if (_cache == null) {
+                await BuildCacheAsync();
+            }
+
             await _gitClient.MergeAsync(repoPath);
 
             var template = _cache.SingleOrDefault(t => t.LocalFolderPath == repoPath);

--- a/Python/Product/Cookiecutter/Model/LocalTemplateSource.cs
+++ b/Python/Product/Cookiecutter/Model/LocalTemplateSource.cs
@@ -64,18 +64,16 @@ namespace Microsoft.CookiecutterTools.Model {
             return Task.CompletedTask;
         }
 
-        public async Task<ProcessOutputResult> UpdateTemplateAsync(string repoPath) {
-            var res = await _gitClient.MergeAsync(repoPath);
+        public async Task UpdateTemplateAsync(string repoPath) {
+            await _gitClient.MergeAsync(repoPath);
 
             var template = _cache.SingleOrDefault(t => t.LocalFolderPath == repoPath);
             if (template != null) {
                 template.ClonedLastUpdate = await _gitClient.GetLastCommitDateAsync(template.LocalFolderPath);
             }
-
-            return res;
         }
 
-        public async Task<Tuple<bool?, ProcessOutputResult>> CheckForUpdateAsync(string repoPath) {
+        public async Task<bool?> CheckForUpdateAsync(string repoPath) {
             if (_cache == null) {
                 await BuildCacheAsync();
             }
@@ -85,7 +83,7 @@ namespace Microsoft.CookiecutterTools.Model {
                 return null;
             }
 
-            var res = await _gitClient.FetchAsync(template.LocalFolderPath);
+            await _gitClient.FetchAsync(template.LocalFolderPath);
 
             template.ClonedLastUpdate = await _gitClient.GetLastCommitDateAsync(template.LocalFolderPath);
             template.RemoteLastUpdate = await _gitClient.GetLastCommitDateAsync(template.LocalFolderPath, "origin/master");
@@ -94,7 +92,7 @@ namespace Microsoft.CookiecutterTools.Model {
                 var span = template.RemoteLastUpdate - template.ClonedLastUpdate;
             }
 
-            return Tuple.Create(template.UpdateAvailable, res);
+            return template.UpdateAvailable;
         }
 
         private async Task BuildCacheAsync() {

--- a/Python/Product/Cookiecutter/Model/ProcessException.cs
+++ b/Python/Product/Cookiecutter/Model/ProcessException.cs
@@ -15,6 +15,7 @@
 // permissions and limitations under the License.
 
 using System;
+using System.Globalization;
 using System.Threading.Tasks;
 
 namespace Microsoft.CookiecutterTools.Model {
@@ -22,7 +23,8 @@ namespace Microsoft.CookiecutterTools.Model {
     class ProcessException : Exception {
         public ProcessOutputResult Result { get; }
 
-        public ProcessException(ProcessOutputResult result) {
+        public ProcessException(ProcessOutputResult result) :
+            base(string.Format(CultureInfo.CurrentUICulture, Strings.ProcessExitCodeMessage, result.ExeFileName, result.ExitCode)) {
             Result = result;
         }
     }

--- a/Python/Product/Cookiecutter/Model/Template.cs
+++ b/Python/Product/Cookiecutter/Model/Template.cs
@@ -14,6 +14,8 @@
 // See the Apache Version 2.0 License for specific language governing
 // permissions and limitations under the License.
 
+using System;
+
 namespace Microsoft.CookiecutterTools.Model {
     class Template {
         public Template() {
@@ -27,6 +29,18 @@ namespace Microsoft.CookiecutterTools.Model {
         public string RemoteUrl { get; set; }
         public string LocalFolderPath { get; set; }
         public string Description { get; set; }
+        public DateTime? ClonedLastUpdate { get; set; }
+        public DateTime? RemoteLastUpdate { get; set; }
+        public bool? UpdateAvailable {
+            get {
+                if (RemoteLastUpdate.HasValue && ClonedLastUpdate.HasValue) {
+                    var span = RemoteLastUpdate - ClonedLastUpdate;
+                    return span.Value.TotalMinutes > 2;
+                }
+
+                return null;
+            }
+        }
 
         public Template Clone() {
             return (Template)MemberwiseClone();

--- a/Python/Product/Cookiecutter/Strings.Designer.cs
+++ b/Python/Product/Cookiecutter/Strings.Designer.cs
@@ -61,7 +61,9 @@ namespace Microsoft.CookiecutterTools {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to ----- Failed to check for updates -----.
+        ///   Looks up a localized string similar to 
+        ///----- Failed to check for updates -----
+        ///.
         /// </summary>
         internal static string CheckingForAllUpdatesFailed {
             get {
@@ -70,7 +72,9 @@ namespace Microsoft.CookiecutterTools {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to ----- Checking for updates -----.
+        ///   Looks up a localized string similar to 
+        ///----- Checking for updates -----
+        ///.
         /// </summary>
         internal static string CheckingForAllUpdatesStarted {
             get {
@@ -79,7 +83,9 @@ namespace Microsoft.CookiecutterTools {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to ----- Successfully checked for updates -----.
+        ///   Looks up a localized string similar to 
+        ///----- Successfully checked for updates -----
+        ///.
         /// </summary>
         internal static string CheckingForAllUpdatesSuccess {
             get {
@@ -124,7 +130,9 @@ namespace Microsoft.CookiecutterTools {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to ----- Checking for update to template &apos;{0}&apos; from &apos;{1}&apos; -----.
+        ///   Looks up a localized string similar to 
+        ///----- Checking for update to template &apos;{0}&apos; from &apos;{1}&apos; -----
+        ///.
         /// </summary>
         internal static string CheckingTemplateUpdateStarted {
             get {
@@ -144,7 +152,9 @@ namespace Microsoft.CookiecutterTools {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to ----- Failed to clone template &apos;{0}&apos; -----.
+        ///   Looks up a localized string similar to 
+        ///----- Failed to clone template &apos;{0}&apos; -----
+        ///.
         /// </summary>
         internal static string CloningTemplateFailed {
             get {
@@ -153,7 +163,9 @@ namespace Microsoft.CookiecutterTools {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to ----- Cloning template &apos;{0}&apos; -----.
+        ///   Looks up a localized string similar to 
+        ///----- Cloning template &apos;{0}&apos; -----
+        ///.
         /// </summary>
         internal static string CloningTemplateStarted {
             get {
@@ -162,7 +174,9 @@ namespace Microsoft.CookiecutterTools {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to ----- Successfully cloned template &apos;{0}&apos; to &apos;{1}&apos; -----.
+        ///   Looks up a localized string similar to 
+        ///----- Successfully cloned template &apos;{0}&apos; to &apos;{1}&apos; -----
+        ///.
         /// </summary>
         internal static string CloningTemplateSuccess {
             get {
@@ -182,7 +196,9 @@ namespace Microsoft.CookiecutterTools {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to ----- Failed to delete template &apos;{0}&apos; -----.
+        ///   Looks up a localized string similar to 
+        ///----- Failed to delete template &apos;{0}&apos; -----
+        ///.
         /// </summary>
         internal static string DeletingTemplateFailed {
             get {
@@ -191,7 +207,9 @@ namespace Microsoft.CookiecutterTools {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to ----- Deleting template &apos;{0}&apos; -----.
+        ///   Looks up a localized string similar to 
+        ///----- Deleting template &apos;{0}&apos; -----
+        ///.
         /// </summary>
         internal static string DeletingTemplateStarted {
             get {
@@ -200,7 +218,9 @@ namespace Microsoft.CookiecutterTools {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to ----- Successfully deleted template &apos;{0}&apos; -----.
+        ///   Looks up a localized string similar to 
+        ///----- Successfully deleted template &apos;{0}&apos; -----
+        ///.
         /// </summary>
         internal static string DeletingTemplateSuccess {
             get {
@@ -254,7 +274,9 @@ namespace Microsoft.CookiecutterTools {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to ----- Failed to install cookiecutter -----.
+        ///   Looks up a localized string similar to 
+        ///----- Failed to install cookiecutter -----
+        ///.
         /// </summary>
         internal static string InstallingCookiecutterFailed {
             get {
@@ -263,7 +285,9 @@ namespace Microsoft.CookiecutterTools {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to ----- Installing cookiecutter -----.
+        ///   Looks up a localized string similar to 
+        ///----- Installing cookiecutter -----
+        ///.
         /// </summary>
         internal static string InstallingCookiecutterStarted {
             get {
@@ -272,7 +296,9 @@ namespace Microsoft.CookiecutterTools {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to ----- Successfully installed cookiecutter -----.
+        ///   Looks up a localized string similar to 
+        ///----- Successfully installed cookiecutter -----
+        ///.
         /// </summary>
         internal static string InstallingCookiecutterSuccess {
             get {
@@ -299,7 +325,9 @@ namespace Microsoft.CookiecutterTools {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to ----- Failed to load template &apos;{0}&apos; -----.
+        ///   Looks up a localized string similar to 
+        ///----- Failed to load template &apos;{0}&apos; -----
+        ///.
         /// </summary>
         internal static string LoadingTemplateFailed {
             get {
@@ -308,7 +336,9 @@ namespace Microsoft.CookiecutterTools {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to ----- Loading template &apos;{0}&apos; -----.
+        ///   Looks up a localized string similar to 
+        ///----- Loading template &apos;{0}&apos; -----
+        ///.
         /// </summary>
         internal static string LoadingTemplateStarted {
             get {
@@ -317,7 +347,9 @@ namespace Microsoft.CookiecutterTools {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to ----- Successfully loaded template &apos;{0}&apos; -----.
+        ///   Looks up a localized string similar to 
+        ///----- Successfully loaded template &apos;{0}&apos; -----
+        ///.
         /// </summary>
         internal static string LoadingTemplateSuccess {
             get {
@@ -371,7 +403,9 @@ namespace Microsoft.CookiecutterTools {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to ----- Failed to created files using template &apos;{0}&apos; -----.
+        ///   Looks up a localized string similar to 
+        ///----- Failed to create files using template &apos;{0}&apos; -----
+        ///.
         /// </summary>
         internal static string RunningTemplateFailed {
             get {
@@ -380,7 +414,9 @@ namespace Microsoft.CookiecutterTools {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to ----- Creating files using template &apos;{0}&apos; -----.
+        ///   Looks up a localized string similar to 
+        ///----- Creating files using template &apos;{0}&apos; -----
+        ///.
         /// </summary>
         internal static string RunningTemplateStarted {
             get {
@@ -389,7 +425,9 @@ namespace Microsoft.CookiecutterTools {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to ----- Successfully created files using template &apos;{0}&apos; into &apos;{1}&apos; -----.
+        ///   Looks up a localized string similar to 
+        ///----- Successfully created files using template &apos;{0}&apos; into &apos;{1}&apos; -----
+        ///.
         /// </summary>
         internal static string RunningTemplateSuccess {
             get {
@@ -464,7 +502,9 @@ namespace Microsoft.CookiecutterTools {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to ----- Failed to update template &apos;{0}&apos; -----.
+        ///   Looks up a localized string similar to 
+        ///----- Failed to update template &apos;{0}&apos; -----
+        ///.
         /// </summary>
         internal static string UpdatingTemplateFailed {
             get {
@@ -473,7 +513,9 @@ namespace Microsoft.CookiecutterTools {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to ----- Updating template &apos;{0}&apos; -----.
+        ///   Looks up a localized string similar to 
+        ///----- Updating template &apos;{0}&apos; -----
+        ///.
         /// </summary>
         internal static string UpdatingTemplateStarted {
             get {
@@ -482,7 +524,9 @@ namespace Microsoft.CookiecutterTools {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to ----- Successfully updated template &apos;{0}&apos; -----.
+        ///   Looks up a localized string similar to 
+        ///----- Successfully updated template &apos;{0}&apos; -----
+        ///.
         /// </summary>
         internal static string UpdatingTemplateSuccess {
             get {

--- a/Python/Product/Cookiecutter/Strings.Designer.cs
+++ b/Python/Product/Cookiecutter/Strings.Designer.cs
@@ -62,7 +62,7 @@ namespace Microsoft.CookiecutterTools {
         
         /// <summary>
         ///   Looks up a localized string similar to 
-        ///----- Check for updates canceled -----
+        ///----- Check for template updates canceled -----
         ///.
         /// </summary>
         internal static string CheckingForAllUpdatesCanceled {
@@ -73,7 +73,7 @@ namespace Microsoft.CookiecutterTools {
         
         /// <summary>
         ///   Looks up a localized string similar to 
-        ///----- Failed to check for updates -----
+        ///----- Failed to check for template updates -----
         ///.
         /// </summary>
         internal static string CheckingForAllUpdatesFailed {
@@ -84,7 +84,7 @@ namespace Microsoft.CookiecutterTools {
         
         /// <summary>
         ///   Looks up a localized string similar to 
-        ///----- Checking for updates -----
+        ///----- Checking for template updates -----
         ///.
         /// </summary>
         internal static string CheckingForAllUpdatesStarted {
@@ -95,7 +95,7 @@ namespace Microsoft.CookiecutterTools {
         
         /// <summary>
         ///   Looks up a localized string similar to 
-        ///----- Successfully checked for updates -----
+        ///----- Successfully checked for template updates -----
         ///.
         /// </summary>
         internal static string CheckingForAllUpdatesSuccess {
@@ -105,7 +105,7 @@ namespace Microsoft.CookiecutterTools {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Error checking for update..
+        ///   Looks up a localized string similar to Error checking for an update..
         /// </summary>
         internal static string CheckingTemplateUpdateError {
             get {

--- a/Python/Product/Cookiecutter/Strings.Designer.cs
+++ b/Python/Product/Cookiecutter/Strings.Designer.cs
@@ -62,6 +62,17 @@ namespace Microsoft.CookiecutterTools {
         
         /// <summary>
         ///   Looks up a localized string similar to 
+        ///----- Check for updates canceled -----
+        ///.
+        /// </summary>
+        internal static string CheckingForAllUpdatesCanceled {
+            get {
+                return ResourceManager.GetString("CheckingForAllUpdatesCanceled", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to 
         ///----- Failed to check for updates -----
         ///.
         /// </summary>

--- a/Python/Product/Cookiecutter/Strings.Designer.cs
+++ b/Python/Product/Cookiecutter/Strings.Designer.cs
@@ -61,6 +61,78 @@ namespace Microsoft.CookiecutterTools {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to ----- Failed to check for updates -----.
+        /// </summary>
+        internal static string CheckingForAllUpdatesFailed {
+            get {
+                return ResourceManager.GetString("CheckingForAllUpdatesFailed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to ----- Checking for updates -----.
+        /// </summary>
+        internal static string CheckingForAllUpdatesStarted {
+            get {
+                return ResourceManager.GetString("CheckingForAllUpdatesStarted", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to ----- Successfully checked for updates -----.
+        /// </summary>
+        internal static string CheckingForAllUpdatesSuccess {
+            get {
+                return ResourceManager.GetString("CheckingForAllUpdatesSuccess", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Error checking for update..
+        /// </summary>
+        internal static string CheckingTemplateUpdateError {
+            get {
+                return ResourceManager.GetString("CheckingTemplateUpdateError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to An update is available..
+        /// </summary>
+        internal static string CheckingTemplateUpdateFound {
+            get {
+                return ResourceManager.GetString("CheckingTemplateUpdateFound", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Could not determine if an update is available..
+        /// </summary>
+        internal static string CheckingTemplateUpdateInconclusive {
+            get {
+                return ResourceManager.GetString("CheckingTemplateUpdateInconclusive", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Template is already up-to-date..
+        /// </summary>
+        internal static string CheckingTemplateUpdateNotFound {
+            get {
+                return ResourceManager.GetString("CheckingTemplateUpdateNotFound", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to ----- Checking for update to template &apos;{0}&apos; from &apos;{1}&apos; -----.
+        /// </summary>
+        internal static string CheckingTemplateUpdateStarted {
+            get {
+                return ResourceManager.GetString("CheckingTemplateUpdateStarted", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to A different template with the name &apos;{0}&apos; already exists in &apos;{1}&apos;.
         ///
         ///Please delete the installed template and try again..
@@ -388,6 +460,33 @@ namespace Microsoft.CookiecutterTools {
         internal static string UnhandledException {
             get {
                 return ResourceManager.GetString("UnhandledException", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to ----- Failed to update template &apos;{0}&apos; -----.
+        /// </summary>
+        internal static string UpdatingTemplateFailed {
+            get {
+                return ResourceManager.GetString("UpdatingTemplateFailed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to ----- Updating template &apos;{0}&apos; -----.
+        /// </summary>
+        internal static string UpdatingTemplateStarted {
+            get {
+                return ResourceManager.GetString("UpdatingTemplateStarted", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to ----- Successfully updated template &apos;{0}&apos; -----.
+        /// </summary>
+        internal static string UpdatingTemplateSuccess {
+            get {
+                return ResourceManager.GetString("UpdatingTemplateSuccess", resourceCulture);
             }
         }
     }

--- a/Python/Product/Cookiecutter/Strings.resx
+++ b/Python/Product/Cookiecutter/Strings.resx
@@ -259,6 +259,11 @@ Please delete the installed template and try again.</value>
 ----- Failed to check for updates -----
 </value>
   </data>
+  <data name="CheckingForAllUpdatesCanceled" xml:space="preserve">
+    <value>
+----- Check for updates canceled -----
+</value>
+  </data>
   <data name="CheckingTemplateUpdateStarted" xml:space="preserve">
     <value>
 ----- Checking for update to template '{0}' from '{1}' -----

--- a/Python/Product/Cookiecutter/Strings.resx
+++ b/Python/Product/Cookiecutter/Strings.resx
@@ -246,22 +246,22 @@ Please delete the installed template and try again.</value>
   </data>
   <data name="CheckingForAllUpdatesStarted" xml:space="preserve">
     <value>
------ Checking for updates -----
+----- Checking for template updates -----
 </value>
   </data>
   <data name="CheckingForAllUpdatesSuccess" xml:space="preserve">
     <value>
------ Successfully checked for updates -----
+----- Successfully checked for template updates -----
 </value>
   </data>
   <data name="CheckingForAllUpdatesFailed" xml:space="preserve">
     <value>
------ Failed to check for updates -----
+----- Failed to check for template updates -----
 </value>
   </data>
   <data name="CheckingForAllUpdatesCanceled" xml:space="preserve">
     <value>
------ Check for updates canceled -----
+----- Check for template updates canceled -----
 </value>
   </data>
   <data name="CheckingTemplateUpdateStarted" xml:space="preserve">
@@ -276,7 +276,7 @@ Please delete the installed template and try again.</value>
     <value>Template is already up-to-date.</value>
   </data>
   <data name="CheckingTemplateUpdateError" xml:space="preserve">
-    <value>Error checking for update.</value>
+    <value>Error checking for an update.</value>
   </data>
   <data name="CheckingTemplateUpdateInconclusive" xml:space="preserve">
     <value>Could not determine if an update is available.</value>

--- a/Python/Product/Cookiecutter/Strings.resx
+++ b/Python/Product/Cookiecutter/Strings.resx
@@ -170,61 +170,99 @@ You can get more information by running Visual Studio with the /log parameter on
 Please delete the installed template and try again.</value>
   </data>
   <data name="InstallingCookiecutterStarted" xml:space="preserve">
-    <value>----- Installing cookiecutter -----</value>
+    <value>
+----- Installing cookiecutter -----
+</value>
   </data>
   <data name="InstallingCookiecutterSuccess" xml:space="preserve">
-    <value>----- Successfully installed cookiecutter -----</value>
+    <value>
+----- Successfully installed cookiecutter -----
+</value>
   </data>
   <data name="InstallingCookiecutterFailed" xml:space="preserve">
-    <value>----- Failed to install cookiecutter -----</value>
+    <value>
+----- Failed to install cookiecutter -----
+</value>
   </data>
   <data name="CloningTemplateStarted" xml:space="preserve">
-    <value>----- Cloning template '{0}' -----</value>
+    <value>
+----- Cloning template '{0}' -----
+</value>
   </data>
   <data name="CloningTemplateSuccess" xml:space="preserve">
-    <value>----- Successfully cloned template '{0}' to '{1}' -----</value>
+    <value>
+----- Successfully cloned template '{0}' to '{1}' -----
+</value>
   </data>
   <data name="CloningTemplateFailed" xml:space="preserve">
-    <value>----- Failed to clone template '{0}' -----</value>
+    <value>
+----- Failed to clone template '{0}' -----
+</value>
   </data>
   <data name="LoadingTemplateStarted" xml:space="preserve">
-    <value>----- Loading template '{0}' -----</value>
+    <value>
+----- Loading template '{0}' -----
+</value>
   </data>
   <data name="LoadingTemplateSuccess" xml:space="preserve">
-    <value>----- Successfully loaded template '{0}' -----</value>
+    <value>
+----- Successfully loaded template '{0}' -----
+</value>
   </data>
   <data name="LoadingTemplateFailed" xml:space="preserve">
-    <value>----- Failed to load template '{0}' -----</value>
+    <value>
+----- Failed to load template '{0}' -----
+</value>
   </data>
   <data name="RunningTemplateStarted" xml:space="preserve">
-    <value>----- Creating files using template '{0}' -----</value>
+    <value>
+----- Creating files using template '{0}' -----
+</value>
   </data>
   <data name="RunningTemplateSuccess" xml:space="preserve">
-    <value>----- Successfully created files using template '{0}' into '{1}' -----</value>
+    <value>
+----- Successfully created files using template '{0}' into '{1}' -----
+</value>
   </data>
   <data name="RunningTemplateFailed" xml:space="preserve">
-    <value>----- Failed to created files using template '{0}' -----</value>
+    <value>
+----- Failed to create files using template '{0}' -----
+</value>
   </data>
   <data name="DeletingTemplateStarted" xml:space="preserve">
-    <value>----- Deleting template '{0}' -----</value>
+    <value>
+----- Deleting template '{0}' -----
+</value>
   </data>
   <data name="DeletingTemplateSuccess" xml:space="preserve">
-    <value>----- Successfully deleted template '{0}' -----</value>
+    <value>
+----- Successfully deleted template '{0}' -----
+</value>
   </data>
   <data name="DeletingTemplateFailed" xml:space="preserve">
-    <value>----- Failed to delete template '{0}' -----</value>
+    <value>
+----- Failed to delete template '{0}' -----
+</value>
   </data>
   <data name="CheckingForAllUpdatesStarted" xml:space="preserve">
-    <value>----- Checking for updates -----</value>
+    <value>
+----- Checking for updates -----
+</value>
   </data>
   <data name="CheckingForAllUpdatesSuccess" xml:space="preserve">
-    <value>----- Successfully checked for updates -----</value>
+    <value>
+----- Successfully checked for updates -----
+</value>
   </data>
   <data name="CheckingForAllUpdatesFailed" xml:space="preserve">
-    <value>----- Failed to check for updates -----</value>
+    <value>
+----- Failed to check for updates -----
+</value>
   </data>
   <data name="CheckingTemplateUpdateStarted" xml:space="preserve">
-    <value>----- Checking for update to template '{0}' from '{1}' -----</value>
+    <value>
+----- Checking for update to template '{0}' from '{1}' -----
+</value>
   </data>
   <data name="CheckingTemplateUpdateFound" xml:space="preserve">
     <value>An update is available.</value>
@@ -239,13 +277,19 @@ Please delete the installed template and try again.</value>
     <value>Could not determine if an update is available.</value>
   </data>
   <data name="UpdatingTemplateStarted" xml:space="preserve">
-    <value>----- Updating template '{0}' -----</value>
+    <value>
+----- Updating template '{0}' -----
+</value>
   </data>
   <data name="UpdatingTemplateSuccess" xml:space="preserve">
-    <value>----- Successfully updated template '{0}' -----</value>
+    <value>
+----- Successfully updated template '{0}' -----
+</value>
   </data>
   <data name="UpdatingTemplateFailed" xml:space="preserve">
-    <value>----- Failed to update template '{0}' -----</value>
+    <value>
+----- Failed to update template '{0}' -----
+</value>
   </data>
   <data name="TemplateCategoryInstalled" xml:space="preserve">
     <value>Installed</value>

--- a/Python/Product/Cookiecutter/Strings.resx
+++ b/Python/Product/Cookiecutter/Strings.resx
@@ -214,6 +214,39 @@ Please delete the installed template and try again.</value>
   <data name="DeletingTemplateFailed" xml:space="preserve">
     <value>----- Failed to delete template '{0}' -----</value>
   </data>
+  <data name="CheckingForAllUpdatesStarted" xml:space="preserve">
+    <value>----- Checking for updates -----</value>
+  </data>
+  <data name="CheckingForAllUpdatesSuccess" xml:space="preserve">
+    <value>----- Successfully checked for updates -----</value>
+  </data>
+  <data name="CheckingForAllUpdatesFailed" xml:space="preserve">
+    <value>----- Failed to check for updates -----</value>
+  </data>
+  <data name="CheckingTemplateUpdateStarted" xml:space="preserve">
+    <value>----- Checking for update to template '{0}' from '{1}' -----</value>
+  </data>
+  <data name="CheckingTemplateUpdateFound" xml:space="preserve">
+    <value>An update is available.</value>
+  </data>
+  <data name="CheckingTemplateUpdateNotFound" xml:space="preserve">
+    <value>Template is already up-to-date.</value>
+  </data>
+  <data name="CheckingTemplateUpdateError" xml:space="preserve">
+    <value>Error checking for update.</value>
+  </data>
+  <data name="CheckingTemplateUpdateInconclusive" xml:space="preserve">
+    <value>Could not determine if an update is available.</value>
+  </data>
+  <data name="UpdatingTemplateStarted" xml:space="preserve">
+    <value>----- Updating template '{0}' -----</value>
+  </data>
+  <data name="UpdatingTemplateSuccess" xml:space="preserve">
+    <value>----- Successfully updated template '{0}' -----</value>
+  </data>
+  <data name="UpdatingTemplateFailed" xml:space="preserve">
+    <value>----- Failed to update template '{0}' -----</value>
+  </data>
   <data name="TemplateCategoryInstalled" xml:space="preserve">
     <value>Installed</value>
   </data>

--- a/Python/Product/Cookiecutter/Telemetry/CookiecutterTelemetry.cs
+++ b/Python/Product/Cookiecutter/Telemetry/CookiecutterTelemetry.cs
@@ -40,6 +40,7 @@ namespace Microsoft.CookiecutterTools.Telemetry {
         internal class SearchEvents {
             public const string Load = "Load";
             public const string More = "More";
+            public const string CheckUpdate = "CheckUpdate";
         }
 
         internal class TemplateEvents {
@@ -47,6 +48,7 @@ namespace Microsoft.CookiecutterTools.Telemetry {
             public const string Load = "Load";
             public const string Run = "Run";
             public const string Delete = "Delete";
+            public const string Update = "Update";
         }
 
         public static void Initialize(ITelemetryService service = null) {

--- a/Python/Product/Cookiecutter/View/CookiecutterControl.xaml.cs
+++ b/Python/Product/Cookiecutter/View/CookiecutterControl.xaml.cs
@@ -176,6 +176,30 @@ namespace Microsoft.CookiecutterTools.View {
             _searchPage.LoadTemplate();
         }
 
+        internal bool CanUpdateSelection() {
+            return PageSequence.CurrentPosition == 0 && ViewModel.SelectedTemplate != null && ViewModel.SelectedTemplate.IsUpdateAvailable == true;
+        }
+
+        internal void UpdateSelection() {
+            if (!CanUpdateSelection()) {
+                return;
+            }
+
+            _searchPage.UpdateTemplate();
+        }
+
+        internal bool CanCheckForUpdates() {
+            return PageSequence.CurrentPosition == 0;
+        }
+
+        internal void CheckForUpdates() {
+            if (!CanCheckForUpdates()) {
+                return;
+            }
+
+            _searchPage.CheckForUpdates();
+        }
+
         private void UserControl_MouseRightButtonUp(object sender, MouseButtonEventArgs e) {
             var element = (FrameworkElement)sender;
             var point = element.PointToScreen(GetPosition(e, element));

--- a/Python/Product/Cookiecutter/View/CookiecutterControl.xaml.cs
+++ b/Python/Product/Cookiecutter/View/CookiecutterControl.xaml.cs
@@ -49,10 +49,10 @@ namespace Microsoft.CookiecutterTools.View {
             _updateCommandUI = updateCommandUI;
 
             string gitExeFilePath = GitClient.RecommendedGitFilePath;
-            var gitClient = new GitClient(gitExeFilePath);
+            var gitClient = new GitClient(gitExeFilePath, outputWindow);
             var gitHubClient = new GitHubClient();
             ViewModel = new CookiecutterViewModel(
-                CookiecutterClientProvider.Create(),
+                CookiecutterClientProvider.Create(outputWindow),
                 gitHubClient,
                 gitClient,
                 telemetry,

--- a/Python/Product/Cookiecutter/View/CookiecutterControl.xaml.cs
+++ b/Python/Product/Cookiecutter/View/CookiecutterControl.xaml.cs
@@ -97,10 +97,12 @@ namespace Microsoft.CookiecutterTools.View {
 
         private void ViewModel_HomeClicked(object sender, EventArgs e) {
             PageSequence.MoveCurrentToFirst();
+            _updateCommandUI();
         }
 
         private void ViewModel_ContextLoaded(object sender, EventArgs e) {
             PageSequence.MoveCurrentToLast();
+            _updateCommandUI();
         }
 
         public CookiecutterViewModel ViewModel {
@@ -143,6 +145,7 @@ namespace Microsoft.CookiecutterTools.View {
 
         internal void Home() {
             ViewModel.Reset();
+            _updateCommandUI();
         }
 
         internal bool CanDeleteSelection() {

--- a/Python/Product/Cookiecutter/View/CookiecutterControl.xaml.cs
+++ b/Python/Product/Cookiecutter/View/CookiecutterControl.xaml.cs
@@ -146,11 +146,11 @@ namespace Microsoft.CookiecutterTools.View {
         }
 
         internal bool CanDeleteSelection() {
-            return PageSequence.CurrentPosition == 0 && Directory.Exists(ViewModel.SelectedTemplate?.ClonedPath);
+            return PageSequence.CurrentPosition == 0 && ViewModel.CanDeleteSelectedTemplate;
         }
 
         internal bool CanNavigateToGitHub() {
-            return PageSequence.CurrentPosition == 0 && !string.IsNullOrEmpty(ViewModel.SelectedTemplate?.GitHubHomeUrl);
+            return PageSequence.CurrentPosition == 0 && ViewModel.CanNavigateToGitHub;
         }
 
         internal void DeleteSelection() {
@@ -165,7 +165,7 @@ namespace Microsoft.CookiecutterTools.View {
         }
 
         internal bool CanRunSelection() {
-            return PageSequence.CurrentPosition == 0 && ViewModel.SelectedTemplate != null;
+            return PageSequence.CurrentPosition == 0 && ViewModel.CanRunSelectedTemplate;
         }
 
         internal void RunSelection() {
@@ -177,7 +177,7 @@ namespace Microsoft.CookiecutterTools.View {
         }
 
         internal bool CanUpdateSelection() {
-            return PageSequence.CurrentPosition == 0 && ViewModel.SelectedTemplate != null && ViewModel.SelectedTemplate.IsUpdateAvailable == true;
+            return PageSequence.CurrentPosition == 0 && ViewModel.CanUpdateSelectedTemplate;
         }
 
         internal void UpdateSelection() {
@@ -189,7 +189,7 @@ namespace Microsoft.CookiecutterTools.View {
         }
 
         internal bool CanCheckForUpdates() {
-            return PageSequence.CurrentPosition == 0;
+            return PageSequence.CurrentPosition == 0 && ViewModel.CanCheckForUpdates;
         }
 
         internal void CheckForUpdates() {

--- a/Python/Product/Cookiecutter/View/CookiecutterControlDesignData.xaml
+++ b/Python/Product/Cookiecutter/View/CookiecutterControlDesignData.xaml
@@ -17,7 +17,8 @@
             RemoteUrl="https://github.com/brettcannon/python-azure-web-app-cookiecutter"/>
                 <vm:TemplateViewModel
             DisplayName="azure-batch-cookiecutter"
-            RemoteUrl="https://github.com/Azure/azure-batch-cookiecutter"/>
+            RemoteUrl="https://github.com/Azure/azure-batch-cookiecutter"
+            IsUpdateAvailable="True"/>
                 <vm:TemplateViewModel
             DisplayName="azure-hdinsight-eventhubs-cookiecutter"
             RemoteUrl="https://github.com/Azure/azure-hdinsight-eventhubs-cookiecutter"/>

--- a/Python/Product/Cookiecutter/View/CookiecutterOptionsPage.xaml
+++ b/Python/Product/Cookiecutter/View/CookiecutterOptionsPage.xaml
@@ -10,6 +10,7 @@
       xmlns:imaging="clr-namespace:Microsoft.VisualStudio.Imaging;assembly=Microsoft.VisualStudio.Imaging"
       xmlns:img="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Imaging"
       xmlns:imagecatalog="clr-namespace:Microsoft.VisualStudio.Imaging;assembly=Microsoft.VisualStudio.ImageCatalog"
+      wpf:LambdaProperties.ImportedNamespaces="System.Windows Microsoft.CookiecutterTools Microsoft.CookiecutterTools.ViewModel"
       mc:Ignorable="d" 
       d:DataContext="{Binding Source={d:DesignData Source=CookiecutterControlDesignData.xaml}}"
       d:DesignHeight="600" d:DesignWidth="300"
@@ -51,6 +52,9 @@
                                                                Watermark="{Binding Default}" />
                         </StackPanel>
                     </DataTemplate>
+                    <wpf:Lambda x:Key="OperationStatusInProgressToVisibleOrCollapsed">(OperationStatus s) => s == OperationStatus.InProgress ? Visibility.Visible : Visibility.Collapsed</wpf:Lambda>
+                    <wpf:Lambda x:Key="OperationStatusFailedToVisibleOrCollapsed">(OperationStatus s) => s == OperationStatus.Failed ? Visibility.Visible : Visibility.Collapsed</wpf:Lambda>
+                    <wpf:Lambda x:Key="OperationStatusSucceededToVisibleOrCollapsed">(OperationStatus s) => s == OperationStatus.Succeeded ? Visibility.Visible : Visibility.Collapsed</wpf:Lambda>
                     <wpf:Lambda x:Key="BoolToVisibleOrCollapsed">(bool b) => b ? Visibility.Visible : Visibility.Collapsed</wpf:Lambda>
                     <wpf:Lambda x:Key="BoolToVisible">(bool b) => b ? Visibility.Visible : Visibility.Hidden</wpf:Lambda>
                     <wpf:Lambda x:Key="BoolToNotVisible">(bool b) => b ? Visibility.Hidden : Visibility.Visible</wpf:Lambda>
@@ -66,7 +70,7 @@
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
         <StackPanel Grid.Row="0" Margin="4" Orientation="Vertical">
-            <StackPanel Margin="4 4 4 8" Orientation="Horizontal" Visibility="{Binding IsCloningSuccess, Converter={StaticResource BoolToVisibleOrCollapsed}}">
+            <StackPanel Margin="4 4 4 8" Orientation="Horizontal" Visibility="{Binding CloningStatus, Converter={StaticResource OperationStatusSucceededToVisibleOrCollapsed}}">
                 <imaging:CrispImage Width="16" Height="16" Moniker="{x:Static imagecatalog:KnownMonikers.StatusOK}"/>
                 <TextBlock Margin="4 0 0 0" Text="Template cloned successfully."/>
             </StackPanel>
@@ -117,14 +121,14 @@
 
             <StackPanel Margin="4 4 4 8"
                         Orientation="Vertical"
-                        Visibility="{Binding Path=IsCreating, Converter={StaticResource BoolToVisibleOrCollapsed}}">
+                        Visibility="{Binding Path=CreatingStatus, Converter={StaticResource OperationStatusInProgressToVisibleOrCollapsed}}">
                 <TextBlock Text="Creating files..."/>
                 <ProgressBar Margin="4" IsIndeterminate="True"/>
             </StackPanel>
 
             <StackPanel Margin="4 4 4 8"
                         Orientation="Horizontal"
-                        Visibility="{Binding Path=IsCreatingError, Converter={StaticResource BoolToVisibleOrCollapsed}}">
+                        Visibility="{Binding Path=CreatingStatus, Converter={StaticResource OperationStatusFailedToVisibleOrCollapsed}}">
                 <imaging:CrispImage Width="16" Height="16" Moniker="{x:Static imagecatalog:KnownMonikers.StatusError}"/>
                 <TextBlock Margin="4 0 0 0" TextWrapping="Wrap" Text="Error creating files. See output window for details."/>
             </StackPanel>

--- a/Python/Product/Cookiecutter/View/CookiecutterOptionsPage.xaml.cs
+++ b/Python/Product/Cookiecutter/View/CookiecutterOptionsPage.xaml.cs
@@ -41,7 +41,7 @@ namespace Microsoft.CookiecutterTools.View {
         }
 
         private void Home_CanExecute(object sender, CanExecuteRoutedEventArgs e) {
-            e.CanExecute = ViewModel != null && !ViewModel.IsCreating;
+            e.CanExecute = ViewModel != null && ViewModel.CreatingStatus != OperationStatus.InProgress;
             e.Handled = true;
         }
 
@@ -50,7 +50,7 @@ namespace Microsoft.CookiecutterTools.View {
         }
 
         private void CreateFiles_CanExecute(object sender, CanExecuteRoutedEventArgs e) {
-            e.CanExecute = ViewModel != null && !ViewModel.IsCreating && ViewModel.SelectedTemplate != null;
+            e.CanExecute = ViewModel != null && ViewModel.CreatingStatus != OperationStatus.InProgress && ViewModel.SelectedTemplate != null;
             e.Handled = true;
         }
 

--- a/Python/Product/Cookiecutter/View/CookiecutterOptionsPage.xaml.cs
+++ b/Python/Product/Cookiecutter/View/CookiecutterOptionsPage.xaml.cs
@@ -50,7 +50,7 @@ namespace Microsoft.CookiecutterTools.View {
         }
 
         private void CreateFiles_CanExecute(object sender, CanExecuteRoutedEventArgs e) {
-            e.CanExecute = ViewModel != null && ViewModel.CreatingStatus != OperationStatus.InProgress && ViewModel.SelectedTemplate != null;
+            e.CanExecute = ViewModel?.CanRunSelectedTemplate == true;
             e.Handled = true;
         }
 

--- a/Python/Product/Cookiecutter/View/CookiecutterSearchPage.xaml
+++ b/Python/Product/Cookiecutter/View/CookiecutterSearchPage.xaml
@@ -9,7 +9,7 @@
       xmlns:imaging="clr-namespace:Microsoft.VisualStudio.Imaging;assembly=Microsoft.VisualStudio.Imaging"
       xmlns:img="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Imaging"
       xmlns:imagecatalog="clr-namespace:Microsoft.VisualStudio.Imaging;assembly=Microsoft.VisualStudio.ImageCatalog"
-      wpf:LambdaProperties.ImportedNamespaces="System.Windows Microsoft.CookiecutterTools"
+      wpf:LambdaProperties.ImportedNamespaces="System.Windows Microsoft.CookiecutterTools Microsoft.CookiecutterTools.ViewModel"
       mc:Ignorable="d" 
       d:DataContext="{Binding Source={d:DesignData Source=CookiecutterControlDesignData.xaml}}"
       d:DesignHeight="550" d:DesignWidth="300"
@@ -54,6 +54,9 @@
                             <TextBlock Grid.Column="0" Text="{Binding Path=DisplayName}"/>
                         </Grid>
                     </DataTemplate>
+                    <wpf:Lambda x:Key="OperationStatusInProgressToVisibleOrCollapsed">(OperationStatus s) => s == OperationStatus.InProgress ? Visibility.Visible : Visibility.Collapsed</wpf:Lambda>
+                    <wpf:Lambda x:Key="OperationStatusFailedToVisibleOrCollapsed">(OperationStatus s) => s == OperationStatus.Failed ? Visibility.Visible : Visibility.Collapsed</wpf:Lambda>
+                    <wpf:Lambda x:Key="OperationStatusSucceededToVisibleOrCollapsed">(OperationStatus s) => s == OperationStatus.Succeeded ? Visibility.Visible : Visibility.Collapsed</wpf:Lambda>
                     <wpf:Lambda x:Key="BoolToVisibleOrCollapsed">(bool b) => b ? Visibility.Visible : Visibility.Collapsed</wpf:Lambda>
                     <wpf:Lambda x:Key="BoolToVisible">(bool b) => b ? Visibility.Visible : Visibility.Hidden</wpf:Lambda>
                     <wpf:Lambda x:Key="BoolToNotVisible">(bool b) => b ? Visibility.Hidden : Visibility.Visible</wpf:Lambda>
@@ -87,7 +90,7 @@
         </Grid.RowDefinitions>
 
         <!-- Created successfully -->
-        <StackPanel Grid.Row="0" Orientation="Vertical" Visibility="{Binding Path=IsCreatingSuccess, Converter={StaticResource BoolToVisibleOrCollapsed}}">
+        <StackPanel Grid.Row="0" Orientation="Vertical" Visibility="{Binding Path=CreatingStatus, Converter={StaticResource OperationStatusSucceededToVisibleOrCollapsed}}">
             <StackPanel Margin="4 4 4 8"
                         Orientation="Horizontal">
                 <imaging:CrispImage Width="16" Height="16" Moniker="{x:Static imagecatalog:KnownMonikers.StatusOK}"/>
@@ -154,6 +157,14 @@
                         <imaging:CrispImage Width="16" Height="16"
                                             Margin="0 0 0 2"
                                             Moniker="{Binding Path=Image}">
+                        </imaging:CrispImage>
+                        <imaging:CrispImage Width="16" Height="16"
+                                            Margin="0 0 0 2"
+                                            Visibility="{Binding Path=IsUpdateAvailable, Converter={StaticResource BoolToVisibleOrCollapsed}}"
+                                            Moniker="{x:Static imagecatalog:KnownMonikers.Download}">
+                            <imaging:CrispImage.ToolTip>
+                                <TextBlock TextWrapping="Wrap" Text="An update is available"/>
+                            </imaging:CrispImage.ToolTip>
                         </imaging:CrispImage>
                         <TextBlock Margin="4 0 0 0"
                                    Style="{StaticResource TreeViewItemTextBlock}"
@@ -233,7 +244,7 @@
 
             <StackPanel Margin="4 4 4 8"
                         Orientation="Vertical"
-                        Visibility="{Binding Path=IsInstalling, Converter={StaticResource BoolToVisibleOrCollapsed}}">
+                        Visibility="{Binding Path=InstallingStatus, Converter={StaticResource OperationStatusInProgressToVisibleOrCollapsed}}">
                 <Separator/>
                 <TextBlock Text="Installing cookiecutter..."/>
                 <ProgressBar Margin="4" IsIndeterminate="True"/>
@@ -241,14 +252,14 @@
 
             <StackPanel Margin="4 4 4 8"
                         Orientation="Horizontal"
-                        Visibility="{Binding Path=IsInstallingError, Converter={StaticResource BoolToVisibleOrCollapsed}}">
+                        Visibility="{Binding Path=InstallingStatus, Converter={StaticResource OperationStatusFailedToVisibleOrCollapsed}}">
                 <imaging:CrispImage Width="16" Height="16" Moniker="{x:Static imagecatalog:KnownMonikers.StatusError}"/>
                 <TextBlock Margin="4 0 0 0" TextWrapping="Wrap" Text="Error installing cookiecutter. See output window for details."/>
             </StackPanel>
 
             <StackPanel Margin="4 4 4 8"
                         Orientation="Vertical"
-                        Visibility="{Binding Path=IsCloning, Converter={StaticResource BoolToVisibleOrCollapsed}}">
+                        Visibility="{Binding Path=CloningStatus, Converter={StaticResource OperationStatusInProgressToVisibleOrCollapsed}}">
                 <Separator/>
                 <TextBlock Text="Cloning repository..."/>
                 <ProgressBar Margin="4" IsIndeterminate="True"/>
@@ -256,14 +267,14 @@
 
             <StackPanel Margin="4 4 4 8"
                         Orientation="Horizontal"
-                        Visibility="{Binding Path=IsCloningError, Converter={StaticResource BoolToVisibleOrCollapsed}}">
+                        Visibility="{Binding Path=CloningStatus, Converter={StaticResource OperationStatusFailedToVisibleOrCollapsed}}">
                 <imaging:CrispImage Width="16" Height="16" Moniker="{x:Static imagecatalog:KnownMonikers.StatusError}"/>
                 <TextBlock Margin="4 0 0 0" TextWrapping="Wrap" Text="Error cloning repository. See output window for details."/>
             </StackPanel>
 
             <StackPanel Margin="4 4 4 8"
                         Orientation="Vertical"
-                        Visibility="{Binding Path=IsLoading, Converter={StaticResource BoolToVisibleOrCollapsed}}">
+                        Visibility="{Binding Path=LoadingStatus, Converter={StaticResource OperationStatusInProgressToVisibleOrCollapsed}}">
                 <Separator/>
                 <TextBlock Text="Loading template..."/>
                 <ProgressBar Margin="4" IsIndeterminate="True"/>
@@ -271,9 +282,53 @@
 
             <StackPanel Margin="4 4 4 8"
                         Orientation="Horizontal"
-                        Visibility="{Binding Path=IsLoadingError, Converter={StaticResource BoolToVisibleOrCollapsed}}">
+                        Visibility="{Binding Path=LoadingStatus, Converter={StaticResource OperationStatusFailedToVisibleOrCollapsed}}">
                 <imaging:CrispImage Width="16" Height="16" Moniker="{x:Static imagecatalog:KnownMonikers.StatusError}"/>
                 <TextBlock Margin="4 0 0 0" TextWrapping="Wrap" Text="Error loading template. See output window for details."/>
+            </StackPanel>
+
+            <StackPanel Margin="4 4 4 8"
+                        Orientation="Vertical"
+                        Visibility="{Binding Path=CheckingUpdateStatus, Converter={StaticResource OperationStatusInProgressToVisibleOrCollapsed}}">
+                <Separator/>
+                <TextBlock Text="Checking for updates..."/>
+                <ProgressBar Margin="4" IsIndeterminate="True"/>
+            </StackPanel>
+
+            <StackPanel Margin="4 4 4 8"
+                        Orientation="Horizontal"
+                        Visibility="{Binding Path=CheckingUpdateStatus, Converter={StaticResource OperationStatusSucceededToVisibleOrCollapsed}}">
+                <imaging:CrispImage Width="16" Height="16" Moniker="{x:Static imagecatalog:KnownMonikers.StatusOK}"/>
+                <TextBlock Margin="4 0 0 0" TextWrapping="Wrap" Text="Check for updates completed."/>
+            </StackPanel>
+
+            <StackPanel Margin="4 4 4 8"
+                        Orientation="Horizontal"
+                        Visibility="{Binding Path=CheckingUpdateStatus, Converter={StaticResource OperationStatusFailedToVisibleOrCollapsed}}">
+                <imaging:CrispImage Width="16" Height="16" Moniker="{x:Static imagecatalog:KnownMonikers.StatusError}"/>
+                <TextBlock Margin="4 0 0 0" TextWrapping="Wrap" Text="Error checking for updates. See output window for details."/>
+            </StackPanel>
+
+            <StackPanel Margin="4 4 4 8"
+                        Orientation="Vertical"
+                        Visibility="{Binding Path=UpdatingStatus, Converter={StaticResource OperationStatusInProgressToVisibleOrCollapsed}}">
+                <Separator/>
+                <TextBlock Text="Updating template..."/>
+                <ProgressBar Margin="4" IsIndeterminate="True"/>
+            </StackPanel>
+
+            <StackPanel Margin="4 4 4 8"
+                        Orientation="Horizontal"
+                        Visibility="{Binding Path=UpdatingStatus, Converter={StaticResource OperationStatusSucceededToVisibleOrCollapsed}}">
+                <imaging:CrispImage Width="16" Height="16" Moniker="{x:Static imagecatalog:KnownMonikers.StatusOK}"/>
+                <TextBlock Margin="4 0 0 0" TextWrapping="Wrap" Text="Template updated."/>
+            </StackPanel>
+
+            <StackPanel Margin="4 4 4 8"
+                        Orientation="Horizontal"
+                        Visibility="{Binding Path=UpdatingStatus, Converter={StaticResource OperationStatusFailedToVisibleOrCollapsed}}">
+                <imaging:CrispImage Width="16" Height="16" Moniker="{x:Static imagecatalog:KnownMonikers.StatusError}"/>
+                <TextBlock Margin="4 0 0 0" TextWrapping="Wrap" Text="Error updating template. See output window for details."/>
             </StackPanel>
 
             <Separator Margin="4"/>

--- a/Python/Product/Cookiecutter/View/CookiecutterSearchPage.xaml.cs
+++ b/Python/Product/Cookiecutter/View/CookiecutterSearchPage.xaml.cs
@@ -75,7 +75,6 @@ namespace Microsoft.CookiecutterTools.View {
         private void OpenInExplorer_Executed(object sender, ExecutedRoutedEventArgs e) {
             var folderPath = (string)e.Parameter;
             ViewModel.OpenFolderInExplorer(folderPath);
-            Process.Start(folderPath)?.Dispose();
         }
 
         private void LoadMore_CanExecute(object sender, CanExecuteRoutedEventArgs e) {
@@ -89,7 +88,7 @@ namespace Microsoft.CookiecutterTools.View {
         }
 
         private void RunSelection_CanExecute(object sender, CanExecuteRoutedEventArgs e) {
-            e.CanExecute = ViewModel?.SelectedTemplate != null && ViewModel.CloningStatus != OperationStatus.InProgress && ViewModel.LoadingStatus != OperationStatus.InProgress;
+            e.CanExecute = ViewModel?.CanLoadSelectedTemplate == true;
             e.Handled = true;
         }
 

--- a/Python/Product/Cookiecutter/View/CookiecutterSearchPage.xaml.cs
+++ b/Python/Product/Cookiecutter/View/CookiecutterSearchPage.xaml.cs
@@ -89,7 +89,7 @@ namespace Microsoft.CookiecutterTools.View {
         }
 
         private void RunSelection_CanExecute(object sender, CanExecuteRoutedEventArgs e) {
-            e.CanExecute = ViewModel?.SelectedTemplate != null && !ViewModel.IsCloning && !ViewModel.IsLoading;
+            e.CanExecute = ViewModel?.SelectedTemplate != null && ViewModel.CloningStatus != OperationStatus.InProgress && ViewModel.LoadingStatus != OperationStatus.InProgress;
             e.Handled = true;
         }
 
@@ -139,6 +139,14 @@ namespace Microsoft.CookiecutterTools.View {
             }
 
             ViewModel.LoadTemplateAsync().DoNotWait();
+        }
+
+        public void UpdateTemplate() {
+            ViewModel.UpdateTemplateAsync().DoNotWait();
+        }
+
+        internal void CheckForUpdates() {
+            ViewModel.CheckForUpdatesAsync().DoNotWait();
         }
     }
 }

--- a/Python/Product/Cookiecutter/View/CookiecutterSearchPage.xaml.cs
+++ b/Python/Product/Cookiecutter/View/CookiecutterSearchPage.xaml.cs
@@ -113,7 +113,9 @@ namespace Microsoft.CookiecutterTools.View {
                             ViewModel.SelectedTemplate = template;
                         }
 
-                        LoadTemplate();
+                        if (ViewModel.CanLoadSelectedTemplate) {
+                            LoadTemplate();
+                        }
                     }
                 }
             }

--- a/Python/Product/Cookiecutter/ViewModel/CookiecutterViewModel.cs
+++ b/Python/Product/Cookiecutter/ViewModel/CookiecutterViewModel.cs
@@ -273,6 +273,42 @@ namespace Microsoft.CookiecutterTools.ViewModel {
             }
         }
 
+        public bool CanLoadSelectedTemplate {
+            get {
+                return SelectedTemplate != null && CloningStatus != OperationStatus.InProgress && LoadingStatus != OperationStatus.InProgress;
+            }
+        }
+
+        public bool CanRunSelectedTemplate {
+            get {
+                return SelectedTemplate != null && CreatingStatus != OperationStatus.InProgress;
+            }
+        }
+
+        public bool CanDeleteSelectedTemplate {
+            get {
+                return Directory.Exists(SelectedTemplate?.ClonedPath);
+            }
+        }
+
+        public bool CanUpdateSelectedTemplate {
+            get {
+                return SelectedTemplate != null && SelectedTemplate.IsUpdateAvailable;
+            }
+        }
+
+        public bool CanNavigateToGitHub {
+            get {
+                return !string.IsNullOrEmpty(SelectedTemplate?.GitHubHomeUrl);
+            }
+        }
+
+        public bool CanCheckForUpdates {
+            get {
+                return CheckingUpdateStatus != OperationStatus.InProgress;
+            }
+        }
+
         public bool IsOutputFolderEmpty() {
             if (Directory.Exists(OutputFolderPath)) {
                 var files = Directory.EnumerateFileSystemEntries(OutputFolderPath);

--- a/Python/Product/Cookiecutter/ViewModel/CookiecutterViewModel.cs
+++ b/Python/Product/Cookiecutter/ViewModel/CookiecutterViewModel.cs
@@ -19,7 +19,6 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Diagnostics;
-using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Net;
@@ -191,6 +190,7 @@ namespace Microsoft.CookiecutterTools.ViewModel {
                 if (value != _installingStatus) {
                     _installingStatus = value;
                     PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(InstallingStatus)));
+                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsBusy)));
                 }
             }
         }
@@ -204,6 +204,7 @@ namespace Microsoft.CookiecutterTools.ViewModel {
                 if (value != _cloningStatus) {
                     _cloningStatus = value;
                     PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(CloningStatus)));
+                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsBusy)));
                 }
             }
         }
@@ -217,6 +218,7 @@ namespace Microsoft.CookiecutterTools.ViewModel {
                 if (value != _loadingStatus) {
                     _loadingStatus = value;
                     PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(LoadingStatus)));
+                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsBusy)));
                 }
             }
         }
@@ -230,6 +232,7 @@ namespace Microsoft.CookiecutterTools.ViewModel {
                 if (value != _creatingStatus) {
                     _creatingStatus = value;
                     PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(CreatingStatus)));
+                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsBusy)));
                 }
             }
         }
@@ -243,6 +246,7 @@ namespace Microsoft.CookiecutterTools.ViewModel {
                 if (value != _checkingUpdateStatus) {
                     _checkingUpdateStatus = value;
                     PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(CheckingUpdateStatus)));
+                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsBusy)));
                 }
             }
         }
@@ -256,7 +260,19 @@ namespace Microsoft.CookiecutterTools.ViewModel {
                 if (value != _updatingStatus) {
                     _updatingStatus = value;
                     PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(UpdatingStatus)));
+                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsBusy)));
                 }
+            }
+        }
+
+        public bool IsBusy {
+            get {
+                return InstallingStatus == OperationStatus.InProgress ||
+                    CloningStatus == OperationStatus.InProgress ||
+                    LoadingStatus == OperationStatus.InProgress ||
+                    CreatingStatus == OperationStatus.InProgress ||
+                    CheckingUpdateStatus == OperationStatus.InProgress ||
+                    UpdatingStatus == OperationStatus.InProgress;
             }
         }
 
@@ -275,25 +291,25 @@ namespace Microsoft.CookiecutterTools.ViewModel {
 
         public bool CanLoadSelectedTemplate {
             get {
-                return SelectedTemplate != null && CloningStatus != OperationStatus.InProgress && LoadingStatus != OperationStatus.InProgress;
+                return SelectedTemplate != null && !IsBusy;
             }
         }
 
         public bool CanRunSelectedTemplate {
             get {
-                return SelectedTemplate != null && CreatingStatus != OperationStatus.InProgress;
+                return SelectedTemplate != null && !IsBusy;
             }
         }
 
         public bool CanDeleteSelectedTemplate {
             get {
-                return Directory.Exists(SelectedTemplate?.ClonedPath);
+                return Directory.Exists(SelectedTemplate?.ClonedPath) && !IsBusy;
             }
         }
 
         public bool CanUpdateSelectedTemplate {
             get {
-                return SelectedTemplate != null && SelectedTemplate.IsUpdateAvailable;
+                return SelectedTemplate != null && SelectedTemplate.IsUpdateAvailable && !IsBusy;
             }
         }
 
@@ -305,7 +321,7 @@ namespace Microsoft.CookiecutterTools.ViewModel {
 
         public bool CanCheckForUpdates {
             get {
-                return CheckingUpdateStatus != OperationStatus.InProgress;
+                return !IsBusy;
             }
         }
 

--- a/Python/Product/Cookiecutter/ViewModel/CookiecutterViewModel.cs
+++ b/Python/Product/Cookiecutter/ViewModel/CookiecutterViewModel.cs
@@ -482,8 +482,7 @@ namespace Microsoft.CookiecutterTools.ViewModel {
 
                     ReportTemplateEvent(CookiecutterTelemetry.TelemetryArea.Template, CookiecutterTelemetry.TemplateEvents.Clone, selection);
 
-                    // We now have a new template installed, so reload that section of the results
-                    _installedSource.InvalidateCache();
+                    await _installedSource.AddTemplateAsync(selection.ClonedPath);
 
                     _templateRefreshCancelTokenSource?.Cancel();
                     _templateRefreshCancelTokenSource = new CancellationTokenSource();
@@ -521,7 +520,6 @@ namespace Microsoft.CookiecutterTools.ViewModel {
 
                 CheckingUpdateStatus = OperationStatus.InProgress;
 
-                _outputWindow.ShowAndActivate();
                 _outputWindow.WriteLine(Strings.CheckingForAllUpdatesStarted);
 
                 bool anyError = false;
@@ -545,6 +543,10 @@ namespace Microsoft.CookiecutterTools.ViewModel {
                             installed.IsUpdateAvailable = available == true;
                         }
                     } catch (Exception ex) when (!ex.IsCriticalException()) {
+                        if (!anyError) {
+                            _outputWindow.ShowAndActivate();
+                        }
+
                         anyError = true;
 
                         _outputWindow.WriteErrorLine(ex.Message);
@@ -558,7 +560,7 @@ namespace Microsoft.CookiecutterTools.ViewModel {
 
                 ReportEvent(CookiecutterTelemetry.TelemetryArea.Search, CookiecutterTelemetry.SearchEvents.CheckUpdate, (!anyError).ToString());
             } catch (OperationCanceledException) {
-                CheckingUpdateStatus = OperationStatus.Failed;
+                CheckingUpdateStatus = OperationStatus.Canceled;
                 _outputWindow.WriteLine(Strings.CheckingForAllUpdatesCanceled);
             }
         }

--- a/Python/Product/Cookiecutter/ViewModel/CookiecutterViewModel.cs
+++ b/Python/Product/Cookiecutter/ViewModel/CookiecutterViewModel.cs
@@ -54,23 +54,19 @@ namespace Microsoft.CookiecutterTools.ViewModel {
         private string _openInExplorerFolderPath;
         private string _selectedDescription;
         private string _selectedLocation;
-        private bool _isInstalling;
-        private bool _isInstallingSuccess;
-        private bool _isInstallingError;
-        private bool _isCloning;
-        private bool _isCloningSuccess;
-        private bool _isCloningError;
-        private bool _isLoading;
-        private bool _isLoadingSuccess;
-        private bool _isLoadingError;
-        private bool _isCreating;
-        private bool _isCreatingSuccess;
-        private bool _isCreatingError;
+
+        private OperationStatus _installingStatus;
+        private OperationStatus _cloningStatus;
+        private OperationStatus _loadingStatus;
+        private OperationStatus _creatingStatus;
+        private OperationStatus _checkingUpdateStatus;
+        private OperationStatus _updatingStatus;
+
         private TemplateViewModel _selectedTemplate;
         private CancellationTokenSource _templateRefreshCancelTokenSource;
 
         private ITemplateSource _recommendedSource;
-        private ITemplateSource _installedSource;
+        private ILocalTemplateSource _installedSource;
         private ITemplateSource _githubSource;
 
         private string _templateLocalFolderPath;
@@ -104,7 +100,7 @@ namespace Microsoft.CookiecutterTools.ViewModel {
         public CookiecutterViewModel() {
         }
 
-        public CookiecutterViewModel(ICookiecutterClient cutter, IGitHubClient githubClient, IGitClient gitClient, ICookiecutterTelemetry telemetry, Redirector outputWindow, ITemplateSource installedTemplateSource, ITemplateSource feedTemplateSource, ITemplateSource gitHubTemplateSource, Action<string> openFolder) {
+        public CookiecutterViewModel(ICookiecutterClient cutter, IGitHubClient githubClient, IGitClient gitClient, ICookiecutterTelemetry telemetry, Redirector outputWindow, ILocalTemplateSource installedTemplateSource, ITemplateSource feedTemplateSource, ITemplateSource gitHubTemplateSource, Action<string> openFolder) {
             _cutterClient = cutter;
             _githubClient = githubClient;
             _gitClient = gitClient;
@@ -186,158 +182,80 @@ namespace Microsoft.CookiecutterTools.ViewModel {
             }
         }
 
-        public bool IsInstalling {
+        public OperationStatus InstallingStatus {
             get {
-                return _isInstalling;
+                return _installingStatus;
             }
 
             set {
-                if (value != _isInstalling) {
-                    _isInstalling = value;
-                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsInstalling)));
+                if (value != _installingStatus) {
+                    _installingStatus = value;
+                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(InstallingStatus)));
                 }
             }
         }
 
-        public bool IsInstallingSuccess {
+        public OperationStatus CloningStatus {
             get {
-                return _isInstallingSuccess;
+                return _cloningStatus;
             }
 
             set {
-                if (value != _isInstallingSuccess) {
-                    _isInstallingSuccess = value;
-                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsInstallingSuccess)));
+                if (value != _cloningStatus) {
+                    _cloningStatus = value;
+                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(CloningStatus)));
                 }
             }
         }
 
-        public bool IsInstallingError {
+        public OperationStatus LoadingStatus {
             get {
-                return _isInstallingError;
+                return _loadingStatus;
             }
 
             set {
-                if (value != _isInstallingError) {
-                    _isInstallingError = value;
-                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsInstallingError)));
+                if (value != _loadingStatus) {
+                    _loadingStatus = value;
+                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(LoadingStatus)));
                 }
             }
         }
 
-        public bool IsCloning {
+        public OperationStatus CreatingStatus {
             get {
-                return _isCloning;
+                return _creatingStatus;
             }
 
             set {
-                if (value != _isCloning) {
-                    _isCloning = value;
-                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsCloning)));
+                if (value != _creatingStatus) {
+                    _creatingStatus = value;
+                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(CreatingStatus)));
                 }
             }
         }
 
-        public bool IsCloningSuccess {
+        public OperationStatus CheckingUpdateStatus {
             get {
-                return _isCloningSuccess;
+                return _checkingUpdateStatus;
             }
 
             set {
-                if (value != _isCloningSuccess) {
-                    _isCloningSuccess = value;
-                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsCloningSuccess)));
+                if (value != _checkingUpdateStatus) {
+                    _checkingUpdateStatus = value;
+                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(CheckingUpdateStatus)));
                 }
             }
         }
 
-        public bool IsCloningError {
+        public OperationStatus UpdatingStatus {
             get {
-                return _isCloningError;
+                return _updatingStatus;
             }
 
             set {
-                if (value != _isCloningError) {
-                    _isCloningError = value;
-                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsCloningError)));
-                }
-            }
-        }
-
-        public bool IsLoading {
-            get {
-                return _isLoading;
-            }
-
-            set {
-                if (value != _isLoading) {
-                    _isLoading = value;
-                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsLoading)));
-                }
-            }
-        }
-
-        public bool IsLoadingSuccess {
-            get {
-                return _isLoadingSuccess;
-            }
-
-            set {
-                if (value != _isLoadingSuccess) {
-                    _isLoadingSuccess = value;
-                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsLoadingSuccess)));
-                }
-            }
-        }
-
-        public bool IsLoadingError {
-            get {
-                return _isLoadingError;
-            }
-
-            set {
-                if (value != _isLoadingError) {
-                    _isLoadingError = value;
-                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsLoadingError)));
-                }
-            }
-        }
-
-        public bool IsCreating {
-            get {
-                return _isCreating;
-            }
-
-            set {
-                if (value != _isCreating) {
-                    _isCreating = value;
-                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsCreating)));
-                }
-            }
-        }
-
-        public bool IsCreatingSuccess {
-            get {
-                return _isCreatingSuccess;
-            }
-
-            set {
-                if (value != _isCreatingSuccess) {
-                    _isCreatingSuccess = value;
-                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsCreatingSuccess)));
-                }
-            }
-        }
-
-        public bool IsCreatingError {
-            get {
-                return _isCreatingError;
-            }
-
-            set {
-                if (value != _isCreatingError) {
-                    _isCreatingError = value;
-                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsCreatingError)));
+                if (value != _updatingStatus) {
+                    _updatingStatus = value;
+                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(UpdatingStatus)));
                 }
             }
         }
@@ -424,13 +342,13 @@ namespace Microsoft.CookiecutterTools.ViewModel {
             await Task.WhenAll(recommendedTask, installedTask, githubTask);
         }
 
-        public Task DeleteTemplateAsync(TemplateViewModel template) {
+        public async Task DeleteTemplateAsync(TemplateViewModel template) {
             try {
                 string remote = template.RemoteUrl;
 
                 _outputWindow.WriteLine(string.Format(CultureInfo.CurrentUICulture, Strings.DeletingTemplateStarted, template.ClonedPath));
 
-                ShellUtils.DeleteDirectory(template.ClonedPath);
+                await _installedSource.DeleteTemplateAsync(template.ClonedPath);
 
                 _outputWindow.WriteLine(string.Empty);
                 _outputWindow.WriteLine(string.Format(CultureInfo.CurrentUICulture, Strings.DeletingTemplateSuccess, template.ClonedPath));
@@ -467,8 +385,6 @@ namespace Microsoft.CookiecutterTools.ViewModel {
 
                 ReportTemplateEvent(CookiecutterTelemetry.TelemetryArea.Template, CookiecutterTelemetry.TemplateEvents.Delete, template, ex);
             }
-
-            return Task.CompletedTask;
         }
 
         public bool IsCloneNeeded(TemplateViewModel template) {
@@ -498,10 +414,10 @@ namespace Microsoft.CookiecutterTools.ViewModel {
                 throw new InvalidOperationException("LoadTemplateAsync called with null SelectedTemplate");
             }
 
+            ResetStatus();
+
             if (IsCloneNeeded(selection)) {
-                IsCloning = true;
-                IsCloningSuccess = false;
-                IsCloningError = false;
+                CloningStatus = OperationStatus.InProgress;
 
                 try {
                     _outputWindow.WriteLine(string.Format(CultureInfo.CurrentUICulture, Strings.CloningTemplateStarted, selection.DisplayName));
@@ -511,9 +427,7 @@ namespace Microsoft.CookiecutterTools.ViewModel {
                     var result = await _gitClient.CloneAsync(selection.RemoteUrl, InstalledFolderPath);
                     selection.ClonedPath = result.Item1;
 
-                    IsCloning = false;
-                    IsCloningSuccess = true;
-                    IsCloningError = false;
+                    CloningStatus = OperationStatus.Succeeded;
 
                     _outputWindow.WriteLine(string.Join(Environment.NewLine, result.Item2.StandardOutputLines));
                     _outputWindow.WriteErrorLine(string.Join(Environment.NewLine, result.Item2.StandardErrorLines));
@@ -539,9 +453,7 @@ namespace Microsoft.CookiecutterTools.ViewModel {
 
                     await RefreshContextAsync(selection);
                 } catch (ProcessException ex) {
-                    IsCloning = false;
-                    IsCloningSuccess = false;
-                    IsCloningError = true;
+                    CloningStatus = OperationStatus.Failed;
 
                     _outputWindow.WriteLine(string.Format(CultureInfo.CurrentUICulture, Strings.ProcessExitCodeMessage, ex.Result.ExeFileName, ex.Result.ExitCode));
                     _outputWindow.WriteLine(string.Join(Environment.NewLine, ex.Result.StandardOutputLines));
@@ -553,9 +465,7 @@ namespace Microsoft.CookiecutterTools.ViewModel {
 
                     ReportTemplateEvent(CookiecutterTelemetry.TelemetryArea.Template, CookiecutterTelemetry.TemplateEvents.Clone, selection, ex);
                 } catch (Exception ex) when (!ex.IsCriticalException()) {
-                    IsCloning = false;
-                    IsCloningSuccess = false;
-                    IsCloningError = true;
+                    CloningStatus = OperationStatus.Failed;
 
                     _outputWindow.WriteErrorLine(ex.Message);
 
@@ -573,24 +483,124 @@ namespace Microsoft.CookiecutterTools.ViewModel {
             }
         }
 
+        public async Task CheckForUpdatesAsync() {
+            ResetStatus();
+
+            CheckingUpdateStatus = OperationStatus.InProgress;
+
+            _outputWindow.WriteLine(Strings.CheckingForAllUpdatesStarted);
+
+            bool anyError = false;
+            var templatesResult = await _installedSource.GetTemplatesAsync(null, null, CancellationToken.None);
+            foreach (var template in templatesResult.Templates) {
+                try {
+                    var availableResult = await _installedSource.CheckForUpdateAsync(template.RemoteUrl);
+                    _outputWindow.WriteLine(string.Format(CultureInfo.CurrentUICulture, Strings.CheckingTemplateUpdateStarted, template.Name, template.RemoteUrl));
+                    _outputWindow.WriteLine(string.Join(Environment.NewLine, availableResult.Item2.StandardOutputLines));
+                    _outputWindow.WriteErrorLine(string.Join(Environment.NewLine, availableResult.Item2.StandardErrorLines));
+
+                    if (availableResult.Item1.HasValue) {
+                        _outputWindow.WriteLine(availableResult.Item1.Value ? Strings.CheckingTemplateUpdateFound : Strings.CheckingTemplateUpdateNotFound);
+                    } else {
+                        _outputWindow.WriteLine(Strings.CheckingTemplateUpdateInconclusive);
+                    }
+
+                    var installed = Installed.Templates.OfType<TemplateViewModel>().SingleOrDefault(vm => vm.RemoteUrl == template.RemoteUrl);
+                    if (installed != null) {
+                        installed.IsUpdateAvailable = availableResult.Item1 == true;
+                    }
+                } catch (ProcessException ex) {
+                    anyError = true;
+
+                    _outputWindow.WriteLine(Strings.CheckingTemplateUpdateError);
+                    _outputWindow.WriteLine(string.Format(CultureInfo.CurrentUICulture, Strings.ProcessExitCodeMessage, ex.Result.ExeFileName, ex.Result.ExitCode));
+                    _outputWindow.WriteLine(string.Join(Environment.NewLine, ex.Result.StandardOutputLines));
+                    _outputWindow.WriteErrorLine(string.Join(Environment.NewLine, ex.Result.StandardErrorLines));
+                } catch (Exception ex) when (!ex.IsCriticalException()) {
+                    anyError = true;
+
+                    _outputWindow.WriteLine(Strings.CheckingTemplateUpdateError);
+                    _outputWindow.WriteErrorLine(ex.Message);
+                }
+            }
+
+            CheckingUpdateStatus = anyError ? OperationStatus.Failed : OperationStatus.Succeeded;
+
+            _outputWindow.WriteLine(string.Empty);
+            _outputWindow.WriteLine(anyError ? Strings.CheckingForAllUpdatesFailed : Strings.CheckingForAllUpdatesSuccess);
+            _outputWindow.ShowAndActivate();
+
+            ReportEvent(CookiecutterTelemetry.TelemetryArea.Search, CookiecutterTelemetry.SearchEvents.CheckUpdate, (!anyError).ToString());
+        }
+
+        public async Task UpdateTemplateAsync() {
+            var selection = SelectedTemplate;
+            Debug.Assert(selection != null);
+            if (selection == null) {
+                throw new InvalidOperationException("UpdateTemplateAsync called with null SelectedTemplate");
+            }
+
+            ResetStatus();
+
+            try {
+                UpdatingStatus = OperationStatus.InProgress;
+
+                _outputWindow.WriteLine(string.Format(CultureInfo.CurrentUICulture, Strings.UpdatingTemplateStarted, selection.DisplayName));
+
+                var result = await _installedSource.UpdateTemplateAsync(selection.ClonedPath);
+                selection.IsUpdateAvailable = false;
+
+                UpdatingStatus = OperationStatus.Succeeded;
+
+                _outputWindow.WriteLine(string.Join(Environment.NewLine, result.StandardOutputLines));
+                _outputWindow.WriteErrorLine(string.Join(Environment.NewLine, result.StandardErrorLines));
+
+                _outputWindow.WriteLine(string.Empty);
+                _outputWindow.WriteLine(string.Format(CultureInfo.CurrentUICulture, Strings.UpdatingTemplateSuccess, selection.DisplayName, selection.ClonedPath));
+                _outputWindow.ShowAndActivate();
+
+                ReportTemplateEvent(CookiecutterTelemetry.TelemetryArea.Template, CookiecutterTelemetry.TemplateEvents.Update, selection);
+            } catch (ProcessException ex) {
+                UpdatingStatus = OperationStatus.Failed;
+
+                _outputWindow.WriteLine(string.Format(CultureInfo.CurrentUICulture, Strings.ProcessExitCodeMessage, ex.Result.ExeFileName, ex.Result.ExitCode));
+                _outputWindow.WriteLine(string.Join(Environment.NewLine, ex.Result.StandardOutputLines));
+                _outputWindow.WriteErrorLine(string.Join(Environment.NewLine, ex.Result.StandardErrorLines));
+
+                _outputWindow.WriteLine(string.Empty);
+                _outputWindow.WriteLine(string.Format(CultureInfo.CurrentUICulture, Strings.UpdatingTemplateFailed, selection.DisplayName));
+                _outputWindow.ShowAndActivate();
+
+                ReportTemplateEvent(CookiecutterTelemetry.TelemetryArea.Template, CookiecutterTelemetry.TemplateEvents.Update, selection, ex);
+            } catch (Exception ex) when (!ex.IsCriticalException()) {
+                UpdatingStatus = OperationStatus.Failed;
+
+                _outputWindow.WriteErrorLine(ex.Message);
+
+                _outputWindow.WriteLine(string.Empty);
+                _outputWindow.WriteLine(string.Format(CultureInfo.CurrentUICulture, Strings.UpdatingTemplateFailed, selection.DisplayName));
+                _outputWindow.ShowAndActivate();
+
+                ReportTemplateEvent(CookiecutterTelemetry.TelemetryArea.Template, CookiecutterTelemetry.TemplateEvents.Update, selection, ex);
+            }
+        }
+
         public void Reset() {
             ContextItems.Clear();
 
-            IsCloning = false;
-            IsCloningSuccess = false;
-            IsCloningError = false;
-
-            IsLoading = false;
-            IsLoadingSuccess = false;
-            IsLoadingError = false;
-
-            IsCreating = false;
-            IsCreatingSuccess = false;
-            IsCreatingError = false;
+            ResetStatus();
 
             _templateLocalFolderPath = null;
 
             HomeClicked?.Invoke(this, EventArgs.Empty);
+        }
+
+        private void ResetStatus() {
+            CloningStatus = OperationStatus.NotStarted;
+            LoadingStatus = OperationStatus.NotStarted;
+            CreatingStatus = OperationStatus.NotStarted;
+            CheckingUpdateStatus = OperationStatus.NotStarted;
+            UpdatingStatus = OperationStatus.NotStarted;
         }
 
         public async Task CreateFilesAsync() {
@@ -600,13 +610,9 @@ namespace Microsoft.CookiecutterTools.ViewModel {
                 throw new InvalidOperationException("CreateFilesAsync called with null SelectedTemplate");
             }
 
-            IsCloning = false;
-            IsCloningError = false;
-            IsCloningSuccess = false;
+            ResetStatus();
 
-            IsCreating = true;
-            IsCreatingError = false;
-            IsCreatingSuccess = false;
+            CreatingStatus = OperationStatus.InProgress;
             OpenInExplorerFolderPath = null;
 
             try {
@@ -627,9 +633,7 @@ namespace Microsoft.CookiecutterTools.ViewModel {
 
                 Reset();
 
-                IsCreating = false;
-                IsCreatingSuccess = true;
-                IsCreatingError = false;
+                CreatingStatus = OperationStatus.Succeeded;
 
                 _outputWindow.WriteLine(string.Join(Environment.NewLine, result.StandardOutputLines));
                 _outputWindow.WriteErrorLine(string.Join(Environment.NewLine, result.StandardErrorLines));
@@ -640,9 +644,7 @@ namespace Microsoft.CookiecutterTools.ViewModel {
 
                 ReportTemplateEvent(CookiecutterTelemetry.TelemetryArea.Template, CookiecutterTelemetry.TemplateEvents.Run, selection);
             } catch (ProcessException ex) {
-                IsCreating = false;
-                IsCreatingSuccess = false;
-                IsCreatingError = true;
+                CreatingStatus = OperationStatus.Failed;
 
                 _outputWindow.WriteLine(string.Format(CultureInfo.CurrentUICulture, Strings.ProcessExitCodeMessage, ex.Result.ExeFileName, ex.Result.ExitCode));
                 _outputWindow.WriteLine(string.Join(Environment.NewLine, ex.Result.StandardOutputLines));
@@ -654,9 +656,7 @@ namespace Microsoft.CookiecutterTools.ViewModel {
 
                 ReportTemplateEvent(CookiecutterTelemetry.TelemetryArea.Template, CookiecutterTelemetry.TemplateEvents.Run, selection, ex);
             } catch (Exception ex) when (!ex.IsCriticalException()) {
-                IsCreating = false;
-                IsCreatingSuccess = false;
-                IsCreatingError = true;
+                CreatingStatus = OperationStatus.Failed;
 
                 _outputWindow.WriteErrorLine(ex.Message);
 
@@ -721,9 +721,9 @@ namespace Microsoft.CookiecutterTools.ViewModel {
                 return true;
             }
 
-            IsInstalling = true;
-            IsInstallingSuccess = false;
-            IsInstallingError = false;
+            ResetStatus();
+
+            InstallingStatus = OperationStatus.InProgress;
 
             try {
                 _outputWindow.WriteLine(string.Format(CultureInfo.CurrentUICulture, Strings.InstallingCookiecutterStarted));
@@ -740,16 +740,12 @@ namespace Microsoft.CookiecutterTools.ViewModel {
                 _outputWindow.WriteLine(string.Format(CultureInfo.CurrentUICulture, Strings.InstallingCookiecutterSuccess));
                 _outputWindow.ShowAndActivate();
 
-                IsInstalling = false;
-                IsInstallingSuccess = true;
-                IsInstallingError = false;
+                InstallingStatus = OperationStatus.Succeeded;
 
                 ReportEvent(CookiecutterTelemetry.TelemetryArea.Prereqs, CookiecutterTelemetry.PrereqsEvents.Install, true.ToString());
                 return true;
             } catch (ProcessException ex) {
-                IsInstalling = false;
-                IsInstallingSuccess = false;
-                IsInstallingError = true;
+                InstallingStatus = OperationStatus.Failed;
 
                 _outputWindow.WriteLine(string.Format(CultureInfo.CurrentUICulture, Strings.ProcessExitCodeMessage, ex.Result.ExeFileName, ex.Result.ExitCode));
                 _outputWindow.WriteLine(string.Join(Environment.NewLine, ex.Result.StandardOutputLines));
@@ -762,9 +758,7 @@ namespace Microsoft.CookiecutterTools.ViewModel {
                 ReportEvent(CookiecutterTelemetry.TelemetryArea.Prereqs, CookiecutterTelemetry.PrereqsEvents.Install, false.ToString());
                 return false;
             } catch (Exception ex) when (!ex.IsCriticalException()) {
-                IsInstalling = false;
-                IsInstallingSuccess = false;
-                IsInstallingError = true;
+                InstallingStatus = OperationStatus.Failed;
 
                 _outputWindow.WriteErrorLine(ex.Message);
 
@@ -791,6 +785,7 @@ namespace Microsoft.CookiecutterTools.ViewModel {
                     vm.Description = t.Description;
                     vm.RemoteUrl = t.RemoteUrl;
                     vm.ClonedPath = t.LocalFolderPath;
+                    vm.IsUpdateAvailable = t.UpdateAvailable == true;
                     vm.Image = image;
                     parent.Templates.Add(vm);
                 }
@@ -817,9 +812,7 @@ namespace Microsoft.CookiecutterTools.ViewModel {
             }
 
             try {
-                IsLoading = true;
-                IsLoadingSuccess = false;
-                IsLoadingError = false;
+                LoadingStatus = OperationStatus.InProgress;
 
                 var result = await _cutterClient.LoadContextAsync(selection.ClonedPath, UserConfigFilePath);
 
@@ -828,9 +821,7 @@ namespace Microsoft.CookiecutterTools.ViewModel {
                     ContextItems.Add(new ContextItemViewModel(item.Name, item.DefaultValue, item.Values));
                 }
 
-                IsLoading = false;
-                IsLoadingSuccess = true;
-                IsLoadingError = false;
+                LoadingStatus = OperationStatus.Succeeded;
 
                 _outputWindow.WriteLine(string.Empty);
                 _outputWindow.WriteLine(string.Format(CultureInfo.CurrentUICulture, Strings.LoadingTemplateSuccess, selection.DisplayName));
@@ -841,9 +832,7 @@ namespace Microsoft.CookiecutterTools.ViewModel {
                 // Go to the context page
                 ContextLoaded?.Invoke(this, EventArgs.Empty);
             } catch (InvalidOperationException ex) {
-                IsLoading = false;
-                IsLoadingSuccess = false;
-                IsLoadingError = true;
+                LoadingStatus = OperationStatus.Failed;
 
                 _outputWindow.WriteErrorLine(ex.Message);
 
@@ -853,9 +842,7 @@ namespace Microsoft.CookiecutterTools.ViewModel {
 
                 ReportTemplateEvent(CookiecutterTelemetry.TelemetryArea.Template, CookiecutterTelemetry.TemplateEvents.Load, selection, ex);
             } catch (ProcessException ex) {
-                IsLoading = false;
-                IsLoadingSuccess = false;
-                IsLoadingError = true;
+                LoadingStatus = OperationStatus.Failed;
 
                 _outputWindow.WriteLine(string.Format(CultureInfo.CurrentUICulture, Strings.ProcessExitCodeMessage, ex.Result.ExeFileName, ex.Result.ExitCode));
                 _outputWindow.WriteLine(string.Join(Environment.NewLine, ex.Result.StandardOutputLines));

--- a/Python/Product/Cookiecutter/ViewModel/OperationStatus.cs
+++ b/Python/Product/Cookiecutter/ViewModel/OperationStatus.cs
@@ -14,15 +14,11 @@
 // See the Apache Version 2.0 License for specific language governing
 // permissions and limitations under the License.
 
-using System;
-using System.Threading.Tasks;
-
-namespace Microsoft.CookiecutterTools.Model {
-    interface IGitClient {
-        Task<Tuple<string, ProcessOutputResult>> CloneAsync(string repoUrl, string targetParentFolderPath);
-        Task<string> GetRemoteOriginAsync(string repoFolderPath);
-        Task<DateTime?> GetLastCommitDateAsync(string repoFolderPath, string branch = null);
-        Task<ProcessOutputResult> FetchAsync(string repoFolderPath);
-        Task<ProcessOutputResult> MergeAsync(string repoFolderPath);
+namespace Microsoft.CookiecutterTools.ViewModel {
+    enum OperationStatus {
+        NotStarted,
+        InProgress,
+        Succeeded,
+        Failed,
     }
 }

--- a/Python/Product/Cookiecutter/ViewModel/OperationStatus.cs
+++ b/Python/Product/Cookiecutter/ViewModel/OperationStatus.cs
@@ -20,5 +20,6 @@ namespace Microsoft.CookiecutterTools.ViewModel {
         InProgress,
         Succeeded,
         Failed,
+        Canceled,
     }
 }

--- a/Python/Product/Cookiecutter/ViewModel/TemplateViewModel.cs
+++ b/Python/Product/Cookiecutter/ViewModel/TemplateViewModel.cs
@@ -25,6 +25,7 @@ namespace Microsoft.CookiecutterTools.ViewModel {
         private string _clonedPath;
         private string _description;
         private bool _isSearchTerm;
+        private bool _isUpdateAvailable;
         private ImageMoniker _image;
 
         public event PropertyChangedEventHandler PropertyChanged;
@@ -140,6 +141,19 @@ namespace Microsoft.CookiecutterTools.ViewModel {
                 if (value != _isSearchTerm) {
                     _isSearchTerm = value;
                     PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsSearchTerm)));
+                }
+            }
+        }
+
+        public bool IsUpdateAvailable {
+            get {
+                return _isUpdateAvailable;
+            }
+
+            set {
+                if (value != _isUpdateAvailable) {
+                    _isUpdateAvailable = value;
+                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsUpdateAvailable)));
                 }
             }
         }

--- a/Python/Tests/CookiecutterTests/CookiecutterIntegrationTests.cs
+++ b/Python/Tests/CookiecutterTests/CookiecutterIntegrationTests.cs
@@ -89,9 +89,9 @@ namespace CookiecutterTests {
             var installedPath = TestInstalledTemplateFolderPath;
             var userConfigFilePath = TestUserConfigFilePath;
 
-            _gitClient = new GitClient(GitClient.RecommendedGitFilePath);
+            _gitClient = new GitClient(GitClient.RecommendedGitFilePath, _redirector);
             _gitHubClient = new GitHubClient();
-            _cutterClient = CookiecutterClientProvider.Create();
+            _cutterClient = CookiecutterClientProvider.Create(_redirector);
             _telemetry = new CookiecutterTelemetry(new TelemetryTestService());
             _installedTemplateSource = new LocalTemplateSource(installedPath, _gitClient);
             _gitHubTemplateSource = new GitHubTemplateSource(_gitHubClient);

--- a/Python/Tests/CookiecutterTests/CookiecutterIntegrationTests.cs
+++ b/Python/Tests/CookiecutterTests/CookiecutterIntegrationTests.cs
@@ -54,7 +54,7 @@ namespace CookiecutterTests {
         private ICookiecutterClient _cutterClient;
         private ICookiecutterTelemetry _telemetry;
         private CookiecutterViewModel _vm;
-        private ITemplateSource _installedTemplateSource;
+        private ILocalTemplateSource _installedTemplateSource;
         private ITemplateSource _gitHubTemplateSource;
         private ITemplateSource _feedTemplateSource;
         private string _openedFolder;
@@ -225,9 +225,7 @@ namespace CookiecutterTests {
             await _vm.LoadTemplateAsync();
 
             // Local template doesn't need to be cloned
-            Assert.IsFalse(_vm.IsCloning);
-            Assert.IsFalse(_vm.IsCloningError);
-            Assert.IsFalse(_vm.IsCloningSuccess);
+            Assert.AreEqual(OperationStatus.NotStarted, _vm.CloningStatus);
 
             PrintContextItems(_vm.ContextItems);
             CollectionAssert.AreEqual(LocalTemplateWithUserConfigContextItems, _vm.ContextItems, new ContextItemViewModelComparer());
@@ -238,9 +236,7 @@ namespace CookiecutterTests {
 
             await _vm.CreateFilesAsync();
 
-            Assert.IsFalse(_vm.IsCreating);
-            Assert.IsTrue(_vm.IsCreatingSuccess);
-            Assert.IsFalse(_vm.IsCreatingError);
+            Assert.AreEqual(OperationStatus.Succeeded, _vm.CreatingStatus);
 
             var reportFilePath = Path.Combine(_vm.OutputFolderPath, "report.txt");
             Assert.IsTrue(File.Exists(reportFilePath), "Failed to generate some project files.");
@@ -274,9 +270,7 @@ namespace CookiecutterTests {
             await _vm.LoadTemplateAsync();
 
             // Local template needs to be cloned
-            Assert.IsFalse(_vm.IsCloning);
-            Assert.IsFalse(_vm.IsCloningError);
-            Assert.IsTrue(_vm.IsCloningSuccess);
+            Assert.AreEqual(OperationStatus.Succeeded, _vm.CloningStatus);
 
             PrintContextItems(_vm.ContextItems);
 
@@ -285,9 +279,7 @@ namespace CookiecutterTests {
 
             await _vm.CreateFilesAsync();
 
-            Assert.IsFalse(_vm.IsCreating);
-            Assert.IsTrue(_vm.IsCreatingSuccess);
-            Assert.IsFalse(_vm.IsCreatingError);
+            Assert.AreEqual(OperationStatus.Succeeded, _vm.CreatingStatus);
             Assert.AreEqual(_vm.OutputFolderPath, _vm.OpenInExplorerFolderPath);
 
             Assert.IsTrue(Directory.Exists(Path.Combine(_vm.OutputFolderPath, "static_files")));

--- a/Python/Tests/CookiecutterTests/CookiecutterViewModelTests.cs
+++ b/Python/Tests/CookiecutterTests/CookiecutterViewModelTests.cs
@@ -112,6 +112,8 @@ namespace CookiecutterTests {
             Assert.IsTrue(_vm.Installed.Templates.Count == 1);
 
             await _vm.CheckForUpdatesAsync();
+            Assert.AreEqual(OperationStatus.Succeeded, _vm.CheckingUpdateStatus);
+
             var t1 = _vm.Installed.Templates.OfType<TemplateViewModel>().FirstOrDefault();
             Assert.IsTrue(t1.IsUpdateAvailable);
         }
@@ -133,15 +135,16 @@ namespace CookiecutterTests {
             await _vm.SearchAsync();
             Assert.IsTrue(_vm.Installed.Templates.Count == 1);
 
-            var t1 = _vm.Installed.Templates.OfType<TemplateViewModel>().FirstOrDefault();
-            _vm.SelectedTemplate = t1;
+            var templateViewModel = _vm.Installed.Templates.OfType<TemplateViewModel>().FirstOrDefault();
+            _vm.SelectedTemplate = templateViewModel;
 
             await _vm.UpdateTemplateAsync();
-            Assert.IsFalse(t1.IsUpdateAvailable);
+            Assert.AreEqual(OperationStatus.Succeeded, _vm.UpdatingStatus);
+            Assert.IsFalse(templateViewModel.IsUpdateAvailable);
 
-            //CollectionAssert.AreEquivalent(
-            //    new string[] { "https://github.com/owner1/template1" },
-            //    _installedTemplateSource.Updated);
+            CollectionAssert.AreEquivalent(
+                new string[] { Path.Combine(_vm.InstalledFolderPath, "template1") },
+                _installedTemplateSource.Updated);
         }
     }
 }

--- a/Python/Tests/CookiecutterTests/MockCookiecutterClient.cs
+++ b/Python/Tests/CookiecutterTests/MockCookiecutterClient.cs
@@ -20,6 +20,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.CookiecutterTools;
+using Microsoft.CookiecutterTools.Infrastructure;
 using Microsoft.CookiecutterTools.Model;
 
 namespace CookiecutterTests {
@@ -30,15 +31,15 @@ namespace CookiecutterTests {
             }
         }
 
-        public Task<ProcessOutputResult> CreateCookiecutterEnv() {
+        public Task CreateCookiecutterEnv() {
             throw new NotImplementedException();
         }
 
-        public Task<ProcessOutputResult> GenerateProjectAsync(string localTemplateFolder, string userConfigFilePath, string contextFilePath, string outputFolderPath) {
+        public Task GenerateProjectAsync(string localTemplateFolder, string userConfigFilePath, string contextFilePath, string outputFolderPath) {
             throw new NotImplementedException();
         }
 
-        public Task<ProcessOutputResult> InstallPackage() {
+        public Task InstallPackage() {
             throw new NotImplementedException();
         }
 
@@ -46,7 +47,7 @@ namespace CookiecutterTests {
             throw new NotImplementedException();
         }
 
-        public Task<Tuple<ContextItem[], ProcessOutputResult>> LoadContextAsync(string localTemplateFolder, string userConfigFilePath) {
+        public Task<ContextItem[]> LoadContextAsync(string localTemplateFolder, string userConfigFilePath) {
             throw new NotImplementedException();
         }
     }

--- a/Python/Tests/CookiecutterTests/MockGitClient.cs
+++ b/Python/Tests/CookiecutterTests/MockGitClient.cs
@@ -28,7 +28,19 @@ namespace CookiecutterTests {
             throw new NotImplementedException();
         }
 
+        public Task<DateTime?> GetLastCommitDateAsync(string repoFolderPath, string branch = null) {
+            throw new NotImplementedException();
+        }
+
         public Task<string> GetRemoteOriginAsync(string repoFolderPath) {
+            throw new NotImplementedException();
+        }
+
+        public Task<ProcessOutputResult> MergeAsync(string repoFolderPath) {
+            throw new NotImplementedException();
+        }
+
+        Task<ProcessOutputResult> IGitClient.FetchAsync(string repoFolderPath) {
             throw new NotImplementedException();
         }
     }

--- a/Python/Tests/CookiecutterTests/MockGitClient.cs
+++ b/Python/Tests/CookiecutterTests/MockGitClient.cs
@@ -20,11 +20,12 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.CookiecutterTools;
+using Microsoft.CookiecutterTools.Infrastructure;
 using Microsoft.CookiecutterTools.Model;
 
 namespace CookiecutterTests {
     class MockGitClient : IGitClient {
-        public Task<Tuple<string, ProcessOutputResult>> CloneAsync(string repoUrl, string targetParentFolderPath) {
+        public Task<string> CloneAsync(Redirector redirector, string repoUrl, string targetParentFolderPath) {
             throw new NotImplementedException();
         }
 
@@ -36,11 +37,15 @@ namespace CookiecutterTests {
             throw new NotImplementedException();
         }
 
-        public Task<ProcessOutputResult> MergeAsync(string repoFolderPath) {
+        public Task MergeAsync(string repoFolderPath) {
             throw new NotImplementedException();
         }
 
-        Task<ProcessOutputResult> IGitClient.FetchAsync(string repoFolderPath) {
+        public Task FetchAsync(string repoFolderPath) {
+            throw new NotImplementedException();
+        }
+
+        public Task<string> CloneAsync(string repoUrl, string targetParentFolderPath) {
             throw new NotImplementedException();
         }
     }

--- a/Python/Tests/CookiecutterTests/MockTemplateSource.cs
+++ b/Python/Tests/CookiecutterTests/MockTemplateSource.cs
@@ -51,7 +51,11 @@ namespace CookiecutterTests {
         }
 
         Task<bool?> ILocalTemplateSource.CheckForUpdateAsync(string repoPath) {
-            return Task.FromResult(UpdatesAvailable[repoPath]);
+            bool? available;
+            if (!UpdatesAvailable.TryGetValue(repoPath, out available)) {
+                available = false;
+            }
+            return Task.FromResult(available);
         }
 
         public Task AddTemplateAsync(string repoPath) {

--- a/Python/Tests/CookiecutterTests/MockTemplateSource.cs
+++ b/Python/Tests/CookiecutterTests/MockTemplateSource.cs
@@ -27,9 +27,10 @@ using Microsoft.CookiecutterTools.Model;
 namespace CookiecutterTests {
     class MockTemplateSource : ILocalTemplateSource {
         public Dictionary<Tuple<string, string>, Tuple<Template[], string>> Templates { get; } = new Dictionary<Tuple<string, string>, Tuple<Template[], string>>();
-        public bool Invalidated { get; set; }
         public Dictionary<string, bool?> UpdatesAvailable { get; } = new Dictionary<string, bool?>();
         public List<string> Updated { get; } = new List<string>();
+        public List<string> Added { get; } = new List<string>();
+        public List<string> Deleted { get; } = new List<string>();
 
         public Task<TemplateEnumerationResult> GetTemplatesAsync(string filter, string continuationToken, CancellationToken cancellationToken) {
             Tuple<Template[], string> result;
@@ -39,11 +40,8 @@ namespace CookiecutterTests {
             return Task.FromResult(new TemplateEnumerationResult(new Template[0]));
         }
 
-        public void InvalidateCache() {
-            Invalidated = true;
-        }
-
         public Task DeleteTemplateAsync(string repoPath) {
+            Deleted.Add(repoPath);
             return Task.CompletedTask;
         }
 
@@ -54,6 +52,11 @@ namespace CookiecutterTests {
 
         Task<bool?> ILocalTemplateSource.CheckForUpdateAsync(string repoPath) {
             return Task.FromResult(UpdatesAvailable[repoPath]);
+        }
+
+        public Task AddTemplateAsync(string repoPath) {
+            Added.Add(repoPath);
+            return Task.CompletedTask;
         }
     }
 }

--- a/Python/Tests/CookiecutterTests/MockTemplateSource.cs
+++ b/Python/Tests/CookiecutterTests/MockTemplateSource.cs
@@ -27,6 +27,8 @@ namespace CookiecutterTests {
     class MockTemplateSource : ILocalTemplateSource {
         public Dictionary<Tuple<string, string>, Tuple<Template[], string>> Templates { get; } = new Dictionary<Tuple<string, string>, Tuple<Template[], string>>();
         public bool Invalidated { get; set; }
+        public Dictionary<string, bool?> UpdatesAvailable { get; } = new Dictionary<string, bool?>();
+        public List<string> Updated { get; } = new List<string>();
 
         public Task<TemplateEnumerationResult> GetTemplatesAsync(string filter, string continuationToken, CancellationToken cancellationToken) {
             Tuple<Template[], string> result;
@@ -45,11 +47,12 @@ namespace CookiecutterTests {
         }
 
         public Task UpdateTemplateAsync(string repoPath) {
-            return Task.FromResult(new ProcessOutputResult());
+            Updated.Add(repoPath);
+            return Task.CompletedTask;
         }
 
         Task<bool?> ILocalTemplateSource.CheckForUpdateAsync(string repoPath) {
-            throw new NotImplementedException();
+            return Task.FromResult(UpdatesAvailable[repoPath]);
         }
     }
 }

--- a/Python/Tests/CookiecutterTests/MockTemplateSource.cs
+++ b/Python/Tests/CookiecutterTests/MockTemplateSource.cs
@@ -44,11 +44,11 @@ namespace CookiecutterTests {
             return Task.CompletedTask;
         }
 
-        public Task<ProcessOutputResult> UpdateTemplateAsync(string repoPath) {
+        public Task UpdateTemplateAsync(string repoPath) {
             return Task.FromResult(new ProcessOutputResult());
         }
 
-        Task<Tuple<bool?, ProcessOutputResult>> ILocalTemplateSource.CheckForUpdateAsync(string repoPath) {
+        Task<bool?> ILocalTemplateSource.CheckForUpdateAsync(string repoPath) {
             throw new NotImplementedException();
         }
     }

--- a/Python/Tests/CookiecutterTests/MockTemplateSource.cs
+++ b/Python/Tests/CookiecutterTests/MockTemplateSource.cs
@@ -21,6 +21,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CookiecutterTools;
+using Microsoft.CookiecutterTools.Infrastructure;
 using Microsoft.CookiecutterTools.Model;
 
 namespace CookiecutterTests {

--- a/Python/Tests/CookiecutterTests/MockTemplateSource.cs
+++ b/Python/Tests/CookiecutterTests/MockTemplateSource.cs
@@ -24,7 +24,7 @@ using Microsoft.CookiecutterTools;
 using Microsoft.CookiecutterTools.Model;
 
 namespace CookiecutterTests {
-    class MockTemplateSource : ITemplateSource {
+    class MockTemplateSource : ILocalTemplateSource {
         public Dictionary<Tuple<string, string>, Tuple<Template[], string>> Templates { get; } = new Dictionary<Tuple<string, string>, Tuple<Template[], string>>();
         public bool Invalidated { get; set; }
 
@@ -38,6 +38,18 @@ namespace CookiecutterTests {
 
         public void InvalidateCache() {
             Invalidated = true;
+        }
+
+        public Task DeleteTemplateAsync(string repoPath) {
+            return Task.CompletedTask;
+        }
+
+        public Task<ProcessOutputResult> UpdateTemplateAsync(string repoPath) {
+            return Task.FromResult(new ProcessOutputResult());
+        }
+
+        Task<Tuple<bool?, ProcessOutputResult>> ILocalTemplateSource.CheckForUpdateAsync(string repoPath) {
+            throw new NotImplementedException();
         }
     }
 }


### PR DESCRIPTION
Automatic update option
 - Delayed after initialization (may need to adjust those delays)
Check for update command
Update template command

Reduce code duplication in CookiecutterViewModel
 - Enum variables instead of multiple bool variables for state
 - Pass down the Redirector so that writing to output is immediate (especially good for when generating files), reduces client code needed to print to output, and simplifies the APIs that don't need to return captured output

Some non integration tests enabled, will add more over time.
