### PR TITLE
Fixes #1751 Smart indent does not work in REPL

### DIFF
--- a/Common/Tests/Utilities.UI/UI/ReplWindowProxy.cs
+++ b/Common/Tests/Utilities.UI/UI/ReplWindowProxy.cs
@@ -137,6 +137,7 @@ namespace TestUtilities.UI {
 
         public void Hide() {
             ErrorHandler.ThrowOnFailure(((IVsWindowFrame)_toolWindow.Frame).Hide());
+            ErrorHandler.ThrowOnFailure(((IVsWindowPane)_toolWindow.GetIVsWindowPane()).ClosePane());
         }
 
         public void Invoke(Action action) {

--- a/Python/Product/PythonTools/PythonTools/Editor/AutoIndent.cs
+++ b/Python/Product/PythonTools/PythonTools/Editor/AutoIndent.cs
@@ -26,8 +26,6 @@ using Microsoft.VisualStudio.Text.Editor.OptionsExtensionMethods;
 
 namespace Microsoft.PythonTools.Editor {
     internal static class AutoIndent {
-        private static readonly Version RequireMapIndentToSurfaceBuffer = new Version(1, 0, 0, 50618);
-
         internal static int GetIndentation(string line, int tabSize) {
             int res = 0;
             for (int i = 0; i < line.Length; i++) {
@@ -180,11 +178,9 @@ namespace Microsoft.PythonTools.Editor {
 
             // Map indentation back to the view's text buffer.
             int offset = 0;
-            if (Repl.PythonInteractiveEvaluator.VSInteractiveVersion > RequireMapIndentToSurfaceBuffer) {
-                var viewLineStart = textView.BufferGraph.MapUpToSnapshot(line.Start, PointTrackingMode.Positive, PositionAffinity.Successor, textView.TextSnapshot);
-                if (viewLineStart.HasValue) {
-                    offset = viewLineStart.Value.Position - viewLineStart.Value.GetContainingLine().Start.Position;
-                }
+            var viewLineStart = textView.BufferGraph.MapUpToSnapshot(line.Start, PointTrackingMode.Positive, PositionAffinity.Successor, textView.TextSnapshot);
+            if (viewLineStart.HasValue) {
+                offset = viewLineStart.Value.Position - viewLineStart.Value.GetContainingLine().Start.Position;
             }
 
             return offset + indentation;

--- a/Python/Product/PythonTools/PythonTools/Repl/PythonInteractiveEvaluator.cs
+++ b/Python/Product/PythonTools/PythonTools/Repl/PythonInteractiveEvaluator.cs
@@ -851,26 +851,6 @@ namespace Microsoft.PythonTools.Repl {
         }
 
         #endregion
-
-        #region Compatibility
-
-        private static Version _vsInteractiveVersion;
-
-        internal static Version VSInteractiveVersion {
-            get {
-                if (_vsInteractiveVersion == null) {
-                    _vsInteractiveVersion = typeof(IInteractiveWindow).Assembly
-                        .GetCustomAttributes(typeof(System.Reflection.AssemblyInformationalVersionAttribute), false)
-                        .OfType<System.Reflection.AssemblyInformationalVersionAttribute>()
-                        .Select(a => { Version v; return Version.TryParse(a.InformationalVersion, out v) ? v : null; })
-                        .FirstOrDefault(v => v != null) ?? new Version();
-                }
-                return _vsInteractiveVersion;
-            }
-        }
-
-
-        #endregion
     }
 
     internal static class PythonInteractiveEvaluatorExtensions {

--- a/Python/Tests/Utilities.Python/PythonReplWindowProxySettings.cs
+++ b/Python/Tests/Utilities.Python/PythonReplWindowProxySettings.cs
@@ -72,19 +72,6 @@ namespace TestUtilities.UI.Python {
             app.OnDispose(() => options.Intellisense.AddNewLineAtEndOfFullyTypedWord = oldAddNewLineAtEndOfFullyTypedWord);
             options.Intellisense.AddNewLineAtEndOfFullyTypedWord = AddNewLineAtEndOfFullyTypedWord;
 
-            bool success = false;
-            for (int retries = 1; retries < 20; ++retries) {
-                try {
-                    app.ExecuteCommand("Python.Interactive", "/e:\"" + description + "\"");
-                    success = true;
-                    break;
-                } catch (AggregateException) {
-                }
-                app.DismissAllDialogs();
-                app.SetFocus();
-                Thread.Sleep(retries * 100);
-            }
-            Assert.IsTrue(success, "Unable to open " + description + " through DTE");
             var interpreters = app.ComponentModel.GetService<IInterpreterRegistryService>();
             var replId = PythonReplEvaluatorProvider.GetEvaluatorId(
                 interpreters.FindConfiguration(Version.Id)


### PR DESCRIPTION
Fixes #1751 Smart indent does not work in REPL
Removes old compatibility code
Removes duplicate REPLs opening during tests and tries harder to close the one we just finished using.