### PR TITLE
Fix 1727 test not executing

### DIFF
--- a/Python/Tests/TestAdapterTests/TestInfo.cs
+++ b/Python/Tests/TestAdapterTests/TestInfo.cs
@@ -105,17 +105,24 @@ namespace TestAdapterTests {
         public static TestInfo[] TestAdapterBTests {
             get {
                 return new TestInfo[] {
+                    RenamedImportSuccess,
+                    RenamedImportFailure,
+                    TimeoutSuccess,
+                    TestInPackageSuccess,
+                    TestInPackageFailure
+                };
+            }
+        }
+
+        public static TestInfo[] TestAdapterBInheritanceTests {
+            get {
+                return new TestInfo[] {
                     BaseSuccess,
                     BaseFailure,
                     DerivedBaseSuccess,
                     DerivedBaseFailure,
                     DerivedSuccess,
                     DerivedFailure,
-                    RenamedImportSuccess,
-                    RenamedImportFailure,
-                    TimeoutSuccess,
-                    TestInPackageSuccess,
-                    TestInPackageFailure
                 };
             }
         }
@@ -127,6 +134,17 @@ namespace TestAdapterTests {
         public static TestInfo[] TestAdapterMultiprocessingTests {
             get {
                 return new[] { MultiprocessingSuccess };
+            }
+        }
+
+        private static TestInfo LoadErrorImportError = TestInfo.FromRelativePaths("ImportErrorTests", "test_import_error", @"TestData\TestAdapterTests\LoadErrorTest.pyproj", @"TestData\TestAdapterTests\LoadErrorTestImportError.py", 5, TestOutcome.Failed);
+        private static TestInfo LoadErrorNoError = TestInfo.FromRelativePaths("NoErrorTests", "test_no_error", @"TestData\TestAdapterTests\LoadErrorTest.pyproj", @"TestData\TestAdapterTests\LoadErrorTestNoError.py", 4, TestOutcome.Passed);
+
+        public static string TestAdapterLoadErrorTestProjectFilePath = TestData.GetPath(@"TestData\TestAdapterTests\LoadErrorTest.pyproj");
+
+        public static TestInfo[] TestAdapterLoadErrorTests {
+            get {
+                return new[] { LoadErrorImportError, LoadErrorNoError };
             }
         }
 

--- a/Python/Tests/TestData/TestAdapterLibraryOar/TestAdapterLibraryOar.pyproj
+++ b/Python/Tests/TestData/TestAdapterLibraryOar/TestAdapterLibraryOar.pyproj
@@ -13,7 +13,7 @@
     <Name>LibraryOar</Name>
     <RootNamespace>LibraryOar</RootNamespace>
     <IsWindowsApplication>False</IsWindowsApplication>
-    <InterpreterId>Global|PythonCore|3.3|x64</InterpreterId>
+    <InterpreterId>Global|PythonCore|3.3</InterpreterId>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Python/Tests/TestData/TestAdapterTestB/TestAdapterTestB.pyproj
+++ b/Python/Tests/TestData/TestAdapterTestB/TestAdapterTestB.pyproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -12,7 +12,7 @@
     <Name>UnitTestProjectB</Name>
     <RootNamespace>UnitTestProjectB</RootNamespace>
     <IsWindowsApplication>False</IsWindowsApplication>
-    <InterpreterId>Global|PythonCore|3.3|x64</InterpreterId>
+    <InterpreterId>Global|PythonCore|3.3</InterpreterId>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Python/Tests/TestData/TestAdapterTests/LoadErrorTest.pyproj
+++ b/Python/Tests/TestData/TestAdapterTests/LoadErrorTest.pyproj
@@ -3,16 +3,16 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <SchemaVersion>2.0</SchemaVersion>
-    <ProjectGuid>d0c7948a-de98-4d88-a6eb-3a73bd1cc06f</ProjectGuid>
+    <ProjectGuid>41C5103E-0A73-40D4-9B81-13DC704B715E</ProjectGuid>
     <ProjectHome>.</ProjectHome>
-    <StartupFile>BarTest.py</StartupFile>
-    <SearchPath>..\;..\TestAdapterTestB\</SearchPath>
+    <StartupFile>LoadErrorTest.py</StartupFile>
+    <SearchPath></SearchPath>
     <WorkingDirectory>.</WorkingDirectory>
     <OutputPath>.</OutputPath>
-    <Name>UnitTestProjectA</Name>
-    <RootNamespace>UnitTestProjectA</RootNamespace>
+    <Name>LoadErrorTest</Name>
+    <RootNamespace>LoadErrorTest</RootNamespace>
     <IsWindowsApplication>False</IsWindowsApplication>
-    <InterpreterId>Global|PythonCore|2.7</InterpreterId>
+    <InterpreterId>Global|PythonCore|2.7-32</InterpreterId>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
     <DebugSymbols>true</DebugSymbols>
@@ -23,10 +23,8 @@
     <EnableUnmanagedDebugging>false</EnableUnmanagedDebugging>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="OarTest.py" />
-    <Compile Include="..\TestAdapterTestB\LinkedTest.py">
-      <Link>LinkedTest.py</Link>
-    </Compile>
+    <Compile Include="LoadErrorTestImportError.py" />
+    <Compile Include="LoadErrorTestNoError.py" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\Python Tools\Microsoft.PythonTools.targets" />
 </Project>

--- a/Python/Tests/TestData/TestAdapterTests/LoadErrorTestImportError.py
+++ b/Python/Tests/TestData/TestAdapterTests/LoadErrorTestImportError.py
@@ -1,5 +1,5 @@
 import unittest
-import foooo
+import boooo
 
 class ImportErrorTests(unittest.TestCase):
     def test_import_error(self):

--- a/Python/Tests/TestData/TestAdapterTests/LoadErrorTestImportError.py
+++ b/Python/Tests/TestData/TestAdapterTests/LoadErrorTestImportError.py
@@ -1,0 +1,9 @@
+import unittest
+import foooo
+
+class ImportErrorTests(unittest.TestCase):
+    def test_import_error(self):
+        pass
+
+if __name__ == '__main__':
+    unittest.main()

--- a/Python/Tests/TestData/TestAdapterTests/LoadErrorTestNoError.py
+++ b/Python/Tests/TestData/TestAdapterTests/LoadErrorTestNoError.py
@@ -1,0 +1,8 @@
+import unittest
+
+class NoErrorTests(unittest.TestCase):
+    def test_no_error(self):
+        pass
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Fixes https://github.com/Microsoft/PTVS/issues/1727

It fixes some of the existing test adapter tests (unrelated to 1727).  Inheritance related tests are still failing, so I've moved them to a separate test so that the main tests `Run` and `RunAll` now pass.