### PR TITLE
Fixes #1759 No cookiecutter icons on VS 15

### DIFF
--- a/Build/Common.Build.CSharp.targets
+++ b/Build/Common.Build.CSharp.targets
@@ -121,9 +121,34 @@
     </ExtractLambdasFromXaml>
   </Target>
 
+  <Target Name="_CompileImageManifest" Condition="@(ImageManifest) != ''">
+    <Copy SourceFiles="%(ImageManifest.FullPath)" DestinationFiles="$(IntermediateOutputPath)%(Filename)%(Extension)" OverwriteReadOnlyFiles="true" />
+
+    <PropertyGroup>
+      <_NS>
+        <Namespace Prefix="im" Uri="http://schemas.microsoft.com/VisualStudio/ImageManifestSchema/2014" />
+      </_NS>
+      <_FullAssemblyName>$(AssemblyName)%3bv$(StableVersion)%3bb03f5f7f11d50a3a</_FullAssemblyName>
+    </PropertyGroup>
+    
+    <XmlPoke XmlInputPath="$(IntermediateOutputPath)%(ImageManifest.Filename)%(Extension)"
+             Namespaces="$(_NS)"
+             Query="/im:ImageManifest/im:Symbols/im:String[@Name='AssemblyName']/@Value"
+             Value="$(_FullAssemblyName)" />
+
+    <ItemGroup>
+      <Content Include="$(IntermediateOutputPath)%(ImageManifest.Filename)%(ImageManifest.Extension)">
+        <IncludeInVSIX>true</IncludeInVSIX>
+        <VSIXSubPath>.</VSIXSubPath>
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </Content>
+    </ItemGroup>
+  </Target>
+
   <PropertyGroup>
     <CoreCompileDependsOn>
       ExtractLambdasFromXaml;
+      _CompileImageManifest;
       $(CoreCompileDependsOn)
     </CoreCompileDependsOn>
   </PropertyGroup>

--- a/Python/Product/Cookiecutter/Cookiecutter.csproj
+++ b/Python/Product/Cookiecutter/Cookiecutter.csproj
@@ -276,10 +276,9 @@
   </ItemGroup>
   <ItemGroup>
     <Resource Include="Shared\readme.txt" />
-    <Content Include="Resources\Images.imagemanifest">
-      <IncludeInVSIX>true</IncludeInVSIX>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
+    <ImageManifest Include="Resources\Images.imagemanifest">
+      <SubType>Designer</SubType>
+    </ImageManifest>
     <None Include="source.extension.vsixmanifest">
       <SubType>Designer</SubType>
     </None>

--- a/Python/Product/Cookiecutter/Resources/Images.imagemanifest
+++ b/Python/Product/Cookiecutter/Resources/Images.imagemanifest
@@ -1,9 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <ImageManifest xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                           xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-                           xmlns="http://schemas.microsoft.com/VisualStudio/ImageManifestSchema/2014">
+               xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+               xmlns="http://schemas.microsoft.com/VisualStudio/ImageManifestSchema/2014">
   <Symbols>
-    <String Name="Resources" Value="/Microsoft.CookiecutterTools;Component/Resources"/>
+    <!-- The value of AssemblyName will be replaced at build with the full name -->
+    <String Name="AssemblyName" Value="Microsoft.CookiecutterTools"/>
+    <String Name="Resources" Value="/$(AssemblyName);Component/Resources"/>
     <Guid Name="CookiecutterImagesGuid" Value="{50EDF200-5C99-4968-ABC0-CF1A2C490F00}"/>
     <ID Name="Cancel" Value="1"/>
     <ID Name="Cookiecutter" Value="2"/>


### PR DESCRIPTION
Fixes #1759 No cookiecutter icons on VS 15
Had to move the location of the imagemanifest on deployment and insert the full assembly name.