### PR TITLE
Fix test launcher handling of import errors on Python 3.5

### DIFF
--- a/Python/Tests/TestAdapterTests/TestExecutorTests.cs
+++ b/Python/Tests/TestAdapterTests/TestExecutorTests.cs
@@ -310,16 +310,38 @@ namespace TestAdapterTests {
 
         [TestMethod, Priority(1)]
         [TestCategory("10s")]
-        public void TestLoadError() {
+        public void TestLoadError27() {
             PythonPaths.Python27_x64.AssertInstalled();
 
+            TestLoadError("LoadErrorTest27");
+        }
+
+        [TestMethod, Priority(1)]
+        [TestCategory("10s")]
+        public void TestLoadError34() {
+            PythonPaths.Python34_x64.AssertInstalled();
+
+            TestLoadError("LoadErrorTest34");
+        }
+
+        [TestMethod, Priority(1)]
+        [TestCategory("10s")]
+        public void TestLoadError35() {
+            // Handling of import error when loading a test changed in Python 3.5
+            // so it's important to test 3.4 and 3.5
+            PythonPaths.Python35_x64.AssertInstalled();
+
+            TestLoadError("LoadErrorTest35");
+        }
+
+        private static void TestLoadError(string projectName) {
             // A load error is when unittest module fails to load the test (prior to running it)
             // For example, if the file where the test is defined has an unhandled ImportError.
             // We check that this only causes the tests that can't be loaded to fail,
             // all other tests in the test run which can be loaded successfully will be run.
             var executor = new TestExecutor();
             var recorder = new MockTestExecutionRecorder();
-            var expectedTests = TestInfo.TestAdapterLoadErrorTests;
+            var expectedTests = TestInfo.GetTestAdapterLoadErrorTests(projectName);
             var runContext = CreateRunContext(expectedTests);
             var testCases = expectedTests.Select(tr => tr.TestCase);
 

--- a/Python/Tests/TestAdapterTests/TestInfo.cs
+++ b/Python/Tests/TestAdapterTests/TestInfo.cs
@@ -137,15 +137,11 @@ namespace TestAdapterTests {
             }
         }
 
-        private static TestInfo LoadErrorImportError = TestInfo.FromRelativePaths("ImportErrorTests", "test_import_error", @"TestData\TestAdapterTests\LoadErrorTest.pyproj", @"TestData\TestAdapterTests\LoadErrorTestImportError.py", 5, TestOutcome.Failed);
-        private static TestInfo LoadErrorNoError = TestInfo.FromRelativePaths("NoErrorTests", "test_no_error", @"TestData\TestAdapterTests\LoadErrorTest.pyproj", @"TestData\TestAdapterTests\LoadErrorTestNoError.py", 4, TestOutcome.Passed);
+        private static TestInfo GetLoadErrorImportError(string projectName) => TestInfo.FromRelativePaths("ImportErrorTests", "test_import_error", $"TestData\\TestAdapterTests\\{projectName}.pyproj", @"TestData\TestAdapterTests\LoadErrorTestImportError.py", 5, TestOutcome.Failed);
+        private static TestInfo GetLoadErrorNoError(string projectName) => TestInfo.FromRelativePaths("NoErrorTests", "test_no_error", $"TestData\\TestAdapterTests\\{projectName}.pyproj", @"TestData\TestAdapterTests\LoadErrorTestNoError.py", 4, TestOutcome.Passed);
 
-        public static string TestAdapterLoadErrorTestProjectFilePath = TestData.GetPath(@"TestData\TestAdapterTests\LoadErrorTest.pyproj");
-
-        public static TestInfo[] TestAdapterLoadErrorTests {
-            get {
-                return new[] { LoadErrorImportError, LoadErrorNoError };
-            }
+        public static TestInfo[] GetTestAdapterLoadErrorTests(string projectName) {
+            return new[] { GetLoadErrorImportError(projectName), GetLoadErrorNoError(projectName) };
         }
 
         public static string TestAdapterEnvironmentProject = TestData.GetPath(@"TestData\TestAdapterTests\EnvironmentTest.pyproj");

--- a/Python/Tests/TestData/TestAdapterTests/LoadErrorTest27.pyproj
+++ b/Python/Tests/TestData/TestAdapterTests/LoadErrorTest27.pyproj
@@ -12,7 +12,7 @@
     <Name>LoadErrorTest</Name>
     <RootNamespace>LoadErrorTest</RootNamespace>
     <IsWindowsApplication>False</IsWindowsApplication>
-    <InterpreterId>Global|PythonCore|2.7-32</InterpreterId>
+    <InterpreterId>Global|PythonCore|2.7</InterpreterId>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Python/Tests/TestData/TestAdapterTests/LoadErrorTest34.pyproj
+++ b/Python/Tests/TestData/TestAdapterTests/LoadErrorTest34.pyproj
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>41C5103E-0A73-40D4-9B81-13DC704B715E</ProjectGuid>
+    <ProjectHome>.</ProjectHome>
+    <StartupFile>LoadErrorTest.py</StartupFile>
+    <SearchPath></SearchPath>
+    <WorkingDirectory>.</WorkingDirectory>
+    <OutputPath>.</OutputPath>
+    <Name>LoadErrorTest</Name>
+    <RootNamespace>LoadErrorTest</RootNamespace>
+    <IsWindowsApplication>False</IsWindowsApplication>
+    <InterpreterId>Global|PythonCore|3.4</InterpreterId>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
+    <DebugSymbols>true</DebugSymbols>
+    <EnableUnmanagedDebugging>false</EnableUnmanagedDebugging>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+    <DebugSymbols>true</DebugSymbols>
+    <EnableUnmanagedDebugging>false</EnableUnmanagedDebugging>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="LoadErrorTestImportError.py" />
+    <Compile Include="LoadErrorTestNoError.py" />
+  </ItemGroup>
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\Python Tools\Microsoft.PythonTools.targets" />
+</Project>

--- a/Python/Tests/TestData/TestAdapterTests/LoadErrorTest35.pyproj
+++ b/Python/Tests/TestData/TestAdapterTests/LoadErrorTest35.pyproj
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>41C5103E-0A73-40D4-9B81-13DC704B715E</ProjectGuid>
+    <ProjectHome>.</ProjectHome>
+    <StartupFile>LoadErrorTest.py</StartupFile>
+    <SearchPath></SearchPath>
+    <WorkingDirectory>.</WorkingDirectory>
+    <OutputPath>.</OutputPath>
+    <Name>LoadErrorTest</Name>
+    <RootNamespace>LoadErrorTest</RootNamespace>
+    <IsWindowsApplication>False</IsWindowsApplication>
+    <InterpreterId>Global|PythonCore|3.5</InterpreterId>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
+    <DebugSymbols>true</DebugSymbols>
+    <EnableUnmanagedDebugging>false</EnableUnmanagedDebugging>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+    <DebugSymbols>true</DebugSymbols>
+    <EnableUnmanagedDebugging>false</EnableUnmanagedDebugging>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="LoadErrorTestImportError.py" />
+    <Compile Include="LoadErrorTestNoError.py" />
+  </ItemGroup>
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\Python Tools\Microsoft.PythonTools.targets" />
+</Project>


### PR DESCRIPTION
Fixes https://github.com/Microsoft/PTVS/issues/1727 for Python 3.5

Implementation of unittest changed for 3.5, they now handle import errors and create fake test cases for them.  Problem is that the implementation of id() on the fake test cases doesn't match the id that VS has for the test.