### PR TITLE
Fixes #1795 New 'enter' in comment feature indents incorrectly

### DIFF
--- a/Common/Product/SharedProject/UIThread.cs
+++ b/Common/Product/SharedProject/UIThread.cs
@@ -42,7 +42,10 @@ namespace Microsoft.VisualStudioTools {
 
         public override bool InvokeRequired {
             get {
-                return Thread.CurrentThread != _uiThread;
+                // The UI thread may no longer be alive in test situations, as
+                // it is not the main thread. In actual installs this is very
+                // unlikely to ever occur.
+                return Thread.CurrentThread != _uiThread && _uiThread.IsAlive;
             }
         }
 

--- a/Common/Tests/MockVsTests/MockVsServiceProvider.cs
+++ b/Common/Tests/MockVsTests/MockVsServiceProvider.cs
@@ -64,14 +64,11 @@ namespace Microsoft.VisualStudioTools.MockVsTests {
                 return res;
             }
 
-            var msg = string.Format(
+            Console.WriteLine(
                 "Unknown Service {0} ({1:B})",
                 Type.GetTypeFromCLSID(serviceType, false)?.FullName ?? "(unknown)",
                 serviceType
             );
-
-            Console.WriteLine(msg);
-            //throw new NotImplementedException(msg);
             return null;
         }
 

--- a/Common/Tests/MockVsTests/MockVsServiceProvider.cs
+++ b/Common/Tests/MockVsTests/MockVsServiceProvider.cs
@@ -20,10 +20,7 @@ using System.ComponentModel.Composition;
 using System.ComponentModel.Design;
 using System.Runtime.InteropServices;
 using Microsoft.VisualStudio;
-using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.Shell;
-using Microsoft.VisualStudio.Shell.Interop;
-using Microsoft.VisualStudio.TextManager.Interop;
 using IOleServiceProvider = Microsoft.VisualStudio.OLE.Interop.IServiceProvider;
 
 namespace Microsoft.VisualStudioTools.MockVsTests {
@@ -31,20 +28,18 @@ namespace Microsoft.VisualStudioTools.MockVsTests {
     [Export(typeof(MockVsServiceProvider))]
     public class MockVsServiceProvider : SVsServiceProvider, IOleServiceProvider, IServiceContainer, IDisposable {
         private readonly MockVs _vs;
-        private readonly Dictionary<Type, object> _servicesByType = new Dictionary<Type, object>();
         private readonly Dictionary<Guid, object> _servicesByGuid = new Dictionary<Guid, object>();
-        private readonly Dictionary<Type, ServiceCreatorCallback> _serviceCreatorByType = new Dictionary<Type, ServiceCreatorCallback>();
+        private readonly Dictionary<Guid, ServiceCreatorCallback> _serviceCreatorByGuid = new Dictionary<Guid, ServiceCreatorCallback>();
         private readonly List<IDisposable> _disposeAtEnd = new List<IDisposable>();
         private bool _isDisposed;
 
         [ImportingConstructor]
         public MockVsServiceProvider(MockVs mockVs) {
             _vs = mockVs;
-            _servicesByType.Add(typeof(IOleServiceProvider), this);
+            _servicesByGuid.Add(typeof(IOleServiceProvider).GUID, this);
         }
 
         public void AddService(Type type, object inst) {
-            _servicesByType[type] = inst;
             _servicesByGuid[type.GUID] = inst;
         }
 
@@ -57,24 +52,11 @@ namespace Microsoft.VisualStudioTools.MockVsTests {
             if (_servicesByGuid.TryGetValue(serviceType, out res)) {
                 return res;
             }
-            Console.WriteLine("Unknown service: " + serviceType);
-            throw new NotImplementedException();
-        }
-
-        public object GetService(Type serviceType) {
-            object res;
-            if (_servicesByType.TryGetValue(serviceType, out res)) {
-                return res;
-            }
-
-            if (_servicesByGuid.TryGetValue(serviceType.GUID, out res)) {
-                return res;
-            }
 
             ServiceCreatorCallback creator;
-            if (_serviceCreatorByType.TryGetValue(serviceType, out creator)) {
-                _servicesByType[serviceType] = res = creator(this, serviceType);
-                _serviceCreatorByType.Remove(serviceType);
+            if (_serviceCreatorByGuid.TryGetValue(serviceType, out creator)) {
+                _servicesByGuid[serviceType] = res = creator(this, Type.GetTypeFromCLSID(serviceType));
+                _serviceCreatorByGuid.Remove(serviceType);
                 var disposable = res as IDisposable;
                 if (disposable != null) {
                     _disposeAtEnd.Add(disposable);
@@ -82,13 +64,24 @@ namespace Microsoft.VisualStudioTools.MockVsTests {
                 return res;
             }
 
-            Console.WriteLine("Unknown service: " + serviceType.FullName);
+            var msg = string.Format(
+                "Unknown Service {0} ({1:B})",
+                Type.GetTypeFromCLSID(serviceType, false)?.FullName ?? "(unknown)",
+                serviceType
+            );
+
+            Console.WriteLine(msg);
+            //throw new NotImplementedException(msg);
             return null;
+        }
+
+        public object GetService(Type serviceType) {
+            return GetService(serviceType.GUID);
         }
 
         public int QueryService(ref Guid guidService, ref Guid riid, out IntPtr ppvObject) {
             object res;
-            if (_servicesByGuid.TryGetValue(guidService, out res)) {
+            if ((res = GetService(guidService)) != null) {
                 IntPtr punk = Marshal.GetIUnknownForObject(res);
                 try {
                     return Marshal.QueryInterface(punk, ref riid, out ppvObject);
@@ -103,22 +96,21 @@ namespace Microsoft.VisualStudioTools.MockVsTests {
         }
 
         public void AddService(Type serviceType, ServiceCreatorCallback callback, bool promote) {
-            _serviceCreatorByType[serviceType] = callback;
+            _serviceCreatorByGuid[serviceType.GUID] = callback;
         }
 
         public void AddService(Type serviceType, ServiceCreatorCallback callback) {
-            _serviceCreatorByType[serviceType] = callback;
+            _serviceCreatorByGuid[serviceType.GUID] = callback;
         }
 
         public void RemoveService(Type serviceType, bool promote) {
-            _servicesByType.Remove(serviceType);
             _servicesByGuid.Remove(serviceType.GUID);
-            _serviceCreatorByType.Remove(serviceType);
+            _serviceCreatorByGuid.Remove(serviceType.GUID);
         }
 
         public void RemoveService(Type serviceType) {
-            _servicesByType.Remove(serviceType);
-            _serviceCreatorByType.Remove(serviceType);
+            _servicesByGuid.Remove(serviceType.GUID);
+            _serviceCreatorByGuid.Remove(serviceType.GUID);
         }
 
         public void Dispose() {
@@ -128,9 +120,8 @@ namespace Microsoft.VisualStudioTools.MockVsTests {
                     d.Dispose();
                 }
                 _disposeAtEnd.Clear();
-                _servicesByType.Clear();
                 _servicesByGuid.Clear();
-                _serviceCreatorByType.Clear();
+                _serviceCreatorByGuid.Clear();
             }
         }
     }

--- a/Python/Product/PythonTools/PythonTools/Intellisense/TaskProvider.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/TaskProvider.cs
@@ -606,7 +606,14 @@ namespace Microsoft.PythonTools.Intellisense {
             // Otherwise abort and we'll try again later
             var cts = new CancellationTokenSource(1000);
             try {
-                RefreshAsync(cts.Token).WaitAndUnwrapExceptions();
+                try {
+                    RefreshAsync(cts.Token).Wait(cts.Token);
+                } catch (AggregateException ex) {
+                    if (ex.InnerExceptions.Count == 1) {
+                        throw ex.InnerException;
+                    }
+                    throw;
+                }
             } catch (OperationCanceledException) {
                 return false;
             } catch (Exception ex) when (!ex.IsCriticalException()) {

--- a/Python/Product/VSInterpreters/CPythonInterpreterFactoryProvider.cs
+++ b/Python/Product/VSInterpreters/CPythonInterpreterFactoryProvider.cs
@@ -32,7 +32,7 @@ namespace Microsoft.PythonTools.Interpreter {
         private readonly Dictionary<string, PythonInterpreterInformation> _factories = new Dictionary<string, PythonInterpreterInformation>();
         const string PythonPath = "Software\\Python";
         internal const string FactoryProviderName = "Global";
-        private bool _watchRegistry;
+        internal bool _watchRegistry;
         private bool _initialized;
 
         public CPythonInterpreterFactoryProvider() : this(true) { }

--- a/Python/Product/VSInterpreters/CPythonInterpreterFactoryProvider.cs
+++ b/Python/Product/VSInterpreters/CPythonInterpreterFactoryProvider.cs
@@ -32,7 +32,7 @@ namespace Microsoft.PythonTools.Interpreter {
         private readonly Dictionary<string, PythonInterpreterInformation> _factories = new Dictionary<string, PythonInterpreterInformation>();
         const string PythonPath = "Software\\Python";
         internal const string FactoryProviderName = "Global";
-        internal bool _watchRegistry;
+        private bool _watchRegistry;
         private bool _initialized;
 
         public CPythonInterpreterFactoryProvider() : this(true) { }

--- a/Python/Tests/Core/CPythonInterpreterTests.cs
+++ b/Python/Tests/Core/CPythonInterpreterTests.cs
@@ -32,7 +32,7 @@ using TestUtilities.Python;
 namespace PythonToolsTests {
     [TestClass]
     public class CPythonInterpreterTests {
-        internal static readonly CPythonInterpreterFactoryProvider InterpFactory = new CPythonInterpreterFactoryProvider();
+        internal static readonly CPythonInterpreterFactoryProvider InterpFactory = new CPythonInterpreterFactoryProvider(false);
 
         [ClassInitialize]
         public static void DoDeployment(TestContext context) {

--- a/Python/Tests/PythonToolsMockTests/EditorTests.cs
+++ b/Python/Tests/PythonToolsMockTests/EditorTests.cs
@@ -404,7 +404,7 @@ class B:
                 view.Enter();
                 Assert.AreEqual(2, view.CurrentSnapshot.LineCount);
                 Assert.AreEqual("# ", view.CurrentSnapshot.GetLineFromLineNumber(0).GetText());
-                Assert.AreEqual("#comment", view.CurrentSnapshot.GetLineFromLineNumber(1).GetText());
+                Assert.AreEqual("# comment", view.CurrentSnapshot.GetLineFromLineNumber(1).GetText());
             }
 
             using (var view = new PythonEditor(@"# comment")) {
@@ -420,7 +420,7 @@ class B:
                 view.Enter();
                 Assert.AreEqual(2, view.CurrentSnapshot.LineCount);
                 Assert.AreEqual("    # ", view.CurrentSnapshot.GetLineFromLineNumber(0).GetText());
-                Assert.AreEqual("    #comment", view.CurrentSnapshot.GetLineFromLineNumber(1).GetText());
+                Assert.AreEqual("    # comment", view.CurrentSnapshot.GetLineFromLineNumber(1).GetText());
             }
         }
     }

--- a/Python/Tests/PythonToolsMockTests/MockPythonToolsPackage.cs
+++ b/Python/Tests/PythonToolsMockTests/MockPythonToolsPackage.cs
@@ -51,18 +51,16 @@ namespace PythonToolsMockTests {
             ErrorHandler.ThrowOnFailure(settings.GetWritableSettingsStore((uint)SettingsScope.Configuration, out store));
             
             
-            _serviceContainer.AddService(typeof(IPythonToolsOptionsService), new MockPythonToolsOptionsService());
-            var errorProvider = new MockErrorProviderFactory();
-            _serviceContainer.AddService(typeof(MockErrorProviderFactory), errorProvider, true);
-            _serviceContainer.AddService(typeof(IClipboardService), new MockClipboardService());
-            UIThread.EnsureService(_serviceContainer);
-
+            _serviceContainer.AddService(typeof(IPythonToolsOptionsService), (sp, t) => new MockPythonToolsOptionsService());
+            _serviceContainer.AddService(typeof(IClipboardService), (sp, t) => new MockClipboardService());
+            _serviceContainer.AddService(typeof(MockErrorProviderFactory), (sp, t) => new MockErrorProviderFactory(), true);
+            _serviceContainer.AddService(typeof(PythonLanguageInfo), (sp, t) => new PythonLanguageInfo(sp), true);
+            _serviceContainer.AddService(typeof(PythonToolsService), (sp, t) => new PythonToolsService(sp), true);
             _serviceContainer.AddService(typeof(ErrorTaskProvider), CreateTaskProviderService, true);
             _serviceContainer.AddService(typeof(CommentTaskProvider), CreateTaskProviderService, true);
+            _serviceContainer.AddService(typeof(SolutionEventsListener), (sp, t) => new SolutionEventsListener(sp), true);
 
-            var pyService = new PythonToolsService(_serviceContainer);
-            _onDispose.Add(() => ((IDisposable)pyService).Dispose());
-            _serviceContainer.AddService(typeof(PythonToolsService), pyService, true);
+            UIThread.EnsureService(_serviceContainer);
 
             _serviceContainer.AddService(typeof(IPythonLibraryManager), (object)null);
 


### PR DESCRIPTION
Fixes #1795 New 'enter' in comment feature indents incorrectly
Fixes indentation
Fixes issues with mock test infrastructure
Prevents deadlock on exit due to error task providers (attempt #3)