### PR TITLE
Cookiecutter git.exe location

### DIFF
--- a/Python/Product/Cookiecutter/Cookiecutter.csproj
+++ b/Python/Product/Cookiecutter/Cookiecutter.csproj
@@ -149,6 +149,7 @@
     <Compile Include="Commands\RunCommand.cs" />
     <Compile Include="Commands\CheckForUpdatesCommand.cs" />
     <Compile Include="Commands\UpdateCommand.cs" />
+    <Compile Include="Model\GitClientProvider.cs" />
     <Compile Include="Model\Selectors.cs" />
     <Compile Include="Model\ILocalTemplateSource.cs" />
     <Compile Include="View\LoadingPage.xaml.cs">

--- a/Python/Product/Cookiecutter/CookiecutterToolWindow.cs
+++ b/Python/Product/Cookiecutter/CookiecutterToolWindow.cs
@@ -123,7 +123,13 @@ namespace Microsoft.CookiecutterTools {
                 feedUrl = UrlConstants.DefaultRecommendedFeed;
             }
 
-            _cookiecutterPage = new CookiecutterContainerPage(outputWindow, CookiecutterTelemetry.Current, new Uri(feedUrl), OpenGeneratedFolder, UpdateCommandUI);
+            object commonIdeFolderPath;
+            var shell = (IVsShell)GetService(typeof(SVsShell));
+            ErrorHandler.ThrowOnFailure(shell.GetProperty((int)__VSSPROPID.VSSPROPID_InstallDirectory, out commonIdeFolderPath));
+
+            var gitClient = GitClientProvider.Create(outputWindow, commonIdeFolderPath as string);
+
+            _cookiecutterPage = new CookiecutterContainerPage(outputWindow, CookiecutterTelemetry.Current, gitClient, new Uri(feedUrl), OpenGeneratedFolder, UpdateCommandUI);
             _cookiecutterPage.ContextMenuRequested += OnContextMenuRequested;
             _cookiecutterPage.InitializeAsync(CookiecutterPackage.Instance.CheckForTemplateUpdate).HandleAllExceptions(this, GetType()).DoNotWait();
 

--- a/Python/Product/Cookiecutter/Model/GitClient.cs
+++ b/Python/Product/Cookiecutter/Model/GitClient.cs
@@ -16,12 +16,9 @@
 
 using System;
 using System.Collections.Generic;
-using System.ComponentModel;
-using System.Diagnostics;
 using System.IO;
 using System.Threading.Tasks;
 using Microsoft.CookiecutterTools.Infrastructure;
-using Microsoft.Win32;
 
 namespace Microsoft.CookiecutterTools.Model {
     class GitClient : IGitClient {
@@ -31,50 +28,6 @@ namespace Microsoft.CookiecutterTools.Model {
         public GitClient(string gitExeFilePath, Redirector redirector) {
             _gitExeFilePath = gitExeFilePath;
             _redirector = redirector;
-        }
-
-        public static string RecommendedGitFilePath {
-            get {
-                string gitExeFilePath = TeamExplorerGitFilePath;
-                if (File.Exists(gitExeFilePath)) {
-                    return gitExeFilePath;
-                }
-
-                try {
-                    if (ExecutableOnPath(GitExecutableName)) {
-                        return GitExecutableName;
-                    }
-                } catch (NotSupportedException) {
-                }
-
-                return null;
-            }
-        }
-
-        private static string GitExecutableName {
-            get {
-                return "git.exe";
-            }
-        }
-
-        private static string TeamExplorerGitFilePath {
-            get {
-                try {
-                    using (var key = Registry.LocalMachine.OpenSubKey(@"Software\\Microsoft\VisualStudio\SxS\VS7")) {
-                        var installRoot = (string)key.GetValue(AssemblyVersionInfo.VSVersion);
-                        if (installRoot != null) {
-                            // git.exe is in a folder path with a symlink to the actual extension dir with random name
-                            var gitFolder = Path.Combine(installRoot, @"Common7\IDE\CommonExtensions\Microsoft\TeamFoundation\Team Explorer\Git\cmd");
-                            var finalGitFolder = PathUtils.GetFinalPathName(gitFolder);
-                            var gitExe = Path.Combine(finalGitFolder, GitExecutableName);
-                            return gitExe;
-                        }
-                    }
-                } catch (Exception e) when (!e.IsCriticalException()) {
-                }
-
-                return null;
-            }
         }
 
         public async Task<string> CloneAsync(string repoUrl, string targetParentFolderPath) {
@@ -210,19 +163,6 @@ namespace Microsoft.CookiecutterTools.Model {
 
             name = repoUrl.Substring(index + 1);
             return true;
-        }
-
-        private static bool ExecutableOnPath(string executable) {
-            try {
-                ProcessStartInfo info = new ProcessStartInfo("where", executable);
-                info.UseShellExecute = false;
-                info.CreateNoWindow = true;
-                var process = Process.Start(info);
-                process.WaitForExit();
-                return process.ExitCode == 0;
-            } catch (Win32Exception) {
-                throw new NotSupportedException();
-            }
         }
     }
 }

--- a/Python/Product/Cookiecutter/Model/GitClientProvider.cs
+++ b/Python/Product/Cookiecutter/Model/GitClientProvider.cs
@@ -1,0 +1,75 @@
+﻿// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABLITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System;
+using System.IO;
+using Microsoft.CookiecutterTools.Infrastructure;
+using Microsoft.Win32;
+
+namespace Microsoft.CookiecutterTools.Model {
+    internal static class GitClientProvider {
+        public static IGitClient Create(Redirector redirector, string commonIdeFolderPath) {
+            string gitExeFilePath = null;
+
+            // Try to locate Team Explorer's git.exe using the running instance ide folder
+            if (!string.IsNullOrEmpty(commonIdeFolderPath)) {
+                gitExeFilePath = GetTeamExplorerGitFilePathFromIdeFolderPath(commonIdeFolderPath);
+            }
+
+            // Try to locate Team Explorer's git.exe using the Dev 15 install path from registry
+            // (for tests with no running instance of VS, or when running in Dev 14)
+            if (!File.Exists(gitExeFilePath)) {
+                gitExeFilePath = GetTeamExplorerGitFilePathFromRegistry();
+            }
+
+            // Just use git.exe, and it will work if it's in PATH
+            // If it's not, the error will be output in redirector at time of use
+            if (!File.Exists(gitExeFilePath)) {
+                gitExeFilePath = GitExecutableName;
+            }
+
+            return new GitClient(gitExeFilePath, redirector);
+        }
+
+        private static string GitExecutableName {
+            get {
+                return "git.exe";
+            }
+        }
+
+        private static string GetTeamExplorerGitFilePathFromRegistry() {
+            try {
+                using (var key = Registry.LocalMachine.OpenSubKey(@"Software\\Microsoft\VisualStudio\SxS\VS7")) {
+                    var installRoot = (string)key.GetValue(AssemblyVersionInfo.VSVersion);
+                    if (installRoot != null) {
+                        return GetTeamExplorerGitFilePathFromIdeFolderPath(Path.Combine(installRoot, @"Common7\IDE"));
+                    }
+                }
+            } catch (Exception e) when (!e.IsCriticalException()) {
+            }
+
+            return null;
+        }
+
+        private static string GetTeamExplorerGitFilePathFromIdeFolderPath(string ideFolderPath) {
+            // git.exe is in a folder path with a symlink to the actual extension dir with random name
+            var gitFolder = Path.Combine(ideFolderPath, @"CommonExtensions\Microsoft\TeamFoundation\Team Explorer\Git\cmd");
+            var finalGitFolder = PathUtils.GetFinalPathName(gitFolder);
+            var gitExe = Path.Combine(finalGitFolder, GitExecutableName);
+            return gitExe;
+        }
+    }
+}

--- a/Python/Product/Cookiecutter/View/CookiecutterContainerPage.xaml.cs
+++ b/Python/Product/Cookiecutter/View/CookiecutterContainerPage.xaml.cs
@@ -50,14 +50,12 @@ namespace Microsoft.CookiecutterTools.View {
             InitializeComponent();
         }
 
-        public CookiecutterContainerPage(Redirector outputWindow, ICookiecutterTelemetry telemetry, Uri feedUrl, Action<string> openFolder, Action updateCommandUI) {
+        public CookiecutterContainerPage(Redirector outputWindow, ICookiecutterTelemetry telemetry, IGitClient gitClient, Uri feedUrl, Action<string> openFolder, Action updateCommandUI) {
             _updateCommandUI = updateCommandUI;
 
             _checkForUpdatesTimer = new DispatcherTimer();
             _checkForUpdatesTimer.Tick += new EventHandler(CheckForUpdateTimer_Tick);
 
-            string gitExeFilePath = GitClient.RecommendedGitFilePath;
-            var gitClient = new GitClient(gitExeFilePath, outputWindow);
             var gitHubClient = new GitHubClient();
             ViewModel = new CookiecutterViewModel(
                 CookiecutterClientProvider.Create(outputWindow),

--- a/Python/Tests/CookiecutterTests/CookiecutterIntegrationTests.cs
+++ b/Python/Tests/CookiecutterTests/CookiecutterIntegrationTests.cs
@@ -89,7 +89,7 @@ namespace CookiecutterTests {
             var installedPath = TestInstalledTemplateFolderPath;
             var userConfigFilePath = TestUserConfigFilePath;
 
-            _gitClient = new GitClient(GitClient.RecommendedGitFilePath, _redirector);
+            _gitClient = GitClientProvider.Create(_redirector, null);
             _gitHubClient = new GitHubClient();
             _cutterClient = CookiecutterClientProvider.Create(_redirector);
             _telemetry = new CookiecutterTelemetry(new TelemetryTestService());


### PR DESCRIPTION
Use the VS running instance location in order to locate git.exe, instead of using registry.
That's not always possible (tests, dev 14), so we still fallback to registry and global git.exe.

Don't merge yet, I still need to test on Dev 15.