### PR TITLE
Fixes #1634 Fix mixed-mode debugging for 3.6

### DIFF
--- a/Python/Product/Common/Infrastructure/EnumerableExtensions.cs
+++ b/Python/Product/Common/Infrastructure/EnumerableExtensions.cs
@@ -63,5 +63,25 @@ namespace Microsoft.PythonTools.Infrastructure {
                 yield return new KeyValuePair<TKey, TValue>((TKey)entry.Key, (TValue)entry.Value);
             }
         }
+
+        private class TakeWhileCounter<T> {
+            private ulong _remaining;
+
+            public TakeWhileCounter(ulong count) {
+                _remaining = count;
+            }
+
+            public bool ShouldTake(T value) {
+                if (_remaining == 0) {
+                    return false;
+                }
+                _remaining -= 1;
+                return true;
+            }
+        }
+
+        public static IEnumerable<T> Take<T>(this IEnumerable<T> source, ulong count) {
+            return source.TakeWhile(new TakeWhileCounter<T>(count).ShouldTake);
+        }
     }
 }

--- a/Python/Product/Common/Infrastructure/EnumerableExtensions.cs
+++ b/Python/Product/Common/Infrastructure/EnumerableExtensions.cs
@@ -83,5 +83,12 @@ namespace Microsoft.PythonTools.Infrastructure {
         public static IEnumerable<T> Take<T>(this IEnumerable<T> source, ulong count) {
             return source.TakeWhile(new TakeWhileCounter<T>(count).ShouldTake);
         }
+
+        public static IEnumerable<T> Take<T>(this IEnumerable<T> source, long count) {
+            if (count > 0) {
+                return source.TakeWhile(new TakeWhileCounter<T>((ulong)count).ShouldTake);
+            }
+            return Enumerable.Empty<T>();
+        }
     }
 }

--- a/Python/Product/Debugger/Debugger.csproj
+++ b/Python/Product/Debugger/Debugger.csproj
@@ -167,6 +167,9 @@
     <Compile Include="DkmDebugger\Proxies\DataProxy.cs" />
     <Compile Include="DkmDebugger\ExpressionEvaluator.cs" />
     <Compile Include="DkmDebugger\LocalStackWalkingComponent.cs" />
+    <Compile Include="DkmDebugger\Proxies\Structs\PyDictObject27.cs" />
+    <Compile Include="DkmDebugger\Proxies\Structs\PyDictObject36.cs" />
+    <Compile Include="DkmDebugger\Proxies\Structs\PyDictObject33.cs" />
     <Compile Include="DkmDebugger\Proxies\Structs\PyEllipsisObject.cs" />
     <Compile Include="DkmDebugger\Proxies\Structs\PyComplexObject.cs" />
     <Compile Include="DkmDebugger\Proxies\Structs\PyBaseExceptionObject.cs" />

--- a/Python/Product/Debugger/DkmDebugger/Proxies/DataProxy.cs
+++ b/Python/Product/Debugger/DkmDebugger/Proxies/DataProxy.cs
@@ -61,7 +61,7 @@ namespace Microsoft.PythonTools.DkmDebugger.Proxies {
                 FactoryFunc nonPolymorphicFactory;
                 var ctor = typeof(TProxy).GetConstructor(new[] { typeof(DkmProcess), typeof(ulong) });
                 if (ctor != null) {
-                var processParam = Expression.Parameter(typeof(DkmProcess));
+                    var processParam = Expression.Parameter(typeof(DkmProcess));
                     var addressParam = Expression.Parameter(typeof(ulong));
                     var polymorphicParam = Expression.Parameter(typeof(bool));
                     nonPolymorphicFactory = Expression.Lambda<FactoryFunc>(

--- a/Python/Product/Debugger/DkmDebugger/Proxies/Structs/PyByteArrayObject.cs
+++ b/Python/Product/Debugger/DkmDebugger/Proxies/Structs/PyByteArrayObject.cs
@@ -17,6 +17,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using Microsoft.PythonTools.Infrastructure;
 using Microsoft.PythonTools.Parsing;
 using Microsoft.PythonTools.Parsing.Ast;
 using Microsoft.VisualStudio.Debugger;
@@ -80,7 +81,7 @@ namespace Microsoft.PythonTools.DkmDebugger.Proxies.Structs {
             };
 
             if (count > 0) {
-                foreach (var b in GetDataProxy().Take((int)count)) {
+                foreach (var b in GetDataProxy().Take(count)) {
                     yield return new PythonEvaluationResult(b);
                 }
             }

--- a/Python/Product/Debugger/DkmDebugger/Proxies/Structs/PyBytesObject.cs
+++ b/Python/Product/Debugger/DkmDebugger/Proxies/Structs/PyBytesObject.cs
@@ -18,6 +18,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Text;
+using Microsoft.PythonTools.Infrastructure;
 using Microsoft.PythonTools.Parsing;
 using Microsoft.VisualStudio.Debugger;
 using Microsoft.VisualStudio.Debugger.Evaluation;
@@ -91,7 +92,7 @@ namespace Microsoft.PythonTools.DkmDebugger.Proxies.Structs {
                 Category = DkmEvaluationResultCategory.Method
             };
 
-            foreach (var b in ob_sval.Take((int)count)) {
+            foreach (var b in ob_sval.Take(count)) {
                 if (reprOptions.LanguageVersion <= PythonLanguageVersion.V27) {
                     // In 2.x, bytes is a string type, so display characters in object expansion.
                     byte[] bytes = new[] { b.Read() };

--- a/Python/Product/Debugger/DkmDebugger/Proxies/Structs/PyDictObject.cs
+++ b/Python/Product/Debugger/DkmDebugger/Proxies/Structs/PyDictObject.cs
@@ -16,13 +16,10 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.PythonTools.Parsing;
 using Microsoft.VisualStudio.Debugger;
+using Microsoft.VisualStudio.Debugger.Evaluation;
 
 namespace Microsoft.PythonTools.DkmDebugger.Proxies.Structs {
-    using Microsoft.VisualStudio.Debugger.Evaluation;
-    using PyDictEntry = Microsoft.PythonTools.DkmDebugger.Proxies.Structs.PyDictKeyEntry;
-
     internal abstract class PyDictObject : PyObject {
         protected PyDictObject(DkmProcess process, ulong address)
             : base(process, address) {
@@ -60,136 +57,6 @@ namespace Microsoft.PythonTools.DkmDebugger.Proxies.Structs {
         }
     }
 
-    [StructProxy(StructName = "PyDictObject", MaxVersion = PythonLanguageVersion.V27)]
-    [PyType(VariableName = "PyDict_Type", MaxVersion = PythonLanguageVersion.V27)]
-    internal class PyDictObject27 : PyDictObject {
-        private class DummyHolder : DkmDataItem {
-            public readonly PointerProxy<PyObject> Dummy;
-
-            public DummyHolder(DkmProcess process) {
-                Dummy = process.GetPythonRuntimeInfo().DLLs.Python.GetStaticVariable<PointerProxy<PyObject>>("dummy", "dictobject.obj");
-            }
-        }
-
-        private class Fields {
-            public StructField<SSizeTProxy> ma_mask;
-            public StructField<PointerProxy<ArrayProxy<PyDictEntry>>> ma_table;
-        }
-
-        private readonly Fields _fields;
-        private readonly PyObject _dummy;
-
-        public PyDictObject27(DkmProcess process, ulong address)
-            : base(process, address) {
-            InitializeStruct(this, out _fields);
-            CheckPyType<PyDictObject27>();
-
-            _dummy = Process.GetOrCreateDataItem(() => new DummyHolder(Process)).Dummy.TryRead();
-        }
-
-        public PointerProxy<ArrayProxy<PyDictEntry>> ma_table {
-            get { return GetFieldProxy(_fields.ma_table); }
-        }
-
-        public SSizeTProxy ma_mask {
-            get { return GetFieldProxy(_fields.ma_mask); }
-        }
-
-        public override IEnumerable<KeyValuePair<PyObject, PointerProxy<PyObject>>> ReadElements() {
-            if (ma_table.IsNull) {
-                return Enumerable.Empty<KeyValuePair<PyObject, PointerProxy<PyObject>>>();
-            }
-
-            var count = ma_mask.Read() + 1;
-            var entries = ma_table.Read().Take((int)count);
-            var items = from entry in entries
-                        let key = entry.me_key.TryRead()
-                        where key != null && key != _dummy
-                        let valuePtr = entry.me_value
-                        where !valuePtr.IsNull
-                        select new KeyValuePair<PyObject, PointerProxy<PyObject>>(key, valuePtr);
-            return items;
-        }
-    }
-
-    [StructProxy(StructName = "PyDictObject", MinVersion = PythonLanguageVersion.V33)]
-    [PyType(VariableName = "PyDict_Type", MinVersion = PythonLanguageVersion.V33)]
-    internal class PyDictObject33 : PyDictObject {
-        private class Fields {
-            public StructField<PointerProxy<PyDictKeysObject>> ma_keys;
-            public StructField<PointerProxy<ArrayProxy<PointerProxy<PyObject>>>> ma_values;
-        }
-
-        private readonly Fields _fields;
-
-        public PyDictObject33(DkmProcess process, ulong address)
-            : base(process, address) {
-            InitializeStruct(this, out _fields);
-            CheckPyType<PyDictObject33>();
-        }
-
-        public PointerProxy<PyDictKeysObject> ma_keys {
-            get { return GetFieldProxy(_fields.ma_keys); }
-        }
-
-        public PointerProxy<ArrayProxy<PointerProxy<PyObject>>> ma_values {
-            get { return GetFieldProxy(_fields.ma_values); }
-        }
-
-        public override IEnumerable<KeyValuePair<PyObject, PointerProxy<PyObject>>> ReadElements() {
-            if (ma_keys.IsNull) {
-                yield break;
-            }
-
-            var keys = this.ma_keys.Read();
-            var entries = keys.dk_entries.Take((int)keys.dk_size.Read());
-
-            var ma_values = this.ma_values;
-            if (ma_values.IsNull) {
-                foreach (PyDictKeyEntry entry in entries) {
-                    var key = entry.me_key.TryRead();
-                    if (key != null) {
-                        yield return new KeyValuePair<PyObject, PointerProxy<PyObject>>(key, entry.me_value);
-                    }
-                }
-            } else {
-                var valuePtr = ma_values.Read()[0];
-                foreach (PyDictKeyEntry entry in entries) {
-                    var key = entry.me_key.TryRead();
-                    if (key != null) {
-                        yield return new KeyValuePair<PyObject, PointerProxy<PyObject>>(key, valuePtr);
-                    }
-                    valuePtr = valuePtr.GetAdjacentProxy(1);
-                }
-            }
-        }
-    }
-
-    [StructProxy(MinVersion = PythonLanguageVersion.V33, StructName = "_dictkeysobject")]
-    internal class PyDictKeysObject : StructProxy {
-        private class Fields {
-            public StructField<SSizeTProxy> dk_size;
-            public StructField<ArrayProxy<PyDictKeyEntry>> dk_entries;
-        }
-
-        private readonly Fields _fields;
-
-        public SSizeTProxy dk_size {
-            get { return GetFieldProxy(_fields.dk_size); }
-        }
-
-        public ArrayProxy<PyDictKeyEntry> dk_entries {
-            get { return GetFieldProxy(_fields.dk_entries); }
-        }
-
-        public PyDictKeysObject(DkmProcess process, ulong address)
-            : base(process, address) {
-            InitializeStruct(this, out _fields);
-        }
-    }
-
-    [StructProxy(MaxVersion = PythonLanguageVersion.V27, StructName = "PyDictEntry")]
-    [StructProxy(MinVersion = PythonLanguageVersion.V33)]
     internal class PyDictKeyEntry : StructProxy {
         private class Fields {
             public StructField<PointerProxy<PyObject>> me_key;

--- a/Python/Product/Debugger/DkmDebugger/Proxies/Structs/PyDictObject27.cs
+++ b/Python/Product/Debugger/DkmDebugger/Proxies/Structs/PyDictObject27.cs
@@ -1,0 +1,74 @@
+// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABLITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.PythonTools.Parsing;
+using Microsoft.VisualStudio.Debugger;
+
+namespace Microsoft.PythonTools.DkmDebugger.Proxies.Structs {
+    [StructProxy(StructName = "PyDictObject", MaxVersion = PythonLanguageVersion.V27)]
+    [PyType(VariableName = "PyDict_Type", MaxVersion = PythonLanguageVersion.V27)]
+    internal class PyDictObject27 : PyDictObject {
+        private class DummyHolder : DkmDataItem {
+            public readonly PointerProxy<PyObject> Dummy;
+
+            public DummyHolder(DkmProcess process) {
+                Dummy = process.GetPythonRuntimeInfo().DLLs.Python.GetStaticVariable<PointerProxy<PyObject>>("dummy", "dictobject.obj");
+            }
+        }
+
+        private class Fields {
+            public StructField<SSizeTProxy> ma_mask;
+            public StructField<PointerProxy<ArrayProxy<PyDictKeyEntry>>> ma_table;
+        }
+
+        private readonly Fields _fields;
+        private readonly PyObject _dummy;
+
+        public PyDictObject27(DkmProcess process, ulong address)
+            : base(process, address) {
+            InitializeStruct(this, out _fields);
+            CheckPyType<PyDictObject27>();
+
+            _dummy = Process.GetOrCreateDataItem(() => new DummyHolder(Process)).Dummy.TryRead();
+        }
+
+        public PointerProxy<ArrayProxy<PyDictKeyEntry>> ma_table {
+            get { return GetFieldProxy(_fields.ma_table); }
+        }
+
+        public SSizeTProxy ma_mask {
+            get { return GetFieldProxy(_fields.ma_mask); }
+        }
+
+        public override IEnumerable<KeyValuePair<PyObject, PointerProxy<PyObject>>> ReadElements() {
+            if (ma_table.IsNull) {
+                return Enumerable.Empty<KeyValuePair<PyObject, PointerProxy<PyObject>>>();
+            }
+
+            var count = ma_mask.Read() + 1;
+            var entries = ma_table.Read().Take((int)count);
+            var items = from entry in entries
+                        let key = entry.me_key.TryRead()
+                        where key != null && key != _dummy
+                        let valuePtr = entry.me_value
+                        where !valuePtr.IsNull
+                        select new KeyValuePair<PyObject, PointerProxy<PyObject>>(key, valuePtr);
+            return items;
+        }
+    }
+}

--- a/Python/Product/Debugger/DkmDebugger/Proxies/Structs/PyDictObject27.cs
+++ b/Python/Product/Debugger/DkmDebugger/Proxies/Structs/PyDictObject27.cs
@@ -16,6 +16,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.PythonTools.Infrastructure;
 using Microsoft.PythonTools.Parsing;
 using Microsoft.VisualStudio.Debugger;
 
@@ -61,7 +62,7 @@ namespace Microsoft.PythonTools.DkmDebugger.Proxies.Structs {
             }
 
             var count = ma_mask.Read() + 1;
-            var entries = ma_table.Read().Take((int)count);
+            var entries = ma_table.Read().Take(count);
             var items = from entry in entries
                         let key = entry.me_key.TryRead()
                         where key != null && key != _dummy

--- a/Python/Product/Debugger/DkmDebugger/Proxies/Structs/PyDictObject33.cs
+++ b/Python/Product/Debugger/DkmDebugger/Proxies/Structs/PyDictObject33.cs
@@ -1,0 +1,98 @@
+// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABLITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.PythonTools.Parsing;
+using Microsoft.VisualStudio.Debugger;
+
+namespace Microsoft.PythonTools.DkmDebugger.Proxies.Structs {
+    [StructProxy(StructName = "PyDictObject", MinVersion = PythonLanguageVersion.V33, MaxVersion = PythonLanguageVersion.V35)]
+    [PyType(VariableName = "PyDict_Type", MinVersion = PythonLanguageVersion.V33, MaxVersion = PythonLanguageVersion.V35)]
+    internal class PyDictObject33 : PyDictObject {
+        private class Fields {
+            public StructField<PointerProxy<PyDictKeysObject33>> ma_keys;
+            public StructField<PointerProxy<ArrayProxy<PointerProxy<PyObject>>>> ma_values;
+        }
+
+        private readonly Fields _fields;
+
+        public PyDictObject33(DkmProcess process, ulong address)
+            : base(process, address) {
+            InitializeStruct(this, out _fields);
+            CheckPyType<PyDictObject33>();
+        }
+
+        public PointerProxy<PyDictKeysObject33> ma_keys {
+            get { return GetFieldProxy(_fields.ma_keys); }
+        }
+
+        public PointerProxy<ArrayProxy<PointerProxy<PyObject>>> ma_values {
+            get { return GetFieldProxy(_fields.ma_values); }
+        }
+
+        public override IEnumerable<KeyValuePair<PyObject, PointerProxy<PyObject>>> ReadElements() {
+            if (ma_keys.IsNull) {
+                yield break;
+            }
+
+            var keys = this.ma_keys.Read();
+            var entries = keys.dk_entries.Take((int)keys.dk_size.Read());
+
+            var ma_values = this.ma_values;
+            if (ma_values.IsNull) {
+                foreach (var entry in entries) {
+                    var key = entry.me_key.TryRead();
+                    if (key != null) {
+                        yield return new KeyValuePair<PyObject, PointerProxy<PyObject>>(key, entry.me_value);
+                    }
+                }
+            } else {
+                var valuePtr = ma_values.Read()[0];
+                foreach (var entry in entries) {
+                    var key = entry.me_key.TryRead();
+                    if (key != null) {
+                        yield return new KeyValuePair<PyObject, PointerProxy<PyObject>>(key, valuePtr);
+                    }
+                    valuePtr = valuePtr.GetAdjacentProxy(1);
+                }
+            }
+        }
+    }
+
+    [StructProxy(MinVersion = PythonLanguageVersion.V33, MaxVersion = PythonLanguageVersion.V35, StructName = "_dictkeysobject")]
+    internal class PyDictKeysObject33 : StructProxy {
+        private class Fields {
+            public StructField<SSizeTProxy> dk_size;
+            public StructField<ArrayProxy<PyDictKeyEntry>> dk_entries;
+        }
+
+        private readonly Fields _fields;
+
+        public SSizeTProxy dk_size {
+            get { return GetFieldProxy(_fields.dk_size); }
+        }
+
+        public ArrayProxy<PyDictKeyEntry> dk_entries {
+            get { return GetFieldProxy(_fields.dk_entries); }
+        }
+
+        public PyDictKeysObject33(DkmProcess process, ulong address)
+            : base(process, address) {
+            InitializeStruct(this, out _fields);
+        }
+    }
+}

--- a/Python/Product/Debugger/DkmDebugger/Proxies/Structs/PyDictObject33.cs
+++ b/Python/Product/Debugger/DkmDebugger/Proxies/Structs/PyDictObject33.cs
@@ -16,6 +16,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.PythonTools.Infrastructure;
 using Microsoft.PythonTools.Parsing;
 using Microsoft.VisualStudio.Debugger;
 
@@ -50,7 +51,7 @@ namespace Microsoft.PythonTools.DkmDebugger.Proxies.Structs {
             }
 
             var keys = this.ma_keys.Read();
-            var entries = keys.dk_entries.Take((int)keys.dk_size.Read());
+            var entries = keys.dk_entries.Take(keys.dk_size.Read());
 
             var ma_values = this.ma_values;
             if (ma_values.IsNull) {

--- a/Python/Product/Debugger/DkmDebugger/Proxies/Structs/PyDictObject36.cs
+++ b/Python/Product/Debugger/DkmDebugger/Proxies/Structs/PyDictObject36.cs
@@ -1,0 +1,137 @@
+// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABLITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using Microsoft.PythonTools.Infrastructure;
+using Microsoft.PythonTools.Parsing;
+using Microsoft.VisualStudio.Debugger;
+
+namespace Microsoft.PythonTools.DkmDebugger.Proxies.Structs {
+    [StructProxy(StructName = "PyDictObject", MinVersion = PythonLanguageVersion.V36)]
+    [PyType(VariableName = "PyDict_Type", MinVersion = PythonLanguageVersion.V36)]
+    internal class PyDictObject36 : PyDictObject {
+        private class Fields {
+            public StructField<PointerProxy<PyDictKeysObject36>> ma_keys;
+            public StructField<PointerProxy<ArrayProxy<PointerProxy<PyObject>>>> ma_values;
+        }
+
+        private readonly Fields _fields;
+
+        public PyDictObject36(DkmProcess process, ulong address)
+            : base(process, address) {
+            InitializeStruct(this, out _fields);
+            CheckPyType<PyDictObject36>();
+        }
+
+        public PointerProxy<PyDictKeysObject36> ma_keys {
+            get { return GetFieldProxy(_fields.ma_keys); }
+        }
+
+        public PointerProxy<ArrayProxy<PointerProxy<PyObject>>> ma_values {
+            get { return GetFieldProxy(_fields.ma_values); }
+        }
+
+        public override IEnumerable<KeyValuePair<PyObject, PointerProxy<PyObject>>> ReadElements() {
+            if (ma_keys.IsNull) {
+                yield break;
+            }
+
+            var keys = ma_keys.Read();
+            var size = keys.dk_size.Read();
+            if (size <= 0) {
+                yield break;
+            }
+
+            var n = keys.dk_nentries.Read();
+            var dk_entries = keys.dk_entries;
+            var entry = dk_entries[0];
+
+            if (!ma_values.IsNull) {
+                var values = ma_values.Read();
+                var value = values[0];
+
+                for (int i = 0; i < n; ++i) {
+                    var key = entry.me_key;
+                    if (!value.IsNull && !key.IsNull) {
+                        yield return new KeyValuePair<PyObject, PointerProxy<PyObject>>(key.Read(), value);
+                    }
+                    entry = entry.GetAdjacentProxy(1);
+                    value = value.GetAdjacentProxy(1);
+                }
+            } else {
+                for (int i = 0; i < n; ++i) {
+                    var key = entry.me_key;
+                    var value = entry.me_value;
+                    if (!key.IsNull && !value.IsNull) {
+                        yield return new KeyValuePair<PyObject, PointerProxy<PyObject>>(key.Read(), value);
+                    }
+                    entry = entry.GetAdjacentProxy(1);
+                }
+            }
+        }
+    }
+
+    [StructProxy(MinVersion = PythonLanguageVersion.V36, StructName = "_dictkeysobject")]
+    internal class PyDictKeysObject36 : StructProxy {
+        public class Fields {
+            public StructField<SSizeTProxy> dk_size;
+            public StructField<SSizeTProxy> dk_nentries;
+            public StructField<ArrayProxy<SByteProxy>> dk_indices;
+        }
+
+        public readonly Fields _fields;
+
+        public SSizeTProxy dk_size {
+            get { return GetFieldProxy(_fields.dk_size); }
+        }
+
+        public SSizeTProxy dk_nentries {
+            get { return GetFieldProxy(_fields.dk_nentries); }
+        }
+
+        public ArrayProxy<PyDictKeyEntry> dk_entries {
+            get {
+                // dk_entries is located after dk_indices, which is
+                // variable length depending on the size of the table.
+                long size = dk_size.Read();
+                long offset = _fields.dk_indices.Offset;
+                if (size <= 0) {
+                    return default(ArrayProxy<PyDictKeyEntry>);
+                } else if (size <= 0xFF) {
+                    offset += size;
+                } else if (size <= 0xFFFF) {
+                    offset += size * 2;
+                } else if (size <= 0xFFFFFFFF) {
+                    offset += size * 4;
+                } else {
+                    offset += size * 8;
+                }
+
+                return DataProxy.Create<ArrayProxy<PyDictKeyEntry>>(
+                    Process,
+                    Address.OffsetBy(offset)
+                );
+            }
+        }
+
+        public PyDictKeysObject36(DkmProcess process, ulong address)
+            : base(process, address) {
+            InitializeStruct(this, out _fields);
+        }
+    }
+}

--- a/Python/Product/Debugger/DkmDebugger/Proxies/Structs/PyFrameObject.cs
+++ b/Python/Product/Debugger/DkmDebugger/Proxies/Structs/PyFrameObject.cs
@@ -16,14 +16,14 @@
 
 using System;
 using System.Diagnostics;
-using Microsoft.PythonTools.Debugger;
+using Microsoft.PythonTools.Parsing;
 using Microsoft.VisualStudio.Debugger;
 using Microsoft.VisualStudio.Debugger.CallStack;
 using Microsoft.VisualStudio.Debugger.Evaluation;
 
 namespace Microsoft.PythonTools.DkmDebugger.Proxies.Structs {
-    internal class PyFrameObject : PyObject {
-        public class Fields {
+    internal class PyFrameObject : PyVarObject {
+        public class Fields_27_35 {
             public StructField<PointerProxy<PyCodeObject>> f_code;
             public StructField<PointerProxy<PyDictObject>> f_globals;
             public StructField<PointerProxy<PyDictObject>> f_locals;
@@ -31,22 +31,60 @@ namespace Microsoft.PythonTools.DkmDebugger.Proxies.Structs {
             public StructField<ArrayProxy<PointerProxy<PyObject>>> f_localsplus;
         }
 
-        private readonly Fields _fields;
+        public class Fields_36 {
+            public StructField<PointerProxy<PyFrameObject>> f_back;
+            public StructField<PointerProxy<PyCodeObject>> f_code;
+            public StructField<PointerProxy<PyDictObject>> f_globals;
+            public StructField<PointerProxy<PyDictObject>> f_locals;
+            public StructField<Int32Proxy> f_lineno;
+            public StructField<ArrayProxy<PointerProxy<PyObject>>> f_localsplus;
+        }
+
+        private readonly object _fields;
 
         public PyFrameObject(DkmProcess process, ulong address)
             : base(process, address) {
-            InitializeStruct(this, out _fields);
+            var pythonInfo = process.GetPythonRuntimeInfo();
+            if (pythonInfo.LanguageVersion <= PythonLanguageVersion.V35) {
+                Fields_27_35 fields;
+                InitializeStruct(this, out fields);
+                _fields = fields;
+            } else {
+                Fields_36 fields;
+                InitializeStruct(this, out fields);
+                _fields = fields;
+            }
             CheckPyType<PyFrameObject>();
+        }
+
+        private static bool IsInEvalFrame(DkmStackWalkFrame frame) {
+            var process = frame.Process;
+            var pythonInfo = process.GetPythonRuntimeInfo();
+            ulong addr = 0;
+            if (pythonInfo.LanguageVersion <= PythonLanguageVersion.V35) {
+                if (frame.ModuleInstance == pythonInfo.DLLs.Python) {
+                    addr = pythonInfo.DLLs.Python.GetFunctionAddress("PyEval_EvalFrameEx");
+                }
+            } else {
+                if (frame.ModuleInstance == pythonInfo.DLLs.DebuggerHelper) {
+                    addr = pythonInfo.DLLs.DebuggerHelper.GetFunctionAddress("EvalFrameFunc");
+                }
+            }
+
+            if (addr == 0) {
+                return false;
+            }
+
+            return frame.InstructionAddress.IsInSameFunction(process.CreateNativeInstructionAddress(addr));
         }
 
         public static unsafe PyFrameObject TryCreate(DkmStackWalkFrame frame) {
             var process = frame.Process;
-            var PyEval_EvalFrameEx = process.CreateNativeInstructionAddress(process.GetPythonRuntimeInfo().DLLs.Python.GetFunctionAddress("PyEval_EvalFrameEx"));
 
             if (frame.InstructionAddress == null) {
                 return null;
             } 
-            if (frame.RuntimeInstance.Id.RuntimeType != Guids.PythonRuntimeTypeGuid && !frame.InstructionAddress.IsInSameFunction(PyEval_EvalFrameEx)) {
+            if (frame.RuntimeInstance.Id.RuntimeType != Guids.PythonRuntimeTypeGuid && !IsInEvalFrame(frame)) {
                 return null;
             }
 
@@ -74,24 +112,29 @@ namespace Microsoft.PythonTools.DkmDebugger.Proxies.Structs {
             return new PyFrameObject(frame.Process, framePtr);
         }
 
-        public PointerProxy<PyCodeObject> f_code {
-            get { return GetFieldProxy(_fields.f_code); }
+        public virtual PointerProxy<PyFrameObject> f_back {
+            get { return GetFieldProxy((_fields as Fields_36)?.f_back); }
         }
 
-        public PointerProxy<PyDictObject> f_globals {
-            get { return GetFieldProxy(_fields.f_globals); }
+        public virtual PointerProxy<PyCodeObject> f_code {
+            get { return GetFieldProxy((_fields as Fields_36)?.f_code ?? (_fields as Fields_27_35)?.f_code); }
         }
 
-        public PointerProxy<PyDictObject> f_locals {
-            get { return GetFieldProxy(_fields.f_locals); }
+        public virtual PointerProxy<PyDictObject> f_globals {
+            get { return GetFieldProxy((_fields as Fields_36)?.f_globals ?? (_fields as Fields_27_35)?.f_globals); }
         }
 
-        public Int32Proxy f_lineno {
-            get { return GetFieldProxy(_fields.f_lineno); }
+        public virtual PointerProxy<PyDictObject> f_locals {
+            get { return GetFieldProxy((_fields as Fields_36)?.f_locals ?? (_fields as Fields_27_35)?.f_locals); }
         }
 
-        public ArrayProxy<PointerProxy<PyObject>> f_localsplus {
-            get { return GetFieldProxy(_fields.f_localsplus); }
+        public virtual Int32Proxy f_lineno {
+            get { return GetFieldProxy((_fields as Fields_36)?.f_lineno ?? (_fields as Fields_27_35)?.f_lineno); }
         }
+
+        public virtual ArrayProxy<PointerProxy<PyObject>> f_localsplus {
+            get { return GetFieldProxy((_fields as Fields_36)?.f_localsplus ?? (_fields as Fields_27_35)?.f_localsplus); }
+        }
+
     }
 }

--- a/Python/Product/Debugger/DkmDebugger/Proxies/Structs/PyFrameObject.cs
+++ b/Python/Product/Debugger/DkmDebugger/Proxies/Structs/PyFrameObject.cs
@@ -112,27 +112,27 @@ namespace Microsoft.PythonTools.DkmDebugger.Proxies.Structs {
             return new PyFrameObject(frame.Process, framePtr);
         }
 
-        public virtual PointerProxy<PyFrameObject> f_back {
+        public PointerProxy<PyFrameObject> f_back {
             get { return GetFieldProxy((_fields as Fields_36)?.f_back); }
         }
 
-        public virtual PointerProxy<PyCodeObject> f_code {
+        public PointerProxy<PyCodeObject> f_code {
             get { return GetFieldProxy((_fields as Fields_36)?.f_code ?? (_fields as Fields_27_35)?.f_code); }
         }
 
-        public virtual PointerProxy<PyDictObject> f_globals {
+        public PointerProxy<PyDictObject> f_globals {
             get { return GetFieldProxy((_fields as Fields_36)?.f_globals ?? (_fields as Fields_27_35)?.f_globals); }
         }
 
-        public virtual PointerProxy<PyDictObject> f_locals {
+        public PointerProxy<PyDictObject> f_locals {
             get { return GetFieldProxy((_fields as Fields_36)?.f_locals ?? (_fields as Fields_27_35)?.f_locals); }
         }
 
-        public virtual Int32Proxy f_lineno {
+        public Int32Proxy f_lineno {
             get { return GetFieldProxy((_fields as Fields_36)?.f_lineno ?? (_fields as Fields_27_35)?.f_lineno); }
         }
 
-        public virtual ArrayProxy<PointerProxy<PyObject>> f_localsplus {
+        public ArrayProxy<PointerProxy<PyObject>> f_localsplus {
             get { return GetFieldProxy((_fields as Fields_36)?.f_localsplus ?? (_fields as Fields_27_35)?.f_localsplus); }
         }
 

--- a/Python/Product/Debugger/DkmDebugger/Proxies/Structs/PyInterpreterState.cs
+++ b/Python/Product/Debugger/DkmDebugger/Proxies/Structs/PyInterpreterState.cs
@@ -15,6 +15,7 @@
 // permissions and limitations under the License.
 
 using System.Collections.Generic;
+using Microsoft.PythonTools.Parsing;
 using Microsoft.VisualStudio.Debugger;
 
 namespace Microsoft.PythonTools.DkmDebugger.Proxies.Structs {
@@ -23,6 +24,8 @@ namespace Microsoft.PythonTools.DkmDebugger.Proxies.Structs {
             public StructField<PointerProxy<PyInterpreterState>> next;
             public StructField<PointerProxy<PyThreadState>> tstate_head;
             public StructField<PointerProxy<PyDictObject>> modules;
+            [FieldProxy(MinVersion = PythonLanguageVersion.V36)]
+            public StructField<PointerProxy> eval_frame;
         }
 
         private readonly Fields _fields;
@@ -30,6 +33,14 @@ namespace Microsoft.PythonTools.DkmDebugger.Proxies.Structs {
         public PyInterpreterState(DkmProcess process, ulong address)
             : base(process, address) {
             InitializeStruct(this, out _fields);
+        }
+
+        public static PyInterpreterState TryCreate(DkmProcess process, ulong address) {
+            if (address == 0) {
+                return null;
+            }
+
+            return new PyInterpreterState(process, address);
         }
 
         public PointerProxy<PyInterpreterState> next {
@@ -42,6 +53,10 @@ namespace Microsoft.PythonTools.DkmDebugger.Proxies.Structs {
 
         public PointerProxy<PyDictObject> modules {
             get { return GetFieldProxy(_fields.modules); }
+        }
+
+        public PointerProxy eval_frame {
+            get { return GetFieldProxy(_fields.eval_frame); }
         }
 
         private class InterpHeadHolder : DkmDataItem {

--- a/Python/Product/Debugger/DkmDebugger/Proxies/Structs/PyListObject.cs
+++ b/Python/Product/Debugger/DkmDebugger/Proxies/Structs/PyListObject.cs
@@ -16,6 +16,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.PythonTools.Infrastructure;
 using Microsoft.VisualStudio.Debugger;
 using Microsoft.VisualStudio.Debugger.Evaluation;
 
@@ -42,7 +43,7 @@ namespace Microsoft.PythonTools.DkmDebugger.Proxies.Structs {
                 return Enumerable.Empty<PointerProxy<PyObject>>();
             }
 
-            return ob_item.Read().Take((int)ob_size.Read());
+            return ob_item.Read().Take(ob_size.Read());
         }
 
         public override void Repr(ReprBuilder builder) {

--- a/Python/Product/Debugger/DkmDebugger/Proxies/Structs/PySetObject.cs
+++ b/Python/Product/Debugger/DkmDebugger/Proxies/Structs/PySetObject.cs
@@ -16,6 +16,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.PythonTools.Infrastructure;
 using Microsoft.PythonTools.Parsing;
 using Microsoft.VisualStudio.Debugger;
 using Microsoft.VisualStudio.Debugger.Evaluation;
@@ -81,7 +82,7 @@ namespace Microsoft.PythonTools.DkmDebugger.Proxies.Structs {
             }
 
             var count = mask.Read() + 1;
-            var entries = table.Read().Take((int)count);
+            var entries = table.Read().Take(count);
             var items = from entry in entries
                         let key = entry.key.TryRead()
                         where key != null && key != _dummy

--- a/Python/Product/Debugger/DkmDebugger/Proxies/Structs/PyThreadState.cs
+++ b/Python/Product/Debugger/DkmDebugger/Proxies/Structs/PyThreadState.cs
@@ -41,6 +41,13 @@ namespace Microsoft.PythonTools.DkmDebugger.Proxies.Structs {
             InitializeStruct(this, out _fields);
         }
 
+        public static PyThreadState TryCreate(DkmProcess process, ulong address) {
+            if (address == 0) {
+                return null;
+            }
+            return new PyThreadState(process, address);
+        }
+
         public PointerProxy<PyThreadState> next {
             get { return GetFieldProxy(_fields.next); }
         }

--- a/Python/Product/Debugger/DkmDebugger/Proxies/Structs/PyTupleObject.cs
+++ b/Python/Product/Debugger/DkmDebugger/Proxies/Structs/PyTupleObject.cs
@@ -16,6 +16,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.PythonTools.Infrastructure;
 using Microsoft.VisualStudio.Debugger;
 using Microsoft.VisualStudio.Debugger.Evaluation;
 
@@ -38,7 +39,7 @@ namespace Microsoft.PythonTools.DkmDebugger.Proxies.Structs {
         }
 
         public IEnumerable<PointerProxy<PyObject>> ReadElements() {
-            return ob_item.Take((int)ob_size.Read());
+            return ob_item.Take(ob_size.Read());
         }
 
         public override void Repr(ReprBuilder builder) {

--- a/Python/Product/Debugger/DkmDebugger/PythonRuntimeInfo.cs
+++ b/Python/Product/Debugger/DkmDebugger/PythonRuntimeInfo.cs
@@ -70,6 +70,7 @@ namespace Microsoft.PythonTools.DkmDebugger {
                 case "33": return PythonLanguageVersion.V33;
                 case "34": return PythonLanguageVersion.V34;
                 case "35": return PythonLanguageVersion.V35;
+                case "36": return PythonLanguageVersion.V36;
                 default: return PythonLanguageVersion.None;
             }
         }

--- a/Python/Product/Debugger/VsPackageMessage.cs
+++ b/Python/Product/Debugger/VsPackageMessage.cs
@@ -18,7 +18,8 @@ namespace Microsoft.PythonTools.DkmDebugger {
     public enum VsPackageMessage {
         None = 0,
         WarnAboutPythonSymbols = 1,
-        WarnAboutPGO = 2,
+        // TODO: Evaluate if this is still necessary
+        //WarnAboutPGO = 2,
         SetDebugOptions = 3,
     }
 }

--- a/Python/Product/DebuggerHelper/trace.cpp
+++ b/Python/Product/DebuggerHelper/trace.cpp
@@ -22,6 +22,8 @@ struct PyObject {};
 
 template<class T>
 T ReadField(const void* p, int64_t offset) {
+    if (offset < 0)
+        return 0;
     return *reinterpret_cast<const T*>(reinterpret_cast<const char*>(p) + offset);
 }
 
@@ -49,7 +51,7 @@ struct {
         int64_t ob_size;
     } PyVarObject;
     struct {
-        int64_t f_code, f_globals, f_locals, f_lineno;
+        int64_t f_back, f_code, f_globals, f_locals, f_lineno;
     } PyFrameObject;
     struct {
         int64_t co_varnames, co_filename, co_name;
@@ -551,6 +553,19 @@ int TraceFunc(void* obj, void* frame, int what, void* arg) {
     }
 
     return 0;
+}
+
+typedef void* (*_PyFrameEvalFunction)(void*, int);
+__declspec(dllexport)
+_PyFrameEvalFunction DefaultEvalFrameFunc = nullptr;
+
+__declspec(dllexport)
+void *EvalFrameFunc(void* f, int throwFlag)
+{
+    if (DefaultEvalFrameFunc)
+        return (*DefaultEvalFrameFunc)(f, throwFlag);
+
+    return nullptr;
 }
 
 }

--- a/Python/Product/PythonTools/PythonTools/Debugger/CustomDebuggerEventHandler.cs
+++ b/Python/Product/PythonTools/PythonTools/Debugger/CustomDebuggerEventHandler.cs
@@ -40,9 +40,10 @@ namespace Microsoft.PythonTools.Debugger {
                 case VsPackageMessage.WarnAboutPythonSymbols:
                     WarnAboutPythonSymbols((string)message.Parameter1);
                     return VSConstants.S_OK;
-                case VsPackageMessage.WarnAboutPGO:
-                    WarnAboutPGO((string)message.Parameter1);
-                    return VSConstants.S_OK;
+                // TODO: Evaluate if this is still necessary
+                //case VsPackageMessage.WarnAboutPGO:
+                //    WarnAboutPGO((string)message.Parameter1);
+                //    return VSConstants.S_OK;
                 case VsPackageMessage.SetDebugOptions:
                     SetDebugOptions((IDebugEngine2)message.Parameter1);
                     return VSConstants.S_OK;
@@ -80,13 +81,14 @@ namespace Microsoft.PythonTools.Debugger {
             }
         }
 
-        private void WarnAboutPGO(string moduleName) {
-            const string content =
-                "Python/native mixed-mode debugging does not support Python interpreters that are built with PGO (profile-guided optimization) enabled. " +
-                "If you are using a stock Python interpreter, you should upgrade to a more recent version of it. If you're using a custom built " +
-                "interpreter, please disable PGO.";
-            MessageBox.Show(content, "PGO Is Not Supported", MessageBoxButton.OK, MessageBoxImage.Error);
-        }
+        // TODO: Evaluate if this is still necessary
+        //private void WarnAboutPGO(string moduleName) {
+        //    const string content =
+        //        "Python/native mixed-mode debugging does not support Python interpreters that are built with PGO (profile-guided optimization) enabled. " +
+        //        "If you are using a stock Python interpreter, you should upgrade to a more recent version of it. If you're using a custom built " +
+        //        "interpreter, please disable PGO.";
+        //    MessageBox.Show(content, "PGO Is Not Supported", MessageBoxButton.OK, MessageBoxImage.Error);
+        //}
 
         private void SetDebugOptions(IDebugEngine2 engine) {
             var pyService = _serviceProvider.GetPythonToolsService();

--- a/Python/Product/PythonTools/PythonTools/Intellisense/ProjectAnalyzer.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/ProjectAnalyzer.cs
@@ -494,7 +494,7 @@ namespace Microsoft.PythonTools.Intellisense {
                 }
 
                 var monitoredResult = await MonitorTextBufferAsync(buffers[0]);
-                if (monitoredResult.AnalysisEntry != null) {
+                if (monitoredResult?.AnalysisEntry != null) {
                     for (int i = 1; i < buffers.Length; i++) {
                         monitoredResult.AddBuffer(buffers[i]);
                     }


### PR DESCRIPTION
Fixes #1634 Fix mixed-mode debugging for 3.6
Enables MMD for 3.6 via eval_frame hook
Fixes PyDictObject implementation
Removes PGO block to evaluate whether it is still necessary

I want to leave the PGO checks commented out for now, in case we have to bring them back before final release. In my testing, I encountered no problems with Python 3.6 x64, which was compiled with PGO, so either the PDBs are now more valid or the code that was relying on valid FuncDebugEnd values is totally gone (I definitely removed some in the past).

I ran this change through the internal VS test infrastructure for debuggers and it passed 100%.