### PR TITLE
Prevent UI delay caused by not returning to UI thread after downloading package data

### DIFF
--- a/Python/Product/VSInterpreters/PipPackageManager.cs
+++ b/Python/Product/VSInterpreters/PipPackageManager.cs
@@ -76,7 +76,7 @@ namespace Microsoft.PythonTools.Interpreter {
 
             _factory = factory;
 
-            _cache = PipPackageCache.GetCache(new Uri("https://pypi.python.org/pypi/"));
+            _cache = PipPackageCache.GetCache();
 
             if (_libWatchers != null) {
                 CreateLibraryWatchers().DoNotWait();


### PR DESCRIPTION
Prevent UI delay caused by not returning to UI thread after downloading package data
Switch to using a fwlink as the base URL for PyPI