### PR TITLE
Reset search when navigating to home page

### DIFF
--- a/Python/Product/Cookiecutter/View/CookiecutterContainerPage.xaml.cs
+++ b/Python/Product/Cookiecutter/View/CookiecutterContainerPage.xaml.cs
@@ -134,8 +134,7 @@ namespace Microsoft.CookiecutterTools.View {
         }
 
         private void ViewModel_HomeClicked(object sender, EventArgs e) {
-            PageSequence.MoveCurrentToFirst();
-            _updateCommandUI();
+            Home();
         }
 
         private void ViewModel_ContextLoaded(object sender, EventArgs e) {
@@ -182,8 +181,11 @@ namespace Microsoft.CookiecutterTools.View {
         }
 
         internal void Home() {
-            ViewModel.ResetAsync().DoNotWait();
+            PageSequence.MoveCurrentToFirst();
             _updateCommandUI();
+
+            ViewModel.SearchTerm = string.Empty;
+            ViewModel.SearchAsync().DoNotWait();
         }
 
         internal bool CanDeleteSelection() {

--- a/Python/Product/Cookiecutter/View/CookiecutterContainerPage.xaml.cs
+++ b/Python/Product/Cookiecutter/View/CookiecutterContainerPage.xaml.cs
@@ -182,7 +182,7 @@ namespace Microsoft.CookiecutterTools.View {
         }
 
         internal void Home() {
-            ViewModel.Reset();
+            ViewModel.ResetAsync().DoNotWait();
             _updateCommandUI();
         }
 

--- a/Python/Product/Cookiecutter/View/CookiecutterOptionsPage.xaml.cs
+++ b/Python/Product/Cookiecutter/View/CookiecutterOptionsPage.xaml.cs
@@ -57,7 +57,7 @@ namespace Microsoft.CookiecutterTools.View {
         }
 
         private void Home_Executed(object sender, ExecutedRoutedEventArgs e) {
-            ViewModel.Reset();
+            ViewModel.ResetAsync().DoNotWait();
         }
 
         private void CreateFiles_CanExecute(object sender, CanExecuteRoutedEventArgs e) {

--- a/Python/Product/Cookiecutter/View/CookiecutterOptionsPage.xaml.cs
+++ b/Python/Product/Cookiecutter/View/CookiecutterOptionsPage.xaml.cs
@@ -57,7 +57,7 @@ namespace Microsoft.CookiecutterTools.View {
         }
 
         private void Home_Executed(object sender, ExecutedRoutedEventArgs e) {
-            ViewModel.ResetAsync().DoNotWait();
+            ViewModel.Home();
         }
 
         private void CreateFiles_CanExecute(object sender, CanExecuteRoutedEventArgs e) {

--- a/Python/Product/Cookiecutter/ViewModel/CookiecutterViewModel.cs
+++ b/Python/Product/Cookiecutter/ViewModel/CookiecutterViewModel.cs
@@ -595,12 +595,15 @@ namespace Microsoft.CookiecutterTools.ViewModel {
             }
         }
 
-        public void Reset() {
+        public async Task ResetAsync() {
             ContextItems.Clear();
 
             ResetStatus();
 
             _templateLocalFolderPath = null;
+
+            SearchTerm = string.Empty;
+            await SearchAsync();
 
             HomeClicked?.Invoke(this, EventArgs.Empty);
         }
@@ -640,15 +643,14 @@ namespace Microsoft.CookiecutterTools.ViewModel {
                 } catch (IOException) {
                 }
 
-                OpenInExplorerFolderPath = OutputFolderPath;
-
-                Reset();
-
-                CreatingStatus = OperationStatus.Succeeded;
-
                 _outputWindow.WriteLine(Strings.RunningTemplateSuccess.FormatUI(selection.DisplayName, OutputFolderPath));
 
                 ReportTemplateEvent(CookiecutterTelemetry.TelemetryArea.Template, CookiecutterTelemetry.TemplateEvents.Run, selection);
+
+                await ResetAsync();
+
+                OpenInExplorerFolderPath = OutputFolderPath;
+                CreatingStatus = OperationStatus.Succeeded;
             } catch (Exception ex) when (!ex.IsCriticalException()) {
                 CreatingStatus = OperationStatus.Failed;
 

--- a/Python/Product/Cookiecutter/ViewModel/CookiecutterViewModel.cs
+++ b/Python/Product/Cookiecutter/ViewModel/CookiecutterViewModel.cs
@@ -595,25 +595,16 @@ namespace Microsoft.CookiecutterTools.ViewModel {
             }
         }
 
-        public async Task ResetAsync() {
-            ContextItems.Clear();
-
-            ResetStatus();
-
-            _templateLocalFolderPath = null;
-
-            SearchTerm = string.Empty;
-            await SearchAsync();
-
-            HomeClicked?.Invoke(this, EventArgs.Empty);
-        }
-
         private void ResetStatus() {
             CloningStatus = OperationStatus.NotStarted;
             LoadingStatus = OperationStatus.NotStarted;
             CreatingStatus = OperationStatus.NotStarted;
             CheckingUpdateStatus = OperationStatus.NotStarted;
             UpdatingStatus = OperationStatus.NotStarted;
+        }
+
+        public void Home() {
+            HomeClicked?.Invoke(this, EventArgs.Empty);
         }
 
         public async Task CreateFilesAsync() {
@@ -647,10 +638,13 @@ namespace Microsoft.CookiecutterTools.ViewModel {
 
                 ReportTemplateEvent(CookiecutterTelemetry.TelemetryArea.Template, CookiecutterTelemetry.TemplateEvents.Run, selection);
 
-                await ResetAsync();
-
+                ContextItems.Clear();
+                ResetStatus();
+                _templateLocalFolderPath = null;
                 OpenInExplorerFolderPath = OutputFolderPath;
                 CreatingStatus = OperationStatus.Succeeded;
+
+                Home();
             } catch (Exception ex) when (!ex.IsCriticalException()) {
                 CreatingStatus = OperationStatus.Failed;
 

--- a/Python/Tests/CookiecutterTests/CookiecutterIntegrationTests.cs
+++ b/Python/Tests/CookiecutterTests/CookiecutterIntegrationTests.cs
@@ -156,23 +156,6 @@ namespace CookiecutterTests {
         }
 
         [TestMethod]
-        public async Task ResetClearsSearch() {
-            _vm.SearchTerm = OnlineTemplateUrl;
-            await _vm.SearchAsync();
-
-            Assert.AreEqual(0, _vm.Installed.Templates.Count);
-            Assert.AreEqual(0, _vm.GitHub.Templates.Count);
-            Assert.AreEqual(0, _vm.Recommended.Templates.Count);
-            Assert.AreEqual(1, _vm.Custom.Templates.Count);
-
-            await _vm.ResetAsync();
-
-            Assert.AreEqual("", _vm.SearchTerm);
-            Assert.AreEqual(1, _vm.Installed.Templates.Count);
-            Assert.AreEqual(6, _vm.Recommended.Templates.Count);
-        }
-
-        [TestMethod]
         public async Task SearchNonExistingLocalTemplate() {
             _vm.SearchTerm = NonExistingLocalTemplatePath;
             await _vm.SearchAsync();

--- a/Python/Tests/CookiecutterTests/CookiecutterIntegrationTests.cs
+++ b/Python/Tests/CookiecutterTests/CookiecutterIntegrationTests.cs
@@ -156,6 +156,23 @@ namespace CookiecutterTests {
         }
 
         [TestMethod]
+        public async Task ResetClearsSearch() {
+            _vm.SearchTerm = OnlineTemplateUrl;
+            await _vm.SearchAsync();
+
+            Assert.AreEqual(0, _vm.Installed.Templates.Count);
+            Assert.AreEqual(0, _vm.GitHub.Templates.Count);
+            Assert.AreEqual(0, _vm.Recommended.Templates.Count);
+            Assert.AreEqual(1, _vm.Custom.Templates.Count);
+
+            await _vm.ResetAsync();
+
+            Assert.AreEqual("", _vm.SearchTerm);
+            Assert.AreEqual(1, _vm.Installed.Templates.Count);
+            Assert.AreEqual(6, _vm.Recommended.Templates.Count);
+        }
+
+        [TestMethod]
         public async Task SearchNonExistingLocalTemplate() {
             _vm.SearchTerm = NonExistingLocalTemplatePath;
             await _vm.SearchAsync();


### PR DESCRIPTION
These operations navigate to the search page, clear the search term and refreshes the search results.
- Click Home on toolbar
- Click Cancel on options page
- Successful file creation

Fixes https://github.com/Microsoft/PTVS/issues/1817