### PR TITLE
Fixes #1836 Isolate code coverage

### DIFF
--- a/Python/Product/TestAdapter/TestAdapter.csproj
+++ b/Python/Product/TestAdapter/TestAdapter.csproj
@@ -34,7 +34,6 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.PythonTools.TestAdapter</RootNamespace>
     <AssemblyName>Microsoft.PythonTools.TestAdapter</AssemblyName>
-    <DefineConstants Condition="$(IncludeCodeCoverage)">$(DefineConstants);INCLUDE_CODE_COVERAGE</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Platform)' == 'AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -103,13 +102,7 @@
     </Otherwise>
   </Choose>
   <Choose>
-    <When Condition="$(IncludeCodeCoverage)">
-      <ItemGroup>
-        <Reference Include="Microsoft.VisualStudio.TestWindow.CodeCoverage">
-          <HintPath>$(DevEnvDir)\CommonExtensions\Microsoft\AnalyzeCodeCoverage\Microsoft.VisualStudio.TestWindow.CodeCoverage.dll</HintPath>
-        </Reference>
-      </ItemGroup>
-    </When>
+    <When Condition="$(IncludeCodeCoverage)" />
   </Choose>
   <ItemGroup>
     <Compile Include="..\..\..\Common\Product\SharedProject\CommonConstants.cs">

--- a/Python/Product/TestAdapter/TestAdapter.csproj
+++ b/Python/Product/TestAdapter/TestAdapter.csproj
@@ -101,9 +101,6 @@
       </ItemGroup>
     </Otherwise>
   </Choose>
-  <Choose>
-    <When Condition="$(IncludeCodeCoverage)" />
-  </Choose>
   <ItemGroup>
     <Compile Include="..\..\..\Common\Product\SharedProject\CommonConstants.cs">
       <Link>CommonConstants.cs</Link>

--- a/Python/products.settings
+++ b/Python/products.settings
@@ -12,9 +12,5 @@
     
     <!-- Include UWP by default -->
     <IncludeUwp Condition="'$(IncludeUwp)' == ''">true</IncludeUwp>
-    
-    <!-- Include code coverage if available -->
-    <IncludeCodeCoverage Condition="'$(IncludeCodeCoverage)' == '' and Exists('$(DevEnvDir)\CommonExtensions\Microsoft\AnalyzeCodeCoverage\Microsoft.VisualStudio.TestWindow.CodeCoverage.dll')">true</IncludeCodeCoverage>
-    <IncludeCodeCoverage Condition="'$(IncludeCodeCoverage)' == ''">$(ReleaseBuild)</IncludeCodeCoverage>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Fixes #1836 Isolate code coverage
Removes direct dependency on code coverage assembly
Removes IncludeCodeCoverage property