### PR TITLE
Fixes #1831 Cookiecutter output when checking for updates

### DIFF
--- a/Python/Product/Cookiecutter/Strings.Designer.cs
+++ b/Python/Product/Cookiecutter/Strings.Designer.cs
@@ -61,9 +61,7 @@ namespace Microsoft.CookiecutterTools {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to 
-        ///----- Check for template updates canceled -----
-        ///.
+        ///   Looks up a localized string similar to ----- Check for template updates canceled -----.
         /// </summary>
         internal static string CheckingForAllUpdatesCanceled {
             get {
@@ -72,9 +70,7 @@ namespace Microsoft.CookiecutterTools {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to 
-        ///----- Failed to check for template updates -----
-        ///.
+        ///   Looks up a localized string similar to ----- Failed to check for template updates -----.
         /// </summary>
         internal static string CheckingForAllUpdatesFailed {
             get {
@@ -83,9 +79,7 @@ namespace Microsoft.CookiecutterTools {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to 
-        ///----- Checking for template updates -----
-        ///.
+        ///   Looks up a localized string similar to ----- Checking for template updates -----.
         /// </summary>
         internal static string CheckingForAllUpdatesStarted {
             get {
@@ -94,9 +88,7 @@ namespace Microsoft.CookiecutterTools {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to 
-        ///----- Successfully checked for template updates -----
-        ///.
+        ///   Looks up a localized string similar to ----- Successfully checked for template updates -----.
         /// </summary>
         internal static string CheckingForAllUpdatesSuccess {
             get {
@@ -141,9 +133,7 @@ namespace Microsoft.CookiecutterTools {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to 
-        ///----- Checking for update to template &apos;{0}&apos; from &apos;{1}&apos; -----
-        ///.
+        ///   Looks up a localized string similar to ----- Checking for update to template &apos;{0}&apos; from &apos;{1}&apos; -----.
         /// </summary>
         internal static string CheckingTemplateUpdateStarted {
             get {
@@ -163,9 +153,7 @@ namespace Microsoft.CookiecutterTools {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to 
-        ///----- Failed to clone template &apos;{0}&apos; -----
-        ///.
+        ///   Looks up a localized string similar to ----- Failed to clone template &apos;{0}&apos; -----.
         /// </summary>
         internal static string CloningTemplateFailed {
             get {
@@ -174,9 +162,7 @@ namespace Microsoft.CookiecutterTools {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to 
-        ///----- Cloning template &apos;{0}&apos; -----
-        ///.
+        ///   Looks up a localized string similar to ----- Cloning template &apos;{0}&apos; -----.
         /// </summary>
         internal static string CloningTemplateStarted {
             get {
@@ -185,9 +171,7 @@ namespace Microsoft.CookiecutterTools {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to 
-        ///----- Successfully cloned template &apos;{0}&apos; to &apos;{1}&apos; -----
-        ///.
+        ///   Looks up a localized string similar to ----- Successfully cloned template &apos;{0}&apos; to &apos;{1}&apos; -----.
         /// </summary>
         internal static string CloningTemplateSuccess {
             get {
@@ -216,9 +200,7 @@ namespace Microsoft.CookiecutterTools {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to 
-        ///----- Failed to delete template &apos;{0}&apos; -----
-        ///.
+        ///   Looks up a localized string similar to ----- Failed to delete template &apos;{0}&apos; -----.
         /// </summary>
         internal static string DeletingTemplateFailed {
             get {
@@ -227,9 +209,7 @@ namespace Microsoft.CookiecutterTools {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to 
-        ///----- Deleting template &apos;{0}&apos; -----
-        ///.
+        ///   Looks up a localized string similar to ----- Deleting template &apos;{0}&apos; -----.
         /// </summary>
         internal static string DeletingTemplateStarted {
             get {
@@ -238,9 +218,7 @@ namespace Microsoft.CookiecutterTools {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to 
-        ///----- Successfully deleted template &apos;{0}&apos; -----
-        ///.
+        ///   Looks up a localized string similar to ----- Successfully deleted template &apos;{0}&apos; -----.
         /// </summary>
         internal static string DeletingTemplateSuccess {
             get {
@@ -294,9 +272,7 @@ namespace Microsoft.CookiecutterTools {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to 
-        ///----- Failed to install cookiecutter -----
-        ///.
+        ///   Looks up a localized string similar to ----- Failed to install cookiecutter -----.
         /// </summary>
         internal static string InstallingCookiecutterFailed {
             get {
@@ -305,9 +281,7 @@ namespace Microsoft.CookiecutterTools {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to 
-        ///----- Installing cookiecutter -----
-        ///.
+        ///   Looks up a localized string similar to ----- Installing cookiecutter -----.
         /// </summary>
         internal static string InstallingCookiecutterStarted {
             get {
@@ -316,9 +290,7 @@ namespace Microsoft.CookiecutterTools {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to 
-        ///----- Successfully installed cookiecutter -----
-        ///.
+        ///   Looks up a localized string similar to ----- Successfully installed cookiecutter -----.
         /// </summary>
         internal static string InstallingCookiecutterSuccess {
             get {
@@ -345,9 +317,7 @@ namespace Microsoft.CookiecutterTools {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to 
-        ///----- Failed to load template &apos;{0}&apos; -----
-        ///.
+        ///   Looks up a localized string similar to ----- Failed to load template &apos;{0}&apos; -----.
         /// </summary>
         internal static string LoadingTemplateFailed {
             get {
@@ -356,9 +326,7 @@ namespace Microsoft.CookiecutterTools {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to 
-        ///----- Loading template &apos;{0}&apos; -----
-        ///.
+        ///   Looks up a localized string similar to ----- Loading template &apos;{0}&apos; -----.
         /// </summary>
         internal static string LoadingTemplateStarted {
             get {
@@ -367,9 +335,7 @@ namespace Microsoft.CookiecutterTools {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to 
-        ///----- Successfully loaded template &apos;{0}&apos; -----
-        ///.
+        ///   Looks up a localized string similar to ----- Successfully loaded template &apos;{0}&apos; -----.
         /// </summary>
         internal static string LoadingTemplateSuccess {
             get {
@@ -423,9 +389,7 @@ namespace Microsoft.CookiecutterTools {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to 
-        ///----- Failed to create files using template &apos;{0}&apos; -----
-        ///.
+        ///   Looks up a localized string similar to ----- Failed to create files using template &apos;{0}&apos; -----.
         /// </summary>
         internal static string RunningTemplateFailed {
             get {
@@ -434,9 +398,7 @@ namespace Microsoft.CookiecutterTools {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to 
-        ///----- Creating files using template &apos;{0}&apos; -----
-        ///.
+        ///   Looks up a localized string similar to ----- Creating files using template &apos;{0}&apos; -----.
         /// </summary>
         internal static string RunningTemplateStarted {
             get {
@@ -445,9 +407,7 @@ namespace Microsoft.CookiecutterTools {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to 
-        ///----- Successfully created files using template &apos;{0}&apos; into &apos;{1}&apos; -----
-        ///.
+        ///   Looks up a localized string similar to ----- Successfully created files using template &apos;{0}&apos; into &apos;{1}&apos; -----.
         /// </summary>
         internal static string RunningTemplateSuccess {
             get {
@@ -522,9 +482,7 @@ namespace Microsoft.CookiecutterTools {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to 
-        ///----- Failed to update template &apos;{0}&apos; -----
-        ///.
+        ///   Looks up a localized string similar to ----- Failed to update template &apos;{0}&apos; -----.
         /// </summary>
         internal static string UpdatingTemplateFailed {
             get {
@@ -533,9 +491,7 @@ namespace Microsoft.CookiecutterTools {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to 
-        ///----- Updating template &apos;{0}&apos; -----
-        ///.
+        ///   Looks up a localized string similar to ----- Updating template &apos;{0}&apos; -----.
         /// </summary>
         internal static string UpdatingTemplateStarted {
             get {
@@ -544,9 +500,7 @@ namespace Microsoft.CookiecutterTools {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to 
-        ///----- Successfully updated template &apos;{0}&apos; -----
-        ///.
+        ///   Looks up a localized string similar to ----- Successfully updated template &apos;{0}&apos; -----.
         /// </summary>
         internal static string UpdatingTemplateSuccess {
             get {

--- a/Python/Product/Cookiecutter/Strings.resx
+++ b/Python/Product/Cookiecutter/Strings.resx
@@ -170,104 +170,64 @@ You can get more information by running Visual Studio with the /log parameter on
 Please delete the installed template and try again.</value>
   </data>
   <data name="InstallingCookiecutterStarted" xml:space="preserve">
-    <value>
------ Installing cookiecutter -----
-</value>
+    <value>----- Installing cookiecutter -----</value>
   </data>
   <data name="InstallingCookiecutterSuccess" xml:space="preserve">
-    <value>
------ Successfully installed cookiecutter -----
-</value>
+    <value>----- Successfully installed cookiecutter -----</value>
   </data>
   <data name="InstallingCookiecutterFailed" xml:space="preserve">
-    <value>
------ Failed to install cookiecutter -----
-</value>
+    <value>----- Failed to install cookiecutter -----</value>
   </data>
   <data name="CloningTemplateStarted" xml:space="preserve">
-    <value>
------ Cloning template '{0}' -----
-</value>
+    <value>----- Cloning template '{0}' -----</value>
   </data>
   <data name="CloningTemplateSuccess" xml:space="preserve">
-    <value>
------ Successfully cloned template '{0}' to '{1}' -----
-</value>
+    <value>----- Successfully cloned template '{0}' to '{1}' -----</value>
   </data>
   <data name="CloningTemplateFailed" xml:space="preserve">
-    <value>
------ Failed to clone template '{0}' -----
-</value>
+    <value>----- Failed to clone template '{0}' -----</value>
   </data>
   <data name="LoadingTemplateStarted" xml:space="preserve">
-    <value>
------ Loading template '{0}' -----
-</value>
+    <value>----- Loading template '{0}' -----</value>
   </data>
   <data name="LoadingTemplateSuccess" xml:space="preserve">
-    <value>
------ Successfully loaded template '{0}' -----
-</value>
+    <value>----- Successfully loaded template '{0}' -----</value>
   </data>
   <data name="LoadingTemplateFailed" xml:space="preserve">
-    <value>
------ Failed to load template '{0}' -----
-</value>
+    <value>----- Failed to load template '{0}' -----</value>
   </data>
   <data name="RunningTemplateStarted" xml:space="preserve">
-    <value>
------ Creating files using template '{0}' -----
-</value>
+    <value>----- Creating files using template '{0}' -----</value>
   </data>
   <data name="RunningTemplateSuccess" xml:space="preserve">
-    <value>
------ Successfully created files using template '{0}' into '{1}' -----
-</value>
+    <value>----- Successfully created files using template '{0}' into '{1}' -----</value>
   </data>
   <data name="RunningTemplateFailed" xml:space="preserve">
-    <value>
------ Failed to create files using template '{0}' -----
-</value>
+    <value>----- Failed to create files using template '{0}' -----</value>
   </data>
   <data name="DeletingTemplateStarted" xml:space="preserve">
-    <value>
------ Deleting template '{0}' -----
-</value>
+    <value>----- Deleting template '{0}' -----</value>
   </data>
   <data name="DeletingTemplateSuccess" xml:space="preserve">
-    <value>
------ Successfully deleted template '{0}' -----
-</value>
+    <value>----- Successfully deleted template '{0}' -----</value>
   </data>
   <data name="DeletingTemplateFailed" xml:space="preserve">
-    <value>
------ Failed to delete template '{0}' -----
-</value>
+    <value>----- Failed to delete template '{0}' -----</value>
   </data>
   <data name="CheckingForAllUpdatesStarted" xml:space="preserve">
-    <value>
------ Checking for template updates -----
-</value>
+    <value>----- Checking for template updates -----</value>
   </data>
   <data name="CheckingForAllUpdatesSuccess" xml:space="preserve">
-    <value>
------ Successfully checked for template updates -----
-</value>
+    <value>----- Successfully checked for template updates -----</value>
   </data>
   <data name="CheckingForAllUpdatesFailed" xml:space="preserve">
-    <value>
------ Failed to check for template updates -----
-</value>
+    <value>----- Failed to check for template updates -----</value>
   </data>
   <data name="CheckingForAllUpdatesCanceled" xml:space="preserve">
-    <value>
------ Check for template updates canceled -----
-</value>
+    <value>----- Check for template updates canceled -----</value>
   </data>
   <data name="CheckingTemplateUpdateStarted" xml:space="preserve">
-    <value>
------ Checking for update to template '{0}' from '{1}' -----
-</value>
+    <value>----- Checking for update to template '{0}' from '{1}' -----</value>
   </data>
   <data name="CheckingTemplateUpdateFound" xml:space="preserve">
     <value>An update is available.</value>
@@ -282,19 +242,13 @@ Please delete the installed template and try again.</value>
     <value>Could not determine if an update is available.</value>
   </data>
   <data name="UpdatingTemplateStarted" xml:space="preserve">
-    <value>
------ Updating template '{0}' -----
-</value>
+    <value>----- Updating template '{0}' -----</value>
   </data>
   <data name="UpdatingTemplateSuccess" xml:space="preserve">
-    <value>
------ Successfully updated template '{0}' -----
-</value>
+    <value>----- Successfully updated template '{0}' -----</value>
   </data>
   <data name="UpdatingTemplateFailed" xml:space="preserve">
-    <value>
------ Failed to update template '{0}' -----
-</value>
+    <value>----- Failed to update template '{0}' -----</value>
   </data>
   <data name="TemplateCategoryInstalled" xml:space="preserve">
     <value>Installed</value>


### PR DESCRIPTION
Fixes #1831 Cookiecutter output when checking for updates
Disables update messages unless an error occurs (or we are in a debug build)
Removes unnecessary newlines from output messages.