### PR TITLE
Cookiecutter template update improvements

### DIFF
--- a/Python/Product/Cookiecutter/Model/GitClient.cs
+++ b/Python/Product/Cookiecutter/Model/GitClient.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.CookiecutterTools.Infrastructure;
 
@@ -100,11 +101,14 @@ namespace Microsoft.CookiecutterTools.Model {
 
         public async Task FetchAsync(string repoFolderPath) {
             var arguments = new string[] { "fetch" };
-            using (var output = ProcessOutput.Run(_gitExeFilePath, arguments, repoFolderPath, null, false, _redirector)) {
-                if (await output < 0) {
+            using (var output = ProcessOutput.Run(_gitExeFilePath, arguments, repoFolderPath, null, false, null)) {
+                await output;
+                if (output.ExitCode < 0 || output.StandardErrorLines.Any(line => line.StartsWith("fatal", StringComparison.InvariantCultureIgnoreCase))) {
                     throw new ProcessException(new ProcessOutputResult() {
                         ExeFileName = _gitExeFilePath,
                         ExitCode = output.ExitCode,
+                        StandardErrorLines = output.StandardErrorLines.ToArray(),
+                        StandardOutputLines = output.StandardOutputLines.ToArray(),
                     });
                 }
             }

--- a/Python/Product/Cookiecutter/View/CookiecutterSearchPage.xaml
+++ b/Python/Product/Cookiecutter/View/CookiecutterSearchPage.xaml
@@ -280,7 +280,7 @@
                         Visibility="{Binding Path=CheckingUpdateStatus, Converter={StaticResource OperationStatusInProgressToVisibleOrCollapsed}}">
                 <Separator/>
                 <TextBlock Text="Checking for updates..."/>
-                <ProgressBar Margin="4" IsIndeterminate="True"/>
+                <ProgressBar Margin="4" Value="{Binding Path=CheckingUpdatePercentComplete,Mode=OneWay}" Maximum="100"/>
             </StackPanel>
 
             <StackPanel Margin="4 4 4 8"

--- a/Python/Product/Cookiecutter/ViewModel/CookiecutterViewModel.cs
+++ b/Python/Product/Cookiecutter/ViewModel/CookiecutterViewModel.cs
@@ -55,6 +55,7 @@ namespace Microsoft.CookiecutterTools.ViewModel {
         private string _selectedDescription;
         private ImageSource _selectedImage;
         private string _selectedLocation;
+        private int _checkingUpdatePercentComplete;
 
         private OperationStatus _installingStatus;
         private OperationStatus _cloningStatus;
@@ -286,6 +287,19 @@ namespace Microsoft.CookiecutterTools.ViewModel {
                     LoadingStatus == OperationStatus.InProgress ||
                     CreatingStatus == OperationStatus.InProgress ||
                     UpdatingStatus == OperationStatus.InProgress;
+            }
+        }
+
+        public int CheckingUpdatePercentComplete {
+            get {
+                return _checkingUpdatePercentComplete;
+            }
+
+            set {
+                if (value != _checkingUpdatePercentComplete) {
+                    _checkingUpdatePercentComplete = value;
+                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(CheckingUpdatePercentComplete)));
+                }
             }
         }
 
@@ -539,6 +553,7 @@ namespace Microsoft.CookiecutterTools.ViewModel {
                 _checkUpdatesCancelTokenSource = new CancellationTokenSource();
 
                 CheckingUpdateStatus = OperationStatus.InProgress;
+                CheckingUpdatePercentComplete = 0;
 
 #if DEBUG || VERBOSE_UPDATES
                 _outputWindow.WriteLine(String.Empty);
@@ -546,7 +561,10 @@ namespace Microsoft.CookiecutterTools.ViewModel {
 #endif
 
                 var templatesResult = await _installedSource.GetTemplatesAsync(null, null, CancellationToken.None);
-                foreach (var template in templatesResult.Templates) {
+                for (int i = 0; i < templatesResult.Templates.Count; i++) {
+                    CheckingUpdatePercentComplete = (int)((i / (double)templatesResult.Templates.Count) * 100);
+                    var template = templatesResult.Templates[i];
+
                     _checkUpdatesCancelTokenSource.Token.ThrowIfCancellationRequested();
 
                     try {
@@ -583,11 +601,18 @@ namespace Microsoft.CookiecutterTools.ViewModel {
 
                         _outputWindow.WriteLine(Strings.CheckingTemplateUpdateStarted.FormatUI(template.Name, template.RemoteUrl));
                         _outputWindow.WriteErrorLine(ex.Message);
+
+                        var pex = ex as ProcessException;
+                        if (pex != null) {
+                            _outputWindow.WriteErrorLine(string.Join(Environment.NewLine, pex.Result.StandardErrorLines ?? new string[0]));
+                        }
+
                         _outputWindow.WriteLine(Strings.CheckingTemplateUpdateError);
                     }
                 }
 
                 CheckingUpdateStatus = anyError ? OperationStatus.Failed : OperationStatus.Succeeded;
+                CheckingUpdatePercentComplete = 100;
 
                 if (anyError) {
                     _outputWindow.WriteLine(Strings.CheckingForAllUpdatesFailed);


### PR DESCRIPTION
Fix #1849 Cookiecutter check for updates progress bar should be determinate
Fix #1832 Cookiecutter check for update doesn't properly detect errors

Here's an example of the output window when I pull the cord in the middle of a check for updates.

RELEASE
```
----- Checking for update to template 'cookiecutter-flask' from 'https://github.com/sloria/cookiecutter-flask' -----
git.exe returned an exit code of 128.
fatal: unable to access 'https://github.com/sloria/cookiecutter-flask/': Unknown SSL protocol error in connection to github.com:443 
Error checking for an update.
----- Checking for update to template 'cookiecutter-ptvs-bottle' from 'https://github.com/huguesv/cookiecutter-ptvs-bottle' -----
git.exe returned an exit code of 128.
fatal: unable to access 'https://github.com/huguesv/cookiecutter-ptvs-bottle/': Couldn't resolve host 'github.com'
Error checking for an update.
----- Checking for update to template 'cookiecutter-ptvs-test-bottle' from 'https://github.com/huguesv/cookiecutter-ptvs-test-bottle' -----
git.exe returned an exit code of 128.
fatal: unable to access 'https://github.com/huguesv/cookiecutter-ptvs-test-bottle/': Couldn't resolve host 'github.com'
Error checking for an update.
----- Checking for update to template 'cookiecutter-ptvs-test-pyodbc' from 'https://github.com/huguesv/cookiecutter-ptvs-test-pyodbc' -----
git.exe returned an exit code of 128.
fatal: unable to access 'https://github.com/huguesv/cookiecutter-ptvs-test-pyodbc/': Couldn't resolve host 'github.com'
Error checking for an update.
----- Checking for update to template 'cookiecutter-pyvanguard' from 'https://github.com/robinandeer/cookiecutter-pyvanguard' -----
git.exe returned an exit code of 128.
fatal: unable to access 'https://github.com/robinandeer/cookiecutter-pyvanguard/': Couldn't resolve host 'github.com'
Error checking for an update.
----- Checking for update to template 'python-azure-web-app-cookiecutter' from 'https://github.com/brettcannon/python-azure-web-app-cookiecutter' -----
git.exe returned an exit code of 128.
fatal: unable to access 'https://github.com/brettcannon/python-azure-web-app-cookiecutter/': Couldn't resolve host 'github.com'
Error checking for an update.
----- Checking for update to template 'servant-template' from 'https://github.com/jml/servant-template' -----
git.exe returned an exit code of 128.
fatal: unable to access 'https://github.com/jml/servant-template/': Couldn't resolve host 'github.com'
Error checking for an update.
----- Checking for update to template 'wagtail-cookiecutter-foundation' from 'https://github.com/chrisdev/wagtail-cookiecutter-foundation' -----
git.exe returned an exit code of 128.
fatal: unable to access 'https://github.com/chrisdev/wagtail-cookiecutter-foundation/': Couldn't resolve host 'github.com'
Error checking for an update.
----- Failed to check for template updates -----

```

DEBUG:

```
----- Checking for template updates -----
----- Checking for update to template 'cookiecutter-android' from 'https://github.com/quintoandar/cookiecutter-android' -----
Template is already up-to-date.
----- Checking for update to template 'cookiecutter-django' from 'https://github.com/pydanny/cookiecutter-django' -----
An update is available.
----- Checking for update to template 'cookiecutter-flask' from 'https://github.com/sloria/cookiecutter-flask' -----
An update is available.
----- Checking for update to template 'cookiecutter-ptvs-bottle' from 'https://github.com/huguesv/cookiecutter-ptvs-bottle' -----

----- Checking for template updates -----
----- Checking for update to template 'cookiecutter-ptvs-bottle' from 'https://github.com/huguesv/cookiecutter-ptvs-bottle' -----
git.exe returned an exit code of 128.
fatal: unable to access 'https://github.com/huguesv/cookiecutter-ptvs-bottle/': Couldn't resolve host 'github.com'
Error checking for an update.
----- Checking for update to template 'cookiecutter-ptvs-test-bottle' from 'https://github.com/huguesv/cookiecutter-ptvs-test-bottle' -----
----- Checking for update to template 'cookiecutter-ptvs-test-bottle' from 'https://github.com/huguesv/cookiecutter-ptvs-test-bottle' -----
git.exe returned an exit code of 128.
fatal: unable to access 'https://github.com/huguesv/cookiecutter-ptvs-test-bottle/': Couldn't resolve host 'github.com'
Error checking for an update.
----- Checking for update to template 'cookiecutter-ptvs-test-pyodbc' from 'https://github.com/huguesv/cookiecutter-ptvs-test-pyodbc' -----
----- Checking for update to template 'cookiecutter-ptvs-test-pyodbc' from 'https://github.com/huguesv/cookiecutter-ptvs-test-pyodbc' -----
git.exe returned an exit code of 128.
fatal: unable to access 'https://github.com/huguesv/cookiecutter-ptvs-test-pyodbc/': Couldn't resolve host 'github.com'
Error checking for an update.
----- Checking for update to template 'cookiecutter-pyvanguard' from 'https://github.com/robinandeer/cookiecutter-pyvanguard' -----
----- Checking for update to template 'cookiecutter-pyvanguard' from 'https://github.com/robinandeer/cookiecutter-pyvanguard' -----
git.exe returned an exit code of 128.
fatal: unable to access 'https://github.com/robinandeer/cookiecutter-pyvanguard/': Couldn't resolve host 'github.com'
Error checking for an update.
----- Checking for update to template 'python-azure-web-app-cookiecutter' from 'https://github.com/brettcannon/python-azure-web-app-cookiecutter' -----
----- Checking for update to template 'python-azure-web-app-cookiecutter' from 'https://github.com/brettcannon/python-azure-web-app-cookiecutter' -----
git.exe returned an exit code of 128.
fatal: unable to access 'https://github.com/brettcannon/python-azure-web-app-cookiecutter/': Couldn't resolve host 'github.com'
Error checking for an update.
----- Checking for update to template 'servant-template' from 'https://github.com/jml/servant-template' -----
----- Checking for update to template 'servant-template' from 'https://github.com/jml/servant-template' -----
git.exe returned an exit code of 128.
fatal: unable to access 'https://github.com/jml/servant-template/': Couldn't resolve host 'github.com'
Error checking for an update.
----- Checking for update to template 'wagtail-cookiecutter-foundation' from 'https://github.com/chrisdev/wagtail-cookiecutter-foundation' -----
----- Checking for update to template 'wagtail-cookiecutter-foundation' from 'https://github.com/chrisdev/wagtail-cookiecutter-foundation' -----
git.exe returned an exit code of 128.
fatal: unable to access 'https://github.com/chrisdev/wagtail-cookiecutter-foundation/': Couldn't resolve host 'github.com'
Error checking for an update.
----- Failed to check for template updates -----
```

