### PR TITLE
Fixes #1840 Syntax error when sending/typing comment to REPL

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Repl/PythonInteractiveEvaluator.cs
+++ b/Python/Product/PythonTools/PythonTools/Repl/PythonInteractiveEvaluator.cs
@@ -308,7 +308,7 @@ namespace Microsoft.PythonTools.Repl {
         }
 
         public bool CanExecuteCode(string text) {
-            if (text.EndsWith("\n")) {
+            if (text.EndsWith("\n") || string.IsNullOrEmpty(text)) {
                 return true;
             }
 
@@ -316,7 +316,7 @@ namespace Microsoft.PythonTools.Repl {
             using (var parser = Parser.CreateParser(new StringReader(text), LanguageVersion)) {
                 ParseResult pr;
                 parser.ParseInteractiveCode(out pr);
-                if (pr == ParseResult.IncompleteToken || pr == ParseResult.IncompleteStatement) {
+                if (pr == ParseResult.Empty || pr == ParseResult.IncompleteToken || pr == ParseResult.IncompleteStatement) {
                     return false;
                 }
             }

--- a/Python/Tests/Core/ReplEvaluatorTests.cs
+++ b/Python/Tests/Core/ReplEvaluatorTests.cs
@@ -178,6 +178,13 @@ g()",
     f()
     g()",
                     Expected = new[] { "def f():\r\n    pass\r\n", "f()", "f()", "def g():\r\n    pass\r\n", "f()", "g()" }
+                },
+                new {
+                    Code = @"# Comment
+
+f()
+f()",
+                    Expected = new[] { "# Comment\r\n\r\nf()\r\n", "f()" }
                 }
             };
 

--- a/Python/Tests/Core/ReplEvaluatorTests.cs
+++ b/Python/Tests/Core/ReplEvaluatorTests.cs
@@ -97,6 +97,12 @@ namespace PythonToolsTests {
                 Assert.IsTrue(evaluator.CanExecuteCode("try:\r\n    print 'hello'\r\nfinally:\r\n    print 'goodbye'\r\n    \r\n"));
                 Assert.IsFalse(evaluator.CanExecuteCode("x = \\"));
                 Assert.IsTrue(evaluator.CanExecuteCode("x = \\\r\n42\r\n\r\n"));
+
+                Assert.IsTrue(evaluator.CanExecuteCode(""));
+                Assert.IsFalse(evaluator.CanExecuteCode(" "));
+                Assert.IsFalse(evaluator.CanExecuteCode("# Comment"));
+                Assert.IsTrue(evaluator.CanExecuteCode("\r\n"));
+                Assert.IsFalse(evaluator.CanExecuteCode("\r\n#Comment"));
             }
         }
 


### PR DESCRIPTION
Fixes #1840 Syntax error when sending/typing comment to REPL
Checks for empty AST when determining whether to evaluate code.