### PR TITLE
Fixes #1841 Start debugging says no python interpreter available

### DIFF
--- a/Python/Product/Analyzer/Intellisense/OutOfProcProjectAnalyzer.cs
+++ b/Python/Product/Analyzer/Intellisense/OutOfProcProjectAnalyzer.cs
@@ -1513,7 +1513,6 @@ namespace Microsoft.PythonTools.Intellisense {
 
         abstract class CodeInfo {
             public readonly int Version;
-            public object Code; // Stream or TextReader
 
             public CodeInfo(int version) {
                 Version = version;

--- a/Python/Product/Common/Strings.Designer.cs
+++ b/Python/Product/Common/Strings.Designer.cs
@@ -280,6 +280,15 @@ namespace Microsoft.PythonTools {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The project cannot be launched because the startup file is not specified..
+        /// </summary>
+        public static string DebugLaunchScriptNameMissing {
+            get {
+                return ResourceManager.GetString("DebugLaunchScriptNameMissing", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The project cannot be launched because the no working directory was provided. Please check the Project Properties window and correct any configuration errors..
         /// </summary>
         public static string DebugLaunchWorkingDirectoryMissing {

--- a/Python/Product/Common/Strings.resx
+++ b/Python/Product/Common/Strings.resx
@@ -938,4 +938,7 @@ modified from these scripts.</value>
   <data name="WebPIReferenceDeprecated" xml:space="preserve">
     <value>WebPI references have been deprecated. We recommend replacing the reference with a custom installation script.</value>
   </data>
+  <data name="DebugLaunchScriptNameMissing" xml:space="preserve">
+    <value>The project cannot be launched because the startup file is not specified.</value>
+  </data>
 </root>

--- a/Python/Product/Workspace/PythonLaunchDebugTargetProvider.cs
+++ b/Python/Product/Workspace/PythonLaunchDebugTargetProvider.cs
@@ -45,6 +45,8 @@ namespace Microsoft.PythonTools.Workspace {
         public const string NativeDebuggingKey = "nativeDebug";
         public const string WebBrowserUrlKey = "webBrowserUrl";
 
+        public const string DefaultInterpreterValue = "(default)";
+
         public const string JsonSchema = @"{
   ""definitions"": {
     ""python"": {
@@ -77,13 +79,29 @@ namespace Microsoft.PythonTools.Workspace {
             var registry = serviceProvider.GetComponentModel().GetService<IInterpreterRegistryService>();
 
             var settings = debugLaunchActionContext.LaunchConfiguration;
+            var scriptName = settings.GetValue(ScriptNameKey, string.Empty);
             var debug = !settings.GetValue("noDebug", false);
             var path = settings.GetValue(InterpreterKey, string.Empty);
             InterpreterConfiguration config = null;
 
-            if (!string.IsNullOrEmpty(path)) {
+            if (string.IsNullOrEmpty(scriptName)) {
+                throw new InvalidOperationException(Strings.DebugLaunchScriptNameMissing);
+            }
+
+            if (!string.IsNullOrEmpty(path) && !DefaultInterpreterValue.Equals(path, StringComparison.OrdinalIgnoreCase)) {
                 if (PathUtils.IsValidPath(path) && !Path.IsPathRooted(path)) {
-                    // TODO: Find location of launch.json
+                    // Cannot (currently?) get the workspace path easily from here, so we'll start from
+                    // the startup file and work our way up until we find it.
+                    var basePath = PathUtils.GetParent(scriptName);
+                    string candidate = null;
+                    
+                    while (Directory.Exists(basePath)) {
+                        candidate = PathUtils.GetAbsoluteFilePath(basePath, path);
+                        if (File.Exists(candidate)) {
+                            path = candidate;
+                            break;
+                        }
+                    }
                 }
 
                 if (File.Exists(path)) {
@@ -107,7 +125,7 @@ namespace Microsoft.PythonTools.Workspace {
             var launchConfig = new LaunchConfiguration(config) {
                 InterpreterPath = config == null ? path : null,
                 InterpreterArguments = settings.GetValue(InterpreterArgumentsKey, string.Empty),
-                ScriptName = settings.GetValue(ScriptNameKey, string.Empty),
+                ScriptName = scriptName,
                 ScriptArguments = settings.GetValue(ScriptArgumentsKey, string.Empty),
                 WorkingDirectory = settings.GetValue(WorkingDirectoryKey, string.Empty),
                 // TODO: Support search paths


### PR DESCRIPTION
Fixes #1841 Start debugging says no python interpreter available
Handles "(default)" value correctly.
Also fixes handling of relative paths (e.g. "env\\scripts\\python.exe")
Fixes build issue on VS "15"