### PR TITLE
Fixes #1611 cookiecutter should default to user's projects path

### DIFF
--- a/Python/Product/Cookiecutter/CookiecutterToolWindow.cs
+++ b/Python/Product/Cookiecutter/CookiecutterToolWindow.cs
@@ -129,7 +129,15 @@ namespace Microsoft.CookiecutterTools {
 
             var gitClient = GitClientProvider.Create(outputWindow, commonIdeFolderPath as string);
 
-            _cookiecutterPage = new CookiecutterContainerPage(outputWindow, CookiecutterTelemetry.Current, gitClient, new Uri(feedUrl), OpenGeneratedFolder, UpdateCommandUI);
+            _cookiecutterPage = new CookiecutterContainerPage(
+                this,
+                outputWindow,
+                CookiecutterTelemetry.Current,
+                gitClient,
+                new Uri(feedUrl),
+                OpenGeneratedFolder,
+                UpdateCommandUI
+            );
             _cookiecutterPage.ContextMenuRequested += OnContextMenuRequested;
             _cookiecutterPage.InitializeAsync(CookiecutterPackage.Instance.CheckForTemplateUpdate).HandleAllExceptions(this, GetType()).DoNotWait();
 

--- a/Python/Product/Cookiecutter/Model/CookiecutterClientProvider.cs
+++ b/Python/Product/Cookiecutter/Model/CookiecutterClientProvider.cs
@@ -23,10 +23,10 @@ using Microsoft.CookiecutterTools.Interpreters;
 
 namespace Microsoft.CookiecutterTools.Model {
     static class CookiecutterClientProvider {
-        public static ICookiecutterClient Create(Redirector redirector) {
+        public static ICookiecutterClient Create(IServiceProvider provider, Redirector redirector) {
             var interpreter = FindCompatibleInterpreter();
             if (interpreter != null) {
-                return new CookiecutterClient(interpreter, redirector);
+                return new CookiecutterClient(provider, interpreter, redirector);
             }
 
             return null;

--- a/Python/Product/Cookiecutter/Model/ICookiecutterClient.cs
+++ b/Python/Product/Cookiecutter/Model/ICookiecutterClient.cs
@@ -26,5 +26,6 @@ namespace Microsoft.CookiecutterTools.Model {
         Task InstallPackage();
         Task<ContextItem[]> LoadContextAsync(string localTemplateFolder, string userConfigFilePath);
         Task GenerateProjectAsync(string localTemplateFolder, string userConfigFilePath, string contextFilePath, string outputFolderPath);
+        Task<string> GetDefaultOutputFolderAsync(string shortName);
     }
 }

--- a/Python/Product/Cookiecutter/View/CookiecutterContainerPage.xaml.cs
+++ b/Python/Product/Cookiecutter/View/CookiecutterContainerPage.xaml.cs
@@ -30,6 +30,7 @@ using Microsoft.CookiecutterTools.Infrastructure;
 using Microsoft.CookiecutterTools.Model;
 using Microsoft.CookiecutterTools.Telemetry;
 using Microsoft.CookiecutterTools.ViewModel;
+using Microsoft.VisualStudio.Shell.Interop;
 
 namespace Microsoft.CookiecutterTools.View {
     /// <summary>
@@ -50,7 +51,7 @@ namespace Microsoft.CookiecutterTools.View {
             InitializeComponent();
         }
 
-        public CookiecutterContainerPage(Redirector outputWindow, ICookiecutterTelemetry telemetry, IGitClient gitClient, Uri feedUrl, Action<string> openFolder, Action updateCommandUI) {
+        public CookiecutterContainerPage(IServiceProvider provider, Redirector outputWindow, ICookiecutterTelemetry telemetry, IGitClient gitClient, Uri feedUrl, Action<string> openFolder, Action updateCommandUI) {
             _updateCommandUI = updateCommandUI;
 
             _checkForUpdatesTimer = new DispatcherTimer();
@@ -58,7 +59,7 @@ namespace Microsoft.CookiecutterTools.View {
 
             var gitHubClient = new GitHubClient();
             ViewModel = new CookiecutterViewModel(
-                CookiecutterClientProvider.Create(outputWindow),
+                CookiecutterClientProvider.Create(provider, outputWindow),
                 gitHubClient,
                 gitClient,
                 telemetry,
@@ -70,7 +71,7 @@ namespace Microsoft.CookiecutterTools.View {
             );
 
             ViewModel.UserConfigFilePath = CookiecutterViewModel.GetUserConfigPath();
-            ViewModel.OutputFolderPath = string.Empty; // leaving this empty for now, force user to enter one
+            ViewModel.OutputFolderPath = string.Empty; // leaving this empty for now, initialize on context creation
             ViewModel.ContextLoaded += ViewModel_ContextLoaded;
             ViewModel.HomeClicked += ViewModel_HomeClicked;
 

--- a/Python/Product/Cookiecutter/ViewModel/CookiecutterViewModel.cs
+++ b/Python/Product/Cookiecutter/ViewModel/CookiecutterViewModel.cs
@@ -527,6 +527,7 @@ namespace Microsoft.CookiecutterTools.ViewModel {
 
                     _templateLocalFolderPath = selection.ClonedPath;
 
+                    await SetDefaultOutputFolder(_templateLocalFolderPath);
                     await RefreshContextAsync(selection);
                 } catch (Exception ex) when (!ex.IsCriticalException()) {
                     CloningStatus = OperationStatus.Failed;
@@ -539,7 +540,7 @@ namespace Microsoft.CookiecutterTools.ViewModel {
             } else {
                 Debug.Assert(!string.IsNullOrEmpty(selection.ClonedPath));
                 _templateLocalFolderPath = selection.ClonedPath;
-
+                await SetDefaultOutputFolder(_templateLocalFolderPath);
                 await RefreshContextAsync(selection);
             }
         }
@@ -859,6 +860,11 @@ namespace Microsoft.CookiecutterTools.ViewModel {
             } finally {
                 parent.Templates.Remove(loading);
             }
+        }
+
+        private async Task SetDefaultOutputFolder(string localTemplatePath) {
+            OutputFolderPath = await _cutterClient.GetDefaultOutputFolderAsync(PathUtils.GetFileOrDirectoryName(_templateLocalFolderPath));
+            Debug.Assert(!Directory.Exists(OutputFolderPath) && !File.Exists(PathUtils.TrimEndSeparator(OutputFolderPath)));
         }
 
         private async Task RefreshContextAsync(TemplateViewModel selection) {

--- a/Python/Tests/CookiecutterTests/CookiecutterClientTests.cs
+++ b/Python/Tests/CookiecutterTests/CookiecutterClientTests.cs
@@ -18,9 +18,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.CookiecutterTools;
 using Microsoft.CookiecutterTools.Model;
 using Microsoft.CookiecutterTools.ViewModel;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -91,7 +89,7 @@ namespace CookiecutterTests {
 
         [TestInitialize]
         public void SetupTest() {
-            _client = CookiecutterClientProvider.Create(_redirector);
+            _client = CookiecutterClientProvider.Create(null, _redirector);
             Assert.IsNotNull(_client, "The system doesn't have any compatible Python interpreters.");
         }
 

--- a/Python/Tests/CookiecutterTests/CookiecutterIntegrationTests.cs
+++ b/Python/Tests/CookiecutterTests/CookiecutterIntegrationTests.cs
@@ -59,6 +59,8 @@ namespace CookiecutterTests {
         private ITemplateSource _feedTemplateSource;
         private string _openedFolder;
 
+        private string DefaultBasePath => ((CookiecutterClient)_cutterClient)?.DefaultBasePath;
+
         internal static ContextItemViewModel[] LocalTemplateWithUserConfigContextItems { get; } = new ContextItemViewModel[] {
                 new ContextItemViewModel("full_name", Selectors.String, null, null, "Configured User"),
                 new ContextItemViewModel("email", Selectors.String, null, null, "configured@email"),
@@ -91,15 +93,16 @@ namespace CookiecutterTests {
 
             _gitClient = GitClientProvider.Create(_redirector, null);
             _gitHubClient = new GitHubClient();
-            _cutterClient = CookiecutterClientProvider.Create(_redirector);
+            _cutterClient = CookiecutterClientProvider.Create(null, _redirector);
             _telemetry = new CookiecutterTelemetry(new TelemetryTestService());
             _installedTemplateSource = new LocalTemplateSource(installedPath, _gitClient);
             _gitHubTemplateSource = new GitHubTemplateSource(_gitHubClient);
             _feedTemplateSource = new FeedTemplateSource(feedUrl);
 
+
             _vm = new CookiecutterViewModel(_cutterClient, _gitHubClient, _gitClient, _telemetry, _redirector, _installedTemplateSource, _feedTemplateSource, _gitHubTemplateSource, OpenFolder);
             _vm.UserConfigFilePath = userConfigFilePath;
-            _vm.OutputFolderPath = outputProjectFolder;
+            ((CookiecutterClient)_cutterClient).DefaultBasePath = outputProjectFolder;
         }
 
         private void OpenFolder(string folderPath) {
@@ -113,8 +116,8 @@ namespace CookiecutterTests {
             Assert.AreEqual(1, _vm.Installed.Templates.Count);
             Assert.AreEqual(6, _vm.Recommended.Templates.Count);
 
-            Assert.AreEqual(27, _vm.GitHub.Templates.Count);
-            Assert.AreEqual(26, _vm.GitHub.Templates.OfType<TemplateViewModel>().Count());
+            Assert.AreEqual(28, _vm.GitHub.Templates.Count);
+            Assert.AreEqual(27, _vm.GitHub.Templates.OfType<TemplateViewModel>().Count());
             Assert.AreEqual(1, _vm.GitHub.Templates.OfType<ContinuationViewModel>().Count());
 
             var continuationVM = _vm.GitHub.Templates.Last() as ContinuationViewModel;
@@ -235,17 +238,22 @@ namespace CookiecutterTests {
 
             _vm.ContextItems.Single(item => item.Name == "full_name").Val = "Integration Test User";
             _vm.ContextItems.Single(item => item.Name == "open_source_license").Val = "Apache Software License 2.0";
-            _vm.OutputFolderPath = Path.Combine(_vm.OutputFolderPath, "LocalTemplate");
 
-            await _vm.CreateFilesAsync();
+            var targetPath = _vm.OutputFolderPath;
+            Assert.IsTrue(Path.IsPathRooted(targetPath), "{0} is not a full path".FormatInvariant(targetPath));
+            Assert.IsTrue(PathUtils.IsSubpathOf(DefaultBasePath, targetPath),
+                "{0} is not in the {1} folder".FormatInvariant(targetPath, DefaultBasePath));
 
-            Assert.AreEqual(OperationStatus.Succeeded, _vm.CreatingStatus);
+            try {
+                await _vm.CreateFilesAsync();
 
-            var reportFilePath = Path.Combine(_vm.OutputFolderPath, "report.txt");
-            Assert.IsTrue(File.Exists(reportFilePath), "Failed to generate some project files.");
-            var report = CookiecutterClientTests.ReadReport(reportFilePath);
+                Assert.AreEqual(OperationStatus.Succeeded, _vm.CreatingStatus);
 
-            var expected = new Dictionary<string, string>() {
+                var reportFilePath = Path.Combine(_vm.OutputFolderPath, "report.txt");
+                Assert.IsTrue(File.Exists(reportFilePath), "Failed to generate some project files.");
+                var report = CookiecutterClientTests.ReadReport(reportFilePath);
+
+                var expected = new Dictionary<string, string>() {
                 { "full_name", "Integration Test User" },
                 { "email", "configured@email" },
                 { "github_username", "configuredgithubuser" },
@@ -257,7 +265,10 @@ namespace CookiecutterTests {
                 { "open_source_license", "Apache Software License 2.0" },
                 { "port", "5000" },
             };
-            CollectionAssert.AreEqual(expected, report);
+                CollectionAssert.AreEqual(expected, report);
+            } finally {
+                FileUtils.DeleteDirectory(targetPath);
+            }
         }
 
         [TestMethod]
@@ -275,49 +286,56 @@ namespace CookiecutterTests {
 
             await _vm.LoadTemplateAsync();
 
-            // Local template needs to be cloned
+            // Online template needs to be cloned
             Assert.AreEqual(OperationStatus.Succeeded, _vm.CloningStatus);
 
             PrintContextItems(_vm.ContextItems);
 
             _vm.ContextItems.Single(item => item.Name == "static_assets_directory").Val = "static_files";
-            _vm.OutputFolderPath = Path.Combine(_vm.OutputFolderPath, "OnlineTemplate");
+            var targetPath = _vm.OutputFolderPath;
+            Assert.IsTrue(Path.IsPathRooted(targetPath), "{0} is not a full path".FormatInvariant(targetPath));
+            Assert.IsTrue(PathUtils.IsSubpathOf(DefaultBasePath, targetPath),
+                "{0} is not in the {1} folder".FormatInvariant(targetPath, DefaultBasePath));
 
-            await _vm.CreateFilesAsync();
+            try {
+                await _vm.CreateFilesAsync();
 
-            Assert.AreEqual(OperationStatus.Succeeded, _vm.CreatingStatus);
-            Assert.AreEqual(_vm.OutputFolderPath, _vm.OpenInExplorerFolderPath);
+                Assert.AreEqual(OperationStatus.Succeeded, _vm.CreatingStatus);
+                Assert.AreEqual(_vm.OutputFolderPath, _vm.OpenInExplorerFolderPath);
 
-            Assert.IsTrue(Directory.Exists(Path.Combine(_vm.OutputFolderPath, "static_files")));
-            Assert.IsTrue(Directory.Exists(Path.Combine(_vm.OutputFolderPath, "post-deployment")));
-            Assert.IsTrue(File.Exists(Path.Combine(_vm.OutputFolderPath, "web.config")));
-            Assert.IsTrue(File.Exists(Path.Combine(_vm.OutputFolderPath, "static_files", "web.config")));
-            Assert.IsTrue(File.Exists(Path.Combine(_vm.OutputFolderPath, "post-deployment", "install-requirements.ps1")));
-            Assert.IsFalse(File.Exists(Path.Combine(_vm.OutputFolderPath, "install-requirements.ps1")));
+                Assert.IsTrue(Directory.Exists(Path.Combine(_vm.OutputFolderPath, "static_files")));
+                Assert.IsTrue(Directory.Exists(Path.Combine(_vm.OutputFolderPath, "post-deployment")));
+                Assert.IsTrue(File.Exists(Path.Combine(_vm.OutputFolderPath, "web.config")));
+                Assert.IsTrue(File.Exists(Path.Combine(_vm.OutputFolderPath, "static_files", "web.config")));
+                Assert.IsTrue(File.Exists(Path.Combine(_vm.OutputFolderPath, "post-deployment", "install-requirements.ps1")));
+                Assert.IsFalse(File.Exists(Path.Combine(_vm.OutputFolderPath, "install-requirements.ps1")));
 
-            var log = ((ITelemetryTestSupport)_telemetry.TelemetryService).SessionLog;
+                var log = ((ITelemetryTestSupport)_telemetry.TelemetryService).SessionLog;
 
-            Assert.IsTrue(log.Contains("Test/Cookiecutter/Search/Load"));
-            Assert.IsTrue(log.Contains("Test/Cookiecutter/Template/Clone"));
-            Assert.IsTrue(log.Contains("Test/Cookiecutter/Template/Load"));
-            Assert.IsTrue(log.Contains("Test/Cookiecutter/Template/Run"));
+                Assert.IsTrue(log.Contains("Test/Cookiecutter/Search/Load"));
+                Assert.IsTrue(log.Contains("Test/Cookiecutter/Template/Clone"));
+                Assert.IsTrue(log.Contains("Test/Cookiecutter/Template/Load"));
+                Assert.IsTrue(log.Contains("Test/Cookiecutter/Template/Run"));
 
-            Assert.IsTrue(log.Contains(template.RemoteUrl.GetSha512()));
-            Assert.IsTrue(log.Contains(template.RepositoryFullName.GetSha512()));
-            Assert.IsTrue(log.Contains(template.RepositoryName.GetSha512()));
-            Assert.IsTrue(log.Contains(template.RepositoryOwner.GetSha512()));
+                Assert.IsTrue(log.Contains(template.RemoteUrl.GetSha512()));
+                Assert.IsTrue(log.Contains(template.RepositoryFullName.GetSha512()));
+                Assert.IsTrue(log.Contains(template.RepositoryName.GetSha512()));
+                Assert.IsTrue(log.Contains(template.RepositoryOwner.GetSha512()));
 
-            Assert.IsFalse(log.Contains(template.DisplayName));
-            Assert.IsFalse(log.Contains(template.Description));
-            Assert.IsFalse(log.Contains(template.ClonedPath));
-            Assert.IsFalse(log.Contains(template.RemoteUrl));
-            Assert.IsFalse(log.Contains(template.RepositoryFullName));
-            Assert.IsFalse(log.Contains(template.RepositoryName));
-            Assert.IsFalse(log.Contains(template.RepositoryOwner));
+                Assert.IsFalse(log.Contains(template.DisplayName));
+                Assert.IsFalse(log.Contains(template.Description));
+                Assert.IsFalse(log.Contains(template.ClonedPath));
+                Assert.IsFalse(log.Contains(template.RemoteUrl));
+                Assert.IsFalse(log.Contains(template.RepositoryFullName));
+                Assert.IsFalse(log.Contains(template.RepositoryName));
+                Assert.IsFalse(log.Contains(template.RepositoryOwner));
 
-            Assert.AreEqual(null, _openedFolder);
-            _vm.OpenFolderInExplorer(_vm.OpenInExplorerFolderPath);
-            Assert.AreEqual(_vm.OpenInExplorerFolderPath, _openedFolder);
+                Assert.AreEqual(null, _openedFolder);
+                _vm.OpenFolderInExplorer(_vm.OpenInExplorerFolderPath);
+                Assert.AreEqual(_vm.OpenInExplorerFolderPath, _openedFolder);
+            } finally {
+                FileUtils.DeleteDirectory(targetPath);
+            }
         }
 
         [TestMethod]

--- a/Python/Tests/CookiecutterTests/MockCookiecutterClient.cs
+++ b/Python/Tests/CookiecutterTests/MockCookiecutterClient.cs
@@ -39,6 +39,10 @@ namespace CookiecutterTests {
             throw new NotImplementedException();
         }
 
+        public Task<string> GetDefaultOutputFolderAsync(string shortName) {
+            throw new NotImplementedException();
+        }
+
         public Task InstallPackage() {
             throw new NotImplementedException();
         }


### PR DESCRIPTION
Fixes #1611 cookiecutter should default to user's projects path
Sets a default project path when moving to the template.

We still need to add support for using the current project's path when "Add new item" entry point is used. I'll file a new issue for that.