### PR TITLE
Cookiecutter default list selection

### DIFF
--- a/Python/Product/Cookiecutter/Model/GitClient.cs
+++ b/Python/Product/Cookiecutter/Model/GitClient.cs
@@ -40,18 +40,29 @@ namespace Microsoft.CookiecutterTools.Model {
                 ShellUtils.DeleteDirectory(localTemplateFolder);
             }
 
+            // Ensure we always capture the output, because we need to check for errors in stderr
+            var stdOut = new List<string>();
+            var stdErr = new List<string>();
+
+            Redirector redirector;
+            if (_redirector != null) {
+                redirector = new TeeRedirector(_redirector, new ListRedirector(stdOut, stdErr));
+            } else {
+                redirector = new ListRedirector(stdOut, stdErr);
+            }
+
             var arguments = new string[] { "clone", repoUrl };
-            using (var output = ProcessOutput.Run(_gitExeFilePath, arguments, targetParentFolderPath, null, false, _redirector)) {
+            using (var output = ProcessOutput.Run(_gitExeFilePath, arguments, targetParentFolderPath, null, false, redirector)) {
                 await output;
 
                 var r = new ProcessOutputResult() {
                     ExeFileName = _gitExeFilePath,
                     ExitCode = output.ExitCode,
-                    StandardOutputLines = output.StandardOutputLines.ToArray(),
-                    StandardErrorLines = output.StandardErrorLines.ToArray(),
+                    StandardOutputLines = stdOut.ToArray(),
+                    StandardErrorLines = stdErr.ToArray(),
                 };
 
-                if (output.ExitCode < 0 || HasFatalError(output)) {
+                if (output.ExitCode < 0 || HasFatalError(stdErr)) {
                     if (Directory.Exists(localTemplateFolder)) {
                         // Don't leave a failed clone on disk
                         try {
@@ -113,7 +124,7 @@ namespace Microsoft.CookiecutterTools.Model {
             var arguments = new string[] { "fetch" };
             using (var output = ProcessOutput.Run(_gitExeFilePath, arguments, repoFolderPath, null, false, null)) {
                 await output;
-                if (output.ExitCode < 0 || HasFatalError(output)) {
+                if (output.ExitCode < 0 || HasFatalError(output.StandardErrorLines)) {
                     throw new ProcessException(new ProcessOutputResult() {
                         ExeFileName = _gitExeFilePath,
                         ExitCode = output.ExitCode,
@@ -136,8 +147,8 @@ namespace Microsoft.CookiecutterTools.Model {
             }
         }
 
-        private static bool HasFatalError(ProcessOutput output) {
-            return output.StandardErrorLines.Any(line => line.StartsWith("fatal:", StringComparison.InvariantCultureIgnoreCase));
+        private static bool HasFatalError(IEnumerable<string> standardErrorLines) {
+            return standardErrorLines.Any(line => line.StartsWith("fatal:", StringComparison.InvariantCultureIgnoreCase));
         }
 
         private static string GetClonedFolder(string repoUrl, string targetParentFolderPath) {

--- a/Python/Product/Cookiecutter/Shared/Wpf/ConfigurationControl.cs
+++ b/Python/Product/Cookiecutter/Shared/Wpf/ConfigurationControl.cs
@@ -53,15 +53,9 @@ namespace Microsoft.VisualStudioTools.Wpf {
     }
 
     sealed class ConfigurationComboBoxWithHelp : Control {
-        public static readonly DependencyProperty WatermarkProperty = DependencyProperty.Register("Watermark", typeof(string), typeof(ConfigurationComboBoxWithHelp), new PropertyMetadata());
         public static readonly DependencyProperty HelpTextProperty = DependencyProperty.Register("HelpText", typeof(string), typeof(ConfigurationComboBoxWithHelp), new PropertyMetadata());
         public static readonly DependencyProperty ValueProperty = DependencyProperty.Register("Value", typeof(string), typeof(ConfigurationComboBoxWithHelp), new PropertyMetadata());
         public static readonly DependencyProperty ValuesProperty = DependencyProperty.Register("Values", typeof(IList<string>), typeof(ConfigurationComboBoxWithHelp), new PropertyMetadata());
-
-        public string Watermark {
-            get { return (string)GetValue(WatermarkProperty); }
-            set { SetValue(WatermarkProperty, value); }
-        }
 
         public string HelpText {
             get { return (string)GetValue(HelpTextProperty); }

--- a/Python/Product/Cookiecutter/View/CookiecutterOptionsPage.xaml
+++ b/Python/Product/Cookiecutter/View/CookiecutterOptionsPage.xaml
@@ -65,8 +65,7 @@
                             <wpf:ConfigurationComboBoxWithHelp Margin="4 0 8 4"
                                                                Value="{Binding Val, Mode=TwoWay}"
                                                                Values="{Binding Items}"
-                                                               HelpText="{Binding Description}"
-                                                               Watermark="{Binding Default}" />
+                                                               HelpText="{Binding Description}" />
                         </StackPanel>
                     </DataTemplate>
                     <DataTemplate x:Key="yesnoTemplate">
@@ -81,8 +80,7 @@
                             <wpf:ConfigurationComboBoxWithHelp Margin="4 0 8 4"
                                                                Value="{Binding Val, Mode=TwoWay}"
                                                                Values="{StaticResource ResourceKey=yesnoValues}"
-                                                               HelpText="{Binding Description}"
-                                                               Watermark="{Binding Default}" />
+                                                               HelpText="{Binding Description}" />
                         </StackPanel>
                     </DataTemplate>
                     <wpf:Lambda x:Key="OperationStatusInProgressToVisibleOrCollapsed">(OperationStatus s) => s == OperationStatus.InProgress ? Visibility.Visible : Visibility.Collapsed</wpf:Lambda>

--- a/Python/Product/Cookiecutter/ViewModel/ContextItemViewModel.cs
+++ b/Python/Product/Cookiecutter/ViewModel/ContextItemViewModel.cs
@@ -47,6 +47,12 @@ namespace Microsoft.CookiecutterTools.ViewModel {
             _items = new List<string>();
             if (items != null && items.Length > 0) {
                 _items.AddRange(items);
+            }
+
+            // These selectors don't have a way of showing the default value (watermark)
+            // when no value is set (and there's no way to unset the value once it is set).
+            // So we'll always start with the value set to default.
+            if (selector == Selectors.YesNo || selector == Selectors.List) {
                 _val = _default;
             }
         }

--- a/Python/Product/Cookiecutter/ViewModel/ContextItemViewModel.cs
+++ b/Python/Product/Cookiecutter/ViewModel/ContextItemViewModel.cs
@@ -45,8 +45,9 @@ namespace Microsoft.CookiecutterTools.ViewModel {
             _val = string.Empty;
             _default = defaultValue;
             _items = new List<string>();
-            if (items != null) {
+            if (items != null && items.Length > 0) {
                 _items.AddRange(items);
+                _val = _default;
             }
         }
 


### PR DESCRIPTION
Fix #1799

Also updates git clone implementation to fix tests that were passing a mock redirector, ending up with null StandardErrorLines.

By the way, cookiecutter always uses the first entry in a list as the default.

I considered having an extra combo box item (first in list) for selecting default value (basically treat it as 'unset'), but since that would always be the same as the second item (the true first item in the list), there didn't seem to be much benefit.