### PR TITLE
Send PII values properly using TelemetryPiiProperty.

### DIFF
--- a/Python/Product/Cookiecutter/Shared/Infrastructure/StringExtensions.cs
+++ b/Python/Product/Cookiecutter/Shared/Infrastructure/StringExtensions.cs
@@ -93,12 +93,5 @@ namespace Microsoft.CookiecutterTools.Infrastructure {
 
             return str.Substring(0, length);
         }
-
-        public static string GetSha512(this string input) {
-            SHA512 sha = SHA512.Create();
-            byte[] inputBytes = Encoding.Unicode.GetBytes(input);
-            byte[] hash = sha.ComputeHash(inputBytes);
-            return BitConverter.ToString(hash);
-        }
     }
 }

--- a/Python/Product/Cookiecutter/ViewModel/CookiecutterViewModel.cs
+++ b/Python/Product/Cookiecutter/ViewModel/CookiecutterViewModel.cs
@@ -30,6 +30,7 @@ using System.Windows.Media.Imaging;
 using Microsoft.CookiecutterTools.Infrastructure;
 using Microsoft.CookiecutterTools.Model;
 using Microsoft.CookiecutterTools.Telemetry;
+using Microsoft.VisualStudio.Telemetry;
 using Newtonsoft.Json;
 
 namespace Microsoft.CookiecutterTools.ViewModel {
@@ -968,10 +969,10 @@ namespace Microsoft.CookiecutterTools.ViewModel {
 
                 var obj = new {
                     Success = error == null,
-                    RepoUrl = repoUrl?.GetSha512(),
-                    RepoFullName = repoFullName?.GetSha512(),
-                    RepoOwner = repoOwner?.GetSha512(),
-                    RepoName = repoName?.GetSha512(),
+                    RepoUrl = new TelemetryPiiProperty(repoUrl),
+                    RepoFullName = new TelemetryPiiProperty(repoFullName),
+                    RepoOwner = new TelemetryPiiProperty(repoOwner),
+                    RepoName = new TelemetryPiiProperty(repoName),
                 };
                 ReportEvent(area, eventName, obj);
             } catch (Exception ex) {

--- a/Python/Tests/CookiecutterTests/CookiecutterIntegrationTests.cs
+++ b/Python/Tests/CookiecutterTests/CookiecutterIntegrationTests.cs
@@ -317,18 +317,13 @@ namespace CookiecutterTests {
                 Assert.IsTrue(log.Contains("Test/Cookiecutter/Template/Load"));
                 Assert.IsTrue(log.Contains("Test/Cookiecutter/Template/Run"));
 
-                Assert.IsTrue(log.Contains(template.RemoteUrl.GetSha512()));
-                Assert.IsTrue(log.Contains(template.RepositoryFullName.GetSha512()));
-                Assert.IsTrue(log.Contains(template.RepositoryName.GetSha512()));
-                Assert.IsTrue(log.Contains(template.RepositoryOwner.GetSha512()));
-
-                Assert.IsFalse(log.Contains(template.DisplayName));
                 Assert.IsFalse(log.Contains(template.Description));
                 Assert.IsFalse(log.Contains(template.ClonedPath));
-                Assert.IsFalse(log.Contains(template.RemoteUrl));
-                Assert.IsFalse(log.Contains(template.RepositoryFullName));
-                Assert.IsFalse(log.Contains(template.RepositoryName));
-                Assert.IsFalse(log.Contains(template.RepositoryOwner));
+
+                Assert.IsTrue(log.Contains(PII(template.RemoteUrl)));
+                Assert.IsTrue(log.Contains(PII(template.RepositoryFullName)));
+                Assert.IsTrue(log.Contains(PII(template.RepositoryName)));
+                Assert.IsTrue(log.Contains(PII(template.RepositoryOwner)));
 
                 Assert.AreEqual(null, _openedFolder);
                 _vm.OpenFolderInExplorer(_vm.OpenInExplorerFolderPath);
@@ -358,6 +353,10 @@ namespace CookiecutterTests {
             // After cloning the same template multiple times, make sure it only appears once in the installed section
             var installed = _vm.Installed.Templates.OfType<TemplateViewModel>().Where(t => t.DisplayName == OnlineTemplateRepoName).ToArray();
             Assert.AreEqual(1, installed.Length);
+        }
+
+        private static string PII(string text) {
+            return $"PII({text})";
         }
 
         private async Task EnsureCookiecutterInstalledAsync() {


### PR DESCRIPTION
Fix #1861

I double-checked the data types (using the debugger) in the properties dictionary at the point where TelemetrySession.PostEvent is called, to make sure it's sending the class instance, not a string representation.