### PR TITLE
Fixes #1739 Analysis does not restart if Python is installed while VS is running

### DIFF
--- a/Python/Product/Analyzer/Intellisense/AnalysisProtocol.cs
+++ b/Python/Product/Analyzer/Intellisense/AnalysisProtocol.cs
@@ -847,6 +847,17 @@ namespace Microsoft.PythonTools.Intellisense {
             public Navigation[] children;
         }
 
+        internal class AnalyzerWarningEvent : Event {
+            public string message;
+            public const string Name = "analyzerWarning";
+
+            public AnalyzerWarningEvent(string message) {
+                this.message = message;
+            }
+
+            public override string name => Name;
+        }
+
         internal class UnhandledExceptionEvent : Event {
             public string message;
             public const string Name = "unhandledException";

--- a/Python/Product/Analyzer/Intellisense/OutOfProcProjectAnalyzer.cs
+++ b/Python/Product/Analyzer/Intellisense/OutOfProcProjectAnalyzer.cs
@@ -71,7 +71,6 @@ namespace Microsoft.PythonTools.Intellisense {
         private readonly Dictionary<string, IAnalysisExtension> _extensionsByName = new Dictionary<string, IAnalysisExtension>();
 
         private readonly Connection _connection;
-        internal Task ReloadTask;
 
         internal OutOfProcProjectAnalyzer(Stream writer, Stream reader) {
             _analysisQueue = new AnalysisQueue(this);
@@ -178,7 +177,7 @@ namespace Microsoft.PythonTools.Intellisense {
                 case AP.ModuleImportsRequest.Command: response = GetModuleImports((AP.ModuleImportsRequest)request); break;
                 case AP.ValueDescriptionRequest.Command: response = GetValueDescriptions((AP.ValueDescriptionRequest)request); break;
                 case AP.ExtensionRequest.Command: response = ExtensionRequest((AP.ExtensionRequest)request); break;
-                case AP.InitializeRequest.Command: response = Initialize((AP.InitializeRequest)request); break;
+                case AP.InitializeRequest.Command: response = await Initialize((AP.InitializeRequest)request); break;
                 case AP.ExpressionForDataTipRequest.Command: response = ExpressionForDataTip((AP.ExpressionForDataTipRequest)request); break;
                 case AP.ExitRequest.Command: throw new OperationCanceledException();
                 default:
@@ -194,7 +193,7 @@ namespace Microsoft.PythonTools.Intellisense {
             ).Wait();
         }
 
-        private Response Initialize(AP.InitializeRequest request) {
+        private async Task<Response> Initialize(AP.InitializeRequest request) {
             List<AssemblyCatalog> catalogs = new List<AssemblyCatalog>();
 
             HashSet<string> assemblies = new HashSet<string>(request.mefExtensions);
@@ -262,11 +261,13 @@ namespace Microsoft.PythonTools.Intellisense {
             }
 
             if (factory == null) {
-                error = String.Format("No active interpreter found for interpreter ID: {0}", request.interpreterId);
-                return new AP.InitializeResponse() {
-                    failedLoads = failures.ToArray(),
-                    error = error
-                };
+                if (_connection != null) {
+                    await _connection.SendEventAsync(
+                        new AP.AnalyzerWarningEvent(string.Format("No active interpreter found for interpreter ID: {0}", request.interpreterId))
+                    );
+                }
+                var db = PythonTypeDatabase.CreateDefaultTypeDatabase();
+                factory = InterpreterFactoryCreator.CreateAnalysisInterpreterFactory(db.LanguageVersion, db);
             }
 
             _interpreterFactory = factory;
@@ -276,8 +277,7 @@ namespace Microsoft.PythonTools.Intellisense {
             if (interpreter != null) {
                 try {
                     _pyAnalyzer = PythonAnalyzer.Create(factory, interpreter);
-                    ReloadTask = _pyAnalyzer.ReloadModulesAsync()/*.HandleAllExceptions(_serviceProvider, GetType())*/;
-                    ReloadTask.ContinueWith(_ => ReloadTask = null);
+                    await _pyAnalyzer.ReloadModulesAsync();
                     interpreter.ModuleNamesChanged += OnModulesChanged;
                 } catch (InvalidOperationException ex) {
                     error = ex.ToString();

--- a/Python/Product/PythonTools/PythonTools/Commands/DiagnosticsCommand.cs
+++ b/Python/Product/PythonTools/PythonTools/Commands/DiagnosticsCommand.cs
@@ -224,30 +224,32 @@ namespace Microsoft.PythonTools.Commands {
                 res.AppendLine();
             }
 
-            try {
-                res.AppendLine("System events:");
+            if (!skipAnalysisLog) {
+                try {
+                    res.AppendLine("System events:");
 
-                var application = new EventLog("Application");
-                var lastWeek = DateTime.Now.Subtract(TimeSpan.FromDays(7));
-                foreach (var entry in application.Entries.Cast<EventLogEntry>()
-                    .Where(e => e.InstanceId == 1026L)  // .NET Runtime
-                    .Where(e => e.TimeGenerated >= lastWeek)
-                    .Where(e => InterestingApplicationLogEntries.IsMatch(e.Message))
-                    .OrderByDescending(e => e.TimeGenerated)
-                ) {
-                    res.AppendLine(string.Format("Time: {0:s}", entry.TimeGenerated));
-                    using (var reader = new StringReader(entry.Message.TrimEnd())) {
-                        for (var line = reader.ReadLine(); line != null; line = reader.ReadLine()) {
-                            res.AppendLine(line);
+                    var application = new EventLog("Application");
+                    var lastWeek = DateTime.Now.Subtract(TimeSpan.FromDays(7));
+                    foreach (var entry in application.Entries.Cast<EventLogEntry>()
+                        .Where(e => e.InstanceId == 1026L)  // .NET Runtime
+                        .Where(e => e.TimeGenerated >= lastWeek)
+                        .Where(e => InterestingApplicationLogEntries.IsMatch(e.Message))
+                        .OrderByDescending(e => e.TimeGenerated)
+                    ) {
+                        res.AppendLine(string.Format("Time: {0:s}", entry.TimeGenerated));
+                        using (var reader = new StringReader(entry.Message.TrimEnd())) {
+                            for (var line = reader.ReadLine(); line != null; line = reader.ReadLine()) {
+                                res.AppendLine(line);
+                            }
                         }
+                        res.AppendLine();
                     }
+
+                } catch (Exception ex) when (!ex.IsCriticalException()) {
+                    res.AppendLine("  Failed to access event log.");
+                    res.AppendLine(ex.ToString());
                     res.AppendLine();
                 }
-
-            } catch (Exception ex) when (!ex.IsCriticalException()) {
-                res.AppendLine("  Failed to access event log.");
-                res.AppendLine(ex.ToString());
-                res.AppendLine();
             }
 
             res.AppendLine("Loaded assemblies:");

--- a/Python/Product/PythonTools/PythonTools/Intellisense/ProjectAnalyzer.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/ProjectAnalyzer.cs
@@ -411,11 +411,14 @@ namespace Microsoft.PythonTools.Intellisense {
                         _projectFilesById[childFile.fileId] = _projectFiles[childFile.filename] = entry;
                     }
                     break;
+                case AP.AnalyzerWarningEvent.Name:
+                    var warning = (AP.AnalyzerWarningEvent)e.Event;
+                    _pyService.Logger.LogEvent(Logging.PythonLogEvent.AnalysisWarning, warning.message);
+                    break;
                 case AP.UnhandledExceptionEvent.Name:
                     Debug.Fail("Unhandled exception from analyzer");
                     var exception = (AP.UnhandledExceptionEvent)e.Event;
-
-                    VisualStudio.Shell.ActivityLog.LogError(Strings.ProductTitle, exception.message);
+                    _pyService.Logger.LogEvent(Logging.PythonLogEvent.AnalysisOperationFailed, exception.message);
                     break;
             }
         }

--- a/Python/Product/PythonTools/PythonTools/Logging/InMemoryLogger.cs
+++ b/Python/Product/PythonTools/PythonTools/Logging/InMemoryLogger.cs
@@ -60,13 +60,10 @@ namespace Microsoft.PythonTools.Logging {
                     _analysisInfo.Add(argument as AnalysisInfo);
                     break;
                 case PythonLogEvent.AnalysisExitedAbnormally:
-                    _analysisAbnormalities.Add(DateTime.Now + " Abnormal exit: " + argument);
-                    break;
                 case PythonLogEvent.AnalysisOperationCancelled:
-                    _analysisAbnormalities.Add(DateTime.Now + " Operation Cancelled");
-                    break;
                 case PythonLogEvent.AnalysisOperationFailed:
-                    _analysisAbnormalities.Add(DateTime.Now + " Operation Failed " + argument);
+                case PythonLogEvent.AnalysisWarning:
+                    _analysisAbnormalities.Add("[{0}] {1}: {2}".FormatInvariant(DateTime.Now, logEvent, argument as string ?? ""));
                     break;
             }
         }

--- a/Python/Product/PythonTools/PythonTools/Logging/VsTelemetryLogger.cs
+++ b/Python/Product/PythonTools/PythonTools/Logging/VsTelemetryLogger.cs
@@ -44,6 +44,15 @@ namespace Microsoft.PythonTools.Logging {
                 return;
             }
 
+            // Certain events are not collected
+            switch (logEvent) {
+                case PythonLogEvent.AnalysisWarning:
+                case PythonLogEvent.AnalysisOperationFailed:
+                case PythonLogEvent.AnalysisOperationCancelled:
+                case PythonLogEvent.AnalysisExitedAbnormally:
+                    return;
+            }
+
             var evt = new TelemetryEvent(EventPrefix + logEvent.ToString());
             var props = PythonToolsLoggerData.AsDictionary(argument);
             if (props != null) {

--- a/Python/Product/PythonTools/PythonTools/Project/PythonProjectNode.cs
+++ b/Python/Product/PythonTools/PythonTools/Project/PythonProjectNode.cs
@@ -175,12 +175,14 @@ namespace Microsoft.PythonTools.Project {
         }
 
         private void OnInterpreterRegistryChanged(object sender, EventArgs e) {
-            // Check whether the active interpreter factory has changed.
-            var fact = InterpreterRegistry.FindInterpreter(ActiveInterpreter.Configuration.Id);
-            if (fact != null && fact != ActiveInterpreter) {
-                ActiveInterpreter = fact;
+            Site.GetUIThread().Invoke(() => {
+                // Check whether the active interpreter factory has changed.
+                var fact = InterpreterRegistry.FindInterpreter(ActiveInterpreter.Configuration.Id);
+                if (fact != null && fact != ActiveInterpreter) {
+                    ActiveInterpreter = fact;
+                }
                 InterpreterFactoriesChanged?.Invoke(this, EventArgs.Empty);
-            }
+            });
         }
 
         public IInterpreterOptionsService InterpreterOptions {
@@ -222,13 +224,10 @@ namespace Microsoft.PythonTools.Project {
 
                 if (_active != oldActive) {
                     if (oldActive == null) {
-                        // No longer need to listen to this event
                         var defaultInterp = InterpreterOptions.DefaultInterpreter as PythonInterpreterFactoryWithDatabase;
                         if (defaultInterp != null) {
                             defaultInterp.NewDatabaseAvailable -= OnNewDatabaseAvailable;
                         }
-
-                        InterpreterOptions.DefaultInterpreterChanged -= GlobalDefaultInterpreterChanged;
                     } else {
                         var oldInterpWithDb = oldActive as PythonInterpreterFactoryWithDatabase;
                         if (oldInterpWithDb != null) {
@@ -247,17 +246,19 @@ namespace Microsoft.PythonTools.Project {
                         );
                     } else {
                         BuildProject.SetProperty(MSBuildConstants.InterpreterIdProperty, "");
-                        // Need to start listening to this event
-
-                        InterpreterOptions.DefaultInterpreterChanged += GlobalDefaultInterpreterChanged;
-
                         var defaultInterp = InterpreterOptions.DefaultInterpreter as PythonInterpreterFactoryWithDatabase;
                         if (defaultInterp != null) {
                             defaultInterp.NewDatabaseAvailable += OnNewDatabaseAvailable;
                         }
                     }
                     BuildProject.MarkDirty();
+                }
 
+                // https://github.com/Microsoft/PTVS/issues/1739
+                // When we go from "no interpreters" to "global default", we see
+                // _active == oldActive == null. Previously we would not trigger
+                // new analysis in this case.
+                if (_active != oldActive || oldActive == null) {
                     ActiveInterpreterChanged?.Invoke(this, EventArgs.Empty);
                 }
             }
@@ -276,11 +277,10 @@ namespace Microsoft.PythonTools.Project {
         }
 
         private void GlobalDefaultInterpreterChanged(object sender, EventArgs e) {
-            // This event is only raised when our active interpreter is the
-            // global default.
-            var evt = ActiveInterpreterChanged;
-            if (evt != null) {
-                evt(this, EventArgs.Empty);
+            if (_active == null) {
+                // This event is only raised when our active interpreter is the
+                // global default.
+                ActiveInterpreterChanged?.Invoke(this, EventArgs.Empty);
             }
         }
 
@@ -431,11 +431,7 @@ namespace Microsoft.PythonTools.Project {
             ActiveInterpreter = newActive;
         }
 
-        internal bool IsActiveInterpreterGlobalDefault {
-            get {
-                return _active == null;
-            }
-        }
+        internal bool IsActiveInterpreterGlobalDefault => _active == null;
 
         internal IEnumerable<InterpreterConfiguration> InterpreterConfigurations {
             get {

--- a/Python/Product/PythonTools/PythonTools/Repl/SelectableReplEvaluator.cs
+++ b/Python/Product/PythonTools/PythonTools/Repl/SelectableReplEvaluator.cs
@@ -101,7 +101,7 @@ namespace Microsoft.PythonTools.Repl {
                 _serviceProvider.GetPythonToolsService().SaveString("Id", _settingsCategory, _evaluatorId);
                 return;
             }
-            if (pyEval.Configuration == null) {
+            if (pyEval.Configuration?.Interpreter == null) {
                 // Invalid configuration - don't serialize it
                 ClearPersistedEvaluator();
                 return;

--- a/Python/Product/VSCommon/Logging/PythonLogEvent.cs
+++ b/Python/Product/VSCommon/Logging/PythonLogEvent.cs
@@ -63,7 +63,10 @@ namespace Microsoft.PythonTools.Logging {
         /// <summary>
         /// A call to the analysis process failed and raised an exception.
         /// </summary>
-        AnalysisOperationFailed
-
+        AnalysisOperationFailed,
+        /// <summary>
+        /// The analysis process raised a warning
+        /// </summary>
+        AnalysisWarning
     }
 }


### PR DESCRIPTION
Fixes #1739 Analysis does not restart if Python is installed while VS is running
Fixes notifications when going from "no interpreters" to "global default" interpreter
Fixes analyzer not starting when no interpreters are available
Fixes errors being swallowed by analyzer
Fixes thread safety issues when loading the default interpreter
Excludes some logged events from telemetry collection
Excludes (slow) Event Log data from diagnostics when Shift is held