### PR TITLE
Fix 1887: Assertion failed: Unhandled exception when launching web project

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Logging/InMemoryLogger.cs
+++ b/Python/Product/PythonTools/PythonTools/Logging/InMemoryLogger.cs
@@ -42,7 +42,7 @@ namespace Microsoft.PythonTools.Logging {
 
             switch (logEvent) {
                 case PythonLogEvent.Launch:
-                    if ((int)argument != 0) {
+                    if (((LaunchInfo)argument).IsDebug) {
                         _debugLaunchCount++;
                     } else {
                         _normalLaunchCount++;

--- a/Python/Product/PythonTools/PythonTools/WebProject/PythonWebLauncher.cs
+++ b/Python/Product/PythonTools/PythonTools/WebProject/PythonWebLauncher.cs
@@ -108,8 +108,6 @@ namespace Microsoft.PythonTools.Project.Web {
                     dsi.Launch();
                 }
             } else {
-                _pyService.Logger.LogEvent(Logging.PythonLogEvent.Launch, 0);
-
                 var psi = DebugLaunchHelper.CreateProcessStartInfo(_serviceProvider, config);
 
                 var process = Process.Start(psi);


### PR DESCRIPTION
There's another (correct) LogEvent in PythonWebLauncher a few lines up, so I removed the extra (incorrect) one.