### PR TITLE
Fixes #1394 Test adapter should not list all tests on command line

### DIFF
--- a/Python/Product/Common/Strings.Designer.cs
+++ b/Python/Product/Common/Strings.Designer.cs
@@ -1995,11 +1995,11 @@ namespace Microsoft.PythonTools {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Failed to attach debugger because the process has already exited..
+        ///   Looks up a localized string similar to Failed to execute tests because the process has already exited..
         /// </summary>
-        public static string Test_FailedToAttachExited {
+        public static string Test_FailedToStartExited {
             get {
-                return ResourceManager.GetString("Test_FailedToAttachExited", resourceCulture);
+                return ResourceManager.GetString("Test_FailedToStartExited", resourceCulture);
             }
         }
         

--- a/Python/Product/Common/Strings.resx
+++ b/Python/Product/Common/Strings.resx
@@ -812,8 +812,8 @@ modified from these scripts.</value>
   <data name="Test_ErrorConnecting" xml:space="preserve">
     <value>Error occurred connecting to debuggee.</value>
   </data>
-  <data name="Test_FailedToAttachExited" xml:space="preserve">
-    <value>Failed to attach debugger because the process has already exited.</value>
+  <data name="Test_FailedToStartExited" xml:space="preserve">
+    <value>Failed to execute tests because the process has already exited.</value>
   </data>
   <data name="Test_InterpreterDoesNotExist" xml:space="preserve">
     <value>Interpreter path does not exist: {0}</value>


### PR DESCRIPTION
Fixes #1394 Test adapter should not list all tests on command line
Adds support for passing tests in a plain-text file.