### PR TITLE
Fixes #1897 Python Environments only shows one venv

### DIFF
--- a/Python/Product/EnvironmentsList/ToolWindow.xaml.cs
+++ b/Python/Product/EnvironmentsList/ToolWindow.xaml.cs
@@ -549,10 +549,28 @@ namespace Microsoft.PythonTools.EnvironmentsList {
                     }
                 }
 
-                return StringComparer.CurrentCultureIgnoreCase.Compare(
+                int result = StringComparer.CurrentCultureIgnoreCase.Compare(
                     x.Description,
                     y.Description
                 );
+
+                if (result == 0) {
+                    // Any missing information means not equal, so we need to
+                    // pick a winner. We arbitrarily sort the non-null entry
+                    // first, or x if they both have nulls.
+                    if (y.Factory?.Configuration?.Id == null) {
+                        result = -1;
+                    } else if (x.Factory?.Configuration?.Id == null) {
+                        result = 1;
+                    } else {
+                        result = StringComparer.Ordinal.Compare(
+                            x.Factory.Configuration.Id,
+                            y.Factory.Configuration.Id
+                        );
+                    }
+                }
+
+                return result;
             }
         }
 

--- a/Python/Product/PythonTools/PythonTools/Project/PythonProjectNode.cs
+++ b/Python/Product/PythonTools/PythonTools/Project/PythonProjectNode.cs
@@ -318,7 +318,7 @@ namespace Microsoft.PythonTools.Project {
             var projectHome = PathUtils.GetAbsoluteDirectoryPath(BuildProject.DirectoryPath, BuildProject.GetPropertyValue("ProjectHome"));
             var rootPath = PathUtils.EnsureEndSeparator(config.PrefixPath);
 
-            var id = MSBuildProjectInterpreterFactoryProvider.GetProjectiveRelativeId(BuildProject.FullPath, config.Id);
+            var id = MSBuildProjectInterpreterFactoryProvider.GetProjectRelativeId(BuildProject.FullPath, config.Id);
             if (string.IsNullOrEmpty(id)) {
                 throw new InvalidOperationException("Adding project environment {0} to wrong project {1}".FormatInvariant(config.Id, BuildProject.FullPath));
             }
@@ -374,7 +374,7 @@ namespace Microsoft.PythonTools.Project {
                 }
             }
 
-            var subid = MSBuildProjectInterpreterFactoryProvider.GetProjectiveRelativeId(BuildProject.FullPath, factory.Configuration.Id);
+            var subid = MSBuildProjectInterpreterFactoryProvider.GetProjectRelativeId(BuildProject.FullPath, factory.Configuration.Id);
             bool projectChanged = false;
 
             if (!string.IsNullOrEmpty(subid)) {

--- a/Python/Product/VSInterpreters/MSBuildProjectInterpreterFactoryProvider.cs
+++ b/Python/Product/VSInterpreters/MSBuildProjectInterpreterFactoryProvider.cs
@@ -136,11 +136,24 @@ namespace Microsoft.PythonTools.Interpreter {
         }
 
         public object GetProperty(string id, string propName) {
+            Match m;
+            string moniker;
+
             switch (propName) {
                 case "ProjectMoniker":
-                    var m = InterpreterIdRegex.Match(id);
-                    if (m.Success && PathUtils.IsValidPath(m.Groups["moniker"].Value)) {
-                        return m.Groups["moniker"].Value;
+                    m = InterpreterIdRegex.Match(id);
+                    if (m.Success && PathUtils.IsValidPath(moniker = m.Groups["moniker"].Value)) {
+                        return moniker;
+                    }
+                    break;
+                case PythonRegistrySearch.CompanyPropertyKey:
+                    m = InterpreterIdRegex.Match(id);
+                    if (m.Success && PathUtils.IsValidPath(moniker = m.Groups["moniker"].Value)) {
+                        try {
+                            return Path.GetFileNameWithoutExtension(moniker);
+                        } catch (ArgumentException) {
+                            return PathUtils.GetFileOrDirectoryName(moniker);
+                        }
                     }
                     break;
             }
@@ -151,7 +164,7 @@ namespace Microsoft.PythonTools.Interpreter {
             return String.Join("|", MSBuildProviderName, id, file);
         }
 
-        public static string GetProjectiveRelativeId(string file, string id) {
+        public static string GetProjectRelativeId(string file, string id) {
             var m = InterpreterIdRegex.Match(id);
             if (m.Success && (m.Groups["moniker"].Value?.Equals(file, StringComparison.OrdinalIgnoreCase) ?? false)) {
                 return m.Groups["id"].Value;


### PR DESCRIPTION
Fixes #1897 Python Environments only shows one venv in case of same venv name in two projects
Updates ordering function to sort by ID if descriptions are equal.
Displays project name for the company for virtual environments.
Fixes oddly named function.