### PR TITLE
Custom environment fixes

### DIFF
--- a/Python/Product/Analysis/Interpreter/InterpreterArchitecture.cs
+++ b/Python/Product/Analysis/Interpreter/InterpreterArchitecture.cs
@@ -15,6 +15,9 @@
 // permissions and limitations under the License.
 
 using System;
+using System.Diagnostics;
+using System.Reflection;
+using Microsoft.PythonTools.Infrastructure;
 
 namespace Microsoft.PythonTools.Interpreter {
     public abstract class InterpreterArchitecture : IFormattable, IComparable<InterpreterArchitecture> {
@@ -67,6 +70,20 @@ namespace Microsoft.PythonTools.Interpreter {
                 throw new FormatException();
             }
             return result;
+        }
+
+        public static InterpreterArchitecture FromExe(string path) {
+            try {
+                switch (NativeMethods.GetBinaryType(path)) {
+                    case ProcessorArchitecture.X86:
+                        return x86;
+                    case ProcessorArchitecture.Amd64:
+                        return x64;
+                }
+            } catch (Exception ex) {
+                Debug.Fail(ex.ToUnhandledExceptionMessage(typeof(InterpreterArchitecture)));
+            }
+            return Unknown;
         }
 
         public int CompareTo(InterpreterArchitecture other) {

--- a/Python/Product/EnvironmentsList/ConfigurationExtension.xaml
+++ b/Python/Product/EnvironmentsList/ConfigurationExtension.xaml
@@ -64,8 +64,6 @@
                     <RowDefinition Height="auto" />
                     <RowDefinition Height="auto" />
                     <RowDefinition Height="auto" />
-                    <RowDefinition Height="auto" />
-                    <RowDefinition Height="auto" />
                     <RowDefinition Height="*" />
                 </Grid.RowDefinitions>
                 
@@ -119,20 +117,8 @@
                     </wpf:ConfigurationTextBoxWithHelp.HelpText>
                 </wpf:ConfigurationTextBoxWithHelp>
 
-                <Label Grid.Column="0" Grid.Row="8">Library path</Label>
-                <wpf:ConfigurationTextBoxWithHelp Grid.Column="0" Grid.Row="9"
-                                                  Text="{Binding LibraryPath,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}"
-                                                  Watermark="e.g. C:\PythonXY\Lib"
-                                                  BrowseButtonStyle="{StaticResource BrowseFolderButton}">
-                    <wpf:ConfigurationTextBoxWithHelp.HelpText>
-                        The library path contains the standard library and the
-                        'site-packages' folder for this environment. Packages installed
-                        into this folder will be analyzed for the completion DB.
-                    </wpf:ConfigurationTextBoxWithHelp.HelpText>
-                </wpf:ConfigurationTextBoxWithHelp>
-
-                <Label Grid.Column="0" Grid.Row="10">Language version</Label>
-                <wpf:ConfigurationComboBoxWithHelp Grid.Column="0" Grid.Row="11"
+                <Label Grid.Column="0" Grid.Row="8">Language version</Label>
+                <wpf:ConfigurationComboBoxWithHelp Grid.Column="0" Grid.Row="9"
                                                    Value="{Binding VersionName,Mode=TwoWay}"
                                                    Values="{Binding VersionNames}"
                                                    Watermark="Language version">
@@ -143,8 +129,8 @@
                     </wpf:ConfigurationComboBoxWithHelp.HelpText>
                 </wpf:ConfigurationComboBoxWithHelp>
 
-                <Label Grid.Column="0" Grid.Row="12">Architecture</Label>
-                <wpf:ConfigurationComboBoxWithHelp Grid.Column="0" Grid.Row="13"
+                <Label Grid.Column="0" Grid.Row="10">Architecture</Label>
+                <wpf:ConfigurationComboBoxWithHelp Grid.Column="0" Grid.Row="11"
                                                    Value="{Binding ArchitectureName,Mode=TwoWay}"
                                                    Values="{Binding ArchitectureNames}"
                                                    Watermark="Architecture">
@@ -156,8 +142,8 @@
                     </wpf:ConfigurationComboBoxWithHelp.HelpText>
                 </wpf:ConfigurationComboBoxWithHelp>
 
-                <Label Grid.Column="0" Grid.Row="14">Path environment variable</Label>
-                <wpf:ConfigurationTextBoxWithHelp Grid.Column="0" Grid.Row="15"
+                <Label Grid.Column="0" Grid.Row="12">Path environment variable</Label>
+                <wpf:ConfigurationTextBoxWithHelp Grid.Column="0" Grid.Row="13"
                                                   Text="{Binding PathEnvironmentVariable,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}"
                                                   Watermark="e.g. PYTHONPATH">
                     <wpf:ConfigurationTextBoxWithHelp.HelpText>

--- a/Python/Product/EnvironmentsList/EnvironmentPathsExtension.xaml
+++ b/Python/Product/EnvironmentsList/EnvironmentPathsExtension.xaml
@@ -207,6 +207,26 @@
 
                     <DataTemplate DataType="{x:Type l:EnvironmentView}" x:Key="EnvironmentLinks">
                         <StackPanel Orientation="Vertical">
+                            <Button Name="ConfigureEnvironment"
+                                    Command="{x:Static l:EnvironmentPathsExtension.ConfigureEnvironment}"
+                                    CommandParameter="{Binding Mode=OneWay}"
+                                    Style="{StaticResource NavigationButton}"
+                                    Margin="6"
+                                    HorizontalAlignment="Left">
+                                <Grid Background="Transparent">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="auto" />
+                                        <ColumnDefinition />
+                                    </Grid.ColumnDefinitions>
+                                    <ContentControl Grid.Column="0"
+                                                    Margin="3 0"
+                                                    Style="{StaticResource SettingsImage}" />
+                                    <TextBlock Grid.Column="1" TextWrapping="WrapWithOverflow">
+                                        Configure or remove environment
+                                    </TextBlock>
+                                </Grid>
+                            </Button>
+                            
                             <Button Command="{x:Static l:EnvironmentPathsExtension.OpenInFileExplorer}"
                                     CommandParameter="{Binding PrefixPath,Mode=OneWay}"
                                     ToolTip="{Binding PrefixPath,Mode=OneWay}"
@@ -306,6 +326,12 @@
                                 </Button.ContextMenu>
                             </Button>
                         </StackPanel>
+
+                        <DataTemplate.Triggers>
+                            <DataTrigger Binding="{Binding IsConfigurable,Mode=OneWay}" Value="False">
+                                <Setter TargetName="ConfigureEnvironment" Property="Visibility" Value="Collapsed" />
+                            </DataTrigger>
+                        </DataTemplate.Triggers>
                     </DataTemplate>
 
                     <DataTemplate DataType="{x:Type l:EnvironmentView}" x:Key="SupportInformation">

--- a/Python/Product/EnvironmentsList/EnvironmentPathsExtension.xaml.cs
+++ b/Python/Product/EnvironmentsList/EnvironmentPathsExtension.xaml.cs
@@ -52,6 +52,7 @@ namespace Microsoft.PythonTools.EnvironmentsList {
         public static readonly ICommand OpenInFileExplorer = new RoutedCommand();
         public static readonly ICommand StartInterpreter = new RoutedCommand();
         public static readonly ICommand StartWindowsInterpreter = new RoutedCommand();
+        public static readonly ICommand ConfigureEnvironment = new RoutedCommand();
 
         public EnvironmentPathsExtension() {
             InitializeComponent();

--- a/Python/Product/EnvironmentsList/EnvironmentView.xaml
+++ b/Python/Product/EnvironmentsList/EnvironmentView.xaml
@@ -124,35 +124,27 @@
             </DataTemplate>
 
             <DataTemplate DataType="{x:Type l:EnvironmentView}" x:Key="AddNewEnvironmentListItem">
-                <Button Style="{StaticResource NavigationButtonInList}"
-                        Margin="6"
-                        Name="Button"
-                        Command="ApplicationCommands.New">
-                    <Grid Background="Transparent">
-                        <Grid.Resources>
-                            <Geometry x:Key="AddGeometry">
-                                F1M9.765625,18.1081237792969L11.078125,18.1081237792969 11.078125,24.5456237792969 17.5,24.5456237792969 17.5,25.8581237792969 11.078125,25.8581237792969 11.078125,32.2956237792969 9.765625,32.2956237792969 9.765625,25.8581237792969 3.328125,25.8581237792969 3.328125,24.5456237792969 9.765625,24.5456237792969 9.765625,18.1081237792969z
-                            </Geometry>
-                        </Grid.Resources>
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="auto" />
-                            <ColumnDefinition />
-                        </Grid.ColumnDefinitions>
-                        <Path Width="12" Height="12"
-                              Margin="4"
-                              Stretch="Uniform"
-                              RenderOptions.EdgeMode="Aliased"
-                              Data="{StaticResource AddGeometry}"
-                              Fill="{Binding Foreground,ElementName=Button}">
-                        </Path>
-                        <Label Grid.Column="1"
-                               VerticalAlignment="Center"
-                               Foreground="{Binding Foreground,ElementName=Button}">
-                            Custom...
-                        </Label>
-                    </Grid>
-                    
-                </Button>
+                <Grid Background="Transparent" Margin="6">
+                    <Grid.Resources>
+                        <Geometry x:Key="AddGeometry">
+                            F1M9.765625,18.1081237792969L11.078125,18.1081237792969 11.078125,24.5456237792969 17.5,24.5456237792969 17.5,25.8581237792969 11.078125,25.8581237792969 11.078125,32.2956237792969 9.765625,32.2956237792969 9.765625,25.8581237792969 3.328125,25.8581237792969 3.328125,24.5456237792969 9.765625,24.5456237792969 9.765625,18.1081237792969z
+                        </Geometry>
+                    </Grid.Resources>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="auto" />
+                        <ColumnDefinition />
+                    </Grid.ColumnDefinitions>
+                    <Path Width="12" Height="12"
+                          Margin="4"
+                          Stretch="Uniform"
+                          RenderOptions.EdgeMode="Aliased"
+                          Data="{StaticResource AddGeometry}"
+                          Fill="{Binding Foreground,ElementName=CustomLabel}">
+                    </Path>
+                    <Label Grid.Column="1" VerticalAlignment="Center" Name="CustomLabel">
+                        Custom...
+                    </Label>
+                </Grid>
             </DataTemplate>
 
             <DataTemplate DataType="{x:Type l:EnvironmentView}" x:Key="OnlineHelpListItem">

--- a/Python/Product/EnvironmentsList/ToolWindow.xaml
+++ b/Python/Product/EnvironmentsList/ToolWindow.xaml
@@ -21,9 +21,12 @@
         <CommandBinding Command="{x:Static l:DBExtension.StartRefreshDB}"
                         CanExecute="StartRefreshDB_CanExecute"
                         Executed="StartRefreshDB_Executed" />
-        <CommandBinding Command="ApplicationCommands.New"
-                        CanExecute="AddCustomEnvironment_CanExecute"
-                        Executed="AddCustomEnvironment_Executed" />
+        <CommandBinding Command="{x:Static l:ConfigurationEnvironmentView.Added}"
+                        CanExecute="ConfigurableViewAdded_CanExecute"
+                        Executed="ConfigurableViewAdded_Executed" />
+        <CommandBinding Command="{x:Static l:EnvironmentPathsExtension.ConfigureEnvironment}"
+                        CanExecute="ConfigureEnvironment_CanExecute"
+                        Executed="ConfigureEnvironment_Executed" />
     </UserControl.CommandBindings>
 
     <UserControl.Resources>
@@ -92,7 +95,7 @@
             </Style>
         </Grid.Resources>
 
-        <Grid x:Name="HorizontalLayout">
+        <Grid x:Name="HorizontalLayout" Visibility="Collapsed">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition x:Name="EnvironmentsColumn" Width="auto" />
                 <ColumnDefinition x:Name="ExtensionsColumn" Width="auto" />

--- a/Python/Product/EnvironmentsList/ToolWindow.xaml.cs
+++ b/Python/Product/EnvironmentsList/ToolWindow.xaml.cs
@@ -110,13 +110,9 @@ namespace Microsoft.PythonTools.EnvironmentsList {
                     var compModel = _site.GetService(typeof(SComponentModel)) as IComponentModel;
                     Service = compModel.GetService<IInterpreterOptionsService>();
                     Interpreters = compModel.GetService<IInterpreterRegistryService>();
-                    _addNewEnvironmentView = EnvironmentView.CreateAddNewEnvironmentView(Service);
-                    _addNewEnvironmentViewOnce = new[] { _addNewEnvironmentView };
                 } else {
                     Service = null;
                     Interpreters = null;
-                    _addNewEnvironmentView = null;
-                    _addNewEnvironmentViewOnce = null;
                 }
             }
         }
@@ -442,6 +438,11 @@ namespace Microsoft.PythonTools.EnvironmentsList {
                 _service = value;
                 if (_service != null) {
                     _service.DefaultInterpreterChanged += Service_DefaultInterpreterChanged;
+                    _addNewEnvironmentView = EnvironmentView.CreateAddNewEnvironmentView(_service);
+                    _addNewEnvironmentViewOnce = new[] { _addNewEnvironmentView };
+                } else {
+                    _addNewEnvironmentView = null;
+                    _addNewEnvironmentViewOnce = null;
                 }
                 if (_interpreters != null) {
                     Dispatcher.InvokeAsync(FirstUpdateEnvironments).Task.DoNotWait();

--- a/Python/Product/EnvironmentsList/ToolWindow.xaml.cs
+++ b/Python/Product/EnvironmentsList/ToolWindow.xaml.cs
@@ -21,7 +21,6 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Reflection;
 using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -45,6 +44,9 @@ namespace Microsoft.PythonTools.EnvironmentsList {
         private IInterpreterRegistryService _interpreters;
         private IInterpreterOptionsService _service;
         private IServiceProvider _site;
+
+        private EnvironmentView _addNewEnvironmentView;
+        private IEnumerable<EnvironmentView> _addNewEnvironmentViewOnce;
 
         private AnalyzerStatusListener _listener;
         private readonly object _listenerLock = new object();
@@ -108,6 +110,13 @@ namespace Microsoft.PythonTools.EnvironmentsList {
                     var compModel = _site.GetService(typeof(SComponentModel)) as IComponentModel;
                     Service = compModel.GetService<IInterpreterOptionsService>();
                     Interpreters = compModel.GetService<IInterpreterRegistryService>();
+                    _addNewEnvironmentView = EnvironmentView.CreateAddNewEnvironmentView(Service);
+                    _addNewEnvironmentViewOnce = new[] { _addNewEnvironmentView };
+                } else {
+                    Service = null;
+                    Interpreters = null;
+                    _addNewEnvironmentView = null;
+                    _addNewEnvironmentViewOnce = null;
                 }
             }
         }
@@ -137,10 +146,12 @@ namespace Microsoft.PythonTools.EnvironmentsList {
                 return;
             }
 
-            if (width <= height * 0.9 || width < 400) {
+            if (width < 500) {
                 SwitchToVerticalLayout();
-            } else if (width >= height * 1.1) {
+            } else if (width >= 600) {
                 SwitchToHorizontalLayout();
+            } else if (VerticalLayout.Visibility != Visibility.Visible) {
+                SwitchToVerticalLayout();
             }
         }
 
@@ -365,7 +376,7 @@ namespace Microsoft.PythonTools.EnvironmentsList {
                         OnViewCreated(view);
                         return view;
                     })
-                    .Concat(EnvironmentView.AddNewEnvironmentViewOnce.Value)
+                    .Concat(_addNewEnvironmentViewOnce ?? Enumerable.Empty<EnvironmentView>())
                     .Concat(EnvironmentView.OnlineHelpViewOnce.Value),
                     EnvironmentComparer.Instance,
                     EnvironmentComparer.Instance
@@ -397,10 +408,7 @@ namespace Microsoft.PythonTools.EnvironmentsList {
         }
 
         private void OnViewCreated(EnvironmentView view) {
-            var evt = ViewCreated;
-            if (evt != null) {
-                evt(this, new EnvironmentViewEventArgs(view));
-            }
+            ViewCreated?.Invoke(this, new EnvironmentViewEventArgs(view));
         }
 
         public event EventHandler<EnvironmentViewEventArgs> ViewCreated;
@@ -466,52 +474,53 @@ namespace Microsoft.PythonTools.EnvironmentsList {
             }
         }
 
-        private void AddCustomEnvironment_CanExecute(object sender, CanExecuteRoutedEventArgs e) {
-            if (_service == null) {
-                e.CanExecute = false;
-                e.Handled = true;
-                return;
-            }
-
-            e.CanExecute = true;
-            // Not handled, in case another handler wants to suppress
-            return;
+        private void ConfigurableViewAdded_CanExecute(object sender, CanExecuteRoutedEventArgs e) {
+            e.CanExecute = e.Parameter is string;
+            e.Handled = true;
         }
 
-        private async void AddCustomEnvironment_Executed(object sender, ExecutedRoutedEventArgs e) {
-            if (_service == null) {
-                return;
-            }
+        private async void ConfigurableViewAdded_Executed(object sender, ExecutedRoutedEventArgs e) {
+            var id = (string)e.Parameter;
+            e.Handled = true;
 
-            const string baseName = "New Environment";
-            string name = baseName;
-            int count = 2;
-            while (_interpreters.FindConfiguration(CPythonInterpreterFactoryConstants.GetInterpreterId("VisualStudio", name)) != null) {
-                name = baseName + " " + count++;
-            }
-
-            var factory = _service.AddConfigurableInterpreter(
-                name,
-                new InterpreterConfiguration(
-                    "",
-                    name,
-                    "",
-                    "python\\python.exe",
-                    arch : InterpreterArchitecture.x86
-                )
-            );
-
-            UpdateEnvironments(factory);
-
-            await Dispatcher.InvokeAsync(() => {
-                var coll = TryFindResource("SortedExtensions") as CollectionViewSource;
-                if (coll != null) {
-                    var select = coll.View.OfType<ConfigurationExtensionProvider>().FirstOrDefault();
-                    if (select != null) {
-                        coll.View.MoveCurrentTo(select);
-                    }
+            for (int retries = 10; retries > 0; --retries) {
+                var env = _environments.FirstOrDefault(ev => ev.Factory?.Configuration?.Id == id);
+                if (env != null) {
+                    Environments.MoveCurrentTo(env);
+                    return;
                 }
-            }, DispatcherPriority.Normal);
+                await Task.Delay(50).ConfigureAwait(continueOnCapturedContext: true);
+            }
+            Debug.Fail("Failed to switch to added environment");
+        }
+
+        private void ConfigureEnvironment_CanExecute(object sender, CanExecuteRoutedEventArgs e) {
+            e.CanExecute = (e.Parameter as EnvironmentView)?.IsConfigurable ?? false;
+            e.Handled = true;
+        }
+
+        private void ConfigureEnvironment_Executed(object sender, ExecutedRoutedEventArgs e) {
+            e.Handled = true;
+
+            var env = (EnvironmentView)e.Parameter;
+            if (Environments.CurrentItem != env) {
+                Environments.MoveCurrentTo(env);
+                if (Environments.CurrentItem != env) {
+                    return;
+                }
+            }
+            var ext = env.Extensions.OfType<ConfigurationExtensionProvider>().FirstOrDefault();
+            if (ext != null) {
+                Extensions.MoveCurrentTo(ext);
+            }
+        }
+
+        private void EnvironmentsList_SelectionChanged(object sender, SelectionChangedEventArgs e) {
+            var list = sender as ListBox;
+            if (list != null && e.AddedItems.Count > 0) {
+                list.ScrollIntoView(e.AddedItems[0]);
+                e.Handled = true;
+            }
         }
 
         class EnvironmentComparer : IEqualityComparer<EnvironmentView>, IComparer<EnvironmentView> {
@@ -534,12 +543,10 @@ namespace Microsoft.PythonTools.EnvironmentsList {
                     return 0;
                 }
 
-                if (EnvironmentView.AddNewEnvironmentView.IsValueCreated) {
-                    if (object.ReferenceEquals(x, EnvironmentView.AddNewEnvironmentView.Value)) {
-                        return 1;
-                    } else if (object.ReferenceEquals(y, EnvironmentView.AddNewEnvironmentView.Value)) {
-                        return -1;
-                    }
+                if (x != null && x._addNewEnvironmentView) {
+                    return 1;
+                } else if (y != null && y._addNewEnvironmentView) {
+                    return -1;
                 }
                 if (EnvironmentView.OnlineHelpView.IsValueCreated) {
                     if (object.ReferenceEquals(x, EnvironmentView.OnlineHelpView.Value)) {
@@ -571,14 +578,6 @@ namespace Microsoft.PythonTools.EnvironmentsList {
                 }
 
                 return result;
-            }
-        }
-
-        private void EnvironmentsList_SelectionChanged(object sender, SelectionChangedEventArgs e) {
-            var list = sender as ListBox;
-            if (list != null && e.AddedItems.Count > 0) {
-                list.ScrollIntoView(e.AddedItems[0]);
-                e.Handled = true;
             }
         }
     }

--- a/Python/Product/PythonTools/pip_downloader.py
+++ b/Python/Product/PythonTools/pip_downloader.py
@@ -157,11 +157,10 @@ def install_from_ensurepip(ensurepip):
     sys.stdout.flush()
 
 def main():
-    #try:
-    install_from_local_source()
-    return
-    #except Exception:
-    #    pass
+    try:
+        install_from_local_source()
+    except Exception:
+        pass
     
     try:
         import ensurepip

--- a/Python/Tests/Core/EnvironmentListTests.cs
+++ b/Python/Tests/Core/EnvironmentListTests.cs
@@ -537,10 +537,37 @@ namespace PythonToolsUITests {
             }
         }
 
+        private static async Task AddCustomEnvironment(EnvironmentListProxy list) {
+
+            var view = list.AddNewEnvironmentView;
+            var extView = view.Extensions.OfType<ConfigurationExtensionProvider>().First().WpfObject;
+
+            // Extension is not sited in the tool window, so we need
+            // to set the DataContext in order to get the Subcontext
+            extView.DataContext = view;
+            var confView = (ConfigurationEnvironmentView)((System.Windows.Controls.Grid)extView.FindName("Subcontext")).DataContext;
+
+            confView.Description = "Test Environment";
+            confView.PrefixPath = @"C:\Test";
+            confView.InterpreterPath = @"C:\Test\python.exe";
+            confView.WindowsInterpreterPath = @"C:\Test\pythonw.exe";
+            confView.VersionName = "3.5";
+            confView.ArchitectureName = "32-bit";
+
+            var origCount = list.Environments.Count;
+
+            ((RoutedCommand)ConfigurationExtension.Apply).Execute(confView, extView);
+
+            while (list.Environments.Count == origCount) {
+                await Task.Delay(10);
+            }
+        }
+
         [TestMethod, Priority(1)]
         public async Task AddUpdateRemoveConfigurableFactoryThroughUI() {
             using (var wpf = new WpfProxy())
             using (var list = new EnvironmentListProxy(wpf)) {
+                string newId = null;
                 var container = CreateCompositionContainer();
                 var service = container.GetExportedValue<IInterpreterOptionsService>();
                 var interpreters = container.GetExportedValue<IInterpreterRegistryService>();
@@ -550,22 +577,23 @@ namespace PythonToolsUITests {
                 var before = wpf.Invoke(() => new HashSet<string>(
                     list.Environments.Where(ev => ev.Factory != null).Select(ev => ev.Factory.Configuration.Id)));
 
-                await list.Execute(ApplicationCommands.New, null);
-                var afterAdd = wpf.Invoke(() => new HashSet<string>(list.Environments.Where(ev => ev.Factory != null).Select(ev => ev.Factory.Configuration.Id)));
-
-                var difference = new HashSet<string>(afterAdd);
-                difference.ExceptWith(before);
-
-                Console.WriteLine("Added {0}", AssertUtil.MakeText(difference));
-                Assert.AreEqual(1, difference.Count, "Did not add a new environment");
-                var newEnv = interpreters.Interpreters.Single(f => difference.Contains(f.Configuration.Id));
-
-                Assert.IsTrue(list.Service.IsConfigurable(newEnv.Configuration.Id), "Did not add a configurable environment");
-
                 try {
+                    wpf.Invoke(() => AddCustomEnvironment(list)).Wait(10000);
+
+                    var afterAdd = wpf.Invoke(() => new HashSet<string>(list.Environments.Where(ev => ev.Factory != null).Select(ev => ev.Factory.Configuration.Id)));
+                    var difference = new HashSet<string>(afterAdd);
+                    difference.ExceptWith(before);
+
+                    Console.WriteLine("Added {0}", AssertUtil.MakeText(difference));
+                    Assert.AreEqual(1, difference.Count, "Did not add a new environment");
+                    var newEnv = interpreters.Interpreters.Single(f => difference.Contains(f.Configuration.Id));
+                    newId = newEnv.Configuration.Id;
+
+                    Assert.IsTrue(list.Service.IsConfigurable(newEnv.Configuration.Id), "Did not add a configurable environment");
+
                     // To remove the environment, we need to trigger the Remove
                     // command on the ConfigurationExtensionProvider's control
-                    var view = wpf.Invoke(() => list.Environments.First(ev => ev.Factory == newEnv));
+                    var view = wpf.Invoke(() => list.Environments.First(ev => ev.Factory.Configuration.Id == newId));
                     var extView = wpf.Invoke(() => view.Extensions.OfType<ConfigurationExtensionProvider>().First().WpfObject);
                     var confView = wpf.Invoke(() => {
                         // Extension is not sited in the tool window, so we need
@@ -580,10 +608,12 @@ namespace PythonToolsUITests {
                     AssertUtil.ContainsExactly(afterRemove, before);
                 } finally {
                     // Just in case, we want to clean up the registration
-                    string company, tag;
-                    if (CPythonInterpreterFactoryConstants.TryParseInterpreterId(newEnv.Configuration.Id, out company, out tag) &&
-                        company == "VisualStudio") {
-                        Registry.CurrentUser.DeleteSubKeyTree("Software\\Python\\VisualStudio\\" + tag, false);
+                    if (newId != null) {
+                        string company, tag;
+                        if (CPythonInterpreterFactoryConstants.TryParseInterpreterId(newId, out company, out tag) &&
+                            company == "VisualStudio") {
+                            Registry.CurrentUser.DeleteSubKeyTree("Software\\Python\\VisualStudio\\" + tag, false);
+                        }
                     }
                 }
             }
@@ -922,10 +952,16 @@ namespace PythonToolsUITests {
                 get {
                     return _proxy.Invoke(() =>
                         Window._environments
-                            .Where(ev => ! ev._addNewEnvironmentView)
+                            .Where(ev => !ev._addNewEnvironmentView)
                             .Except(EnvironmentView.OnlineHelpViewOnce.Value)
                             .ToList()
                     );
+                }
+            }
+
+            public EnvironmentView AddNewEnvironmentView {
+                get {
+                    return _proxy.Invoke(() => Window._environments.Single(ev => ev._addNewEnvironmentView));
                 }
             }
 

--- a/Python/Tests/Core/EnvironmentListTests.cs
+++ b/Python/Tests/Core/EnvironmentListTests.cs
@@ -922,7 +922,7 @@ namespace PythonToolsUITests {
                 get {
                     return _proxy.Invoke(() =>
                         Window._environments
-                            .Except(EnvironmentView.AddNewEnvironmentViewOnce.Value)
+                            .Where(ev => ! ev._addNewEnvironmentView)
                             .Except(EnvironmentView.OnlineHelpViewOnce.Value)
                             .ToList()
                     );


### PR DESCRIPTION
Fixes #1906 New custom environment does not land user in configure
Fixes #1943 Creating Python environment forcibly prepends it with "VisualStudio"
Fixes #1944 Changing environment library path does not toggle Apply button

Reworks how environments are created so that we don't eagerly save any details. Allows much easier cancellation.
Removes the UI for Library Path
Fixes the registry key where we save the display name.
Auto-detect will now fill in the description
Adds a button to the Overview tab to jump to the configure panel.