### PR TITLE
Publish warning dialog fixes

### DIFF
--- a/Common/Product/SharedProject/CommonProjectNodeProperties.cs
+++ b/Common/Product/SharedProject/CommonProjectNodeProperties.cs
@@ -351,7 +351,7 @@ namespace Microsoft.VisualStudioTools.Project {
         }
 
         [Browsable(false)]
-        public VSLangProj.prjOutputType OutputType {
+        public virtual VSLangProj.prjOutputType OutputType {
             get {
                 throw new NotImplementedException();
             }

--- a/Python/Product/Django/Project/DjangoProject.cs
+++ b/Python/Product/Django/Project/DjangoProject.cs
@@ -24,6 +24,7 @@ using System.Runtime.InteropServices;
 using Microsoft.PythonTools.Django.Analysis;
 using Microsoft.PythonTools.Infrastructure;
 using Microsoft.PythonTools.Intellisense;
+using Microsoft.PythonTools.Options;
 using Microsoft.PythonTools.Project;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.OLE.Interop;
@@ -50,6 +51,9 @@ namespace Microsoft.PythonTools.Django.Project {
         private OleMenuCommandService _menuService;
         private readonly List<OleMenuCommand> _commands = new List<OleMenuCommand>();
         private bool _disposed;
+
+        private static readonly Guid PublishCmdGuid = new Guid("{1496a755-94de-11d0-8c3f-00c04fc2aae2}");
+        private static readonly int PublishCmdid = 2006;
 
 #if HAVE_ICONS
         private static ImageList _images;
@@ -739,9 +743,34 @@ namespace Microsoft.PythonTools.Django.Project {
                         return res;
                     }
                 }
+            } else if (pguidCmdGroup == PublishCmdGuid) {
+                if (nCmdID == PublishCmdid) {
+                    // Approximately duplicated from PythonWebProject
+                    var opts = (IPythonToolsOptionsService)serviceProvider.GetService(typeof(IPythonToolsOptionsService));
+                    if (string.IsNullOrEmpty(opts.LoadString(SuppressDialog.PublishToAzure30Setting, SuppressDialog.Category))) {
+                        var td = new TaskDialog(serviceProvider) {
+                            Title = Strings.ProductTitle,
+                            MainInstruction = Strings.PublishToAzure30,
+                            Content = Strings.PublishToAzure30Message,
+                            VerificationText = Strings.DontShowAgain,
+                            SelectedVerified = false,
+                            AllowCancellation = true,
+                            EnableHyperlinks = true
+                        };
+                        td.Buttons.Add(TaskDialogButton.OK);
+                        td.Buttons.Add(TaskDialogButton.Cancel);
+                        if (td.ShowModal() == TaskDialogButton.Cancel) {
+                            return VSConstants.S_OK;
+                        }
+
+                        if (td.SelectedVerified) {
+                            opts.SaveString(SuppressDialog.PublishToAzure30Setting, SuppressDialog.Category, "true");
+                        }
+                    }
+                }
             }
 
-            return ((IOleCommandTarget)_menuService).Exec(ref pguidCmdGroup, nCmdID, nCmdexecopt, pvaIn, pvaOut);
+            return _innerOleCommandTarget.Exec(ref pguidCmdGroup, nCmdID, nCmdexecopt, pvaIn, pvaOut);
         }
 
         private bool AddWebRoleSupportFiles() {
@@ -828,7 +857,7 @@ namespace Microsoft.PythonTools.Django.Project {
                 }
             }
 
-            return ((IOleCommandTarget)_menuService).QueryStatus(ref pguidCmdGroup, cCmds, prgCmds, pCmdText);
+            return _innerOleCommandTarget.QueryStatus(ref pguidCmdGroup, cCmds, prgCmds, pCmdText);
         }
 
         #region IVsProjectFlavorCfgProvider Members

--- a/Python/Product/PythonTools/PythonTools/Options/IPythonToolsOptionsService.cs
+++ b/Python/Product/PythonTools/PythonTools/Options/IPythonToolsOptionsService.cs
@@ -15,7 +15,7 @@
 // permissions and limitations under the License.
 
 namespace Microsoft.PythonTools.Options {
-    interface IPythonToolsOptionsService {
+    public interface IPythonToolsOptionsService {
         void SaveString(string name, string category, string value);
         string LoadString(string name, string category);
         void DeleteCategory(string category);

--- a/Python/Product/PythonTools/PythonTools/Options/PythonGeneralOptionsControl.Designer.cs
+++ b/Python/Product/PythonTools/PythonTools/Options/PythonGeneralOptionsControl.Designer.cs
@@ -36,6 +36,7 @@ namespace Microsoft.PythonTools.Options {
             this._elevateEasyInstall = new System.Windows.Forms.CheckBox();
             this._unresolvedImportWarning = new System.Windows.Forms.CheckBox();
             this._clearGlobalPythonPath = new System.Windows.Forms.CheckBox();
+            this._resetSuppressDialog = new System.Windows.Forms.Button();
             this.tableLayoutPanel3.SuspendLayout();
             this.SuspendLayout();
             // 
@@ -58,11 +59,13 @@ namespace Microsoft.PythonTools.Options {
             this.tableLayoutPanel3.Controls.Add(this._elevateEasyInstall, 0, 3);
             this.tableLayoutPanel3.Controls.Add(this._unresolvedImportWarning, 0, 7);
             this.tableLayoutPanel3.Controls.Add(this._clearGlobalPythonPath, 0, 5);
+            this.tableLayoutPanel3.Controls.Add(this._resetSuppressDialog, 0, 10);
             this.tableLayoutPanel3.Dock = System.Windows.Forms.DockStyle.Fill;
             this.tableLayoutPanel3.Location = new System.Drawing.Point(0, 0);
             this.tableLayoutPanel3.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.tableLayoutPanel3.Name = "tableLayoutPanel3";
-            this.tableLayoutPanel3.RowCount = 11;
+            this.tableLayoutPanel3.RowCount = 12;
+            this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle());
@@ -234,6 +237,20 @@ namespace Microsoft.PythonTools.Options {
             this._clearGlobalPythonPath.Text = "&Ignore system-wide PYTHONPATH variables";
             this._clearGlobalPythonPath.UseVisualStyleBackColor = true;
             // 
+            // _resetSuppressDialog
+            // 
+            this._resetSuppressDialog.Anchor = System.Windows.Forms.AnchorStyles.Top;
+            this._resetSuppressDialog.AutoSize = true;
+            this._resetSuppressDialog.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.tableLayoutPanel3.SetColumnSpan(this._resetSuppressDialog, 2);
+            this._resetSuppressDialog.Location = new System.Drawing.Point(96, 241);
+            this._resetSuppressDialog.Name = "_resetSuppressDialog";
+            this._resetSuppressDialog.Size = new System.Drawing.Size(189, 23);
+            this._resetSuppressDialog.TabIndex = 11;
+            this._resetSuppressDialog.Text = "Reset all permanently hidden dialogs";
+            this._resetSuppressDialog.UseVisualStyleBackColor = true;
+            this._resetSuppressDialog.Click += new System.EventHandler(this._resetSuppressDialog_Click);
+            // 
             // PythonGeneralOptionsControl
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -246,6 +263,7 @@ namespace Microsoft.PythonTools.Options {
             this.tableLayoutPanel3.PerformLayout();
             this.ResumeLayout(false);
             this.PerformLayout();
+
         }
 
         #endregion
@@ -263,5 +281,6 @@ namespace Microsoft.PythonTools.Options {
         private System.Windows.Forms.CheckBox _elevateEasyInstall;
         private System.Windows.Forms.CheckBox _unresolvedImportWarning;
         private System.Windows.Forms.CheckBox _clearGlobalPythonPath;
+        private System.Windows.Forms.Button _resetSuppressDialog;
     }
 }

--- a/Python/Product/PythonTools/PythonTools/Options/PythonGeneralOptionsControl.cs
+++ b/Python/Product/PythonTools/PythonTools/Options/PythonGeneralOptionsControl.cs
@@ -119,5 +119,12 @@ namespace Microsoft.PythonTools.Options {
             pyService.GeneralOptions.UnresolvedImportWarning = _unresolvedImportWarning.Checked;
             pyService.GeneralOptions.ClearGlobalPythonPath = _clearGlobalPythonPath.Checked;
         }
+
+        private void _resetSuppressDialog_Click(object sender, EventArgs e) {
+            System.Diagnostics.Debug.Assert(ResetSuppressDialog != null, "No listener for ResetSuppressDialog event");
+            ResetSuppressDialog?.Invoke(this, EventArgs.Empty);
+        }
+
+        public event EventHandler ResetSuppressDialog;
     }
 }

--- a/Python/Product/PythonTools/PythonTools/Options/PythonGeneralOptionsPage.cs
+++ b/Python/Product/PythonTools/PythonTools/Options/PythonGeneralOptionsPage.cs
@@ -32,10 +32,16 @@ namespace Microsoft.PythonTools.Options {
             get {
                 if (_window == null) {
                     _window = new PythonGeneralOptionsControl();
+                    _window.ResetSuppressDialog += ResetSuppressDialog;
                     LoadSettingsFromStorage();
                 }
                 return _window;
             }
+        }
+
+        private void ResetSuppressDialog(object sender, EventArgs e) {
+            PyService.SuppressDialogOptions.Reset();
+            PyService.SuppressDialogOptions.Save();
         }
 
         /// <summary>

--- a/Python/Product/PythonTools/PythonTools/Options/SuppressDialogOptions.cs
+++ b/Python/Product/PythonTools/PythonTools/Options/SuppressDialogOptions.cs
@@ -17,13 +17,15 @@
 using System;
 
 namespace Microsoft.PythonTools.Options {
+    public static class SuppressDialog {
+        public const string Category = "SuppressDialog";
+
+        public const string SwitchEvaluatorSetting = "SwitchEvaluator";
+        public const string PublishToAzure30Setting = "PublishToAzure30";
+    }
+
     sealed class SuppressDialogOptions {
         private readonly PythonToolsService _service;
-
-        private const string Category = "SuppressDialog";
-
-        private const string SwitchEvaluatorSetting = "SwitchEvaluator";
-        private const string PublishToAzure30Setting = "PublishToAzure30";
 
         internal SuppressDialogOptions(PythonToolsService service) {
             _service = service;
@@ -31,14 +33,14 @@ namespace Microsoft.PythonTools.Options {
         }
 
         public void Load() {
-            SwitchEvaluator = _service.LoadString(SwitchEvaluatorSetting, Category);
-            PublishToAzure30 = _service.LoadString(PublishToAzure30Setting, Category);
+            SwitchEvaluator = _service.LoadString(SuppressDialog.SwitchEvaluatorSetting, SuppressDialog.Category);
+            PublishToAzure30 = _service.LoadString(SuppressDialog.PublishToAzure30Setting, SuppressDialog.Category);
             Changed?.Invoke(this, EventArgs.Empty);
         }
 
         public void Save() {
-            _service.SaveString(SwitchEvaluatorSetting, Category, SwitchEvaluator);
-            _service.SaveString(PublishToAzure30Setting, Category, PublishToAzure30);
+            _service.SaveString(SuppressDialog.SwitchEvaluatorSetting, SuppressDialog.Category, SwitchEvaluator);
+            _service.SaveString(SuppressDialog.PublishToAzure30Setting, SuppressDialog.Category, PublishToAzure30);
             Changed?.Invoke(this, EventArgs.Empty);
         }
 

--- a/Python/Product/PythonTools/PythonTools/Project/PythonProjectNode.cs
+++ b/Python/Product/PythonTools/PythonTools/Project/PythonProjectNode.cs
@@ -688,7 +688,16 @@ namespace Microsoft.PythonTools.Project {
 
             Site.GetUIThread().InvokeTask(async () => {
                 await Task.Delay(10);
-                await ReanalyzeProject();
+                for (int retries = 10; retries > 0; --retries) {
+                    try {
+                        await ReanalyzeProject();
+                        return;
+                    } catch (Exception ex) {
+                        // Cannot allow UI here or we will re-enter with async tasks
+                        ex.ReportUnhandledException(Site, GetType(), allowUI: false);
+                    }
+                    await Task.Delay(50);
+                }
             });
 
             try {

--- a/Python/Product/PythonTools/PythonTools/Project/PythonProjectNodeProperties.cs
+++ b/Python/Product/PythonTools/PythonTools/Project/PythonProjectNodeProperties.cs
@@ -137,5 +137,16 @@ namespace Microsoft.PythonTools.Project {
                 }
             }
         }
+
+        [Browsable(false)]
+        public override VSLangProj.prjOutputType OutputType {
+            get {
+                // This is probably not entirely true, but it helps us deal with
+                // extensions like Azure Tools that try to figure out whether we
+                // support WebForms.
+                return VSLangProj.prjOutputType.prjOutputTypeExe;
+            }
+            set { }
+        }
     }
 }

--- a/Python/Product/PythonTools/PythonTools/WebProject/PythonWebProject.cs
+++ b/Python/Product/PythonTools/PythonTools/WebProject/PythonWebProject.cs
@@ -222,6 +222,7 @@ namespace Microsoft.PythonTools.Project.Web {
                 }
             } else if (pguidCmdGroup == PublishCmdGuid) {
                 if (nCmdID == PublishCmdid) {
+                    // Approximately duplicated in DjangoProject
                     var opts = _site.GetPythonToolsService().SuppressDialogOptions;
                     if (string.IsNullOrEmpty(opts.PublishToAzure30)) {
                         var td = new TaskDialog(_site) {
@@ -229,7 +230,7 @@ namespace Microsoft.PythonTools.Project.Web {
                             MainInstruction = Strings.PublishToAzure30,
                             Content = Strings.PublishToAzure30Message,
                             VerificationText = Strings.DontShowAgain,
-                            SelectedVerified = true,
+                            SelectedVerified = false,
                             AllowCancellation = true,
                             EnableHyperlinks = true
                         };


### PR DESCRIPTION
Fixes #1920 No way of clearing "do not show this again" for publish warning
Adds button to General options to reset all suppressed dialogs

Fixes #1921 Keep the Azure warning around by default
Changes default state of the "do not show this warning again" checkbox to unchecked.

Also enables the dialog for Django projects
Fixes IOleCommandTarget chain for Django projects
Avoids raising many NotImplementedErrors because of Azure Tools.
Handles error when reanalyzing project that is not fully loaded.
Makes options service public.