### PR TITLE
Fixes the classifier and clustering templates with the new URL.

### DIFF
--- a/Python/Templates/Core/ProjectTemplates/Python/Machine Learning/ClassifierTemplate/classifier.py
+++ b/Python/Templates/Core/ProjectTemplates/Python/Machine Learning/ClassifierTemplate/classifier.py
@@ -18,7 +18,7 @@ correct.
 ============
 Example Data
 ============
-The example is from http://archive.ics.uci.edu/ml/datasets/Spambase
+The example is from http://mlr.cs.umass.edu/ml/datasets/Spambase
 It contains pre-processed metrics, such as the frequency of certain
 words and letters, from a collection of emails. A classification for
 each one indicating 'spam' or 'not spam' is in the final column.
@@ -30,7 +30,7 @@ detection systems.
 '''
 
 # Remember to update the script for the new data when you change this URL
-URL = "http://archive.ics.uci.edu/ml/machine-learning-databases/spambase/spambase.data"
+URL = "http://mlr.cs.umass.edu/ml/machine-learning-databases/spambase/spambase.data"
 
 # Uncomment this call when using matplotlib to generate images
 # rather than displaying interactive UI.

--- a/Python/Templates/Core/ProjectTemplates/Python/Machine Learning/ClusteringTemplate/clustering.py
+++ b/Python/Templates/Core/ProjectTemplates/Python/Machine Learning/ClusteringTemplate/clustering.py
@@ -18,7 +18,7 @@ correct.
 ============
 Example Data
 ============
-The example is from http://archive.ics.uci.edu/ml/datasets/Water+Treatment+Plant
+The example is from http://mlr.cs.umass.edu/ml/datasets/Water+Treatment+Plant
 It contains a range of continuous values from sensors at a water
 treatment plant, and the aim is to use unsupervised learners to
 determine whether the plant is operating correctly. See the linked page
@@ -30,7 +30,7 @@ classes.
 '''
 
 # Remember to update the script for the new data when you change this URL
-URL = "http://archive.ics.uci.edu/ml/machine-learning-databases/water-treatment/water-treatment.data"
+URL = "http://mlr.cs.umass.edu/ml/machine-learning-databases/water-treatment/water-treatment.data"
 
 # Uncomment this call when using matplotlib to generate images
 # rather than displaying interactive UI.


### PR DESCRIPTION
This is the quick fix for #1926.

We still need to figure out why the regression sample is broken (seems like a temporary server error rather than a broken link), and really ought to switch these samples over to our own datasets so that we know they won't disappear.