### PR TITLE
Fixes #1951 Cookiecutter treeviewitem Names are not accessible to Screen readers

### DIFF
--- a/Common/Product/SharedProject/Wpf/Controls.xaml
+++ b/Common/Product/SharedProject/Wpf/Controls.xaml
@@ -670,6 +670,7 @@
         <Setter Property="FocusVisualStyle" Value="{x:Null}" />
     </Style>
     <Style TargetType="{x:Type ListViewItem}">
+        <Setter Property="Background" Value="{x:Null}" />
         <Setter Property="FocusVisualStyle" Value="{StaticResource FocusVisualStyle}" />
     </Style>
 
@@ -679,7 +680,7 @@
         <Setter Property="FocusVisualStyle" Value="{x:Null}" />
     </Style>
     <Style TargetType="{x:Type ListBoxItem}">
-        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="Background" Value="{x:Null}" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="ListBoxItem">
@@ -1163,7 +1164,9 @@
                                Target="{Binding ElementName=Content}"
                                Foreground="{DynamicResource {x:Static wpf:Controls.ForegroundKey}}"/>
                         <TextBlock Grid.Row="1" Text="{Binding HelpText}" Style="{StaticResource HelpText}" Name="HelpText" />
-                        <ContentPresenter Grid.Row="2" Content="{Binding Content}" Margin="3" Name="Content" />
+                        <ContentPresenter Grid.Row="2" Content="{Binding Content}" Margin="3" Name="Content"
+                                          AutomationProperties.Name="{TemplateBinding AutomationProperties.Name}"
+                                          AutomationProperties.HelpText="{Binding HelpText}"/>
                     </Grid>
                     <ControlTemplate.Triggers>
                         <Trigger Property="wpf:LabelledControl.HasHelpText" Value="False">
@@ -1209,7 +1212,9 @@
                                 Content="{Binding Content}"
                                 Command="{Binding Command}"
                                 CommandParameter="{Binding CommandParameter}"
-                                CommandTarget="{Binding CommandTarget}" />
+                                CommandTarget="{Binding CommandTarget}"
+                                AutomationProperties.Name="{TemplateBinding AutomationProperties.Name}"
+                                AutomationProperties.HelpText="{Binding HelpText}" />
                         <Label Grid.Column="1" Grid.Row="0"
                                Content="{Binding Title}"
                                Target="{Binding ElementName=Content}"
@@ -1242,14 +1247,29 @@
 
     <Style x:Key="BrowseFolderButton" TargetType="{x:Type Button}" BasedOn="{StaticResource BrowseButton}">
         <Setter Property="Command" Value="{x:Static wpf:Commands.BrowseFolder}" />
+        <Setter Property="AutomationProperties.HelpText">
+            <Setter.Value>
+                Opens a dialog to browse for a folder.
+            </Setter.Value>
+        </Setter>
     </Style>
 
     <Style x:Key="BrowseOpenFileButton" TargetType="{x:Type Button}" BasedOn="{StaticResource BrowseButton}">
         <Setter Property="Command" Value="{x:Static wpf:Commands.BrowseOpenFile}" />
+        <Setter Property="AutomationProperties.HelpText">
+            <Setter.Value>
+                Opens a dialog to browse for an existing file.
+            </Setter.Value>
+        </Setter>
     </Style>
 
     <Style x:Key="BrowseSaveFileButton" TargetType="{x:Type Button}" BasedOn="{StaticResource BrowseButton}">
         <Setter Property="Command" Value="{x:Static wpf:Commands.BrowseSaveFile}" />
+        <Setter Property="AutomationProperties.HelpText">
+            <Setter.Value>
+                Opens a dialog to select a location to save a file.
+            </Setter.Value>
+        </Setter>
     </Style>
 
     <Style TargetType="{x:Type wpf:ConfigurationTextBoxWithHelp}">
@@ -1271,8 +1291,9 @@
                                  Margin="4 4 1 4"
                                  VerticalAlignment="Stretch"
                                  Style="{StaticResource {x:Type TextBox}}"
-                                 Text="{Binding Text,Mode=TwoWay,RelativeSource={RelativeSource TemplatedParent},UpdateSourceTrigger=PropertyChanged}"
-                                 AutomationProperties.HelpText="{TemplateBinding HelpText}">
+                                 AutomationProperties.Name="{TemplateBinding AutomationProperties.Name}"
+                                 AutomationProperties.HelpText="{TemplateBinding HelpText}"
+                                 Text="{Binding Text,Mode=TwoWay,RelativeSource={RelativeSource TemplatedParent},UpdateSourceTrigger=PropertyChanged}">
                             <TextBox.ToolTip>
                                 <ToolTip Placement="Bottom" Content="{TemplateBinding HelpText}">
                                     <ToolTip.ContentTemplate>
@@ -1336,6 +1357,7 @@
                                   SelectedValue="{Binding Value,Mode=TwoWay,RelativeSource={RelativeSource TemplatedParent}}"
                                   IsTextSearchEnabled="True"
                                   IsTextSearchCaseSensitive="False"
+                                  AutomationProperties.Name="{TemplateBinding AutomationProperties.Name}"
                                   AutomationProperties.HelpText="{TemplateBinding HelpText}">
                             <ComboBox.ToolTip>
                                 <ToolTip Placement="Bottom" Content="{TemplateBinding HelpText}">

--- a/Python/Product/Common/Strings.Designer.cs
+++ b/Python/Product/Common/Strings.Designer.cs
@@ -2116,6 +2116,24 @@ namespace Microsoft.PythonTools {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Remove this package.
+        /// </summary>
+        public static string UninstallMessage {
+            get {
+                return ResourceManager.GetString("UninstallMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Remove {0}.
+        /// </summary>
+        public static string UninstallMessage_Package {
+            get {
+                return ResourceManager.GetString("UninstallMessage_Package", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to &apos;{0}&apos; will be uninstalled from {1} ({2})..
         /// </summary>
         public static string UninstallPackage {
@@ -2243,6 +2261,24 @@ namespace Microsoft.PythonTools {
         public static string UpgradedWebBrowserUrlProperty {
             get {
                 return ResourceManager.GetString("UpgradedWebBrowserUrlProperty", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Upgrade to the latest version of this package.
+        /// </summary>
+        public static string UpgradeMessage {
+            get {
+                return ResourceManager.GetString("UpgradeMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Upgrade to {0} version {1}.
+        /// </summary>
+        public static string UpgradeMessage_Package {
+            get {
+                return ResourceManager.GetString("UpgradeMessage_Package", resourceCulture);
             }
         }
         

--- a/Python/Product/Common/Strings.resx
+++ b/Python/Product/Common/Strings.resx
@@ -956,4 +956,18 @@ There are no restrictions on the version of Python you may be using when you dep
 
 Please refer to &lt;a href="https://aka.ms/pythononappservice"&gt;aka.ms/PythonOnAppService&lt;/a&gt; for information about configuring and publishing to Azure App Service.</value>
   </data>
+  <data name="UninstallMessage" xml:space="preserve">
+    <value>Remove this package</value>
+  </data>
+  <data name="UninstallMessage_Package" xml:space="preserve">
+    <value>Remove {0}</value>
+    <comment>{0} is a package name</comment>
+  </data>
+  <data name="UpgradeMessage" xml:space="preserve">
+    <value>Upgrade to the latest version of this package</value>
+  </data>
+  <data name="UpgradeMessage_Package" xml:space="preserve">
+    <value>Upgrade to {0} version {1}</value>
+    <comment>{0} is a package name, {1} is the latest available version number</comment>
+  </data>
 </root>

--- a/Python/Product/Cookiecutter/Shared/Wpf/Controls.xaml
+++ b/Python/Product/Cookiecutter/Shared/Wpf/Controls.xaml
@@ -1164,7 +1164,9 @@
                                Target="{Binding ElementName=Content}"
                                Foreground="{DynamicResource {x:Static wpf:Controls.ForegroundKey}}"/>
                         <TextBlock Grid.Row="1" Text="{Binding HelpText}" Style="{StaticResource HelpText}" Name="HelpText" />
-                        <ContentPresenter Grid.Row="2" Content="{Binding Content}" Margin="3" Name="Content" />
+                        <ContentPresenter Grid.Row="2" Content="{Binding Content}" Margin="3" Name="Content"
+                                          AutomationProperties.Name="{TemplateBinding AutomationProperties.Name}"
+                                          AutomationProperties.HelpText="{Binding HelpText}"/>
                     </Grid>
                     <ControlTemplate.Triggers>
                         <Trigger Property="wpf:LabelledControl.HasHelpText" Value="False">
@@ -1210,7 +1212,9 @@
                                 Content="{Binding Content}"
                                 Command="{Binding Command}"
                                 CommandParameter="{Binding CommandParameter}"
-                                CommandTarget="{Binding CommandTarget}" />
+                                CommandTarget="{Binding CommandTarget}"
+                                AutomationProperties.Name="{TemplateBinding AutomationProperties.Name}"
+                                AutomationProperties.HelpText="{Binding HelpText}" />
                         <Label Grid.Column="1" Grid.Row="0"
                                Content="{Binding Title}"
                                Target="{Binding ElementName=Content}"
@@ -1243,14 +1247,29 @@
 
     <Style x:Key="BrowseFolderButton" TargetType="{x:Type Button}" BasedOn="{StaticResource BrowseButton}">
         <Setter Property="Command" Value="{x:Static wpf:Commands.BrowseFolder}" />
+        <Setter Property="AutomationProperties.HelpText">
+            <Setter.Value>
+                Opens a dialog to browse for a folder.
+            </Setter.Value>
+        </Setter>
     </Style>
 
     <Style x:Key="BrowseOpenFileButton" TargetType="{x:Type Button}" BasedOn="{StaticResource BrowseButton}">
         <Setter Property="Command" Value="{x:Static wpf:Commands.BrowseOpenFile}" />
+        <Setter Property="AutomationProperties.HelpText">
+            <Setter.Value>
+                Opens a dialog to browse for an existing file.
+            </Setter.Value>
+        </Setter>
     </Style>
 
     <Style x:Key="BrowseSaveFileButton" TargetType="{x:Type Button}" BasedOn="{StaticResource BrowseButton}">
         <Setter Property="Command" Value="{x:Static wpf:Commands.BrowseSaveFile}" />
+        <Setter Property="AutomationProperties.HelpText">
+            <Setter.Value>
+                Opens a dialog to select a location to save a file.
+            </Setter.Value>
+        </Setter>
     </Style>
 
     <Style TargetType="{x:Type wpf:ConfigurationTextBoxWithHelp}">
@@ -1272,8 +1291,9 @@
                                  Margin="4 4 1 4"
                                  VerticalAlignment="Stretch"
                                  Style="{StaticResource {x:Type TextBox}}"
-                                 Text="{Binding Text,Mode=TwoWay,RelativeSource={RelativeSource TemplatedParent},UpdateSourceTrigger=PropertyChanged}"
-                                 AutomationProperties.HelpText="{TemplateBinding HelpText}">
+                                 AutomationProperties.Name="{TemplateBinding AutomationProperties.Name}"
+                                 AutomationProperties.HelpText="{TemplateBinding HelpText}"
+                                 Text="{Binding Text,Mode=TwoWay,RelativeSource={RelativeSource TemplatedParent},UpdateSourceTrigger=PropertyChanged}">
                             <TextBox.ToolTip>
                                 <ToolTip Placement="Bottom" Content="{TemplateBinding HelpText}">
                                     <ToolTip.ContentTemplate>
@@ -1337,6 +1357,7 @@
                                   SelectedValue="{Binding Value,Mode=TwoWay,RelativeSource={RelativeSource TemplatedParent}}"
                                   IsTextSearchEnabled="True"
                                   IsTextSearchCaseSensitive="False"
+                                  AutomationProperties.Name="{TemplateBinding AutomationProperties.Name}"
                                   AutomationProperties.HelpText="{TemplateBinding HelpText}">
                             <ComboBox.ToolTip>
                                 <ToolTip Placement="Bottom" Content="{TemplateBinding HelpText}">

--- a/Python/Product/Cookiecutter/View/CookiecutterOptionsPage.xaml
+++ b/Python/Product/Cookiecutter/View/CookiecutterOptionsPage.xaml
@@ -53,31 +53,13 @@
                     <view:TemplateContextItemTemplateSelector x:Key="contextItemSelector"/>
                     <DataTemplate x:Key="stringTemplate">
                         <StackPanel Orientation="Vertical">
-                            <TextBlock Margin="8 4 4 0"
-                                       Visibility="{Binding Path=Url, Converter={StaticResource EmptyStringToVisibleOrCollapsed}}"
+                            <TextBlock x:Name="Label_NotClickable"
+                                       Margin="8 4 4 0"
                                        Text="{Binding Label}"/>
-                            <Button Margin="8 4 4 0"
+                            <Button x:Name="Label_Clickable"
+                                    Margin="8 4 4 0"
                                     Content="{Binding Label}"
                                     ToolTip="{Binding Url}"
-                                    Visibility="{Binding Path=Url, Converter={StaticResource EmptyStringToNotVisibleOrCollapsed}}"
-                                    Command="{x:Static vm:CookiecutterViewModel.OpenInBrowser}"
-                                    CommandParameter="{Binding Url,Mode=OneWay}"
-                                    Style="{StaticResource NavigationButton}"/>
-                            <wpf:ConfigurationTextBoxWithHelp Margin="4 0 8 4"
-                                                              Text="{Binding Val, Mode=TwoWay}"
-                                                              HelpText="{Binding Description}"
-                                                              Watermark="{Binding Default}" />
-                        </StackPanel>
-                    </DataTemplate>
-                    <DataTemplate x:Key="odbcconnectionTemplate">
-                        <StackPanel Orientation="Vertical">
-                            <TextBlock Margin="8 4 4 0"
-                                       Visibility="{Binding Path=Url, Converter={StaticResource EmptyStringToVisibleOrCollapsed}}"
-                                       Text="{Binding Label}"/>
-                            <Button Margin="8 4 4 0"
-                                    Content="{Binding Label}"
-                                    ToolTip="{Binding Url}"
-                                    Visibility="{Binding Path=Url, Converter={StaticResource EmptyStringToNotVisibleOrCollapsed}}"
                                     Command="{x:Static vm:CookiecutterViewModel.OpenInBrowser}"
                                     CommandParameter="{Binding Url,Mode=OneWay}"
                                     Style="{StaticResource NavigationButton}"/>
@@ -85,26 +67,65 @@
                                                               Text="{Binding Val, Mode=TwoWay}"
                                                               HelpText="{Binding Description}"
                                                               Watermark="{Binding Default}"
-                                                              BrowseButtonStyle="{StaticResource BrowseOdbcButton}" />
+                                                              AutomationProperties.Name="{Binding Label}"/>
                         </StackPanel>
+                        <DataTemplate.Triggers>
+                            <DataTrigger Binding="{Binding Url,Mode=OneTime}" Value="">
+                                <Setter TargetName="Label_Clickable" Property="Visibility" Value="Collapsed" />
+                                <Setter TargetName="Label_NotClickable" Property="Visibility" Value="Visible" />
+                            </DataTrigger>
+                        </DataTemplate.Triggers>
+                    </DataTemplate>
+                    <DataTemplate x:Key="odbcconnectionTemplate">
+                        <StackPanel Orientation="Vertical">
+                            <TextBlock x:Name="Label_NotClickable"
+                                       Margin="8 4 4 0"
+                                       Text="{Binding Label}"/>
+                            <Button x:Name="Label_Clickable"
+                                    Margin="8 4 4 0"
+                                    Content="{Binding Label}"
+                                    ToolTip="{Binding Url}"
+                                    Command="{x:Static vm:CookiecutterViewModel.OpenInBrowser}"
+                                    CommandParameter="{Binding Url,Mode=OneWay}"
+                                    Style="{StaticResource NavigationButton}"/>
+                            <wpf:ConfigurationTextBoxWithHelp Margin="4 0 8 4"
+                                                              Text="{Binding Val, Mode=TwoWay}"
+                                                              HelpText="{Binding Description}"
+                                                              Watermark="{Binding Default}"
+                                                              BrowseButtonStyle="{StaticResource BrowseOdbcButton}"
+                                                              AutomationProperties.Name="{Binding Label}"/>
+                        </StackPanel>
+                        <DataTemplate.Triggers>
+                            <DataTrigger Binding="{Binding Url,Mode=OneTime}" Value="">
+                                <Setter TargetName="Label_Clickable" Property="Visibility" Value="Collapsed" />
+                                <Setter TargetName="Label_NotClickable" Property="Visibility" Value="Visible" />
+                            </DataTrigger>
+                        </DataTemplate.Triggers>
                     </DataTemplate>
                     <DataTemplate x:Key="listTemplate">
                         <StackPanel Orientation="Vertical">
-                            <TextBlock Margin="8 4 4 0"
-                                       Visibility="{Binding Path=Url, Converter={StaticResource EmptyStringToVisibleOrCollapsed}}"
+                            <TextBlock x:Name="Label_NotClickable"
+                                       Margin="8 4 4 0"
                                        Text="{Binding Label}"/>
-                            <Button Margin="8 4 4 0"
+                            <Button x:Name="Label_Clickable"
+                                    Margin="8 4 4 0"
                                     Content="{Binding Label}"
                                     ToolTip="{Binding Url}"
-                                    Visibility="{Binding Path=Url, Converter={StaticResource EmptyStringToNotVisibleOrCollapsed}}"
                                     Command="{x:Static vm:CookiecutterViewModel.OpenInBrowser}"
                                     CommandParameter="{Binding Url,Mode=OneWay}"
                                     Style="{StaticResource NavigationButton}"/>
                             <wpf:ConfigurationComboBoxWithHelp Margin="4 0 8 4"
                                                                Value="{Binding Val, Mode=TwoWay}"
                                                                Values="{Binding Items}"
-                                                               HelpText="{Binding Description}" />
+                                                               HelpText="{Binding Description}"
+                                                               AutomationProperties.Name="{Binding Label}"/>
                         </StackPanel>
+                        <DataTemplate.Triggers>
+                            <DataTrigger Binding="{Binding Url,Mode=OneTime}" Value="">
+                                <Setter TargetName="Label_Clickable" Property="Visibility" Value="Collapsed" />
+                                <Setter TargetName="Label_NotClickable" Property="Visibility" Value="Visible" />
+                            </DataTrigger>
+                        </DataTemplate.Triggers>
                     </DataTemplate>
                     <DataTemplate x:Key="yesnoTemplate">
                         <StackPanel Orientation="Vertical">
@@ -114,21 +135,28 @@
                                     <sys:String>n</sys:String>
                                 </x:Array>
                             </StackPanel.Resources>
-                            <TextBlock Margin="8 4 4 0"
-                                       Visibility="{Binding Path=Url, Converter={StaticResource EmptyStringToVisibleOrCollapsed}}"
+                            <TextBlock x:Name="Label_NotClickable"
+                                       Margin="8 4 4 0"
                                        Text="{Binding Label}"/>
-                            <Button Margin="8 4 4 0"
+                            <Button x:Name="Label_Clickable"
+                                    Margin="8 4 4 0"
                                     Content="{Binding Label}"
                                     ToolTip="{Binding Url}"
-                                    Visibility="{Binding Path=Url, Converter={StaticResource EmptyStringToNotVisibleOrCollapsed}}"
                                     Command="{x:Static vm:CookiecutterViewModel.OpenInBrowser}"
                                     CommandParameter="{Binding Url,Mode=OneWay}"
                                     Style="{StaticResource NavigationButton}"/>
                             <wpf:ConfigurationComboBoxWithHelp Margin="4 0 8 4"
                                                                Value="{Binding Val, Mode=TwoWay}"
                                                                Values="{StaticResource ResourceKey=yesnoValues}"
-                                                               HelpText="{Binding Description}" />
+                                                               HelpText="{Binding Description}"
+                                                               AutomationProperties.Name="{Binding Label}"/>
                         </StackPanel>
+                        <DataTemplate.Triggers>
+                            <DataTrigger Binding="{Binding Url,Mode=OneTime}" Value="">
+                                <Setter TargetName="Label_Clickable" Property="Visibility" Value="Collapsed" />
+                                <Setter TargetName="Label_NotClickable" Property="Visibility" Value="Visible" />
+                            </DataTrigger>
+                        </DataTemplate.Triggers>
                     </DataTemplate>
                 </ResourceDictionary>
             </ResourceDictionary.MergedDictionaries>
@@ -165,7 +193,8 @@
                                                   Margin="4 0 4 0"
                                                   Text="{Binding Path=OutputFolderPath,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}"
                                                   Watermark="e.g. C:\Projects\Project1"
-                                                  BrowseButtonStyle="{StaticResource BrowseFolderButton}">
+                                                  BrowseButtonStyle="{StaticResource BrowseFolderButton}"
+                                                  AutomationProperties.Name="Output folder path">
                     <wpf:ConfigurationTextBoxWithHelp.HelpText>
                         Folder location where the files will be created.
                         Files may be replaced if the folder is not empty.

--- a/Python/Product/Cookiecutter/View/CookiecutterSearchPage.xaml
+++ b/Python/Product/Cookiecutter/View/CookiecutterSearchPage.xaml
@@ -96,10 +96,10 @@
                         Orientation="Horizontal">
                 <imaging:CrispImage Margin="20 0 0 0" Width="16" Height="16" Moniker="{x:Static imagecatalog:KnownMonikers.OpenFolder}"/>
                 <Button Style="{StaticResource NavigationButton}"
-                    Margin="4 0 0 0"
-                    Command="{x:Static vm:CookiecutterViewModel.OpenInExplorer}"
-                    CommandParameter="{Binding Path=OpenInExplorerFolderPath,Mode=OneWay}"
-                    HorizontalAlignment="Left">
+                        Margin="4 0 0 0"
+                        Command="{x:Static vm:CookiecutterViewModel.OpenInExplorer}"
+                        CommandParameter="{Binding Path=OpenInExplorerFolderPath,Mode=OneWay}"
+                        HorizontalAlignment="Left">
                     Open in Solution Explorer
                 </Button>
             </StackPanel>
@@ -120,6 +120,7 @@
                 <wpf:ConfigurationTextBoxWithHelp Margin="0 0 0 0"
                                                   Text="{Binding Path=SearchTerm, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                                                   HelpText="Enter search terms or template location (git repository URL or path to local folder)"
+                                                  AutomationProperties.Name="Search terms"
                                                   Watermark="Enter search terms or template location"
                                                   BrowseButtonStyle="{StaticResource SearchButtonStyle}"
                                                   KeyDown="TextBox_KeyDown" />

--- a/Python/Product/Cookiecutter/ViewModel/ContextItemViewModel.cs
+++ b/Python/Product/Cookiecutter/ViewModel/ContextItemViewModel.cs
@@ -110,12 +110,12 @@ namespace Microsoft.CookiecutterTools.ViewModel {
 
         public string Url {
             get {
-                return _url;
+                return _url ?? string.Empty;
             }
 
             set {
                 if (value != _url) {
-                    _url = value;
+                    _url = value ?? string.Empty;
                     PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Url)));
                 }
             }

--- a/Python/Product/Cookiecutter/ViewModel/TemplateViewModel.cs
+++ b/Python/Product/Cookiecutter/ViewModel/TemplateViewModel.cs
@@ -34,6 +34,8 @@ namespace Microsoft.CookiecutterTools.ViewModel {
         public TemplateViewModel() {
         }
 
+        public override string ToString() => DisplayName;
+
         public bool Selectable => true;
 
         public string GitHubHomeUrl => RemoteUrl;

--- a/Python/Product/EnvironmentsList/DBExtension.xaml
+++ b/Python/Product/EnvironmentsList/DBExtension.xaml
@@ -71,7 +71,8 @@
                                     Command="{x:Static l:DBExtension.StartRefreshDB}"
                                     CommandParameter="{Binding EnvironmentView}"
                                     HorizontalAlignment="Center"
-                                    VerticalAlignment="Center">
+                                    VerticalAlignment="Center"
+                                    AutomationProperties.Name="Refresh completion DB">
                                 <Grid>
                                     <Grid.ColumnDefinitions>
                                         <ColumnDefinition Width="auto" />

--- a/Python/Product/EnvironmentsList/DBExtension.xaml.cs
+++ b/Python/Product/EnvironmentsList/DBExtension.xaml.cs
@@ -204,6 +204,8 @@ namespace Microsoft.PythonTools.EnvironmentsList {
             _isUpToDate = true;
         }
 
+        public override string ToString() => Name;
+
         public static IEnumerable<DBPackageView> FromModuleList(
             IList<string> modules,
             IList<string> stdLibModules,

--- a/Python/Product/EnvironmentsList/EnvironmentView.xaml
+++ b/Python/Product/EnvironmentsList/EnvironmentView.xaml
@@ -79,6 +79,8 @@
                             Margin="1"
                             Command="{x:Static l:DBExtension.StartRefreshDB}"
                             CommandParameter="{Binding}"
+                            AutomationProperties.Name="Refresh completion DB"
+                            AutomationProperties.HelpText="Completion DB is not up to date. Click to start refreshing"
                             Visibility="Hidden">
                         <Control Style="{StaticResource RefreshImage}" />
                         <Button.ToolTip>
@@ -92,7 +94,8 @@
                             Cursor="Hand"
                             Margin="1"
                             Command="{x:Static l:EnvironmentView.OpenInteractiveWindow}"
-                            CommandParameter="{Binding}">
+                            CommandParameter="{Binding}"
+                            AutomationProperties.Name="Open Interactive Window">
                         <Control Style="{StaticResource InteractiveWindowImage}" />
                         <Button.ToolTip>
                             Open Interactive Window
@@ -142,7 +145,8 @@
                           Data="{StaticResource AddGeometry}"
                           Fill="{Binding Foreground,ElementName=CustomLabel}">
                     </Path>
-                    <Label Grid.Column="1" VerticalAlignment="Center" Name="CustomLabel">
+                    <Label Grid.Column="1" VerticalAlignment="Center" Name="CustomLabel"
+                           AutomationProperties.Name="Add new environment">
                         Custom...
                     </Label>
                 </Grid>

--- a/Python/Product/EnvironmentsList/PipExtension.xaml
+++ b/Python/Product/EnvironmentsList/PipExtension.xaml
@@ -22,6 +22,10 @@
                                 <ColumnDefinition Width="auto" />
                                 <ColumnDefinition Width="auto" />
                             </Grid.ColumnDefinitions>
+                            <Grid.Resources>
+                                <l:UpgradeMessageConverter x:Key="UpgradeMessageConverter" />
+                                <l:UninstallMessageConverter x:Key="UninstallMessageConverter" />
+                            </Grid.Resources>
                             
                             <Control Grid.Column="0"
                                      Margin="4 2 2 2"
@@ -41,6 +45,18 @@
                                     Cursor="Hand"
                                     Command="{x:Static l:PipExtension.UpgradePackage}"
                                     CommandParameter="{Binding}">
+                                <AutomationProperties.Name>
+                                    <MultiBinding Converter="{StaticResource UpgradeMessageConverter}">
+                                        <Binding Path="Name" />
+                                        <Binding Path="UpgradeVersion" />
+                                    </MultiBinding>
+                                </AutomationProperties.Name>
+                                <Button.ToolTip>
+                                    <MultiBinding Converter="{StaticResource UpgradeMessageConverter}">
+                                        <Binding Path="Name" />
+                                        <Binding Path="UpgradeVersion" />
+                                    </MultiBinding>
+                                </Button.ToolTip>
                                 <Button.Template>
                                     <ControlTemplate TargetType="Button">
                                         <StackPanel Orientation="Horizontal">
@@ -66,9 +82,6 @@
                                         </ControlTemplate.Triggers>
                                     </ControlTemplate>
                                 </Button.Template>
-                                <Button.ToolTip>
-                                    Upgrade to the newest version of this package.
-                                </Button.ToolTip>
                             </Button>
 
                             <Button Grid.Column="3"
@@ -77,7 +90,9 @@
                                     Margin="4"
                                     Cursor="Hand"
                                     Command="{x:Static l:PipExtension.UninstallPackage}"
-                                    CommandParameter="{Binding}">
+                                    CommandParameter="{Binding}"
+                                    AutomationProperties.Name="{Binding Converter={StaticResource UninstallMessageConverter}}"
+                                    ToolTip="{Binding Converter={StaticResource UninstallMessageConverter}}">
                                 <Button.Template>
                                     <ControlTemplate TargetType="Button">
                                         <Canvas Width="16" Height="16">
@@ -96,9 +111,6 @@
                                         </ControlTemplate.Triggers>
                                     </ControlTemplate>
                                 </Button.Template>
-                                <Button.ToolTip>
-                                    Uninstall this package.
-                                </Button.ToolTip>
                             </Button>
                         </Grid>
                     </DataTemplate>
@@ -216,6 +228,7 @@
                          Text="{Binding SearchQuery,UpdateSourceTrigger=PropertyChanged}">
                     <TextBox.InputBindings>
                         <KeyBinding Key="Escape" Command="ApplicationCommands.Delete" CommandTarget="{Binding ElementName=SearchQueryText}" />
+                        <KeyBinding Key="Return" Command="{x:Static l:PipExtension.InstallPackage}" CommandParameter="{Binding Text,ElementName=SearchQueryText}" />
                     </TextBox.InputBindings>
                 </TextBox>
             </Grid>

--- a/Python/Product/EnvironmentsList/PipExtension.xaml.cs
+++ b/Python/Product/EnvironmentsList/PipExtension.xaml.cs
@@ -18,6 +18,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
+using System.Globalization;
 using System.Linq;
 using System.Runtime.ExceptionServices;
 using System.Threading;
@@ -510,5 +511,36 @@ namespace Microsoft.PythonTools.EnvironmentsList {
         public string IndexName => View._provider.IndexName;
         public string DisplayName => Package.DisplayName;
         public string Description => Package.Description;
+    }
+
+    class UpgradeMessageConverter : IMultiValueConverter {
+        public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture) {
+            if (values.Length != 2) {
+                return Strings.UpgradeMessage;
+            }
+
+            var name = (string)values[0];
+            var version = (PackageVersion)values[1];
+            return Strings.UpgradeMessage_Package.FormatUI(name, version);
+        }
+
+        public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture) {
+            throw new NotImplementedException();
+        }
+    }
+
+    [ValueConversion(typeof(PipPackageView), typeof(string))]
+    class UninstallMessageConverter : IValueConverter {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture) {
+            var p = value as PipPackageView;
+            if (p == null) {
+                return Strings.UninstallMessage;
+            }
+            return Strings.UninstallMessage_Package.FormatUI(p.Name);
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/Python/Product/EnvironmentsList/PipPackageView.cs
+++ b/Python/Product/EnvironmentsList/PipPackageView.cs
@@ -35,6 +35,8 @@ namespace Microsoft.PythonTools.EnvironmentsList {
             _isInstalled = isInstalled;
         }
 
+        public override string ToString() => DisplayName;
+
         private async void TriggerUpdate() {
             if (_upgradeVersion.HasValue && !string.IsNullOrEmpty(_package.Description)) {
                 return;


### PR DESCRIPTION
Fixes #1951 Cookiecutter treeviewitem Names are not accessible to Screen Readers
Fixes UI automation properties in cookiecutter and environments list.
Also make it so pressing Enter in the search box will start installing based on the current text.