### PR TITLE
Fixes #1916 Exception popup doesn't show exception name

### DIFF
--- a/Python/Product/Debugger/Debugger.csproj
+++ b/Python/Product/Debugger/Debugger.csproj
@@ -67,6 +67,7 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.VisualStudio.Debugger.Interop.10.0" />
     <Reference Include="Microsoft.VisualStudio.Debugger.Interop.11.0" />
+    <Reference Include="Microsoft.VisualStudio.Debugger.Interop.15.0" />
     <Reference Include="Microsoft.VisualStudio.Debugger.InteropA, Version=9.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
     <Reference Include="Microsoft.VisualStudio.Shell.$(VsTarget)">
       <Aliases>global</Aliases>
@@ -106,6 +107,7 @@
     <Compile Include="Debugger\DebugEngine\AD7EngineEventArgs.cs" />
     <Compile Include="Debugger\DebugEngine\AD7Enums.cs" />
     <Compile Include="Debugger\DebugEngine\AD7Events.cs" />
+    <Compile Include="Debugger\DebugEngine\AD7Exceptions.cs" />
     <Compile Include="Debugger\DebugEngine\AD7MemoryAddress.cs" />
     <Compile Include="Debugger\DebugEngine\AD7Module.cs" />
     <Compile Include="Debugger\DebugEngine\AD7PendingBreakpoint.cs" />

--- a/Python/Product/Debugger/Debugger.csproj
+++ b/Python/Product/Debugger/Debugger.csproj
@@ -67,7 +67,6 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.VisualStudio.Debugger.Interop.10.0" />
     <Reference Include="Microsoft.VisualStudio.Debugger.Interop.11.0" />
-    <Reference Include="Microsoft.VisualStudio.Debugger.Interop.15.0" />
     <Reference Include="Microsoft.VisualStudio.Debugger.InteropA, Version=9.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
     <Reference Include="Microsoft.VisualStudio.Shell.$(VsTarget)">
       <Aliases>global</Aliases>
@@ -84,6 +83,7 @@
   <Choose>
     <When Condition="$(VSTarget) == '15.0'">
       <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.Debugger.Interop.15.0" />
         <Reference Include="Microsoft.VisualStudio.Shell.Framework, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
       </ItemGroup>
     </When>

--- a/Python/Product/Debugger/Debugger/DebugEngine/AD7Engine.cs
+++ b/Python/Product/Debugger/Debugger/DebugEngine/AD7Engine.cs
@@ -179,6 +179,7 @@ namespace Microsoft.PythonTools.Debugger.DebugEngine {
         public AD7Engine() {
             _breakpointManager = new BreakpointManager(this);
             _defaultBreakOnExceptionMode = (int)enum_EXCEPTION_STATE.EXCEPTION_STOP_USER_UNCAUGHT;
+            _debugOptions = PythonDebugOptions.RichExceptions;
             Debug.WriteLine("Python Engine Created " + GetHashCode());
             _engines.Add(new WeakReference(this));
         }
@@ -1386,7 +1387,7 @@ namespace Microsoft.PythonTools.Debugger.DebugEngine {
             AD7Thread thread;
             if (_threads.TryGetValue(e.Thread, out thread)) {
                 Send(
-                    new AD7DebugExceptionEvent(e.Exception.TypeName, e.Exception.Description, e.IsUnhandled),
+                    new AD7DebugExceptionEvent(this, e.Exception),
                     AD7DebugExceptionEvent.IID,
                     thread
                 );

--- a/Python/Product/Debugger/Debugger/DebugEngine/AD7Events.cs
+++ b/Python/Product/Debugger/Debugger/DebugEngine/AD7Events.cs
@@ -266,49 +266,6 @@ namespace Microsoft.PythonTools.Debugger.DebugEngine {
         #endregion
     }
 
-    sealed class AD7DebugExceptionEvent : AD7StoppingEvent, IDebugExceptionEvent2 {
-        public const string IID = "51A94113-8788-4A54-AE15-08B74FF922D0";
-        private readonly string _exception, _description;
-        private readonly bool _isUnhandled;
-
-        public AD7DebugExceptionEvent(string typeName, string description, bool isUnhandled) {
-            _exception = typeName;
-            _description = description;
-            _isUnhandled = isUnhandled;
-        }
-
-        #region IDebugExceptionEvent2 Members
-
-        public int CanPassToDebuggee() {
-            return VSConstants.S_FALSE;
-        }
-
-        public int GetException(EXCEPTION_INFO[] pExceptionInfo) {
-            pExceptionInfo[0].guidType = AD7Engine.DebugEngineGuid;
-            pExceptionInfo[0].bstrExceptionName = _exception;
-            if (_isUnhandled) {
-                pExceptionInfo[0].dwState = enum_EXCEPTION_STATE.EXCEPTION_STOP_USER_UNCAUGHT;
-            } else {
-                pExceptionInfo[0].dwState = enum_EXCEPTION_STATE.EXCEPTION_STOP_FIRST_CHANCE;
-            }
-            return VSConstants.S_OK;
-        }
-
-        public int GetExceptionDescription(out string pbstrDescription) {
-            pbstrDescription = _description;
-            return VSConstants.S_OK;
-        }
-
-        public int PassToDebuggee(int fPass) {
-            if (fPass != 0) {
-                return VSConstants.S_OK;
-            }
-            return VSConstants.E_FAIL;
-        }
-
-        #endregion
-    }
-
     sealed class AD7DebugOutputStringEvent2 : AD7AsynchronousEvent, IDebugOutputStringEvent2 {
         public const string IID = "569C4BB1-7B82-46FC-AE28-4536DDAD753E";
         private readonly string _output;

--- a/Python/Product/Debugger/Debugger/DebugEngine/AD7Exceptions.cs
+++ b/Python/Product/Debugger/Debugger/DebugEngine/AD7Exceptions.cs
@@ -1,0 +1,168 @@
+﻿// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABLITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System;
+using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.Debugger.Interop;
+
+namespace Microsoft.PythonTools.Debugger.DebugEngine {
+    sealed class AD7DebugExceptionEvent : AD7StoppingEvent,
+#if DEV15_OR_LATER
+        IDebugExceptionEvent150,
+#endif
+        IDebugExceptionEvent2 {
+#if DEV15_OR_LATER
+        public const string IID = "01096447-64AE-4ED1-86E8-08C0A3D889DF";
+#else
+        public const string IID = "51A94113-8788-4A54-AE15-08B74FF922D0";
+#endif
+        private readonly AD7Engine _engine;
+        private readonly PythonException _exception;
+
+        public AD7DebugExceptionEvent(AD7Engine engine, PythonException exception) {
+            _engine = engine;
+            _exception = exception;
+        }
+
+        #region IDebugExceptionEvent150 Members
+#if DEV15_OR_LATER
+
+        int IDebugExceptionEvent150.GetException(EXCEPTION_INFO150[] pExceptionInfo) {
+            var info = new EXCEPTION_INFO[1];
+            int hr = ((IDebugExceptionEvent2)this).GetException(info);
+            if (hr != VSConstants.S_OK) {
+                return hr;
+            }
+
+            pExceptionInfo[0].guidType = info[0].guidType;
+            pExceptionInfo[0].bstrExceptionName = info[0].bstrExceptionName;
+            pExceptionInfo[0].bstrProgramName = info[0].bstrProgramName;
+            pExceptionInfo[0].dwCode = info[0].dwCode;
+            pExceptionInfo[0].dwState = (uint)info[0].dwState;
+            pExceptionInfo[0].pProgram = info[0].pProgram;
+            return VSConstants.S_OK;
+        }
+
+        int IDebugExceptionEvent150.GetExceptionDetails(out IDebugExceptionDetails ppDetails) {
+            ppDetails = new AD7DebugExceptionDetails(_exception);
+            return VSConstants.S_OK;
+        }
+#endif
+
+        #endregion
+
+        #region IDebugExceptionEvent2 Members
+
+        int IDebugExceptionEvent2.CanPassToDebuggee() {
+            return VSConstants.S_FALSE;
+        }
+
+        int IDebugExceptionEvent2.GetException(EXCEPTION_INFO[] pExceptionInfo) {
+            if (pExceptionInfo == null || pExceptionInfo.Length == 0) {
+                return VSConstants.E_POINTER;
+            }
+
+            pExceptionInfo[0].guidType = AD7Engine.DebugEngineGuid;
+            pExceptionInfo[0].bstrExceptionName = _exception.TypeName;
+            pExceptionInfo[0].pProgram = _engine;
+            if (_exception.UserUnhandled) {
+                pExceptionInfo[0].dwState = enum_EXCEPTION_STATE.EXCEPTION_STOP_USER_UNCAUGHT;
+            } else {
+                pExceptionInfo[0].dwState = enum_EXCEPTION_STATE.EXCEPTION_STOP_FIRST_CHANCE;
+            }
+            if (_exception.HResult != 0) {
+                pExceptionInfo[0].dwState |= enum_EXCEPTION_STATE.EXCEPTION_CODE_SUPPORTED |
+                    enum_EXCEPTION_STATE.EXCEPTION_CODE_DISPLAY_IN_HEX;
+            }
+
+            return VSConstants.S_OK;
+        }
+
+        int IDebugExceptionEvent2.GetExceptionDescription(out string pbstrDescription) {
+            pbstrDescription = _exception.GetDescription();
+            return VSConstants.S_OK;
+        }
+
+        int IDebugExceptionEvent2.PassToDebuggee(int fPass) {
+            if (fPass != 0) {
+                return VSConstants.S_OK;
+            }
+            return VSConstants.E_FAIL;
+        }
+
+        #endregion
+    }
+
+#if DEV15_OR_LATER
+    sealed class AD7DebugExceptionDetails : IDebugExceptionDetails {
+        private readonly PythonException _exception;
+
+        public AD7DebugExceptionDetails(PythonException exception) {
+            if (exception == null) {
+                throw new ArgumentNullException(nameof(exception));
+            }
+            _exception = exception;
+        }
+
+        int IDebugExceptionDetails.GetExceptionMessage(out string pbstrMessage) {
+            pbstrMessage = _exception.ExceptionMessage;
+            return VSConstants.S_OK;
+        }
+
+        int IDebugExceptionDetails.GetExceptionObjectExpression(out string pbstrExceptionObjectExpression) {
+            pbstrExceptionObjectExpression = _exception.ExceptionObjectExpression;
+            return VSConstants.S_OK;
+        }
+
+        int IDebugExceptionDetails.GetFormattedDescription(out string pbstrDescription) {
+            pbstrDescription = _exception.FormattedDescription;
+            return VSConstants.S_OK;
+        }
+
+        int IDebugExceptionDetails.GetHResult(out uint pHResult) {
+            pHResult = _exception.HResult;
+            return VSConstants.S_OK;
+        }
+
+        int IDebugExceptionDetails.GetInnerExceptionDetails(out IDebugExceptionDetails ppDetails) {
+            if (_exception.InnerException != null) {
+                ppDetails = new AD7DebugExceptionDetails(_exception.InnerException);
+            } else {
+                ppDetails = null;
+            }
+            return VSConstants.S_OK;
+        }
+
+        int IDebugExceptionDetails.GetSource(out string pbstrSource) {
+            pbstrSource = _exception.Source;
+            return VSConstants.S_OK;
+        }
+
+        int IDebugExceptionDetails.GetStackTrace(out string pbstrMessage) {
+            pbstrMessage = _exception.StackTrace;
+            return VSConstants.S_OK;
+        }
+
+        int IDebugExceptionDetails.GetTypeName(int fFullName, out string pbstrTypeName) {
+            pbstrTypeName = _exception.TypeName;
+            if (fFullName == 0 && !string.IsNullOrEmpty(pbstrTypeName)) {
+                pbstrTypeName = pbstrTypeName.Substring(pbstrTypeName.LastIndexOf('.') + 1);
+            }
+            return VSConstants.S_OK;
+        }
+    }
+#endif
+}

--- a/Python/Product/Debugger/Debugger/DebugEngine/AD7Exceptions.cs
+++ b/Python/Product/Debugger/Debugger/DebugEngine/AD7Exceptions.cs
@@ -24,11 +24,7 @@ namespace Microsoft.PythonTools.Debugger.DebugEngine {
         IDebugExceptionEvent150,
 #endif
         IDebugExceptionEvent2 {
-//#if DEV15_OR_LATER
-//        public const string IID = "01096447-64AE-4ED1-86E8-08C0A3D889DF";
-//#else
         public const string IID = "51A94113-8788-4A54-AE15-08B74FF922D0";
-//#endif
         private readonly AD7Engine _engine;
         private readonly PythonException _exception;
 
@@ -60,8 +56,8 @@ namespace Microsoft.PythonTools.Debugger.DebugEngine {
             ppDetails = new AD7DebugExceptionDetails(_exception);
             return VSConstants.S_OK;
         }
-#endif
 
+#endif
         #endregion
 
         #region IDebugExceptionEvent2 Members

--- a/Python/Product/Debugger/Debugger/DebugEngine/AD7Exceptions.cs
+++ b/Python/Product/Debugger/Debugger/DebugEngine/AD7Exceptions.cs
@@ -24,11 +24,11 @@ namespace Microsoft.PythonTools.Debugger.DebugEngine {
         IDebugExceptionEvent150,
 #endif
         IDebugExceptionEvent2 {
-#if DEV15_OR_LATER
-        public const string IID = "01096447-64AE-4ED1-86E8-08C0A3D889DF";
-#else
+//#if DEV15_OR_LATER
+//        public const string IID = "01096447-64AE-4ED1-86E8-08C0A3D889DF";
+//#else
         public const string IID = "51A94113-8788-4A54-AE15-08B74FF922D0";
-#endif
+//#endif
         private readonly AD7Engine _engine;
         private readonly PythonException _exception;
 
@@ -92,7 +92,7 @@ namespace Microsoft.PythonTools.Debugger.DebugEngine {
         }
 
         int IDebugExceptionEvent2.GetExceptionDescription(out string pbstrDescription) {
-            pbstrDescription = _exception.GetDescription();
+            pbstrDescription = _exception.GetDescription(false);
             return VSConstants.S_OK;
         }
 
@@ -119,41 +119,42 @@ namespace Microsoft.PythonTools.Debugger.DebugEngine {
 
         int IDebugExceptionDetails.GetExceptionMessage(out string pbstrMessage) {
             pbstrMessage = _exception.ExceptionMessage;
-            return VSConstants.S_OK;
+            return string.IsNullOrEmpty(_exception.ExceptionMessage) ? VSConstants.S_FALSE : VSConstants.S_OK;
         }
 
         int IDebugExceptionDetails.GetExceptionObjectExpression(out string pbstrExceptionObjectExpression) {
             pbstrExceptionObjectExpression = _exception.ExceptionObjectExpression;
-            return VSConstants.S_OK;
+            return string.IsNullOrEmpty(_exception.ExceptionObjectExpression) ? VSConstants.S_FALSE : VSConstants.S_OK;
         }
 
         int IDebugExceptionDetails.GetFormattedDescription(out string pbstrDescription) {
-            pbstrDescription = _exception.FormattedDescription;
+            pbstrDescription = _exception.GetDescription(true);
             return VSConstants.S_OK;
         }
 
         int IDebugExceptionDetails.GetHResult(out uint pHResult) {
             pHResult = _exception.HResult;
-            return VSConstants.S_OK;
+            return _exception.HResult == 0 ? VSConstants.S_FALSE : VSConstants.S_OK;
         }
 
         int IDebugExceptionDetails.GetInnerExceptionDetails(out IDebugExceptionDetails ppDetails) {
             if (_exception.InnerException != null) {
                 ppDetails = new AD7DebugExceptionDetails(_exception.InnerException);
+                return VSConstants.S_OK;
             } else {
                 ppDetails = null;
+                return VSConstants.S_FALSE;
             }
-            return VSConstants.S_OK;
         }
 
         int IDebugExceptionDetails.GetSource(out string pbstrSource) {
             pbstrSource = _exception.Source;
-            return VSConstants.S_OK;
+            return string.IsNullOrEmpty(_exception.Source) ? VSConstants.S_FALSE : VSConstants.S_OK;
         }
 
         int IDebugExceptionDetails.GetStackTrace(out string pbstrMessage) {
             pbstrMessage = _exception.StackTrace;
-            return VSConstants.S_OK;
+            return string.IsNullOrEmpty(_exception.StackTrace) ? VSConstants.S_FALSE : VSConstants.S_OK;
         }
 
         int IDebugExceptionDetails.GetTypeName(int fFullName, out string pbstrTypeName) {
@@ -161,7 +162,7 @@ namespace Microsoft.PythonTools.Debugger.DebugEngine {
             if (fFullName == 0 && !string.IsNullOrEmpty(pbstrTypeName)) {
                 pbstrTypeName = pbstrTypeName.Substring(pbstrTypeName.LastIndexOf('.') + 1);
             }
-            return VSConstants.S_OK;
+            return string.IsNullOrEmpty(_exception.TypeName) ? VSConstants.S_FALSE : VSConstants.S_OK;
         }
     }
 #endif

--- a/Python/Product/Debugger/Debugger/ExceptionRaisedEventArgs.cs
+++ b/Python/Product/Debugger/Debugger/ExceptionRaisedEventArgs.cs
@@ -20,12 +20,10 @@ namespace Microsoft.PythonTools.Debugger {
     class ExceptionRaisedEventArgs : EventArgs {
         private readonly PythonException _exception;
         private readonly PythonThread _thread;
-        private readonly bool _isUnhandled;
 
-        public ExceptionRaisedEventArgs(PythonThread thread, PythonException exception, bool isUnhandled) {
+        public ExceptionRaisedEventArgs(PythonThread thread, PythonException exception) {
             _thread = thread;
             _exception = exception;
-            _isUnhandled = isUnhandled;
         }
 
         public PythonException Exception {
@@ -37,12 +35,6 @@ namespace Microsoft.PythonTools.Debugger {
         public PythonThread Thread {
             get {
                 return _thread;
-            }
-        }
-
-        public bool IsUnhandled {
-            get {
-                return _isUnhandled;
             }
         }
     }

--- a/Python/Product/Debugger/Debugger/PythonDebugOptions.cs
+++ b/Python/Product/Debugger/Debugger/PythonDebugOptions.cs
@@ -68,5 +68,10 @@ namespace Microsoft.PythonTools.Debugger {
         /// Indicates that the application is a windowed application rather than a console one.
         /// </summary>
         IsWindowsApplication = 0x200,
+
+        /// <summary>
+        /// Indicates that the VS side of the debugger supports rich exception information.
+        /// </summary>
+        RichExceptions = 0x400,
     }
 }

--- a/Python/Product/Debugger/Debugger/PythonException.cs
+++ b/Python/Product/Debugger/Debugger/PythonException.cs
@@ -14,25 +14,186 @@
 // See the Apache Version 2.0 License for specific language governing
 // permissions and limitations under the License.
 
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
 
 namespace Microsoft.PythonTools.Debugger {
     class PythonException {
-        private readonly string _typeName, _description;
+        public PythonException() { }
 
-        public PythonException(string typeName, string description) {
-            _typeName = typeName;
-            _description = description;
+        public string ExceptionMessage { get; set; }
+        public string ExceptionObjectExpression { get; set; }
+        public string FormattedDescription { get; set; }
+        public uint HResult { get; set; }
+        public PythonException InnerException { get; set; }
+        public string Source { get; set; }
+        public string StackTrace { get; set; }
+        public string TypeName { get; set; }
+        public bool UserUnhandled { get; set; }
+
+        public string GetDescription() {
+            if (!string.IsNullOrEmpty(FormattedDescription)) {
+                return FormattedDescription;
+            }
+
+            var sb = new StringBuilder();
+            if (!string.IsNullOrEmpty(TypeName)) {
+                sb.Append(TypeName);
+                if (!string.IsNullOrEmpty(ExceptionMessage)) {
+                    sb.Append(": ");
+                    sb.AppendLine(ExceptionMessage);
+                }
+            } else if (!string.IsNullOrEmpty(ExceptionMessage)) {
+                sb.AppendLine(ExceptionMessage);
+            }
+
+            if (InnerException != null && InnerException != this) {
+                sb.AppendLine("  Inner Exception");
+                sb.AppendLine(InnerException.GetDescription());
+            }
+
+            return sb.ToString();
         }
 
-        public string TypeName {
-            get {
-                return _typeName;
+        internal static string Unescape(StringBuilder sb) {
+            for (int i = 0; i < sb.Length - 1; ++i) {
+                if (sb[i] != '\\') {
+                    continue;
+                }
+
+                char c = sb[i + 1];
+                switch (c) {
+                    case 'n': c = '\n'; break;
+                    case 'r': c = '\r'; break;
+                    case '\\': break;
+                    case '\'': break;
+                    case '"': break;
+                    default: c = '\0'; break;
+                }
+
+                if (c != '\0') {
+                    sb[i] = c;
+                    sb.Remove(i, 1);
+                }
+            }
+
+            while (sb.Length > 0 && char.IsWhiteSpace(sb[sb.Length - 1])) {
+                sb.Length -= 1;
+            }
+            return sb.ToString();
+        }
+
+        internal static IEnumerable<string> SplitReprs(string line) {
+            string endQuote = null;
+            var element = new StringBuilder();
+            foreach (var bit in line.Split(',')) {
+                bool added = false;
+
+                if (endQuote == null) {
+                    if (string.IsNullOrEmpty(bit)) {
+                        yield return string.Empty;
+                    } else if (bit.StartsWith("\"") || bit.StartsWith("'")) {
+                        endQuote = bit.Remove(1);
+                        element.Append(bit.Substring(1));
+                        added = true;
+                    } else {
+                        yield return bit;
+                    }
+                }
+
+                if (endQuote != null && bit.EndsWith(endQuote)) {
+                    if (!added) {
+                        element.Append(',');
+                        element.Append(bit);
+                    }
+                    element.Length -= endQuote.Length;
+                    yield return Unescape(element);
+                    endQuote = null;
+                    element.Clear();
+                }
             }
         }
 
-        public string Description {
-            get {
-                return _description;
+        internal static string ReformatStackTrace(PythonProcess process, string data) {
+            var lines = new Stack<IEnumerable<string>>();
+            var sb = new StringBuilder();
+            using (var reader = new StringReader(data)) {
+                for (var line = reader.ReadLine(); line != null; line = reader.ReadLine()) {
+                    lines.Push(SplitReprs(line).ToArray());
+                }
+            }
+
+            foreach(var line in lines) {
+                var filename = line.ElementAtOrDefault(0);
+                var lineNumber = line.ElementAtOrDefault(1);
+                var functionName = line.ElementAtOrDefault(2);
+                //var text = stackLine.ElementAtOrDefault(3);
+
+                int lineNo;
+                if (process != null &&
+                    !string.IsNullOrEmpty(filename) &&
+                    !string.IsNullOrEmpty(lineNumber) &&
+                    int.TryParse(lineNumber, out lineNo) &&
+                    !string.IsNullOrEmpty(functionName)) {
+                    functionName = PythonStackFrame.GetQualifiedFunctionName(process, filename, lineNo, functionName);
+                }
+
+                if (!string.IsNullOrEmpty(filename)) {
+                    sb.Append(filename);
+                    if (!string.IsNullOrEmpty(lineNumber)) {
+                        sb.Append(":");
+                        sb.Append(lineNumber);
+                    }
+                    sb.Append(" in ");
+                }
+
+                if (string.IsNullOrEmpty(functionName)) {
+                    sb.AppendLine("<unknown>");
+                } else {
+                    sb.AppendLine(functionName);
+                }
+            }
+
+            while (sb.Length > 0 && char.IsWhiteSpace(sb[sb.Length - 1])) {
+                sb.Length -= 1;
+            }
+
+            return sb.ToString();
+        }
+
+        public void SetValue(PythonProcess process, string key, string value) {
+            if (string.IsNullOrEmpty(key)) {
+                Debug.Fail("Unexpected empty key");
+                return;
+            }
+            if (value == null) {
+                Debug.Fail("Unexpected null value");
+                return;
+            }
+
+            switch (key.ToLowerInvariant()) {
+                case "typename":
+                    TypeName = value;
+                    break;
+                case "message":
+                    ExceptionMessage = value;
+                    break;
+                case "trace":
+                    StackTrace = ReformatStackTrace(process, value);
+                    break;
+                case "excvalue":
+                    ExceptionObjectExpression = value;
+                    break;
+                case "breaktype":
+                    UserUnhandled = ("unhandled".Equals(value, StringComparison.OrdinalIgnoreCase));
+                    break;
+                default:
+                    Debug.WriteLine("Unexpected key in rich exception: " + key);
+                    break;
             }
         }
     }

--- a/Python/Product/Debugger/Debugger/PythonException.cs
+++ b/Python/Product/Debugger/Debugger/PythonException.cs
@@ -35,8 +35,8 @@ namespace Microsoft.PythonTools.Debugger {
         public string TypeName { get; set; }
         public bool UserUnhandled { get; set; }
 
-        public string GetDescription() {
-            if (!string.IsNullOrEmpty(FormattedDescription)) {
+        public string GetDescription(bool formatted) {
+            if (formatted && !string.IsNullOrEmpty(FormattedDescription)) {
                 return FormattedDescription;
             }
 
@@ -49,11 +49,6 @@ namespace Microsoft.PythonTools.Debugger {
                 }
             } else if (!string.IsNullOrEmpty(ExceptionMessage)) {
                 sb.AppendLine(ExceptionMessage);
-            }
-
-            if (InnerException != null && InnerException != this) {
-                sb.AppendLine("  Inner Exception");
-                sb.AppendLine(InnerException.GetDescription());
             }
 
             return sb.ToString();

--- a/Python/Product/PythonTools/visualstudio_py_debugger.py
+++ b/Python/Product/PythonTools/visualstudio_py_debugger.py
@@ -133,6 +133,8 @@ BREAK_ON_SYSTEMEXIT_ZERO = False
 DEBUG_STDLIB = False
 DJANGO_DEBUG = False
 
+RICH_EXCEPTIONS = False
+
 # Py3k compat - alias unicode to str
 try:
     unicode
@@ -349,6 +351,7 @@ NEWT = to_bytes('NEWT')
 EXTT = to_bytes('EXTT')
 EXIT = to_bytes('EXIT')
 EXCP = to_bytes('EXCP')
+EXC2 = to_bytes('EXC2')
 MODL = to_bytes('MODL')
 STPD = to_bytes('STPD')
 BRKS = to_bytes('BRKS')
@@ -1627,10 +1630,11 @@ class DebuggerLoop(object):
 
     instance = None
 
-    def __init__(self, conn):
+    def __init__(self, conn, rich_exceptions=False):
         DebuggerLoop.instance = self
         self.conn = conn
         self.repl_backend = None
+        self.rich_exceptions = rich_exceptions
         self.command_table = {
             to_bytes('stpi') : self.command_step_into,
             to_bytes('stpo') : self.command_step_out,
@@ -2036,7 +2040,6 @@ def report_thread_exit(old_thread):
 
 def report_exception(frame, exc_info, tid, break_type):
     exc_type = exc_info[0]
-    exc_name = get_exception_name(exc_type)
     exc_value = exc_info[1]
     tb_value = exc_info[2]
     
@@ -2045,14 +2048,34 @@ def report_exception(frame, exc_info, tid, break_type):
         # so we can get the correct msg.
         exc_value = exc_type(*exc_value)
     
-    excp_text = str(exc_value)
+    data = {
+        'typename': get_exception_name(exc_type),
+        'message': str(exc_value),
+    }
+    if break_type == 1:
+        data['breaktype'] = 'unhandled'
+    if tb_value:
+        data['trace'] = '\n'.join(','.join(repr(v) for v in line) for line in traceback.extract_tb(tb_value))
+    if not DJANGO_DEBUG or get_django_frame_source(frame) is None:
+        frame.f_locals['$exception'] = exc_value
+        data['excvalue'] = '$exception'
 
     with _SendLockCtx:
-        write_bytes(conn, EXCP)
-        write_string(conn, exc_name)
-        write_int(conn, tid)
-        write_int(conn, break_type)
-        write_string(conn, excp_text)
+        if RICH_EXCEPTIONS:
+            write_bytes(conn, EXC2)
+            write_int(conn, tid)
+            write_int(conn, len(data))
+            for key, value in data.items():
+                write_string(conn, key)
+                write_string(conn, str(value))
+        else:
+            # Old message is fixed format. If RichExceptions is not passed in
+            # debug options, we'll send this format.
+            write_bytes(conn, EXCP)
+            write_string(conn, str(data['typename']))
+            write_int(conn, tid)
+            write_int(conn, 1 if 'breaktype' in data else 0)
+            write_string(conn, str(data['message']))
 
 def new_module(frame):
     mod = Module(get_code_filename(frame.f_code))
@@ -2225,6 +2248,7 @@ def attach_process(port_num, debug_id, debug_options, report = False, block = Fa
 
 def attach_process_from_socket(sock, debug_options, report = False, block = False):
     global conn, attach_sent_break, DETACHED, DEBUG_STDLIB, BREAK_ON_SYSTEMEXIT_ZERO, DJANGO_DEBUG
+    global RICH_EXCEPTIONS
 
     BREAK_ON_SYSTEMEXIT_ZERO = 'BreakOnSystemExitZero' in debug_options
     DJANGO_DEBUG = 'DjangoDebugging' in debug_options
@@ -2238,6 +2262,8 @@ def attach_process_from_socket(sock, debug_options, report = False, block = Fals
 
     wait_on_normal_exit = 'WaitOnNormalExit' in debug_options
     wait_on_abnormal_exit = 'WaitOnAbnormalExit' in debug_options
+
+    RICH_EXCEPTIONS = 'RichExceptions' in debug_options
 
     def _excepthook(exc_type, exc_value, exc_tb):
         # Display the exception and wait on exit

--- a/Python/Product/PythonTools/visualstudio_py_debugger.py
+++ b/Python/Product/PythonTools/visualstudio_py_debugger.py
@@ -2055,10 +2055,21 @@ def report_exception(frame, exc_info, tid, break_type):
     if break_type == 1:
         data['breaktype'] = 'unhandled'
     if tb_value:
-        data['trace'] = '\n'.join(','.join(repr(v) for v in line) for line in traceback.extract_tb(tb_value))
+        try:
+            data['trace'] = '\n'.join(','.join(repr(v) for v in line) for line in traceback.extract_tb(tb_value))
+        except:
+            pass
     if not DJANGO_DEBUG or get_django_frame_source(frame) is None:
-        frame.f_locals['$exception'] = exc_value
-        data['excvalue'] = '$exception'
+        data['excvalue'] = '__exception_info'
+        i = 0
+        while data['excvalue'] in frame.f_locals:
+            i += 1
+            data['excvalue'] = '__exception_info_%d' % i
+        frame.f_locals[data['excvalue']] = {
+            'exception': exc_value,
+            'exception_type': exc_type,
+            'message': data['message'],
+        }
 
     with _SendLockCtx:
         if RICH_EXCEPTIONS:


### PR DESCRIPTION
Fixes #1916 Exception popup doesn't show exception name
Provides detailed information to the new exception dialog in VS 2017
Adds a new (optional) exception message format to ptvsd.

This is still in validation, but feel free to weigh in with comments.