### PR TITLE
Improve cookiecutter installation message.

### DIFF
--- a/Python/Product/Cookiecutter/View/CookiecutterSearchPage.xaml
+++ b/Python/Product/Cookiecutter/View/CookiecutterSearchPage.xaml
@@ -221,7 +221,11 @@
                         Orientation="Vertical"
                         Visibility="{Binding Path=InstallingStatus, Converter={StaticResource OperationStatusInProgressToVisibleOrCollapsed}}">
                 <Separator/>
-                <TextBlock Text="Installing cookiecutter..."/>
+                <TextBlock Text="Preparing cookiecutter for first time use...">
+                    <TextBlock.ToolTip>
+                        Downloading and installing the cookiecutter package from the Python Package Index. This may take a few minutes.
+                    </TextBlock.ToolTip>
+                </TextBlock>
                 <ProgressBar Margin="4" IsIndeterminate="True"/>
             </StackPanel>
 


### PR DESCRIPTION
Fix https://github.com/Microsoft/PTVS/issues/1941 Potentially confusing cloning status message: "installing cookiecutter..."
