### PR TITLE
Issue 1911

### DIFF
--- a/Python/Product/Analysis/Interpreter/InterpreterArchitecture.cs
+++ b/Python/Product/Analysis/Interpreter/InterpreterArchitecture.cs
@@ -20,7 +20,11 @@ using System.Reflection;
 using Microsoft.PythonTools.Infrastructure;
 
 namespace Microsoft.PythonTools.Interpreter {
-    public abstract class InterpreterArchitecture : IFormattable, IComparable<InterpreterArchitecture> {
+    public abstract class InterpreterArchitecture : 
+        IFormattable,
+        IComparable<InterpreterArchitecture>,
+        IEquatable<InterpreterArchitecture>
+    {
         protected abstract bool Equals(string value);
 
         public virtual string ToString(string format, IFormatProvider formatProvider, string defaultString) {
@@ -120,6 +124,14 @@ namespace Microsoft.PythonTools.Interpreter {
 
             return GetType().Name.CompareTo(other.GetType().Name);
         }
+
+        public static bool operator ==(InterpreterArchitecture x, InterpreterArchitecture y)
+            => x?.Equals(y) ?? object.ReferenceEquals(y, null);
+        public static bool operator !=(InterpreterArchitecture x, InterpreterArchitecture y)
+            => !(x?.Equals(y) ?? object.ReferenceEquals(y, null));
+        public override bool Equals(object obj) => Equals(obj as InterpreterArchitecture);
+        public bool Equals(InterpreterArchitecture other) => other != null && GetType().IsEquivalentTo(other.GetType());
+        public override int GetHashCode() => GetType().GetHashCode();
 
         private sealed class UnknownArchitecture : InterpreterArchitecture {
             public UnknownArchitecture() { }

--- a/Python/Product/Analysis/Interpreter/InterpreterConfiguration.cs
+++ b/Python/Product/Analysis/Interpreter/InterpreterConfiguration.cs
@@ -17,7 +17,7 @@
 using System;
 
 namespace Microsoft.PythonTools.Interpreter {
-    public sealed class InterpreterConfiguration {
+    public sealed class InterpreterConfiguration : IEquatable<InterpreterConfiguration> {
         /// <summary>
         /// <para>Constructs a new interpreter configuration based on the
         /// provided values.</para>
@@ -100,8 +100,14 @@ namespace Microsoft.PythonTools.Interpreter {
         /// </remarks>
         public InterpreterUIMode UIMode { get; }
 
-        public override bool Equals(object obj) {
-            var other = obj as InterpreterConfiguration;
+        public static bool operator ==(InterpreterConfiguration x, InterpreterConfiguration y)
+            => x?.Equals(y) ?? object.ReferenceEquals(y, null);
+        public static bool operator !=(InterpreterConfiguration x, InterpreterConfiguration y)
+            => !(x?.Equals(y) ?? object.ReferenceEquals(y, null));
+
+        public override bool Equals(object obj) => Equals(obj as InterpreterConfiguration);
+
+        public bool Equals(InterpreterConfiguration other) {
             if (other == null) {
                 return false;
             }

--- a/Python/Product/Common/Infrastructure/ObservableCollectionExtensions.cs
+++ b/Python/Product/Common/Infrastructure/ObservableCollectionExtensions.cs
@@ -60,5 +60,50 @@ namespace Microsoft.PythonTools.Infrastructure {
                 left.Insert(index, item);
             }
         }
+
+        public static void Merge<TLeft, TRight, TKey>(
+            this ObservableCollection<TLeft> left,
+            IEnumerable<TRight> right,
+            Func<TLeft, TKey> getLeftKey,
+            Func<TRight, TKey> getRightKey,
+            Func<TRight, TLeft> project,
+            IEqualityComparer<TKey> compareId,
+            IComparer<TKey> compareSortKey
+        ) {
+            var toAdd = new SortedList<TKey, TRight>(compareSortKey);
+            var toRemove = new Dictionary<TKey, int>(compareId);
+            var alsoRemove = new List<int>();
+            int index = 0;
+            foreach (var item in left) {
+                var key = getLeftKey(item);
+                if (toRemove.ContainsKey(key)) {
+                    alsoRemove.Add(index);
+                } else {
+                    toRemove[key] = index;
+                }
+                index += 1;
+            }
+
+            foreach (var r in right.OrderBy(getRightKey, compareSortKey)) {
+                var key = getRightKey(r);
+                if (toRemove.TryGetValue(key, out index)) {
+                    toRemove.Remove(key);
+                } else {
+                    toAdd[key] = r;
+                }
+            }
+
+            foreach (var removeAt in toRemove.Values.Concat(alsoRemove).OrderByDescending(i => i)) {
+                left.RemoveAt(removeAt);
+            }
+
+            index = 0;
+            foreach (var item in toAdd.Values) {
+                while (index < left.Count && compareSortKey.Compare(getLeftKey(left[index]), getRightKey(item)) <= 0) {
+                    index += 1;
+                }
+                left.Insert(index, project(item));
+            }
+        }
     }
 }

--- a/Python/Product/EnvironmentsList/EnvironmentView.cs
+++ b/Python/Product/EnvironmentsList/EnvironmentView.cs
@@ -83,11 +83,14 @@ namespace Microsoft.PythonTools.EnvironmentsList {
             if (factory == null) {
                 throw new ArgumentNullException(nameof(factory));
             }
+            if (factory.Configuration == null) {
+                throw new ArgumentException("factory must include a configuration");
+            }
 
             _service = service;
             _registry = registry;
             Factory = factory;
-            Configuration = Factory?.Configuration;
+            Configuration = Factory.Configuration;
 
             _withDb = factory as IPythonInterpreterFactoryWithDatabase;
             if (_withDb != null) {
@@ -97,12 +100,12 @@ namespace Microsoft.PythonTools.EnvironmentsList {
             }
             
 
-            if (_service.IsConfigurable(factory.Configuration.Id)) {
+            if (_service.IsConfigurable(Factory.Configuration.Id)) {
                 IsConfigurable = true;
             }
 
             Description = Factory.Configuration.Description;
-            IsDefault = (_service != null && _service.DefaultInterpreter == Factory);
+            IsDefault = (_service != null && _service.DefaultInterpreterId == Configuration.Id);
 
             PrefixPath = Factory.Configuration.PrefixPath;
             InterpreterPath = Factory.Configuration.InterpreterPath;
@@ -130,13 +133,14 @@ namespace Microsoft.PythonTools.EnvironmentsList {
         public static bool IsAddNewEnvironmentView(string id) => AddNewEnvironmentViewId.Equals(id);
         public static bool IsOnlineHelpView(string id) => OnlineHelpViewId.Equals(id);
 
-        public static bool IsAddNewEnvironmentView(EnvironmentView view) => AddNewEnvironmentViewId.Equals(view?.Configuration?.Id);
-        public static bool IsOnlineHelpView(EnvironmentView view) => OnlineHelpViewId.Equals(view?.Configuration?.Id);
+        public static bool IsAddNewEnvironmentView(EnvironmentView view) => AddNewEnvironmentViewId.Equals(view?.Configuration.Id);
+        public static bool IsOnlineHelpView(EnvironmentView view) => OnlineHelpViewId.Equals(view?.Configuration.Id);
 
         public override string ToString() {
             return string.Format(
-                "{{{0}:{1}}}", GetType().FullName,
-                _withDb == null ? "(null)" : _withDb.Configuration.Description
+                "{{{0}:{1}}}",
+                GetType().FullName,
+                _withDb?.Configuration.Description ??"(null)"
             );
         }
 

--- a/Python/Product/EnvironmentsList/ToolWindow.xaml.cs
+++ b/Python/Product/EnvironmentsList/ToolWindow.xaml.cs
@@ -534,17 +534,8 @@ namespace Microsoft.PythonTools.EnvironmentsList {
         class InterpreterConfigurationComparer : IEqualityComparer<InterpreterConfiguration>, IComparer<InterpreterConfiguration> {
             public static readonly InterpreterConfigurationComparer Instance = new InterpreterConfigurationComparer();
 
-            public bool Equals(InterpreterConfiguration x, InterpreterConfiguration y) {
-                if (object.ReferenceEquals(x, y)) {
-                    return true;
-                }
-
-                return x?.Id == y?.Id;
-            }
-
-            public int GetHashCode(InterpreterConfiguration obj) {
-                return obj.Id.GetHashCode();
-            }
+            public bool Equals(InterpreterConfiguration x, InterpreterConfiguration y) => x == y;
+            public int GetHashCode(InterpreterConfiguration obj) => obj.GetHashCode();
 
             public int Compare(InterpreterConfiguration x, InterpreterConfiguration y) {
                 if (object.ReferenceEquals(x, y)) {

--- a/Python/Product/PythonTools/PythonTools/Project/AddInterpreterView.cs
+++ b/Python/Product/PythonTools/PythonTools/Project/AddInterpreterView.cs
@@ -18,24 +18,15 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
-using System.Diagnostics;
-using System.Globalization;
-using System.IO;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows;
-using Microsoft.PythonTools.Analysis;
+using Microsoft.PythonTools.Infrastructure;
 using Microsoft.PythonTools.Interpreter;
-using Microsoft.PythonTools.InterpreterList;
-using Microsoft.VisualStudio.PlatformUI;
-using Microsoft.VisualStudioTools;
 
 namespace Microsoft.PythonTools.Project {
     sealed class AddInterpreterView : DependencyObject, INotifyPropertyChanged, IDisposable {
         private readonly PythonProjectNode _project;
 
-        
         public AddInterpreterView(
             PythonProjectNode project,
             IServiceProvider serviceProvider,

--- a/Python/Product/VSInterpreters/InterpreterOptionsService.cs
+++ b/Python/Product/VSInterpreters/InterpreterOptionsService.cs
@@ -21,6 +21,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Threading;
 using Microsoft.Win32;
 
 namespace Microsoft.PythonTools.Interpreter {
@@ -34,6 +35,9 @@ namespace Microsoft.PythonTools.Interpreter {
         IPythonInterpreterFactory _defaultInterpreter;
         private readonly object _defaultInterpreterLock = new object();
         private EventHandler _defaultInterpreterChanged;
+
+        private int _requireDefaultInterpreterChangeEvent;
+        private int _suppressDefaultInterpreterChangeEvent;
 
         // The second is a static registry entry for the local machine and/or
         // the current user (HKCU takes precedence), intended for being set by
@@ -62,6 +66,8 @@ namespace Microsoft.PythonTools.Interpreter {
 
 
         private void InitializeDefaultInterpreterWatcher() {
+            Debug.Assert(!_defaultInterpreterWatched);
+
             _registryService.Value.InterpretersChanged += Provider_InterpreterFactoriesChanged;
 
             RegistryHive hive = RegistryHive.CurrentUser;
@@ -73,7 +79,7 @@ namespace Microsoft.PythonTools.Interpreter {
             ) == null) {
                 // DefaultInterpreterOptions subkey does not exist yet, so
                 // create it and then start the watcher.
-                SaveDefaultInterpreter(_defaultInterpreter?.Configuration?.Id);
+                SaveDefaultInterpreterId();
 
                 RegistryWatcher.Instance.Add(
                     hive, view, DefaultInterpreterOptionsCollection,
@@ -86,24 +92,12 @@ namespace Microsoft.PythonTools.Interpreter {
 
         private void Provider_InterpreterFactoriesChanged(object sender, EventArgs e) {
             // reload the default interpreter ID and see if it changed...
-            string oldId = _defaultInterpreterId;
-            _defaultInterpreterId = null;
-            LoadDefaultInterpreterId();
-
-            if (oldId != _defaultInterpreterId) {
-                // it changed, invalidate the old interpreter ID.  If no one is watching then
-                // we'll just load it on demand next time someone requests it.
-                _defaultInterpreter = null;
-                if (_defaultInterpreterWatched) {
-                    // someone is watching it, so load it now and raise the changed event.
-                    LoadDefaultInterpreter();
-                }
-            }
+            SetDefaultInterpreter(LoadDefaultInterpreterId(), null);
         }
 
         private void DefaultInterpreterRegistry_Changed(object sender, RegistryChangedEventArgs e) {
             try {
-                LoadDefaultInterpreter();
+                SetDefaultInterpreter(LoadDefaultInterpreterId(), null);
             } catch (InvalidComObjectException) {
                 // Race between VS closing and accessing the settings store.
             } catch (Exception ex) {
@@ -122,69 +116,72 @@ namespace Microsoft.PythonTools.Interpreter {
             }
         }
 
-        private void LoadDefaultInterpreterId() {
-            if (_defaultInterpreterId != null) {
-                return;
+        private string LoadDefaultInterpreterId() {
+            string id;
+            using (var interpreterOptions = Registry.CurrentUser.OpenSubKey(DefaultInterpreterOptionsCollection)) {
+                id = interpreterOptions?.GetValue(DefaultInterpreterSetting) as string;
             }
 
-            lock (_defaultInterpreterLock) {
-                if (_defaultInterpreterId != null) {
-                    return;
+            if (string.IsNullOrEmpty(id)) {
+                return null;
+            }
+
+            InterpreterConfiguration newDefault = null;
+            if (!string.IsNullOrEmpty(id)) {
+                newDefault = _registryService.Value.FindConfiguration(id);
+            }
+
+            if (newDefault == null) {
+                var defaultConfig = _registryService.Value.Configurations.LastOrDefault(c => c.CanBeAutoDefault());
+                id = defaultConfig?.Id;
+            }
+
+            return id;
+        }
+
+        private void SaveDefaultInterpreterId() {
+            var id = _defaultInterpreterId;
+
+            BeginSuppressDefaultInterpreterChangeEvent();
+            try {
+                using (var interpreterOptions = Registry.CurrentUser.CreateSubKey(DefaultInterpreterOptionsCollection, true)) {
+                    if (string.IsNullOrEmpty(id)) {
+                        interpreterOptions.SetValue(DefaultInterpreterSetting, "");
+                    } else {
+                        Debug.Assert(!InterpreterRegistryConstants.IsNoInterpretersFactory(id));
+
+                        interpreterOptions.SetValue(DefaultInterpreterSetting, id);
+                    }
                 }
+            } finally {
+                EndSuppressDefaultInterpreterChangeEvent();
+            }
+        }
 
-                string id = null;
-                using (var interpreterOptions = Registry.CurrentUser.OpenSubKey(DefaultInterpreterOptionsCollection)) {
-                    if (interpreterOptions != null) {
-                        id = interpreterOptions.GetValue(DefaultInterpreterSetting) as string ?? string.Empty;
+        private void SetDefaultInterpreter(string id, IPythonInterpreterFactory factory) {
+            id = id ?? factory?.Configuration?.Id ?? string.Empty;
+
+            BeginSuppressDefaultInterpreterChangeEvent();
+            try {
+                lock (_defaultInterpreterLock) {
+                    if (_defaultInterpreterId == id) {
+                        return;
+                    }
+                    if (string.IsNullOrEmpty(id) && _defaultInterpreterId == null) {
+                        return;
                     }
 
-                    var newDefault = _registryService.Value.FindInterpreter(id);
-
-                    if (newDefault == null) {
-                        var defaultConfig = _registryService.Value.Configurations.LastOrDefault(fact => fact.CanBeAutoDefault());
-                        id = defaultConfig?.Id;
+                    if (string.IsNullOrEmpty(id)) {
+                        _defaultInterpreter = null;
+                    } else {
+                        _defaultInterpreter = factory;
                     }
-
                     _defaultInterpreterId = id;
+                    SaveDefaultInterpreterId();
                 }
-            }
-        }
-
-        private void LoadDefaultInterpreter(bool suppressChangeEvent = false) {
-            if (_defaultInterpreter != null) {
-                return;
-            }
-
-            IPythonInterpreterFactory newDefault = null;
-            lock (_defaultInterpreterLock) {
-                if (_defaultInterpreter != null) {
-                    return;
-                }
-
-                LoadDefaultInterpreterId();
-                if (_defaultInterpreterId != null) {
-                    newDefault = _registryService.Value.FindInterpreter(_defaultInterpreterId);
-                }
-            }
-
-            if (newDefault != null) {
-                if (suppressChangeEvent) {
-                    _defaultInterpreter = newDefault;
-                } else {
-                    DefaultInterpreter = newDefault;
-                }
-            }
-        }
-
-        private void SaveDefaultInterpreter(string id) {
-            using (var interpreterOptions = Registry.CurrentUser.CreateSubKey(DefaultInterpreterOptionsCollection, true)) {
-                if (id == null) {
-                    interpreterOptions.SetValue(DefaultInterpreterSetting, "");
-                } else {
-                    Debug.Assert(!InterpreterRegistryConstants.IsNoInterpretersFactory(id));
-
-                    interpreterOptions.SetValue(DefaultInterpreterSetting, id);
-                }
+                OnDefaultInterpreterChanged();
+            } finally {
+                EndSuppressDefaultInterpreterChangeEvent();
             }
         }
 
@@ -194,40 +191,60 @@ namespace Microsoft.PythonTools.Interpreter {
                 return _defaultInterpreterId;
             }
             set {
-                if (_defaultInterpreterId != value) {
-                    _defaultInterpreterId = value;
-                    _defaultInterpreter = null; // cleared so we'll re-initialize if anyone cares about it.
-                    SaveDefaultInterpreter(value);
-
-                    _defaultInterpreterChanged?.Invoke(this, EventArgs.Empty);
-                }
+                SetDefaultInterpreter(value, null);
             }
         }
 
         public IPythonInterpreterFactory DefaultInterpreter {
             get {
-                LoadDefaultInterpreter(true);
+                IPythonInterpreterFactory factory = _defaultInterpreter;
+                if (factory != null) {
+                    // We've loaded and found the factory already
+                    return factory;
+                }
+                if (_defaultInterpreterId == string.Empty) {
+                    // We've loaded, and there's nothing there
+                    return _registryService.Value.NoInterpretersValue;
+                }
+                lock (_defaultInterpreterLock) {
+                    if (_defaultInterpreterId == null) {
+                        // We haven't loaded yet
+                        LoadDefaultInterpreterId();
+                    }
+                    if (_defaultInterpreter == null && !string.IsNullOrEmpty(_defaultInterpreterId)) {
+                        // We've loaded but haven't found the factory yet
+                        _defaultInterpreter = _registryService.Value.FindInterpreter(_defaultInterpreterId);
+                    }
+                }
                 return _defaultInterpreter ?? _registryService.Value.NoInterpretersValue;
             }
             set {
                 var newDefault = value;
-                if (_defaultInterpreter == null && (newDefault == _registryService.Value.NoInterpretersValue || value == null)) {
-                    // we may have not loaded the default interpreter yet.  Do so 
-                    // now so we know if we need to raise the change event.
-                    LoadDefaultInterpreter();
-                }
-
                 if (newDefault == _registryService.Value.NoInterpretersValue) {
                     newDefault = null;
                 }
-                if (newDefault != _defaultInterpreter) {
-                    _defaultInterpreter = newDefault;
-                    _defaultInterpreterId = _defaultInterpreter?.Configuration?.Id;
-                    SaveDefaultInterpreter(_defaultInterpreter?.Configuration?.Id);
-
-                    _defaultInterpreterChanged?.Invoke(this, EventArgs.Empty);
-                }
+                SetDefaultInterpreter(null, newDefault);
             }
+        }
+
+        private void BeginSuppressDefaultInterpreterChangeEvent() {
+            Interlocked.Increment(ref _suppressDefaultInterpreterChangeEvent);
+        }
+
+        private void EndSuppressDefaultInterpreterChangeEvent() {
+            if (0 == Interlocked.Decrement(ref _suppressDefaultInterpreterChangeEvent) &&
+                0 != Interlocked.Exchange(ref _requireDefaultInterpreterChangeEvent, 0)) {
+                _defaultInterpreterChanged?.Invoke(this, EventArgs.Empty);
+            }
+        }
+
+        private void OnDefaultInterpreterChanged() {
+            if (Volatile.Read(ref _suppressDefaultInterpreterChangeEvent) != 0) {
+                Volatile.Write(ref _requireDefaultInterpreterChangeEvent, 1);
+                return;
+            }
+
+            _defaultInterpreterChanged?.Invoke(this, EventArgs.Empty);
         }
 
         public event EventHandler DefaultInterpreterChanged {
@@ -280,7 +297,6 @@ namespace Microsoft.PythonTools.Interpreter {
             }
 
             return CPythonInterpreterFactoryConstants.GetInterpreterId(CustomCompany, name);
-
         }
 
         public void RemoveConfigurableInterpreter(string id) {
@@ -288,11 +304,13 @@ namespace Microsoft.PythonTools.Interpreter {
             if (CPythonInterpreterFactoryConstants.TryParseInterpreterId(id, out company, out tag) &&
                 company == CustomCompany) {
                 var collection = CustomInterpreterKey + "\\" + tag;
-                try {
-                    Registry.CurrentUser.DeleteSubKeyTree(collection);
+                using (_cpythonProvider.Value.SuppressDiscoverFactories()) {
+                    try {
+                        Registry.CurrentUser.DeleteSubKeyTree(collection);
 
-                    _cpythonProvider.Value.DiscoverInterpreterFactories();
-                } catch (ArgumentException) {
+                        _cpythonProvider.Value.DiscoverInterpreterFactories();
+                    } catch (ArgumentException) {
+                    }
                 }
             }
         }

--- a/Python/Product/VSInterpreters/InterpreterOptionsService.cs
+++ b/Python/Product/VSInterpreters/InterpreterOptionsService.cs
@@ -187,7 +187,9 @@ namespace Microsoft.PythonTools.Interpreter {
 
         public string DefaultInterpreterId {
             get {
-                LoadDefaultInterpreterId();
+                if (_defaultInterpreterId == null) {
+                    _defaultInterpreterId = LoadDefaultInterpreterId();
+                }
                 return _defaultInterpreterId;
             }
             set {
@@ -209,7 +211,7 @@ namespace Microsoft.PythonTools.Interpreter {
                 lock (_defaultInterpreterLock) {
                     if (_defaultInterpreterId == null) {
                         // We haven't loaded yet
-                        LoadDefaultInterpreterId();
+                        _defaultInterpreterId = LoadDefaultInterpreterId();
                     }
                     if (_defaultInterpreter == null && !string.IsNullOrEmpty(_defaultInterpreterId)) {
                         // We've loaded but haven't found the factory yet

--- a/Python/Product/VSInterpreters/PythonRegistrySearch.cs
+++ b/Python/Product/VSInterpreters/PythonRegistrySearch.cs
@@ -180,6 +180,9 @@ namespace Microsoft.PythonTools.Interpreter {
                 tag += "-32";
             }
 
+            var pathVar = tagKey.GetValue("PathEnvironmentVariable") as string ??
+                CPythonInterpreterFactoryConstants.PathEnvironmentVariableName;
+
             var id = CPythonInterpreterFactoryConstants.GetInterpreterId(company, tag);
 
             var description = tagKey.GetValue("DisplayName") as string;
@@ -197,7 +200,7 @@ namespace Microsoft.PythonTools.Interpreter {
                 prefixPath,
                 exePath,
                 exewPath,
-                CPythonInterpreterFactoryConstants.PathEnvironmentVariableName,
+                pathVar,
                 arch,
                 sysVersion
             );

--- a/Python/Tests/Core/EnvironmentListTests.cs
+++ b/Python/Tests/Core/EnvironmentListTests.cs
@@ -952,8 +952,7 @@ namespace PythonToolsUITests {
                 get {
                     return _proxy.Invoke(() =>
                         Window._environments
-                            .Where(ev => !ev._addNewEnvironmentView)
-                            .Except(EnvironmentView.OnlineHelpViewOnce.Value)
+                            .Where(ev => !EnvironmentView.IsAddNewEnvironmentView(ev) && !EnvironmentView.IsOnlineHelpView(ev))
                             .ToList()
                     );
                 }
@@ -961,7 +960,7 @@ namespace PythonToolsUITests {
 
             public EnvironmentView AddNewEnvironmentView {
                 get {
-                    return _proxy.Invoke(() => Window._environments.Single(ev => ev._addNewEnvironmentView));
+                    return _proxy.Invoke(() => Window._environments.Single(ev => EnvironmentView.IsAddNewEnvironmentView(ev)));
                 }
             }
 


### PR DESCRIPTION
Fixes #1911 Default environment does not stick
Fixes issue where we were recreating environment views too often.
Simplifies default interpreter handling to avoid cyclic and repeated event triggers.