### PR TITLE
Fixes #1939 MMD breakpoint in Python file gives weird call stack

### DIFF
--- a/Python/Setup/swix/Packages/Microsoft.PythonTools.Core.Vsix.swixproj
+++ b/Python/Setup/swix/Packages/Microsoft.PythonTools.Core.Vsix.swixproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <Package Include="file_associations.swr" />
+    <Package Include="debug_symbols.swr" />
     <Package Include="targets.swr" />
   </ItemGroup>
 

--- a/Python/Setup/swix/Packages/debug_symbols.swr
+++ b/Python/Setup/swix/Packages/debug_symbols.swr
@@ -1,0 +1,4 @@
+﻿
+folder "InstallDir:\Common7\IDE\Extensions\Microsoft\Python\Core"
+  file source="$(LayoutOutputPath)\Microsoft.PythonTools.Core\Microsoft.PythonTools.Debugger.Helper.x64.pdb"
+  file source="$(LayoutOutputPath)\Microsoft.PythonTools.Core\Microsoft.PythonTools.Debugger.Helper.x86.pdb"


### PR DESCRIPTION
Fixes #1939 MMD breakpoint in Python file gives weird call stack
Ensures the symbols for Microsoft.PythonTools.Debugger.Helper are included.