### PR TITLE
Fixes #1913 Installing packages sometimes causes a crash

### DIFF
--- a/Python/Product/EnvironmentsList/PipExtension.xaml.cs
+++ b/Python/Product/EnvironmentsList/PipExtension.xaml.cs
@@ -180,9 +180,9 @@ namespace Microsoft.PythonTools.EnvironmentsList {
 
     sealed class PipEnvironmentView : DependencyObject, IDisposable {
         private readonly EnvironmentView _view;
-        private ObservableCollection<PipPackageView> _installed;
-        private List<PackageResultView> _installable;
-        private List<PackageResultView> _installableFiltered;
+        private readonly ObservableCollection<PipPackageView> _installed;
+        private readonly List<PackageResultView> _installable;
+        private readonly ObservableCollection<PackageResultView> _installableFiltered;
         private CollectionViewSource _installedView;
         private CollectionViewSource _installableView;
         private readonly Timer _installableViewRefreshTimer;
@@ -208,7 +208,7 @@ namespace Microsoft.PythonTools.EnvironmentsList {
             _installedView.Filter += InstalledView_Filter;
             _installedView.View.CurrentChanged += InstalledView_CurrentChanged;
             _installable = new List<PackageResultView>();
-            _installableFiltered = new List<PackageResultView>();
+            _installableFiltered = new ObservableCollection<PackageResultView>();
             _installableView = new CollectionViewSource { Source = _installableFiltered };
             _installableView.View.CurrentChanged += InstallableView_CurrentChanged;
             _installableViewRefreshTimer = new Timer(InstallablePackages_Refresh);
@@ -321,22 +321,27 @@ namespace Microsoft.PythonTools.EnvironmentsList {
                 ToolWindow.SendUnhandledException(_provider.WpfObject, ExceptionDispatchInfo.Capture(ex));
             }
 
+            PackageResultView[] installable = null;
+
             lock (_installable) {
-                _installableFiltered.Clear();
                 if (_installable.Any() && !string.IsNullOrEmpty(query)) {
-                    _installableFiltered.AddRange(
-                        _installable
-                            .Select(p => Tuple.Create(_matcher.GetSortKey(p.Package.PackageSpec, query), p))
-                            .Where(t => _matcher.IsCandidateMatch(t.Item2.Package.PackageSpec, query, t.Item1))
-                            .OrderByDescending(t => t.Item1)
-                            .Select(t => t.Item2)
-                            .Take(20)
-                    );
+                    installable = _installable
+                        .Select(p => Tuple.Create(_matcher.GetSortKey(p.Package.PackageSpec, query), p))
+                        .Where(t => _matcher.IsCandidateMatch(t.Item2.Package.PackageSpec, query, t.Item1))
+                        .OrderByDescending(t => t.Item1)
+                        .Select(t => t.Item2)
+                        .Take(20)
+                        .ToArray();
                 }
             }
 
             try {
                 await Dispatcher.InvokeAsync(() => {
+                    if (installable != null && installable.Any()) {
+                        _installableFiltered.Merge(installable, PackageViewComparer.Instance, PackageViewComparer.Instance);
+                    } else {
+                        _installableFiltered.Clear();
+                    }
                     _installableView.View.Refresh();
                 });
             } catch (OperationCanceledException) {


### PR DESCRIPTION
Fixes #1913 Installing packages sometimes causes a crash
Ensures package search results are only updated on the UI thread.