### PR TITLE
Fixes #1931 Packages list not synced after pip install

### DIFF
--- a/Python/Product/EnvironmentsList/PipExtensionProvider.cs
+++ b/Python/Product/EnvironmentsList/PipExtensionProvider.cs
@@ -197,6 +197,11 @@ namespace Microsoft.PythonTools.EnvironmentsList {
             OperationFinished?.Invoke(this, new OperationFinishedEventArgs(operation, success));
         }
 
+        public event EventHandler InstalledPackagesChanged {
+            add { _packageManager.InstalledPackagesChanged += value; }
+            remove { _packageManager.InstalledPackagesChanged -= value; }
+        }
+
         sealed class CallOnDispose : IDisposable {
             private readonly Action _action;
             public CallOnDispose(Action action) { _action = action; }


### PR DESCRIPTION
Fixes #1931 Packages list not synced after pip install
Subscribes to the "installed packages changed" event to update the environments window list of packages.