### PR TITLE
Fixes #1864 Missing environments are no longer show in solution explorer

### DIFF
--- a/Python/Product/Common/Strings.Designer.cs
+++ b/Python/Product/Common/Strings.Designer.cs
@@ -670,6 +670,15 @@ namespace Microsoft.PythonTools {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to &apos;{0}&apos; will be removed from the project and all its contents will be deleted from disk..
+        /// </summary>
+        public static string EnvironmentDeleteConfirmation_NoPath {
+            get {
+                return ResourceManager.GetString("EnvironmentDeleteConfirmation_NoPath", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to We weren&apos;t able to delete all the files from {0}.
         ///
         ///Some files may need to be removed manually..
@@ -1280,6 +1289,15 @@ namespace Microsoft.PythonTools {
         public static string MissingEnvironmentUnknownVersion {
             get {
                 return ResourceManager.GetString("MissingEnvironmentUnknownVersion", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to  (missing).
+        /// </summary>
+        public static string MissingSuffix {
+            get {
+                return ResourceManager.GetString("MissingSuffix", resourceCulture);
             }
         }
         

--- a/Python/Product/Common/Strings.resx
+++ b/Python/Product/Common/Strings.resx
@@ -542,6 +542,7 @@ Packages that cannot be installed using pip may prevent all listed packages from
   </data>
   <data name="GlobalDefaultSuffix" xml:space="preserve">
     <value> (global default)</value>
+    <comment>Leading space is important</comment>
   </data>
   <data name="UpgradedRemoveCommonProps" xml:space="preserve">
     <value>This project has had old build references removed and may no longer work with prior PTVS versions.</value>
@@ -1053,5 +1054,12 @@ Please refer to &lt;a href="https://aka.ms/pythononappservice"&gt;aka.ms/PythonO
   </data>
   <data name="RemoteUnsupportedServer_Host" xml:space="preserve">
     <value>The remote server at {0} is not running a remote debugging server, or it is running an unsupported version.</value>
+  </data>
+  <data name="EnvironmentDeleteConfirmation_NoPath" xml:space="preserve">
+    <value>'{0}' will be removed from the project and all its contents will be deleted from disk.</value>
+  </data>
+  <data name="MissingSuffix" xml:space="preserve">
+    <value> (missing)</value>
+    <comment>Leading space is important</comment>
   </data>
 </root>

--- a/Python/Product/PythonTools/PythonTools/InterpreterView.cs
+++ b/Python/Product/PythonTools/PythonTools/InterpreterView.cs
@@ -22,216 +22,66 @@ using System.IO;
 using System.Linq;
 using System.Windows;
 using Microsoft.PythonTools.Analysis.Analyzer;
+using Microsoft.PythonTools.Infrastructure;
 using Microsoft.PythonTools.Interpreter;
 using Microsoft.PythonTools.Project;
 
 namespace Microsoft.PythonTools {
-    internal class InterpreterView : DependencyObject, INotifyPropertyChanged {
-        private readonly string _identifier;
-        private DateTime _expectFirstUpdateBy;
-        private bool _isRunning;
-
+    internal class InterpreterView : DependencyObject {
         public static readonly IEqualityComparer<InterpreterView> EqualityComparer = new InterpreterViewComparer();
         public static readonly IComparer<InterpreterView> Comparer = (IComparer<InterpreterView>)EqualityComparer;
 
         public static IEnumerable<InterpreterView> GetInterpreters(
             IServiceProvider serviceProvider,
-            PythonProjectNode project
+            PythonProjectNode project, 
+            bool onlyGlobalEnvironments = false
         ) {
             var knownProviders = serviceProvider.GetComponentModel().GetService<IInterpreterRegistryService>();
 
-            return knownProviders
-                .Interpreters
-                .Where(p => !p.Configuration.Id.StartsWith("MSBuild|"))
+            var res = knownProviders.Configurations
                 .Where(PythonInterpreterFactoryExtensions.IsUIVisible)
-                .OrderBy(fact => fact.Configuration.Description)
-                .ThenBy(fact => fact.Configuration.Version)
-                .Select(i => new InterpreterView(i, i.Configuration.Description, i == project.ActiveInterpreter));
+                .OrderBy(c => c.Description)
+                .ThenBy(c => c.Version)
+                .Select(c => new InterpreterView(c.Id, c.Description, project));
+
+            if (onlyGlobalEnvironments) {
+                res = res.Where(v => string.IsNullOrEmpty(knownProviders.GetProperty(v.Id, "ProjectMoniker") as string));
+            }
+
+            if (project != null) {
+                res = res.Concat(project.InvalidInterpreterIds
+                    .Select(i => new InterpreterView(i, FormatInvalidId(i), project))
+                    .OrderBy(v => v.Name));
+            }
+
+            return res;
         }
 
-        public InterpreterView(IPythonInterpreterFactory interpreter, string name, PythonProjectNode project)
-            : this(interpreter, name, false) {
+        private static string FormatInvalidId(string id) {
+            string company, tag;
+            if (CPythonInterpreterFactoryConstants.TryParseInterpreterId(id, out company, out tag)) {
+                if (company == PythonRegistrySearch.PythonCoreCompany) {
+                    company = "Python";
+                }
+                return "{0} {1}".FormatUI(company, tag);
+            }
+            return id;
+        }
+
+        public InterpreterView(string id, string name, PythonProjectNode project) {
+            Id = id;
+            Name = name;
             Project = project;
-            if (Project != null) {
-                CanBeDefault = false;
-                SubName = project.Caption;
-            }
         }
 
-        public InterpreterView(IPythonInterpreterFactory interpreter, string name, bool isDefault) {
-            Interpreter = interpreter;
-            Name = name;
-            SubName = string.Empty;
-            Identifier = _identifier = AnalyzerStatusListener.GetIdentifier(interpreter);
+        public override string ToString() => Name;
 
-            var withDb = interpreter as IPythonInterpreterFactoryWithDatabase;
-            if (withDb != null) {
-                CanRefresh = File.Exists(interpreter.Configuration.InterpreterPath);
-                withDb.IsCurrentChanged += Interpreter_IsCurrentChanged;
-                IsCurrent = withDb.IsCurrent;
-                IsCurrentReason = withDb.GetFriendlyIsCurrentReason(CultureInfo.CurrentUICulture);
-            }
-            IsRunning = false;
-            IsDefault = isDefault;
-        }
-
-        public InterpreterView(string name) {
-            Name = name;
-        }
-
-        public override string ToString() {
-            return Name;
-        }
-
-        private void Interpreter_IsCurrentChanged(object sender, EventArgs e) {
-            var withDb = sender as IPythonInterpreterFactoryWithDatabase;
-            if (withDb != null) {
-                IsCurrent = withDb.IsCurrent;
-                IsCurrentReason = withDb.GetFriendlyIsCurrentReason(CultureInfo.CurrentUICulture);
-                IsCheckingDatabase = withDb.IsCheckingDatabase;
-            }
-        }
-
-        public void ProgressUpdate(Dictionary<string, AnalysisProgress> updateInfo) {
-            var withDb = Interpreter as IPythonInterpreterFactoryWithDatabase;
-            if (withDb == null) {
-                return;
-            }
-
-            AnalysisProgress update;
-            if (updateInfo.TryGetValue(_identifier, out update)) {
-                if (!IsRunning) {
-                    // We're analyzing, but we weren't started by this process.
-                    IsRunning = true;
-                }
-
-                // We've received a message, so stop worrying about the timeout.
-                _expectFirstUpdateBy = DateTime.MinValue;
-
-                if (update.Progress < int.MaxValue) {
-                    Dispatcher.BeginInvoke((Action)(() => {
-                        if (update.Progress > Progress || update.Maximum != Maximum) {
-                            Progress = update.Progress;
-                            Maximum = update.Maximum;
-                        }
-                        Message = update.Message;
-                    }));
-                } else {
-                    Dispatcher.BeginInvoke((Action)(() => {
-                        Progress = 0;
-                        Message = "Starting refresh DB";
-                    }));
-                }
-            } else if (IsRunning && DateTime.Now > _expectFirstUpdateBy) {
-                IsRunning = false;
-            }
-        }
-
-        internal void DefaultInterpreterUpdate(IPythonInterpreterFactory newDefault) {
-            if (Dispatcher.CheckAccess()) {
-                IsDefault = (Interpreter == newDefault);
-            } else {
-                Dispatcher.BeginInvoke((Action)(() => DefaultInterpreterUpdate(newDefault)));
-            }
-        }
-
-        public void Start() {
-            if (Dispatcher.CheckAccess()) {
-                var withDb = Interpreter as IPythonInterpreterFactoryWithDatabase;
-                if (withDb != null) {
-                    // Expect the first update within 10 seconds or else stop
-                    // running.
-                    _expectFirstUpdateBy = DateTime.Now + TimeSpan.FromSeconds(10);
-                    IsRunning = true;
-                    Message = "Starting refresh DB";
-                    withDb.GenerateDatabase(GenerateDatabaseOptions.SkipUnchanged, exitCode => {
-                        if (exitCode != PythonTypeDatabase.AlreadyGeneratingExitCode) {
-                            IsRunning = false;
-                        }
-                    });
-                }
-            } else {
-                Dispatcher.BeginInvoke((Action)(() => Start()));
-            }
-        }
-
-        public void Abort() {
-            throw new NotImplementedException();
-        }
-
-        public IPythonInterpreterFactory Interpreter {
-            get;
-            private set;
-        }
-
-        public string Identifier {
-            get;
-            private set;
-        }
-
-        public PythonProjectNode Project {
-            get;
-            private set;
-        }
+        public string Id { get; }
+        public PythonProjectNode Project { get; }
 
         public string Name {
-            get { return (string)GetValue(NameProperty); }
+            get { return (string)SafeGetValue(NameProperty); }
             private set { SafeSetValue(NamePropertyKey, value); }
-        }
-
-        public string SubName {
-            get { return (string)GetValue(SubNameProperty); }
-            private set { SafeSetValue(SubNamePropertyKey, value); }
-        }
-
-        public bool CanRefresh {
-            get { return (bool)SafeGetValue(CanRefreshProperty); }
-            private set { SetValue(CanRefreshPropertyKey, value); }
-        }
-
-        public string IsCurrentReason {
-            get { return (string)GetValue(IsCurrentReasonProperty); }
-            private set { SafeSetValue(IsCurrentReasonPropertyKey, value); }
-        }
-
-        public bool IsRunning {
-            get { return _isRunning; }
-            private set { SafeSetValue(IsRunningPropertyKey, value); }
-        }
-
-        public bool IsCheckingDatabase {
-            get { return (bool)GetValue(IsCheckingDatabaseProperty); }
-            private set { SafeSetValue(IsCheckingDatabasePropertyKey, value); }
-        }
-
-        public bool IsCurrent {
-            get { return (bool)SafeGetValue(IsCurrentProperty); }
-            private set { SafeSetValue(IsCurrentPropertyKey, value); }
-        }
-
-        public int Progress {
-            get { return (int)GetValue(ProgressProperty); }
-            private set { SetValue(ProgressPropertyKey, value); }
-        }
-
-        public string Message {
-            get { return (string)GetValue(MessageProperty); }
-            private set { SafeSetValue(MessagePropertyKey, value); }
-        }
-
-        public int Maximum {
-            get { return (int)GetValue(MaximumProperty); }
-            private set { SetValue(MaximumPropertyKey, value); }
-        }
-
-        public bool IsDefault {
-            get { return (bool)GetValue(IsDefaultProperty); }
-            private set { SetValue(IsDefaultPropertyKey, value); }
-        }
-
-        public bool CanBeDefault {
-            get { return (bool)GetValue(CanBeDefaultProperty); }
-            private set { SetValue(CanBeDefaultPropertyKey, value); }
         }
 
         public bool IsSelected {
@@ -257,70 +107,23 @@ namespace Microsoft.PythonTools {
         }
 
         private static readonly DependencyPropertyKey NamePropertyKey = DependencyProperty.RegisterReadOnly("Name", typeof(string), typeof(InterpreterView), new PropertyMetadata());
-        private static readonly DependencyPropertyKey SubNamePropertyKey = DependencyProperty.RegisterReadOnly("SubName", typeof(string), typeof(InterpreterView), new PropertyMetadata());
-        private static readonly DependencyPropertyKey IsCurrentReasonPropertyKey = DependencyProperty.RegisterReadOnly("IsCurrentReason", typeof(string), typeof(InterpreterView), new PropertyMetadata());
-        private static readonly DependencyPropertyKey IsCurrentPropertyKey = DependencyProperty.RegisterReadOnly("IsCurrent", typeof(bool), typeof(InterpreterView), new PropertyMetadata(true));
-        private static readonly DependencyPropertyKey IsRunningPropertyKey = DependencyProperty.RegisterReadOnly("IsRunning", typeof(bool), typeof(InterpreterView), new PropertyMetadata(false, IsRunning_Changed));
-        private static readonly DependencyPropertyKey IsCheckingDatabasePropertyKey = DependencyProperty.RegisterReadOnly("IsCheckingDatabase", typeof(bool), typeof(InterpreterView), new PropertyMetadata(false));
-        private static readonly DependencyPropertyKey ProgressPropertyKey = DependencyProperty.RegisterReadOnly("Progress", typeof(int), typeof(InterpreterView), new PropertyMetadata(0));
-        private static readonly DependencyPropertyKey MessagePropertyKey = DependencyProperty.RegisterReadOnly("Message", typeof(string), typeof(InterpreterView), new PropertyMetadata());
-        private static readonly DependencyPropertyKey MaximumPropertyKey = DependencyProperty.RegisterReadOnly("Maximum", typeof(int), typeof(InterpreterView), new PropertyMetadata(0));
-        private static readonly DependencyPropertyKey IsDefaultPropertyKey = DependencyProperty.RegisterReadOnly("IsDefault", typeof(bool), typeof(InterpreterView), new PropertyMetadata(false));
-        private static readonly DependencyPropertyKey CanBeDefaultPropertyKey = DependencyProperty.RegisterReadOnly("CanBeDefault", typeof(bool), typeof(InterpreterView), new PropertyMetadata(true));
-        private static readonly DependencyPropertyKey CanRefreshPropertyKey = DependencyProperty.RegisterReadOnly("CanRefresh", typeof(bool), typeof(InterpreterView), new PropertyMetadata(false));
-
         public static readonly DependencyProperty NameProperty = NamePropertyKey.DependencyProperty;
-        public static readonly DependencyProperty SubNameProperty = SubNamePropertyKey.DependencyProperty;
-        public static readonly DependencyProperty IsCurrentReasonProperty = IsCurrentReasonPropertyKey.DependencyProperty;
-        public static readonly DependencyProperty IsCurrentProperty = IsCurrentPropertyKey.DependencyProperty;
-        public static readonly DependencyProperty IsCheckingDatabaseProperty = IsCheckingDatabasePropertyKey.DependencyProperty;
-        public static readonly DependencyProperty IsRunningProperty = IsRunningPropertyKey.DependencyProperty;
-        public static readonly DependencyProperty ProgressProperty = ProgressPropertyKey.DependencyProperty;
-        public static readonly DependencyProperty MessageProperty = MessagePropertyKey.DependencyProperty;
-        public static readonly DependencyProperty MaximumProperty = MaximumPropertyKey.DependencyProperty;
-        public static readonly DependencyProperty IsDefaultProperty = IsDefaultPropertyKey.DependencyProperty;
-        public static readonly DependencyProperty CanBeDefaultProperty = CanBeDefaultPropertyKey.DependencyProperty;
-        public static readonly DependencyProperty CanRefreshProperty = CanRefreshPropertyKey.DependencyProperty;
 
         public static readonly DependencyProperty IsSelectedProperty = DependencyProperty.Register("IsSelected", typeof(bool), typeof(InterpreterView), new PropertyMetadata(false));
 
-        private static void IsRunning_Changed(DependencyObject d, DependencyPropertyChangedEventArgs e) {
-            if (!(e.NewValue as bool? ?? true)) {
-                d.SetValue(ProgressPropertyKey, 0);
-                d.SetValue(MaximumPropertyKey, 0);
-            }
-            var iv = d as InterpreterView;
-            if (iv != null) {
-                iv._isRunning = (e.NewValue as bool?) ?? false;
-            }
-        }
-
-        protected override void OnPropertyChanged(DependencyPropertyChangedEventArgs e) {
-            base.OnPropertyChanged(e);
-            var evt = PropertyChanged;
-            if (evt != null) {
-                evt(this, new PropertyChangedEventArgs(e.Property.Name));
-            }
-        }
-
-        public event PropertyChangedEventHandler PropertyChanged;
-
         private sealed class InterpreterViewComparer : IEqualityComparer<InterpreterView>, IComparer<InterpreterView> {
             public bool Equals(InterpreterView x, InterpreterView y) {
-                return ReferenceEquals(
-                    x == null ? null : x.Interpreter,
-                    y == null ? null : y.Interpreter
-                );
+                return x?.Id == y?.Id;
             }
 
             public int GetHashCode(InterpreterView obj) {
-                return obj == null || obj.Interpreter == null ? 0 : obj.Interpreter.GetHashCode();
+                return obj.Id.GetHashCode();
             }
 
             public int Compare(InterpreterView x, InterpreterView y) {
                 return StringComparer.CurrentCultureIgnoreCase.Compare(
-                    x == null ? "" : x.Name,
-                    y == null ? "" : y.Name
+                    x?.Name ?? "",
+                    y?.Name ?? ""
                 );
             }
         }

--- a/Python/Product/PythonTools/PythonTools/Project/AddInterpreter.xaml.cs
+++ b/Python/Product/PythonTools/PythonTools/Project/AddInterpreter.xaml.cs
@@ -40,31 +40,25 @@ namespace Microsoft.PythonTools.Project {
         private readonly AddInterpreterView _view;
 
         private AddInterpreter(PythonProjectNode project, IInterpreterOptionsService service) {
-            _view = new AddInterpreterView(project, project.Site, project.InterpreterFactories);
-            _view.PropertyChanged += View_PropertyChanged;
+            _view = new AddInterpreterView(project, project.Site, project.InterpreterIds);
             DataContext = _view;
 
             InitializeComponent();
         }
 
         public void Dispose() {
-            _view.PropertyChanged -= View_PropertyChanged;
             _view.Dispose();
         }
 
-        public static IEnumerable<IPythonInterpreterFactory> ShowDialog(
+        public static IEnumerable<string> ShowDialog(
             PythonProjectNode project,
             IInterpreterOptionsService service) {
             using (var wnd = new AddInterpreter(project, service)) {
                 if (wnd.ShowModal() ?? false) {
-                    return wnd._view.Interpreters.Where(iv => iv.IsSelected).Select(iv => iv.Interpreter);
+                    return wnd._view.Interpreters.Where(iv => iv.IsSelected).Select(iv => iv.Id).ToArray();
                 }
             }
             return null;
-        }
-
-        private void View_PropertyChanged(object sender, PropertyChangedEventArgs e) {
-            CommandManager.InvalidateRequerySuggested();
         }
 
         private void Close_CanExecute(object sender, CanExecuteRoutedEventArgs e) {

--- a/Python/Product/PythonTools/PythonTools/Project/AddVirtualEnvironment.xaml.cs
+++ b/Python/Product/PythonTools/PythonTools/Project/AddVirtualEnvironment.xaml.cs
@@ -60,7 +60,7 @@ namespace Microsoft.PythonTools.Project {
             IInterpreterRegistryService service,
             bool browseForExisting = false
         ) {
-            using (var view = new AddVirtualEnvironmentView(project, service, project.ActiveInterpreter)) {
+            using (var view = new AddVirtualEnvironmentView(project, service, project.ActiveInterpreter.Configuration.Id)) {
                 var wnd = new AddVirtualEnvironment(project.Site, view);
 
                 if (browseForExisting) {

--- a/Python/Product/PythonTools/PythonTools/Project/AddVirtualEnvironmentOperation.cs
+++ b/Python/Product/PythonTools/PythonTools/Project/AddVirtualEnvironmentOperation.cs
@@ -25,7 +25,7 @@ namespace Microsoft.PythonTools.Project {
     sealed class AddVirtualEnvironmentOperation {
         private readonly PythonProjectNode _project;
         private readonly string _virtualEnvPath;
-        private readonly IPythonInterpreterFactory _baseInterpreter;
+        private readonly string _baseInterpreter;
         private readonly bool _create;
         private readonly bool _useVEnv;
         private readonly bool _installRequirements;
@@ -34,7 +34,7 @@ namespace Microsoft.PythonTools.Project {
         public AddVirtualEnvironmentOperation(
             PythonProjectNode project,
             string virtualEnvPath,
-            IPythonInterpreterFactory baseInterpreter,
+            string baseInterpreterId,
             bool create,
             bool useVEnv,
             bool installRequirements,
@@ -42,7 +42,7 @@ namespace Microsoft.PythonTools.Project {
         ) {
             _project = project;
             _virtualEnvPath = virtualEnvPath;
-            _baseInterpreter = baseInterpreter;
+            _baseInterpreter = baseInterpreterId;
             _create = create;
             _useVEnv = useVEnv;
             _installRequirements = installRequirements;
@@ -66,11 +66,13 @@ namespace Microsoft.PythonTools.Project {
 
             IPythonInterpreterFactory factory;
             try {
+                var baseInterp = service.FindInterpreter(_baseInterpreter);
+
                 factory = await _project.CreateOrAddVirtualEnvironment(
                     service,
                     _create,
                     _virtualEnvPath,
-                    _baseInterpreter,
+                    baseInterp,
                     _useVEnv
                 );
             } catch (Exception ex) when (!ex.IsCriticalException()) {

--- a/Python/Product/PythonTools/PythonTools/Project/AddVirtualEnvironmentView.cs
+++ b/Python/Product/PythonTools/PythonTools/Project/AddVirtualEnvironmentView.cs
@@ -26,13 +26,8 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
-using Microsoft.PythonTools.Analysis;
 using Microsoft.PythonTools.Infrastructure;
 using Microsoft.PythonTools.Interpreter;
-using Microsoft.PythonTools.InterpreterList;
-using Microsoft.VisualStudio.PlatformUI;
-using Microsoft.VisualStudioTools;
-using Microsoft.VisualStudioTools.Project;
 
 namespace Microsoft.PythonTools.Project {
     sealed class AddVirtualEnvironmentView : DependencyObject, INotifyPropertyChanged, IDisposable {
@@ -45,15 +40,15 @@ namespace Microsoft.PythonTools.Project {
         public AddVirtualEnvironmentView(
             PythonProjectNode project,
             IInterpreterRegistryService interpreterService,
-            IPythonInterpreterFactory selectInterpreter
+            string selectInterpreterId
         ) {
             _interpreterService = interpreterService;
             _project = project;
             VirtualEnvBasePath = _projectHome = project.ProjectHome;
-            Interpreters = new ObservableCollection<InterpreterView>(InterpreterView.GetInterpreters(project.Site, project));
-            var selection = Interpreters.FirstOrDefault(v => v.Interpreter == selectInterpreter);
+            Interpreters = new ObservableCollection<InterpreterView>(InterpreterView.GetInterpreters(project.Site, null, true));
+            var selection = Interpreters.FirstOrDefault(v => v.Id == selectInterpreterId);
             if (selection == null) {
-                selection = Interpreters.FirstOrDefault(v => v.Interpreter == project.GetInterpreterFactory())
+                selection = Interpreters.FirstOrDefault(v => v.Id == project.ActiveInterpreter?.Configuration.Id)
                     ?? Interpreters.LastOrDefault();
             }
             BaseInterpreter = selection;
@@ -74,25 +69,14 @@ namespace Microsoft.PythonTools.Project {
             _ready.Dispose();
         }
 
-        private void OnInterpretersChanged(object sender, EventArgs e) {
-            if (!Dispatcher.CheckAccess()) {
-                Dispatcher.BeginInvoke((Action)(() => OnInterpretersChanged(sender, e)));
-                return;
-            }
-
-            var existing = Interpreters.Where(iv => iv.Interpreter != null).ToDictionary(iv => iv.Interpreter);
-            var def = _project.GetInterpreterFactory();
-
-            int i = 0;
-            foreach (var interp in InterpreterView.GetInterpreters(_project.Site, _project).Select(x => x.Interpreter)) {
-                if (!existing.Remove(interp)) {
-                    Interpreters.Insert(i, new InterpreterView(interp, interp.Configuration.Description, interp == def));
-                }
-                i += 1;
-            }
-            foreach (var kv in existing) {
-                Interpreters.Remove(kv.Value);
-            }
+        private async void OnInterpretersChanged(object sender, EventArgs e) {
+            await Dispatcher.InvokeAsync(() => {
+                Interpreters.Merge(
+                    InterpreterView.GetInterpreters(_project.Site, _project),
+                    InterpreterView.EqualityComparer,
+                    InterpreterView.Comparer
+                );
+            });
         }
 
 
@@ -223,10 +207,8 @@ namespace Microsoft.PythonTools.Project {
 
                 var config = VirtualEnv.FindInterpreterConfiguration(null, path, _interpreterService);
                 if (config != null && File.Exists(config.InterpreterPath)) {
-                    var baseInterp = _interpreterService.FindInterpreter(config.Id);
-                    InterpreterView baseInterpView;
-                    if (baseInterp != null &&
-                        (baseInterpView = Interpreters.FirstOrDefault(iv => iv.Interpreter == baseInterp)) != null) {
+                    var baseInterpView = Interpreters.FirstOrDefault(v => v.Id == config.Id);
+                    if (baseInterpView != null) {
                         if (_lastUserSelectedBaseInterpreter == null) {
                             _lastUserSelectedBaseInterpreter = BaseInterpreter;
                         }
@@ -404,7 +386,8 @@ namespace Microsoft.PythonTools.Project {
                     return;
                 }
 
-                var interp = view.Interpreter;
+                var registry = _project.Site.GetComponentModel().GetService<IInterpreterRegistryService>();
+                var interp = registry.FindInterpreter(view.Id);
                 Debug.Assert(interp != null);
                 if (interp == null) {
                     return;
@@ -522,7 +505,7 @@ namespace Microsoft.PythonTools.Project {
                 var op = new AddVirtualEnvironmentOperation(
                     _project,
                     VirtualEnvPath,
-                    BaseInterpreter.Interpreter,
+                    BaseInterpreter.Id,
                     WillCreateVirtualEnv,
                     UseVEnv,
                     WillInstallRequirementsTxt,
@@ -574,7 +557,7 @@ namespace Microsoft.PythonTools.Project {
             }
         }
 
-        public void SelectInterpreter(IPythonInterpreterFactory selection) {
+        public void SelectInterpreter(string selection) {
             if (selection == null) {
                 return;
             }
@@ -584,7 +567,7 @@ namespace Microsoft.PythonTools.Project {
                 return;
             }
 
-            var sel = Interpreters.FirstOrDefault(iv => iv.Interpreter == selection);
+            var sel = Interpreters.FirstOrDefault(iv => iv.Id == selection);
             if (sel != null) {
                 BaseInterpreter = sel;
             }

--- a/Python/Product/PythonTools/PythonTools/Project/InterpretersNodeProperties.cs
+++ b/Python/Product/PythonTools/PythonTools/Project/InterpretersNodeProperties.cs
@@ -25,8 +25,6 @@ namespace Microsoft.PythonTools.Project {
     [ComVisible(true)]
     [Guid(PythonConstants.InterpretersPropertiesGuid)]
     public class InterpretersNodeProperties : NodeProperties {
-        #region properties
-
         [Browsable(false)]
         [AutomationBrowsable(false)]
         protected IPythonInterpreterFactory Factory {
@@ -66,42 +64,21 @@ namespace Microsoft.PythonTools.Project {
         [SRDisplayName("EnvironmentIdDisplayName")]
         [SRDescription("EnvironmentIdDescription")]
         [AutomationBrowsable(true)]
-        public string Id {
-            get {
-                var fact = Factory;
-                return fact != null ? fact.Configuration.Id : "";
-            }
-        }
+        public string Id => Factory?.Configuration?.Id ?? "";
 #endif
 
         [SRCategory(SR.Misc)]
         [SRDisplayName("EnvironmentVersionDisplayName")]
         [SRDescription("EnvironmentVersionDescription")]
         [AutomationBrowsable(true)]
-        public string Version {
-            get {
-                var fact = Factory;
-                return fact != null ? fact.Configuration.Version.ToString() : "";
-            }
-        }
+        public string Version => Factory?.Configuration?.Version.ToString() ?? "";
 
-        #region properties - used for automation only
         [Browsable(false)]
         [AutomationBrowsable(true)]
-        public string FileName {
-            get {
-                return this.HierarchyNode.Url;
-            }
-        }
+        public string FileName => HierarchyNode.Url;
 
-        #endregion
-
-        #endregion
-
-        #region ctors
         internal InterpretersNodeProperties(HierarchyNode node)
             : base(node) { }
-        #endregion
 
         public override string GetClassName() {
             return "Environment Properties";


### PR DESCRIPTION
Fixes #1864 Missing environments are no longer show in solution explorer
Switches to using IDs in a number of places in the UI so that we can support missing environments
Massively simplifies the view objects for environments in certain dialogs
Allows removing missing environments from a project