### PR TITLE
Fixes #1918 We don't discover unit tests while analysis is running

### DIFF
--- a/Python/Product/Analysis/Interpreter/Ast/AstAnalysisWalker.cs
+++ b/Python/Product/Analysis/Interpreter/Ast/AstAnalysisWalker.cs
@@ -66,6 +66,26 @@ namespace Microsoft.PythonTools.Interpreter.Ast {
             base.PostWalk(node);
         }
 
+        internal LocationInfo GetLoc(ClassDefinition node) {
+            if (node == null || node.StartIndex >= node.EndIndex) {
+                return null;
+            }
+
+            var start = node.NameExpression?.GetStart(_ast) ?? node.GetStart(_ast);
+            var end = node.GetEnd(_ast);
+            return new LocationInfo(_filePath, start.Line, start.Column, end.Line, end.Column);
+        }
+
+        internal LocationInfo GetLoc(FunctionDefinition node) {
+            if (node == null || node.StartIndex >= node.EndIndex) {
+                return null;
+            }
+
+            var start = node.NameExpression?.GetStart(_ast) ?? node.GetStart(_ast);
+            var end = node.GetEnd(_ast);
+            return new LocationInfo(_filePath, start.Line, start.Column, end.Line, end.Column);
+        }
+
         internal LocationInfo GetLoc(Node node) {
             if (node == null || node.StartIndex >= node.EndIndex) {
                 return null;
@@ -246,7 +266,7 @@ namespace Microsoft.PythonTools.Interpreter.Ast {
             if (existing == null) {
                 var m = _scope.Peek();
                 if (m != null) {
-                    m[node.Name] = new AstPythonFunction(_ast, _module, CurrentClass, node, GetDoc(node.Body as SuiteStatement));
+                    m[node.Name] = new AstPythonFunction(_ast, _module, CurrentClass, node, GetLoc(node), GetDoc(node.Body as SuiteStatement));
                 }
             } else {
                 existing.AddOverload(_ast, node);

--- a/Python/Product/Analysis/Interpreter/Ast/AstPythonFunction.cs
+++ b/Python/Product/Analysis/Interpreter/Ast/AstPythonFunction.cs
@@ -14,13 +14,15 @@
 // See the Apache Version 2.0 License for specific language governing
 // permissions and limitations under the License.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.PythonTools.Analysis;
 using Microsoft.PythonTools.Infrastructure;
 using Microsoft.PythonTools.Parsing.Ast;
 
 namespace Microsoft.PythonTools.Interpreter.Ast {
-    class AstPythonFunction : IPythonFunction {
+    class AstPythonFunction : IPythonFunction, ILocatedMember {
         private readonly List<AstPythonFunctionOverload> _overloads;
 
         public AstPythonFunction(PythonAst ast, IPythonModule declModule, IPythonType declType, FunctionDefinition def, string doc) {
@@ -40,6 +42,12 @@ namespace Microsoft.PythonTools.Interpreter.Ast {
 
             _overloads = new List<AstPythonFunctionOverload> {
                 new AstPythonFunctionOverload(Documentation, "", MakeParameters(ast, def), MakeReturns(def))
+            };
+
+            var start = def.GetStart(ast);
+            var end = def.GetEnd(ast);
+            Locations = new[] {
+                new LocationInfo((declModule as IProjectEntry).FilePath, start.Line, start.Column, end.Line, end.Column)
             };
         }
 
@@ -69,5 +77,7 @@ namespace Microsoft.PythonTools.Interpreter.Ast {
         public PythonMemberType MemberType => DeclaringType == null ? PythonMemberType.Function : PythonMemberType.Method;
 
         public IList<IPythonFunctionOverload> Overloads => _overloads.ToArray();
+
+        public IEnumerable<LocationInfo> Locations { get; }
     }
 }

--- a/Python/Product/Analysis/Interpreter/Ast/AstPythonFunction.cs
+++ b/Python/Product/Analysis/Interpreter/Ast/AstPythonFunction.cs
@@ -25,7 +25,7 @@ namespace Microsoft.PythonTools.Interpreter.Ast {
     class AstPythonFunction : IPythonFunction, ILocatedMember {
         private readonly List<AstPythonFunctionOverload> _overloads;
 
-        public AstPythonFunction(PythonAst ast, IPythonModule declModule, IPythonType declType, FunctionDefinition def, string doc) {
+        public AstPythonFunction(PythonAst ast, IPythonModule declModule, IPythonType declType, FunctionDefinition def, LocationInfo loc, string doc) {
             DeclaringModule = declModule;
             DeclaringType = declType;
 
@@ -44,11 +44,7 @@ namespace Microsoft.PythonTools.Interpreter.Ast {
                 new AstPythonFunctionOverload(Documentation, "", MakeParameters(ast, def), MakeReturns(def))
             };
 
-            var start = def.GetStart(ast);
-            var end = def.GetEnd(ast);
-            Locations = new[] {
-                new LocationInfo((declModule as IProjectEntry).FilePath, start.Line, start.Column, end.Line, end.Column)
-            };
+            Locations = new[] { loc };
         }
 
         internal void AddOverload(PythonAst ast, FunctionDefinition def) {

--- a/Python/Product/Analysis/Interpreter/Ast/AstPythonType.cs
+++ b/Python/Product/Analysis/Interpreter/Ast/AstPythonType.cs
@@ -14,22 +14,41 @@
 // See the Apache Version 2.0 License for specific language governing
 // permissions and limitations under the License.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.PythonTools.Analysis;
+using Microsoft.PythonTools.Infrastructure;
 using Microsoft.PythonTools.Parsing.Ast;
 
 namespace Microsoft.PythonTools.Interpreter.Ast {
     class AstPythonType : IPythonType, IMemberContainer, ILocatedMember {
         private readonly Dictionary<string, IMember> _members;
 
-        public AstPythonType(PythonAst ast, IPythonModule declModule, ClassDefinition def, string doc, LocationInfo loc) {
+        private static readonly IPythonModule NoDeclModule = new AstPythonModule();
+
+        public AstPythonType(string name) {
+            _members = new Dictionary<string, IMember>();
+            Name = name;
+            DeclaringModule = NoDeclModule;
+            Mro = Array.Empty<IPythonType>();
+            Locations = Array.Empty<LocationInfo>();
+        }
+
+        public AstPythonType(
+            PythonAst ast,
+            IPythonModule declModule,
+            ClassDefinition def,
+            string doc,
+            LocationInfo loc,
+            IEnumerable<IPythonType> mro
+        ) {
             _members = new Dictionary<string, IMember>();
 
             Name = def.Name;
             Documentation = doc;
             DeclaringModule = declModule;
-            Mro = new IPythonType[0];
+            Mro = mro.MaybeEnumerate().ToArray();
             Locations = new[] { loc };
         }
 

--- a/Python/Product/TestAdapter.Analysis/TestAnalysisExtension.cs
+++ b/Python/Product/TestAdapter.Analysis/TestAnalysisExtension.cs
@@ -14,12 +14,15 @@
 // See the Apache Version 2.0 License for specific language governing
 // permissions and limitations under the License.
 
+using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Linq;
 using System.Web.Script.Serialization;
 using Microsoft.PythonTools.Analysis;
+using Microsoft.PythonTools.Infrastructure;
 using Microsoft.PythonTools.Interpreter;
+using Microsoft.PythonTools.Interpreter.Ast;
 using Microsoft.PythonTools.Projects;
 
 namespace Microsoft.PythonTools.TestAdapter {
@@ -36,27 +39,14 @@ namespace Microsoft.PythonTools.TestAdapter {
             switch (commandId) {
                 case GetTestCasesCommand:
                     IProjectEntry projEntry;
+                    IEnumerable<TestCaseInfo> testCases;
                     if (_analyzer.TryGetProjectEntryByPath(body, out projEntry)) {
-                        var testCases = GetTestCases(projEntry);
-                        List<object> res = new List<object>();
-
-                        foreach (var test in testCases) {
-                            var item = new Dictionary<string, object>() {
-                                { Serialize.Filename, test.Filename },
-                                { Serialize.ClassName, test.ClassName },
-                                { Serialize.MethodName, test.MethodName },
-                                { Serialize.StartLine, test.StartLine},
-                                { Serialize.StartColumn, test.StartColumn},
-                                { Serialize.EndLine, test.EndLine },
-                                { Serialize.Kind, test.Kind.ToString() },
-                            };
-                            res.Add(item);
-                        }
-
-                        return serializer.Serialize(res.ToArray());
+                        testCases = GetTestCasesFromAnalysis(projEntry);
+                    } else {
+                        testCases = GetTestCasesFromAst(body);
                     }
 
-                    break;
+                    return serializer.Serialize(testCases.Select(tc => tc.AsDictionary()).ToArray());
             }
 
             return "";
@@ -105,7 +95,7 @@ namespace Microsoft.PythonTools.TestAdapter {
             return 0;
         }
 
-        class Serialize {
+        public class Serialize {
             public const string Filename = "filename";
             public const string ClassName = "className";
             public const string MethodName = "methodName";
@@ -116,7 +106,7 @@ namespace Microsoft.PythonTools.TestAdapter {
         }
 
 
-        public static IEnumerable<TestCaseInfo> GetTestCases(IProjectEntry projEntry) {
+        public static IEnumerable<TestCaseInfo> GetTestCasesFromAnalysis(IProjectEntry projEntry) {
             var entry = projEntry as IPythonProjectEntry;
             if (entry == null) {
                 yield break;
@@ -156,16 +146,17 @@ namespace Microsoft.PythonTools.TestAdapter {
         }
 
         private static bool IsTestCaseClass(AnalysisValue cls) {
-            if (cls == null ||
-                cls.DeclaringModule != null ||
-                cls.PythonType == null ||
-                cls.PythonType.DeclaringModule == null) {
-                return false;
-            }
-            var mod = cls.PythonType.DeclaringModule.Name;
-            return (mod == "unittest" || mod.StartsWith("unittest.")) && cls.Name == "TestCase";
+            return IsTestCaseClass(cls?.PythonType);
         }
 
+        private static bool IsTestCaseClass(IPythonType cls) {
+            if (cls == null ||
+                cls.DeclaringModule != null) {
+                return false;
+            }
+            var mod = cls.Name;
+            return (mod == "unittest" || mod.StartsWith("unittest.")) && cls.Name == "TestCase";
+        }
         /// <summary>
         /// Get Test Case Members for a class.  If the class has 'test*' tests 
         /// return those.  If there aren't any 'test*' tests return (if one at 
@@ -193,6 +184,67 @@ namespace Microsoft.PythonTools.TestAdapter {
                 .SelectMany(m => analysis.GetValuesByIndex(m.Name, 0))
                 .Where(v => v.MemberType == PythonMemberType.Class)
                 .Where(v => v.Mro.SelectMany(v2 => v2).Any(IsTestCaseClass));
+        }
+
+        private static IEnumerable<IPythonType> GetTestCaseClasses(IPythonModule module, IModuleContext context) {
+            foreach (var name in module.GetMemberNames(context)) {
+                var cls = module.GetMember(context, name) as IPythonType;
+                if (cls != null) {
+                    foreach (var baseCls in cls.Mro.MaybeEnumerate()) {
+                        if (baseCls.Name == "TestCase" ||
+                            baseCls.Name.StartsWith("unittest.") && baseCls.Name.EndsWith(".TestCase")) {
+                            yield return cls;
+                        }
+                    }
+                }
+            }
+        }
+
+        private static IEnumerable<IPythonFunction> GetTestCaseMembers(IPythonType cls, IModuleContext context) {
+            var methodFunctions = cls.GetMemberNames(context).Select(n => cls.GetMember(context, n))
+                .OfType<IPythonFunction>()
+                .ToArray();
+
+            var tests = methodFunctions.Where(v => v.Name.StartsWith("test"));
+            var runTest = methodFunctions.Where(v => v.Name.Equals("runTest"));
+
+            if (tests.Any()) {
+                return tests;
+            } else {
+                return runTest;
+            }
+        }
+
+        public IEnumerable<TestCaseInfo> GetTestCasesFromAst(string path) {
+            IPythonModule module;
+            try {
+                module = AstPythonModule.FromFile(_analyzer.Interpreter, path, _analyzer.LanguageVersion);
+            } catch (Exception ex) when (!ex.IsCriticalException()) {
+                yield break;
+            }
+
+            var ctxt = _analyzer.Interpreter.CreateModuleContext();
+            foreach (var classValue in GetTestCaseClasses(module, ctxt)) {
+                // Check the name of all functions on the class using the
+                // analyzer. This will return functions defined on this
+                // class and base classes
+                foreach (var member in GetTestCaseMembers(classValue, ctxt)) {
+                    // Find the definition to get the real location of the
+                    // member. Otherwise decorators will confuse us.
+                    var location = (member as ILocatedMember)?.Locations?.FirstOrDefault(loc => loc != null);
+
+                    int endLine = location?.EndLine ?? location?.StartLine ?? 0;
+
+                    yield return new TestCaseInfo(
+                        (classValue as ILocatedMember)?.Locations.FirstOrDefault()?.FilePath,
+                        classValue.Name,
+                        member.Name,
+                        location?.StartLine ?? 0,
+                        location?.StartColumn ?? 1,
+                        endLine
+                    );
+                }
+            }
         }
     }
 }

--- a/Python/Product/TestAdapter.Analysis/TestCaseInfo.cs
+++ b/Python/Product/TestAdapter.Analysis/TestCaseInfo.cs
@@ -14,6 +14,8 @@
 // See the Apache Version 2.0 License for specific language governing
 // permissions and limitations under the License.
 
+using System.Collections.Generic;
+
 namespace Microsoft.PythonTools.TestAdapter {
     internal sealed class TestCaseInfo {
         private readonly string _filename;
@@ -42,6 +44,18 @@ namespace Microsoft.PythonTools.TestAdapter {
                 // Currently we don't support other test case kinds
                 return TestCaseKind.UnitTest;
             }
+        }
+
+        public Dictionary<string, object> AsDictionary() {
+            return new Dictionary<string, object>() {
+                { TestAnalyzer.Serialize.Filename, Filename },
+                { TestAnalyzer.Serialize.ClassName, ClassName },
+                { TestAnalyzer.Serialize.MethodName, MethodName },
+                { TestAnalyzer.Serialize.StartLine, StartLine},
+                { TestAnalyzer.Serialize.StartColumn, StartColumn},
+                { TestAnalyzer.Serialize.EndLine, EndLine },
+                { TestAnalyzer.Serialize.Kind, Kind.ToString() },
+            };
         }
     }
 

--- a/Python/Tests/TestAdapterTests/TestDiscovererTests.cs
+++ b/Python/Tests/TestAdapterTests/TestDiscovererTests.cs
@@ -20,9 +20,11 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Threading;
 using Microsoft.PythonTools.Analysis;
 using Microsoft.PythonTools.Interpreter;
+using Microsoft.PythonTools.Interpreter.Ast;
 using Microsoft.PythonTools.Parsing;
 using Microsoft.PythonTools.TestAdapter;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
@@ -91,10 +93,16 @@ namespace TestAdapterTests {
             PrintTestCases(sink.Tests);
         }
 
+        private static IEnumerable<TestCaseInfo> GetTestCasesFromAst(string code, PythonAnalyzer analyzer) {
+            var codeStream = new MemoryStream(Encoding.UTF8.GetBytes(code));
+            var m = AstPythonModule.FromStream(analyzer.Interpreter, codeStream, "<string>", analyzer.LanguageVersion);
+            return TestAnalyzer.GetTestCasesFromAst(m, null);
+        }
+
         [TestMethod, Priority(1)]
         public void DecoratedTests() {
             using (var analyzer = MakeTestAnalyzer()) {
-                var entry = AddModule(analyzer, "Fob", @"import unittest
+                var code = @"import unittest
 
 def decorator(fn):
     def wrapped(*args, **kwargs):
@@ -105,12 +113,17 @@ class MyTest(unittest.TestCase):
     @decorator
     def testAbc(self):
         pass
-");
+";
+                var entry = AddModule(analyzer, "Fob", code);
 
                 entry.Analyze(CancellationToken.None, true);
                 analyzer.AnalyzeQueuedEntries(CancellationToken.None);
 
-                var test = TestAnalyzer.GetTestCases(entry).Single();
+                var test = TestAnalyzer.GetTestCasesFromAnalysis(entry).Single();
+                Assert.AreEqual("testAbc", test.MethodName);
+                Assert.AreEqual(10, test.StartLine);
+
+                test = GetTestCasesFromAst(code, analyzer).Single();
                 Assert.AreEqual("testAbc", test.MethodName);
                 Assert.AreEqual(10, test.StartLine);
             }
@@ -132,7 +145,7 @@ class TestBase(unittest.TestCase):
                     code: @"from .SubPkg import TestBase"
                 );
 
-                var entry3 = AddModule(analyzer, "__main__", @"from Pkg.SubPkg import TestBase as TB1
+                var code = @"from Pkg.SubPkg import TestBase as TB1
 from Pkg import TestBase as TB2
 from Pkg import *
 
@@ -147,34 +160,43 @@ class MyTest2(TB2):
 class MyTest3(TestBase):
     def test3(self):
         pass
-");
+";
+                var entry3 = AddModule(analyzer, "__main__", code);
 
                 entry1.Analyze(CancellationToken.None, true);
                 entry2.Analyze(CancellationToken.None, true);
                 entry3.Analyze(CancellationToken.None, true);
                 analyzer.AnalyzeQueuedEntries(CancellationToken.None);
 
-                var test = TestAnalyzer.GetTestCases(entry3).ToList();
+                var test = TestAnalyzer.GetTestCasesFromAnalysis(entry3).ToList();
                 AssertUtil.ContainsExactly(test.Select(t => t.MethodName), "test1", "test2", "test3");
+
+                // Cannot discover tests from subclasses with just the AST
+                test = GetTestCasesFromAst(code, analyzer).ToList();
+                AssertUtil.ContainsExactly(test.Select(t => t.MethodName));
             }
         }
 
         [TestMethod, Priority(1)]
         public void TestCaseRunTests() {
             using (var analyzer = MakeTestAnalyzer()) {
-                var entry = AddModule(analyzer, "__main__", @"import unittest
+                var code = @"import unittest
 
 class TestBase(unittest.TestCase):
     def runTests(self):
         pass # should not discover this as it isn't runTest or test*
     def runTest(self):
         pass
-");
+";
+                var entry = AddModule(analyzer, "__main__", code);
 
                 entry.Analyze(CancellationToken.None, true);
                 analyzer.AnalyzeQueuedEntries(CancellationToken.None);
 
-                var test = TestAnalyzer.GetTestCases(entry).ToList();
+                var test = TestAnalyzer.GetTestCasesFromAnalysis(entry).ToList();
+                AssertUtil.ContainsExactly(test.Select(t => t.ClassName), "TestBase");
+
+                test = GetTestCasesFromAst(code, analyzer).ToList();
                 AssertUtil.ContainsExactly(test.Select(t => t.ClassName), "TestBase");
             }
         }
@@ -185,19 +207,23 @@ class TestBase(unittest.TestCase):
         [TestMethod, Priority(1)]
         public void TestCaseRunTestsWithTest() {
             using (var analyzer = MakeTestAnalyzer()) {
-                var entry = AddModule(analyzer, "__main__", @"import unittest
+                var code = @"import unittest
 
 class TestBase(unittest.TestCase):
     def test_1(self):
         pass
     def runTest(self):
         pass
-");
+";
+                var entry = AddModule(analyzer, "__main__", code);
 
                 entry.Analyze(CancellationToken.None, true);
                 analyzer.AnalyzeQueuedEntries(CancellationToken.None);
 
-                var test = TestAnalyzer.GetTestCases(entry).ToList();
+                var test = TestAnalyzer.GetTestCasesFromAnalysis(entry).ToList();
+                AssertUtil.ContainsExactly(test.Select(t => t.MethodName), "test_1");
+
+                test = GetTestCasesFromAst(code, analyzer).ToList();
                 AssertUtil.ContainsExactly(test.Select(t => t.MethodName), "test_1");
             }
         }


### PR DESCRIPTION
Fixes #1918 We don't discover unit tests while analysis is running
Adds fallback to use AST to guess at available unit tests.
Also fixes race condition in InMemoryLogger.