### PR TITLE
Fixes #1948 Crash on Go To Definition

### DIFF
--- a/Python/Product/Analysis/Analyzer/DDG.cs
+++ b/Python/Product/Analysis/Analyzer/DDG.cs
@@ -239,10 +239,6 @@ namespace Microsoft.PythonTools.Analysis.Analyzer {
                 added = variable.AddTypes(_unit, userMod.GetModuleMember(node, _unit, impName, addRef, Scope, saveName));
             }
 
-            //if (addRef) {
-            //    variable.AddAssignment(node, _unit);
-            //} 
-            
             if (added) {
                 // anyone who read from the module will now need to get the new values
                 GlobalScope.ModuleDefinition.EnqueueDependents();

--- a/Python/Product/Analysis/Analyzer/DDG.cs
+++ b/Python/Product/Analysis/Analyzer/DDG.cs
@@ -239,9 +239,9 @@ namespace Microsoft.PythonTools.Analysis.Analyzer {
                 added = variable.AddTypes(_unit, userMod.GetModuleMember(node, _unit, impName, addRef, Scope, saveName));
             }
 
-            if (addRef) {
-                variable.AddAssignment(node, _unit);
-            } 
+            //if (addRef) {
+            //    variable.AddAssignment(node, _unit);
+            //} 
             
             if (added) {
                 // anyone who read from the module will now need to get the new values

--- a/Python/Product/Analysis/Analyzer/InterpreterScope.cs
+++ b/Python/Product/Analysis/Analyzer/InterpreterScope.cs
@@ -241,23 +241,17 @@ namespace Microsoft.PythonTools.Analysis.Analyzer {
         }
 
         public virtual VariableDef CreateVariable(Node node, AnalysisUnit unit, string name, bool addRef = true) {
-            var res = GetVariable(node, unit, name, addRef);
-            if (res == null) {
-                res = AddVariable(name);
-                if (addRef) {
-                    res.AddReference(node, unit);
-                }
+            var res = GetVariable(node, unit, name, false) ?? AddVariable(name);
+            if (addRef) {
+                res.AddReference(node, unit);
             }
             return res;
         }
 
         public VariableDef CreateEphemeralVariable(Node node, AnalysisUnit unit, string name, bool addRef = true) {
-            var res = GetVariable(node, unit, name, addRef);
-            if (res == null) {
-                res = AddVariable(name, new EphemeralVariableDef());
-                if (addRef) {
-                    res.AddReference(node, unit);
-                }
+            var res = GetVariable(node, unit, name, false) ?? AddVariable(name, new EphemeralVariableDef());
+            if (addRef) {
+                res.AddReference(node, unit);
             }
             return res;
         }

--- a/Python/Product/PythonTools/PythonTools/Navigation/EditFilter.cs
+++ b/Python/Product/PythonTools/PythonTools/Navigation/EditFilter.cs
@@ -241,7 +241,16 @@ namespace Microsoft.PythonTools.Language {
             definitions = new Dictionary<AnalysisLocation, SimpleLocationInfo>();
             values = new Dictionary<AnalysisLocation, SimpleLocationInfo>();
 
+            if (variables == null) {
+                Debug.Fail("unexpected null variables");
+                return;
+            }
+
             foreach (var v in variables) {
+                if (v?.Location == null) {
+                    Debug.Fail("unexpected null variable or location");
+                    continue;
+                }
                 if (v.Location.FilePath == null) {
                     // ignore references in the REPL
                     continue;

--- a/Python/Tests/Analysis/AnalysisTest.cs
+++ b/Python/Tests/Analysis/AnalysisTest.cs
@@ -2605,8 +2605,6 @@ def f(abc):
                 new VariableLocation(16, 14, VariableType.Reference),
 
                 new VariableLocation(18, 12, VariableType.Reference),
-                new VariableLocation(19, 21, VariableType.Definition),
-                new VariableLocation(20, 28, VariableType.Definition),
 
                 new VariableLocation(22, 8, VariableType.Reference),
                 new VariableLocation(23, 10, VariableType.Reference),
@@ -2791,11 +2789,8 @@ from baz import abc2 as abc";
                 new VariableLocation(1, 7, VariableType.Value),         // possible value
                                                                         //new VariableLocation(1, 7, VariableType.Value),
                                                                         // appears twice for two modules, but cannot test that
-                new VariableLocation(2, 20, VariableType.Definition),   // import
                 new VariableLocation(2, 20, VariableType.Reference),    // import
-                new VariableLocation(4, 1, VariableType.Reference),     // call
-                new VariableLocation(1, 25, VariableType.Definition),   // import in oar
-                new VariableLocation(2, 25, VariableType.Definition)    // import in baz
+                new VariableLocation(4, 1, VariableType.Reference)      // call
             );
         }
 


### PR DESCRIPTION
Fixes #1948 Crash on Go To Definition
Checks for nulls and quietly ignores them (with an assert in debug builds)

Fixes #1466 F12 doesn't take me to definition of function but rather proposes a choice
Stops creating Definitions for from...import names.