### PR TITLE
Fixes #1998 cookiecutter recommended feed should use HTTPS by default

### DIFF
--- a/Python/Product/Cookiecutter/UrlConstants.cs
+++ b/Python/Product/Cookiecutter/UrlConstants.cs
@@ -16,8 +16,8 @@
 
 namespace Microsoft.CookiecutterTools {
     internal static class UrlConstants {
-        public const string DefaultRecommendedFeed = "http://go.microsoft.com/fwlink/?LinkID=823051";
-        public const string HelpUrl = "http://go.microsoft.com/fwlink/?LinkID=827351";
-        public const string InstallPythonUrl = "http://go.microsoft.com/fwlink/?LinkID=827353";
+        public const string DefaultRecommendedFeed = "https://go.microsoft.com/fwlink/?LinkID=823051";
+        public const string HelpUrl = "https://go.microsoft.com/fwlink/?LinkID=827351";
+        public const string InstallPythonUrl = "https://go.microsoft.com/fwlink/?LinkID=827353";
     }
 }


### PR DESCRIPTION
Fixes #1998 cookiecutter recommended feed should use HTTPS by default
Changes fwlink constants to be HTTPS