### PR TITLE
Fixes #1909 Cancelling elevation during uninstall throws error

### DIFF
--- a/Python/Product/Common/Infrastructure/ProcessOutput.cs
+++ b/Python/Product/Common/Infrastructure/ProcessOutput.cs
@@ -306,8 +306,6 @@ namespace Microsoft.PythonTools.Infrastructure {
             var psi = new ProcessStartInfo(PythonToolsInstallPath.GetFile("Microsoft.PythonTools.RunElevated.exe", typeof(ProcessOutput).Assembly));
             psi.CreateNoWindow = true;
             psi.WindowStyle = ProcessWindowStyle.Hidden;
-            psi.UseShellExecute = true;
-            psi.Verb = elevate ? "runas" : null;
 
             var utf8 = new UTF8Encoding(false);
             // Send args and env as base64 to avoid newline issues
@@ -505,6 +503,9 @@ namespace Microsoft.PythonTools.Infrastructure {
 
             try {
                 _process.Start();
+            } catch (Win32Exception ex) {
+                _redirector.WriteErrorLine(ex.Message);
+                _process = null;
             } catch (Exception ex) when (!ex.IsCriticalException()) {
                 foreach (var line in SplitLines(ex.ToString())) {
                     _redirector.WriteErrorLine(line);

--- a/Python/Product/RunElevated/RunElevated.csproj
+++ b/Python/Product/RunElevated/RunElevated.csproj
@@ -41,6 +41,9 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
+  <PropertyGroup>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Windows.Forms" />
@@ -54,6 +57,9 @@
       <Project>{b3db0521-d9e3-4f48-9e2e-e5ecae886049}</Project>
       <Name>Microsoft.PythonTools.Common</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.manifest" />
   </ItemGroup>
   <Import Project="..\ProjectAfter.settings" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/Python/Product/RunElevated/app.manifest
+++ b/Python/Product/RunElevated/app.manifest
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-  <assemblyIdentity version="1.0.0.0" name="MyApplication.app"/>
   <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
     <security>
       <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">

--- a/Python/Product/RunElevated/app.manifest
+++ b/Python/Product/RunElevated/app.manifest
@@ -1,0 +1,40 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity version="1.0.0.0" name="MyApplication.app"/>
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
+    <security>
+      <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">
+        <requestedExecutionLevel level="requireAdministrator" uiAccess="false" />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <!-- Windows 7 -->
+      <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}" />
+
+      <!-- Windows 8 -->
+      <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}" />
+
+      <!-- Windows 8.1 -->
+      <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}" />
+
+      <!-- Windows 10 -->
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
+
+    </application>
+  </compatibility>
+  <dependency>
+    <dependentAssembly>
+      <assemblyIdentity
+          type="win32"
+          name="Microsoft.Windows.Common-Controls"
+          version="6.0.0.0"
+          processorArchitecture="*"
+          publicKeyToken="6595b64144ccf1df"
+          language="*"
+        />
+    </dependentAssembly>
+  </dependency>
+</assembly>

--- a/Python/Product/VSInterpreters/PipPackageManager.cs
+++ b/Python/Product/VSInterpreters/PipPackageManager.cs
@@ -354,7 +354,7 @@ namespace Microsoft.PythonTools.Interpreter {
             try {
                 using (await _working.LockAsync(cancellationToken)) {
                     ui?.OnOperationStarted(this, operation);
-                    ui?.OnOutputTextReceived(this, Strings.InstallingPackageStarted.FormatUI(name));
+                    ui?.OnOutputTextReceived(this, Strings.UninstallingPackageStarted.FormatUI(name));
 
                     using (var output = ProcessOutput.Run(
                         _factory.Configuration.InterpreterPath,


### PR DESCRIPTION
Fixes #1909 Cancelling elevation during uninstall throws error
Adds an elevation manifest to RunElevated and improves logging of Win32Exception messages.
Fixes "installing" string displayed when uninstalling packages.