### PR TITLE
Fixes #1991 .vsp files generated by profile give sharing violation

### DIFF
--- a/Python/Product/Profiling/PythonProfilingPackage.cs
+++ b/Python/Product/Profiling/PythonProfilingPackage.cs
@@ -325,6 +325,7 @@ namespace Microsoft.PythonTools.Profiling {
                     for (int retries = 10; retries > 0; --retries) {
                         try {
                             using (new FileStream(outPath, FileMode.Open, FileAccess.Read, FileShare.None)) { }
+                            break;
                         } catch (IOException) {
                             Thread.Sleep(100);
                         }

--- a/Python/Product/Profiling/PythonProfilingPackage.cs
+++ b/Python/Product/Profiling/PythonProfilingPackage.cs
@@ -21,6 +21,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Runtime.InteropServices;
+using System.Threading;
 using System.Windows;
 using Microsoft.PythonTools.Infrastructure;
 using Microsoft.PythonTools.Interpreter;
@@ -321,6 +322,13 @@ namespace Microsoft.PythonTools.Profiling {
                 _stopCommand.Enabled = false;
                 _startCommand.Enabled = true;
                 if (openReport && File.Exists(outPath)) {
+                    for (int retries = 10; retries > 0; --retries) {
+                        try {
+                            using (new FileStream(outPath, FileMode.Open, FileAccess.Read, FileShare.None)) { }
+                        } catch (IOException) {
+                            Thread.Sleep(100);
+                        }
+                    }
                     dte.ItemOperations.OpenFile(outPath);
                 }
             };


### PR DESCRIPTION
Fixes #1991 .vsp files generated by profile give sharing violation
Waits up to 1 second for file to become accessible before opening.

I can't reproduce the actual issue, so I'm assuming it's a race with the profiling process closing. This change defers the open until we've successfully opened the file without sharing.

As far as I can tell, nothing to do with Anaconda.