### PR TITLE
Fixes #1565, #1994, #2005 Auto-detect crashes with Python 3.6 64-bit

### DIFF
--- a/Python/Product/EnvironmentsList/ConfigurationExtension.xaml.cs
+++ b/Python/Product/EnvironmentsList/ConfigurationExtension.xaml.cs
@@ -185,7 +185,16 @@ namespace Microsoft.PythonTools.EnvironmentsList {
                 )) {
                     var exitCode = await output;
                     if (exitCode == 0) {
-                        view.VersionName = output.StandardOutputLines.FirstOrDefault() ?? view.VersionName;
+                        var vn = output.StandardOutputLines.FirstOrDefault() ?? view.VersionName;
+                        if (ConfigurationEnvironmentView.VersionNames.Contains(vn)) {
+                            view.VersionName = vn;
+                        } else if (vn.CompareTo(ConfigurationEnvironmentView.VersionNames.Last()) > 0) {
+                            view.VersionName = ConfigurationEnvironmentView.VersionNames.Last();
+                        } else if (vn.CompareTo(ConfigurationEnvironmentView.VersionNames.First()) < 0) {
+                            view.VersionName = ConfigurationEnvironmentView.VersionNames.First();
+                        } else {
+                            view.VersionName = "2.7";
+                        }
                     }
                 }
 


### PR DESCRIPTION
Fixes #1565, #1994, #2005 Auto-detect crashes with Python 3.6 64-bit
Improves handling when loading invalid version numbers from the registry
Prevents unsupported version numbers being auto-detected when configuring an environment.