### PR TITLE
Fix 2015 Add From Cookiecutter sometimes reverts to global mode

### DIFF
--- a/Python/Product/Cookiecutter/View/CookiecutterContainerPage.xaml.cs
+++ b/Python/Product/Cookiecutter/View/CookiecutterContainerPage.xaml.cs
@@ -99,7 +99,11 @@ namespace Microsoft.CookiecutterTools.View {
             _searchPage.SelectedTemplateChanged += SearchPage_SelectedTemplateChanged;
         }
 
-        public async Task InitializeAsync(bool checkForUpdates) {
+        public async Task InitializeAsync(bool checkForUpdates, ProjectLocation location) {
+            if (location != null) {
+                SetProjectLocation(location);
+            }
+
             await ViewModel.SearchAsync();
 
             if (checkForUpdates) {
@@ -255,10 +259,14 @@ namespace Microsoft.CookiecutterTools.View {
             Home();
 
             if (location != null) {
-                ViewModel.OutputFolderPath = location.FolderPath;
-                ViewModel.FixedOutputFolder = true;
-                ViewModel.TargetProjectLocation = location;
+                SetProjectLocation(location);
             }
+        }
+
+        private void SetProjectLocation(ProjectLocation location) {
+            ViewModel.OutputFolderPath = location.FolderPath;
+            ViewModel.FixedOutputFolder = true;
+            ViewModel.TargetProjectLocation = location;
         }
 
         private void UserControl_MouseRightButtonUp(object sender, MouseButtonEventArgs e) {


### PR DESCRIPTION
Add From Cookiecutter was basically ignored when the command was ending up creating the tool window for the first time. Due to the tool window performing its actual initialization on idle, the NewSession() which was passing in the target project location was a no-op due to the control not being ready.