### PR TITLE
Improve django url intellisense parameters completion

### DIFF
--- a/Common/Product/SharedProject/Automation/OAProperties.cs
+++ b/Common/Product/SharedProject/Automation/OAProperties.cs
@@ -97,13 +97,13 @@ namespace Microsoft.VisualStudioTools.Project.Automation {
         /// <summary>
         /// Returns an indexed member of a Properties collection. 
         /// </summary>
-        /// <param name="index">The index at which to return a mamber.</param>
+        /// <param name="index">The index at which to return a member.</param>
         /// <returns>A Property object.</returns>
         public virtual EnvDTE.Property Item(object index) {
             if (index is string) {
                 string indexAsString = (string)index;
                 if (this.properties.ContainsKey(indexAsString)) {
-                    return (EnvDTE.Property)this.properties[indexAsString];
+                    return this.properties[indexAsString];
                 }
             } else if (index is int) {
                 int realIndex = (int)index - 1;

--- a/Python/Product/Django.Analysis/DjangoAnalyzer.cs
+++ b/Python/Product/Django.Analysis/DjangoAnalyzer.cs
@@ -34,7 +34,7 @@ namespace Microsoft.PythonTools.Django.Analysis {
         internal const string Name = "django";
         internal readonly Dictionary<string, TagInfo> _tags = new Dictionary<string, TagInfo>();
         internal readonly Dictionary<string, TagInfo> _filters = new Dictionary<string, TagInfo>();
-        internal readonly ISet<DjangoUrl> _urls = new SortedSet<DjangoUrl>();
+        internal readonly IList<DjangoUrl> _urls = new List<DjangoUrl>();
         private readonly HashSet<IPythonProjectEntry> _hookedEntries = new HashSet<IPythonProjectEntry>();
         internal readonly Dictionary<string, TemplateVariables> _templateFiles = new Dictionary<string, TemplateVariables>(StringComparer.OrdinalIgnoreCase);
         private ConditionalWeakTable<Node, ContextMarker> _contextTable = new ConditionalWeakTable<Node, ContextMarker>();
@@ -97,7 +97,8 @@ namespace Microsoft.PythonTools.Django.Analysis {
 
                     return serializer.Serialize(res);
                 case Commands.GetUrls:
-                    return serializer.Serialize(_urls.ToArray());
+                    // GroupBy + Select have the same effect as Distinct with a long EqualityComparer
+                    return serializer.Serialize(_urls.GroupBy(url => url.FullName).Select(urlGroup => urlGroup.First()));
                 case Commands.GetMembers:
                     string[] args = serializer.Deserialize<string[]>(body);
                     var file = args[0];

--- a/Python/Product/Django.Analysis/DjangoUrl.cs
+++ b/Python/Product/Django.Analysis/DjangoUrl.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABLITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System;
 using System.Linq;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;

--- a/Python/Product/Django.Analysis/DjangoUrl.cs
+++ b/Python/Product/Django.Analysis/DjangoUrl.cs
@@ -20,22 +20,27 @@ using System.Collections.Generic;
 using System.Text.RegularExpressions;
 
 namespace Microsoft.PythonTools.Django.Analysis {
-    class DjangoUrl : IComparable<DjangoUrl> {
-        public string FullUrlName;
+    class DjangoUrl {
+        public readonly string Name;
+        public string FullName {
+            get {
+                return Name;
+            }
+        }
         private readonly string _urlRegex;
         private static readonly Regex _regexGroupMatchingRegex = new Regex(@"\(.*?\)");
-        public IList<DjangoUrlParameter> _parameters = new List<DjangoUrlParameter>();
+        public IList<DjangoUrlParameter> Parameters = new List<DjangoUrlParameter>();
 
         public IEnumerable<DjangoUrlParameter> NamedParameters {
             get {
-                return _parameters.Where(p => p.IsNamed);
+                return Parameters.Where(p => p.IsNamed);
             }
         }
 
         public DjangoUrl() { }
 
         public DjangoUrl(string urlName, string urlRegex) {
-            FullUrlName = urlName;
+            Name = urlName;
             _urlRegex = urlRegex;
 
             ParseUrlRegex();
@@ -46,18 +51,10 @@ namespace Microsoft.PythonTools.Django.Analysis {
 
             foreach (Match m in matches) {
                 foreach (Group grp in m.Groups) {
-                    _parameters.Add(new DjangoUrlParameter(grp.Value));
+                    Parameters.Add(new DjangoUrlParameter(grp.Value));
                 }
             }
         }
-
-        #region IComparable implementation
-
-        public int CompareTo(DjangoUrl other) {
-            return FullUrlName.CompareTo(other.FullUrlName);
-        }
-
-        #endregion
     }
 
     class DjangoUrlParameter {

--- a/Python/Product/Django/TemplateParsing/DjangoBlocks/DjangoUrlBlock.cs
+++ b/Python/Product/Django/TemplateParsing/DjangoBlocks/DjangoUrlBlock.cs
@@ -1,4 +1,20 @@
-﻿using Microsoft.PythonTools.Django.Analysis;
+﻿// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABLITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using Microsoft.PythonTools.Django.Analysis;
 using Microsoft.VisualStudio.Language.Intellisense;
 using Microsoft.VisualStudio.Text;
 using System;


### PR DESCRIPTION
Hey hey,

Hesse commits:
- Fix a small typo
- Remove a redundant cast
- add the PTVS Apache License in a file where it should be

but more importantly, it improves the way django url parameters are completed.
It will propose the context variables as completion, as long as not enough parameters have been provided to the url template tag. And it will propose the unused named parameters also as completion.

Some changes are a "preparation"  to the django url namespace support I'm working on.

Cheers,
David