### PR TITLE
Fixes #2041 Constantly creating processes while checking packages

### DIFF
--- a/Python/Product/Analysis/ModulePath.cs
+++ b/Python/Product/Analysis/ModulePath.cs
@@ -366,7 +366,7 @@ namespace Microsoft.PythonTools.Analysis {
         /// not raise exceptions.
         /// </summary>
         public static bool IsPythonFile(string path) {
-            return IsPythonFile(path, true, true);
+            return IsPythonFile(path, true, true, true);
         }
 
         /// <summary>
@@ -381,7 +381,7 @@ namespace Microsoft.PythonTools.Analysis {
         /// ensure the module can be imported.
         /// </remarks>
         public static bool IsPythonSourceFile(string path) {
-            return IsPythonFile(path, false, false);
+            return IsPythonFile(path, false, false, false);
         }
         
         /// <summary>
@@ -396,9 +396,12 @@ namespace Microsoft.PythonTools.Analysis {
         /// names.
         /// </param>
         /// <param name="allowCompiled">
-        /// True if pyd, pyc and pyo files should be allowed.
+        /// True if pyd files should be allowed.
         /// </param>
-        public static bool IsPythonFile(string path, bool strict, bool allowCompiled) {
+        /// <param name="allowCache">
+        /// True if pyc and pyo files should be allowed.
+        /// </param>
+        public static bool IsPythonFile(string path, bool strict, bool allowCompiled, bool allowCache) {
             if (string.IsNullOrEmpty(path)) {
                 return false;
             }
@@ -424,8 +427,8 @@ namespace Microsoft.PythonTools.Analysis {
                 var ext = name.Substring(name.LastIndexOf('.') + 1);
                 return "py".Equals(ext, StringComparison.OrdinalIgnoreCase) ||
                     "pyw".Equals(ext, StringComparison.OrdinalIgnoreCase) ||
-                    (allowCompiled && (
-                        "pyd".Equals(ext, StringComparison.OrdinalIgnoreCase) ||
+                    (allowCompiled && "pyd".Equals(ext, StringComparison.OrdinalIgnoreCase)) ||
+                    (allowCache && (
                         "pyc".Equals(ext, StringComparison.OrdinalIgnoreCase) ||
                         "pyo".Equals(ext, StringComparison.OrdinalIgnoreCase)
                     ));

--- a/Python/Product/VSInterpreters/PipPackageManager.cs
+++ b/Python/Product/VSInterpreters/PipPackageManager.cs
@@ -711,22 +711,8 @@ namespace Microsoft.PythonTools.Interpreter {
             }
         }
 
-        private static bool IsDirectory(string path) {
-            if (!Directory.Exists(path)) {
-                return false;
-            }
-
-            // These are the most likely directories to be created, and we know
-            // that we do not care about the contents, so ignore it.
-            if ("__pycache__".Equals(PathUtils.GetFileOrDirectoryName(path), StringComparison.OrdinalIgnoreCase)) {
-                return false;
-            }
-
-            return true;
-        }
-
         private void OnRenamed(object sender, RenamedEventArgs e) {
-            if (IsDirectory(e.FullPath) ||
+            if (Directory.Exists(e.FullPath) ||
                 ModulePath.IsPythonFile(e.FullPath, false, true, false) ||
                 ModulePath.IsPythonFile(e.OldFullPath, false, true, false)) {
                 try {
@@ -737,7 +723,7 @@ namespace Microsoft.PythonTools.Interpreter {
         }
 
         private void OnChanged(object sender, FileSystemEventArgs e) {
-            if (IsDirectory(e.FullPath) ||
+            if (Directory.Exists(e.FullPath) ||
                 ModulePath.IsPythonFile(e.FullPath, false, true, false)) {
                 try {
                     _refreshIsCurrentTrigger.Change(1000, Timeout.Infinite);

--- a/Python/Tests/Analysis/ModulePathTests.cs
+++ b/Python/Tests/Analysis/ModulePathTests.cs
@@ -58,27 +58,29 @@ namespace AnalysisTests {
         [TestMethod, Priority(1)]
         public void IsPythonFile() {
             foreach (var test in new[] {
-                new { SourceFile = @"spam\abc.py", ExpectedStrict = true, ExpectedNoStrict = true },
-                new { SourceFile = @"spam\abc.pyc", ExpectedStrict = true, ExpectedNoStrict = true },
-                new { SourceFile = @"spam\abc.pyo", ExpectedStrict = true, ExpectedNoStrict = true },
-                new { SourceFile = @"spam\abc.pyd", ExpectedStrict = true, ExpectedNoStrict = true },
-                new { SourceFile = @"spam\abc.cp35-win_amd64.pyd", ExpectedStrict = true, ExpectedNoStrict = true },
-                new { SourceFile = @"spam\abc_d.pyd", ExpectedStrict = true, ExpectedNoStrict = true },
-                new { SourceFile = @"spam\abc_d.cp35-win_amd64.pyd", ExpectedStrict = true, ExpectedNoStrict = true },
-                new { SourceFile = @"spam\abc-123.py", ExpectedStrict = false, ExpectedNoStrict = true },
-                new { SourceFile = @"spam\abc-123.pyc", ExpectedStrict = false, ExpectedNoStrict = true },
-                new { SourceFile = @"spam\abc-123.pyo", ExpectedStrict = false, ExpectedNoStrict = true },
-                new { SourceFile = @"spam\abc-123.pyd", ExpectedStrict = false, ExpectedNoStrict = true },
-                new { SourceFile = @"spam\abc.123.py", ExpectedStrict = false, ExpectedNoStrict = true },
-                new { SourceFile = @"spam\abc.123.pyc", ExpectedStrict = false, ExpectedNoStrict = true },
-                new { SourceFile = @"spam\abc.123.pyo", ExpectedStrict = false, ExpectedNoStrict = true },
-                new { SourceFile = @"spam\abc.123.pyd", ExpectedStrict = true, ExpectedNoStrict = true },
+                new { SourceFile = @"spam\abc.py", ExpectedStrict = true, ExpectedNoStrict = true, ExpectedWithoutCompiled = true, ExpectedWithoutCache = true },
+                new { SourceFile = @"spam\abc.pyc", ExpectedStrict = true, ExpectedNoStrict = true, ExpectedWithoutCompiled = true, ExpectedWithoutCache = false },
+                new { SourceFile = @"spam\abc.pyo", ExpectedStrict = true, ExpectedNoStrict = true, ExpectedWithoutCompiled = true, ExpectedWithoutCache = false },
+                new { SourceFile = @"spam\abc.pyd", ExpectedStrict = true, ExpectedNoStrict = true, ExpectedWithoutCompiled = false, ExpectedWithoutCache = true },
+                new { SourceFile = @"spam\abc.cp35-win_amd64.pyd", ExpectedStrict = true, ExpectedNoStrict = true, ExpectedWithoutCompiled = false, ExpectedWithoutCache = true },
+                new { SourceFile = @"spam\abc_d.pyd", ExpectedStrict = true, ExpectedNoStrict = true, ExpectedWithoutCompiled = false, ExpectedWithoutCache = true },
+                new { SourceFile = @"spam\abc_d.cp35-win_amd64.pyd", ExpectedStrict = true, ExpectedNoStrict = true, ExpectedWithoutCompiled = false, ExpectedWithoutCache = true },
+                new { SourceFile = @"spam\abc-123.py", ExpectedStrict = false, ExpectedNoStrict = true, ExpectedWithoutCompiled = true, ExpectedWithoutCache = true },
+                new { SourceFile = @"spam\abc-123.pyc", ExpectedStrict = false, ExpectedNoStrict = true, ExpectedWithoutCompiled = true, ExpectedWithoutCache = false },
+                new { SourceFile = @"spam\abc-123.pyo", ExpectedStrict = false, ExpectedNoStrict = true, ExpectedWithoutCompiled = true, ExpectedWithoutCache = false },
+                new { SourceFile = @"spam\abc-123.pyd", ExpectedStrict = false, ExpectedNoStrict = true, ExpectedWithoutCompiled = false, ExpectedWithoutCache = true },
+                new { SourceFile = @"spam\abc.123.py", ExpectedStrict = false, ExpectedNoStrict = true, ExpectedWithoutCompiled = true, ExpectedWithoutCache = true },
+                new { SourceFile = @"spam\abc.123.pyc", ExpectedStrict = false, ExpectedNoStrict = true, ExpectedWithoutCompiled = true, ExpectedWithoutCache = false },
+                new { SourceFile = @"spam\abc.123.pyo", ExpectedStrict = false, ExpectedNoStrict = true, ExpectedWithoutCompiled = true, ExpectedWithoutCache = false },
+                new { SourceFile = @"spam\abc.123.pyd", ExpectedStrict = true, ExpectedNoStrict = true, ExpectedWithoutCompiled = false, ExpectedWithoutCache = true },
             }) {
-                Assert.AreEqual(test.ExpectedStrict, ModulePath.IsPythonFile(test.SourceFile, true, true), test.SourceFile);
-                Assert.AreEqual(test.ExpectedNoStrict, ModulePath.IsPythonFile(test.SourceFile, false, true), test.SourceFile);
+                Assert.AreEqual(test.ExpectedStrict, ModulePath.IsPythonFile(test.SourceFile, true, true, true), test.SourceFile);
+                Assert.AreEqual(test.ExpectedNoStrict, ModulePath.IsPythonFile(test.SourceFile, false, true, true), test.SourceFile);
+                Assert.AreEqual(test.ExpectedWithoutCompiled, ModulePath.IsPythonFile(test.SourceFile, false, false, true), test.SourceFile);
+                Assert.AreEqual(test.ExpectedWithoutCache, ModulePath.IsPythonFile(test.SourceFile, false, true, false), test.SourceFile);
                 var withForwards = test.SourceFile.Replace('\\', '/');
-                Assert.AreEqual(test.ExpectedStrict, ModulePath.IsPythonFile(withForwards, true, true), withForwards);
-                Assert.AreEqual(test.ExpectedNoStrict, ModulePath.IsPythonFile(withForwards, false, true), withForwards);
+                Assert.AreEqual(test.ExpectedStrict, ModulePath.IsPythonFile(withForwards, true, true, true), withForwards);
+                Assert.AreEqual(test.ExpectedNoStrict, ModulePath.IsPythonFile(withForwards, false, true, true), withForwards);
             }
         }
 


### PR DESCRIPTION
Fixes #2041 Constantly creating processes while checking packages
Checks whether the file change is a Python source or compiled file before retriggering package scan.