### PR TITLE
Range of important fixes

### DIFF
--- a/Common/Product/SharedProject/TaskDialog.cs
+++ b/Common/Product/SharedProject/TaskDialog.cs
@@ -160,6 +160,10 @@ namespace Microsoft.VisualStudioTools.Infrastructure {
             config.pRadioButtons = IntPtr.Zero;
 
             var uiShell = (IVsUIShell)_provider.GetService(typeof(SVsUIShell));
+            if (uiShell == null) {
+                // We are shutting down, so return the default
+                return SelectedButton;
+            }
             uiShell.GetDialogOwnerHwnd(out config.hwndParent);
             uiShell.EnableModeless(0);
 

--- a/Python/Product/Analysis/Analysis.csproj
+++ b/Python/Product/Analysis/Analysis.csproj
@@ -66,6 +66,7 @@
     <Compile Include="Interpreter\Ast\AstPythonFunctionOverload.cs" />
     <Compile Include="Interpreter\Ast\AstPythonModule.cs" />
     <Compile Include="Interpreter\Ast\AstPythonParameterInfo.cs" />
+    <Compile Include="Interpreter\GlobalInterpreterOptions.cs" />
     <Compile Include="Interpreter\InterpreterArchitecture.cs" />
     <Compile Include="Interpreter\IPackageManager.cs" />
     <Compile Include="Interpreter\IPackageManagerUI.cs" />

--- a/Python/Product/Analysis/Interpreter/GlobalInterpreterOptions.cs
+++ b/Python/Product/Analysis/Interpreter/GlobalInterpreterOptions.cs
@@ -1,0 +1,37 @@
+﻿// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABLITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System.ComponentModel.Composition;
+
+namespace Microsoft.PythonTools.Interpreter {
+    /// <summary>
+    /// Allows global (process-wide) options to be set for all interpreters.
+    /// 
+    /// This is intended primarily for the analyzer process. Most code should
+    /// never set these options and should only read them.
+    /// </summary>
+    public static class GlobalInterpreterOptions {
+        /// <summary>
+        /// When True, factories should not watch the file system.
+        /// </summary>
+        public static bool SuppressFileSystemWatchers { get; set; }
+
+        /// <summary>
+        /// When True, factories should never provide a package manager.
+        /// </summary>
+        public static bool SuppressPackageManagers { get; set; }
+    }
+}

--- a/Python/Product/Analysis/Interpreter/IPythonInterpreterFactoryWithDatabase.cs
+++ b/Python/Product/Analysis/Interpreter/IPythonInterpreterFactoryWithDatabase.cs
@@ -89,5 +89,10 @@ namespace Microsoft.PythonTools.Interpreter {
         /// in the database.
         /// </summary>
         IEnumerable<string> GetUpToDateModules();
+
+        /// <summary>
+        /// Raised when a new database is available. 
+        /// </summary>
+        event EventHandler NewDatabaseAvailable;
     }
 }

--- a/Python/Product/Analysis/Interpreter/PythonInterpreterFactoryWithDatabase.cs
+++ b/Python/Product/Analysis/Interpreter/PythonInterpreterFactoryWithDatabase.cs
@@ -87,7 +87,7 @@ namespace Microsoft.PythonTools.Interpreter {
                 throw new ArgumentException(ex.Message, ex);
             }
 
-            if (options.WatchFileSystem && !string.IsNullOrEmpty(DatabasePath)) {
+            if (!GlobalInterpreterOptions.SuppressFileSystemWatchers && options.WatchFileSystem && !string.IsNullOrEmpty(DatabasePath)) {
                 // Assume the database is valid if the version is up to date, then
                 // switch to invalid after we've checked.
                 _isValid = PythonTypeDatabase.IsDatabaseVersionCurrent(DatabasePath);
@@ -110,14 +110,16 @@ namespace Microsoft.PythonTools.Interpreter {
                 _isValid = true;
             }
 
-            try {
-                var pm = options.PackageManager;
-                if (pm != null) {
-                    pm.SetInterpreterFactory(this);
-                    pm.InstalledFilesChanged += PackageManager_InstalledFilesChanged;
-                    PackageManager = pm;
+            if (!GlobalInterpreterOptions.SuppressPackageManagers) {
+                try {
+                    var pm = options.PackageManager;
+                    if (pm != null) {
+                        pm.SetInterpreterFactory(this);
+                        pm.InstalledFilesChanged += PackageManager_InstalledFilesChanged;
+                        PackageManager = pm;
+                    }
+                } catch (NotSupportedException) {
                 }
-            } catch (NotSupportedException) {
             }
         }
 
@@ -344,7 +346,7 @@ namespace Microsoft.PythonTools.Interpreter {
             _hasEverCheckedDatabase = true;
 #endif
 
-            if (string.IsNullOrEmpty(DatabasePath)) {
+            if (GlobalInterpreterOptions.SuppressFileSystemWatchers || string.IsNullOrEmpty(DatabasePath)) {
                 _isCheckingDatabase = false;
                 _isValid = true;
                 _missingModules = null;

--- a/Python/Product/Analyzer/Analyzer.csproj
+++ b/Python/Product/Analyzer/Analyzer.csproj
@@ -62,6 +62,9 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\..\..\Common\Product\SharedProject\DebugTimer.cs">
+      <Link>DebugTimer.cs</Link>
+    </Compile>
     <Compile Include="AssemblyInfo.cs" />
     <Compile Include="Intellisense\AnalysisProtocol.cs" />
     <Compile Include="Intellisense\AnalysisPriority.cs" />

--- a/Python/Product/Analyzer/App.config
+++ b/Python/Product/Analyzer/App.config
@@ -7,5 +7,6 @@
     <add key="matplotlib.CallDepth" value="3"/>
     <add key="pandas.CallDepth" value="0"/>
     <add key="astropy.CallDepth" value="0"/>
+    <add key="delphixpy.CallDepth" value="0"/>
   </appSettings>
 </configuration>

--- a/Python/Product/Analyzer/Intellisense/AnalysisQueue.cs
+++ b/Python/Product/Analyzer/Intellisense/AnalysisQueue.cs
@@ -175,17 +175,15 @@ namespace Microsoft.PythonTools.Intellisense {
                 ((AutoResetEvent)threadStarted).Set();
             }
 
+            AnalysisStarted?.Invoke(this, EventArgs.Empty);
+            _isAnalyzing = true;
+
             while (!_cancel.IsCancellationRequested) {
                 IAnalyzable workItem;
 
                 AnalysisPriority pri;
                 lock (_queueLock) {
                     workItem = GetNextItem(out pri);
-                    _isAnalyzing = true;
-                }
-                var evt = AnalysisStarted;
-                if (evt != null) {
-                    evt(this, EventArgs.Empty);
                 }
 
                 if (workItem != null) {
@@ -208,13 +206,19 @@ namespace Microsoft.PythonTools.Intellisense {
                         _analyzer.ReportUnhandledException(ex);
                         _cancel.Cancel();
                     }
-                } else {
+                } else if (!_workEvent.WaitOne(500)) {
+                    // Short wait for activity before raising the event.
                     _isAnalyzing = false;
-                    AnalysisComplete?.Invoke(this, EventArgs.Empty);
-                    WaitHandle.SignalAndWait(
-                        _analyzer.QueueActivityEvent,
-                        _workEvent
-                    );
+                    var evt = AnalysisComplete;
+                    if (evt != null) {
+                        ThreadPool.QueueUserWorkItem(_ => evt(this, EventArgs.Empty));
+                    }
+                    WaitHandle.SignalAndWait(_analyzer.QueueActivityEvent, _workEvent);
+                    evt = AnalysisStarted;
+                    if (evt != null) {
+                        ThreadPool.QueueUserWorkItem(_ => evt(this, EventArgs.Empty));
+                    }
+                    _isAnalyzing = true;
                 }
             }
             _isAnalyzing = false;

--- a/Python/Product/PythonTools/PythonTools/Project/InterpretersNode.cs
+++ b/Python/Product/PythonTools/PythonTools/Project/InterpretersNode.cs
@@ -117,6 +117,7 @@ namespace Microsoft.PythonTools.Project {
 
         private void RefreshPackages() {
             RefreshPackagesAsync(_factory?.PackageManager)
+                .SilenceException<OperationCanceledException>()
                 .HandleAllExceptions(ProjectMgr.Site, GetType())
                 .DoNotWait();
         }
@@ -206,6 +207,7 @@ namespace Microsoft.PythonTools.Project {
         public void ResumeWatching() {
             _suppressPackageRefresh = false;
             RefreshPackagesAsync(_factory?.PackageManager)
+                .SilenceException<OperationCanceledException>()
                 .HandleAllExceptions(ProjectMgr.Site, GetType())
                 .DoNotWait();
         }

--- a/Python/Product/PythonTools/PythonTools/Project/PythonFileNode.cs
+++ b/Python/Product/PythonTools/PythonTools/Project/PythonFileNode.cs
@@ -234,7 +234,7 @@ namespace Microsoft.PythonTools.Project {
 
                 var textBuffer = GetTextBuffer(false);
 
-                BufferParser parser = analysis?.BufferParser;
+                BufferParser parser = analysis?.TryGetBufferParser();
                 if (parser != null) {
                     analyzer.ReAnalyzeTextBuffers(parser);
                 }

--- a/Python/Product/PythonTools/PythonTools/Project/PythonProjectNode.cs
+++ b/Python/Product/PythonTools/PythonTools/Project/PythonProjectNode.cs
@@ -1025,11 +1025,6 @@ namespace Microsoft.PythonTools.Project {
             }
         }
 
-        /*
-        public PythonAnalyzer GetProjectAnalyzer() {
-            return GetAnalyzer().Project;
-        }
-        */
         VsProjectAnalyzer IPythonProject.GetProjectAnalyzer() {
             return GetAnalyzer();
         }
@@ -1072,6 +1067,8 @@ namespace Microsoft.PythonTools.Project {
                     _analyzer.ClearAllTasks();
 
                     if (_analyzer.RemoveUser()) {
+                        _analyzer.AbnormalAnalysisExit -= AnalysisProcessExited;
+                        _analyzer.AnalyzerNeedsRestart -= OnActiveInterpreterChanged;
                         _analyzer.Dispose();
                     }
                     _analyzer = null;
@@ -1159,7 +1156,7 @@ namespace Microsoft.PythonTools.Project {
                                 return pyProj._analyzer;
                             }
                         }
-                    } catch (COMException) {
+                    } catch (Exception) {
                         Debug.Fail("Failed to get project for {0}".FormatInvariant(projPath));
                         // Can continue searching though, since if the project isn't
                         // valid then we can't very well share the analyzer with it.
@@ -1177,6 +1174,7 @@ namespace Microsoft.PythonTools.Project {
                 BuildProject
             );
             res.AbnormalAnalysisExit += AnalysisProcessExited;
+            res.AnalyzerNeedsRestart += OnActiveInterpreterChanged;
 
             HookErrorsAndWarnings(res);
             UpdateAnalyzerSearchPaths(res);

--- a/Python/Product/VSCommon/Infrastructure/TaskDialog.cs
+++ b/Python/Product/VSCommon/Infrastructure/TaskDialog.cs
@@ -160,6 +160,10 @@ namespace Microsoft.PythonTools.Infrastructure {
             config.pRadioButtons = IntPtr.Zero;
 
             var uiShell = (IVsUIShell)_provider.GetService(typeof(SVsUIShell));
+            if (uiShell == null) {
+                // We are shutting down, so return the default
+                return SelectedButton;
+            }
             uiShell.GetDialogOwnerHwnd(out config.hwndParent);
             uiShell.EnableModeless(0);
 

--- a/Python/Product/VSInterpreters/PipPackageManager.cs
+++ b/Python/Product/VSInterpreters/PipPackageManager.cs
@@ -723,7 +723,7 @@ namespace Microsoft.PythonTools.Interpreter {
         }
 
         private void OnChanged(object sender, FileSystemEventArgs e) {
-            if (Directory.Exists(e.FullPath) ||
+            if ((Directory.Exists(e.FullPath) && !"__pycache__".Equals(PathUtils.GetFileOrDirectoryName(e.FullPath))) ||
                 ModulePath.IsPythonFile(e.FullPath, false, true, false)) {
                 try {
                     _refreshIsCurrentTrigger.Change(1000, Timeout.Infinite);

--- a/Python/Tests/PythonToolsMockTests/CompletionTests.cs
+++ b/Python/Tests/PythonToolsMockTests/CompletionTests.cs
@@ -1117,7 +1117,7 @@ async def g():
                 ManualResetEvent mre = new ManualResetEvent(false);
                 view.View.TextView.TextBuffer.RegisterForNewAnalysis(entry => {
                     if (afterEditVersion != null &&
-                    entry.BufferParser.GetAnalysisVersion(snapshot.TextBuffer).VersionNumber >= afterEditVersion.VersionNumber) {
+                    entry.TryGetBufferParser().GetAnalysisVersion(snapshot.TextBuffer).VersionNumber >= afterEditVersion.VersionNumber) {
                         mre.Set();
                     }
                 });

--- a/Python/Tests/PythonToolsMockTests/PythonEditor.cs
+++ b/Python/Tests/PythonToolsMockTests/PythonEditor.cs
@@ -138,7 +138,7 @@ namespace PythonToolsMockTests {
                     var oldVersion = buffer.CurrentSnapshot;
                     buffer.GetPythonAnalysisClassifier().ClassificationChanged += (s, e) => {
                         var entry = View.TextView.GetAnalysisEntry(buffer, VS.ServiceProvider);
-                        if (entry.BufferParser.GetAnalysisVersion(buffer).VersionNumber > oldVersion.Version.VersionNumber) {
+                        if (entry.TryGetBufferParser()?.GetAnalysisVersion(buffer).VersionNumber > oldVersion.Version.VersionNumber) {
                             mre.SetIfNotDisposed();
                         }
                     };
@@ -149,7 +149,7 @@ namespace PythonToolsMockTests {
                     }
 
                     var analysis = View.TextView.GetAnalysisEntry(buffer, VS.ServiceProvider);
-                    analysis.BufferParser.Requeue();    // force the reparse to happen quickly...
+                    analysis.TryGetBufferParser().Requeue();    // force the reparse to happen quickly...
 
                     if (!mre.Wait(10000)) {
                         throw new TimeoutException("Failed to see buffer start analyzing");


### PR DESCRIPTION
Prevents a few crashes at shutdown
Improves encapsulation/creation of BufferParser instances (doesn't quite fix all the races here, but it's a necessary start point - more work coming here)
Avoids sending too many AnalysisComplete events
Avoids creating filesystem watchers and package managers in analyzer process
Fixes analyzer not resetting after database update
Fixes retriggering package scan because of a package scan
Prevents OOM when analyzing delphixpy package