### PR TITLE
Fixes #2057 Multiple project IntelliSense does not work

### DIFF
--- a/Python/Product/Analysis/Values/BuiltinInstanceInfo.cs
+++ b/Python/Product/Analysis/Values/BuiltinInstanceInfo.cs
@@ -302,6 +302,9 @@ namespace Microsoft.PythonTools.Analysis.Values {
         }
 
         internal override int UnionHashCode(int strength) {
+            if (strength >= MergeStrength.ToObject) {
+                return ProjectState.ClassInfos[BuiltinTypeId.Object].GetHashCode();
+            }
             return ClassInfo.UnionHashCode(strength);
         }
 


### PR DESCRIPTION
Fixes #2057 Multiple project IntelliSense does not work
Stops trying to share analyzer processes between projects.
Also fixes incorrect hash code when strongly merging object values.