### PR TITLE
Partially fixes #2602 No navigate to results of object browser items

### DIFF
--- a/Python/Product/Analyzer/Intellisense/AnalysisProtocol.cs
+++ b/Python/Product/Analyzer/Intellisense/AnalysisProtocol.cs
@@ -609,12 +609,21 @@ namespace Microsoft.PythonTools.Intellisense {
             public override string command => Command;
         }
 
-        public class GetModuleMembers : Request<CompletionsResponse> {
+        public class GetModuleMembersRequest : Request<CompletionsResponse> {
             public const string Command = "getModuleMembers";
 
             public int fileId;
             public string[] package;
             public bool includeMembers;
+
+            public override string command => Command;
+        }
+
+        public class GetAllMembersRequest : Request<CompletionsResponse> {
+            public const string Command = "getAllMembers";
+
+            public string prefix;
+            public GetMemberOptions options;
 
             public override string command => Command;
         }

--- a/Python/Product/PythonTools/PythonTools/Intellisense/ProjectAnalyzer.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/ProjectAnalyzer.cs
@@ -1628,7 +1628,7 @@ namespace Microsoft.PythonTools.Intellisense {
         }
 
         internal async Task<IEnumerable<CompletionResult>> GetModuleMembersAsync(AnalysisEntry entry, string[] package, bool includeMembers) {
-            var members = await SendRequestAsync(new AP.GetModuleMembers() {
+            var members = await SendRequestAsync(new AP.GetModuleMembersRequest() {
                 fileId = entry.FileId,
                 package = package,
                 includeMembers = includeMembers

--- a/Python/Product/PythonTools/PythonTools/Navigation/NavigateTo/PythonNavigateToItemProvider.cs
+++ b/Python/Product/PythonTools/PythonTools/Navigation/NavigateTo/PythonNavigateToItemProvider.cs
@@ -16,149 +16,54 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.PythonTools.Analysis;
 using Microsoft.PythonTools.Infrastructure;
 using Microsoft.PythonTools.Intellisense;
-using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Language.Intellisense;
 using Microsoft.VisualStudio.Language.NavigateTo.Interfaces;
 using Microsoft.VisualStudio.Shell.Interop;
-using Microsoft.VisualStudioTools.Navigation;
+using AP = Microsoft.PythonTools.Intellisense.AnalysisProtocol;
 
 namespace Microsoft.PythonTools.Navigation.NavigateTo {
     internal class PythonNavigateToItemProvider : INavigateToItemProvider {
         private readonly IServiceProvider _serviceProvider;
-        private readonly Library _library;
+        private readonly AnalyzerInfo[] _analyzers;
         private readonly FuzzyMatchMode _matchMode;
         private readonly IGlyphService _glyphService;
         private CancellationTokenSource _searchCts;
 
         // Used to propagate information to PythonNavigateToItemDisplay inside NavigateToItem.Tag.
         internal class ItemTag {
-            public LibraryNode Node { get; set; }
+            public IServiceProvider Site { get; set; }
             public IGlyphService GlyphService { get; set; }
+            public AP.Completion Completion { get; set; }
+            public string ProjectName { get; set; }
         }
 
-        private class LibraryNodeVisitor : ILibraryNodeVisitor {
-            private static readonly Dictionary<StandardGlyphGroup, string> _sggToNavItemKind = new Dictionary<StandardGlyphGroup, string>() {
-                { StandardGlyphGroup.GlyphGroupClass, NavigateToItemKind.Class },
-                { StandardGlyphGroup.GlyphGroupMethod, NavigateToItemKind.Method },
-                { StandardGlyphGroup.GlyphGroupField, NavigateToItemKind.Field }
-            };
-
-            private readonly PythonNavigateToItemProvider _itemProvider;
-            private readonly INavigateToCallback _navCallback;
-            private readonly string _searchValue;
-            private readonly Stack<LibraryNode> _path = new Stack<LibraryNode>();
-            private readonly FuzzyStringMatcher _comparer, _regexComparer;
-
-            private static readonly Guid _projectType = new Guid(PythonConstants.ProjectFactoryGuid);
-
-            public LibraryNodeVisitor(
-                PythonNavigateToItemProvider itemProvider,
-                INavigateToCallback navCallback,
-                string searchValue,
-                FuzzyMatchMode matchMode
-            ) {
-                _itemProvider = itemProvider;
-                _navCallback = navCallback;
-                _searchValue = searchValue;
-                _path.Push(null);
-                _comparer = new FuzzyStringMatcher(matchMode);
-                _regexComparer = new FuzzyStringMatcher(FuzzyMatchMode.RegexIgnoreCase);
-            }
-
-            public bool EnterNode(LibraryNode node, CancellationToken ct) {
-                if (ct.IsCancellationRequested) {
-                    _navCallback.Invalidate();
-                    return false;
-                }
-
-                IVsHierarchy hierarchy;
-                uint itemId, itemsCount;
-                Guid projectType;
-                node.SourceItems(out hierarchy, out itemId, out itemsCount);
-                if (hierarchy != null) {
-                    ErrorHandler.ThrowOnFailure(hierarchy.GetGuidProperty(
-                        (uint)VSConstants.VSITEMID.Root,
-                        (int)__VSHPROPID.VSHPROPID_TypeGuid,
-                        out projectType
-                    ));
-                    if (projectType != _projectType) {
-                        return false;
-                    }
-                }
-
-                var parentNode = _path.Peek();
-                _path.Push(node);
-
-                // We don't want to report modules, since they map 1-to-1 to files, and those are already reported by the standard item provider
-                if (node.NodeType.HasFlag(LibraryNodeType.Package)) {
-                    return true;
-                }
-
-                // Match name against search string.
-                string name = node.Name ?? "";
-                MatchKind matchKind;
-                if (_searchValue.Length > 2 && _searchValue.StartsWith("/") && _searchValue.EndsWith("/")) {
-                    if (!_regexComparer.IsCandidateMatch(name, _searchValue.Substring(1, _searchValue.Length - 2))) {
-                        return true;
-                    }
-                    matchKind = MatchKind.Regular;
-                } else if (name.Equals(_searchValue, StringComparison.Ordinal)) {
-                    matchKind = MatchKind.Exact;
-                } else if (_comparer.IsCandidateMatch(name, _searchValue)) {
-                    matchKind = MatchKind.Regular;
-                } else {
-                    return true;
-                }
-
-                string kind;
-                if (!_sggToNavItemKind.TryGetValue(node.GlyphType, out kind)) {
-                    kind = "";
-                }
-                
-                var text = node.GetTextRepresentation(VSTREETEXTOPTIONS.TTO_DISPLAYTEXT);
-                if (parentNode != null) {
-                    switch (parentNode.GlyphType) {
-                        case StandardGlyphGroup.GlyphGroupModule:
-                            text += string.Format(" [of module {0}]", parentNode.Name);
-                            break;
-                        case StandardGlyphGroup.GlyphGroupClass:
-                            text += string.Format(" [of class {0}]", parentNode.Name);
-                            break;
-                        case StandardGlyphGroup.GlyphGroupMethod:
-                            text += string.Format(" [nested in function {0}]", parentNode.Name);
-                            break;
-                    }
-                }
-
-                var tag = new ItemTag { Node = node, GlyphService = _itemProvider._glyphService };
-                _navCallback.AddItem(new NavigateToItem(text, kind, "Python", "", tag, matchKind, PythonNavigateToItemDisplayFactory.Instance));
-                return true;
-            }
-
-            public void LeaveNode(LibraryNode node, CancellationToken ct) {
-                _path.Pop();
-            }
+        private class AnalyzerInfo {
+            public string ProjectName;
+            public VsProjectAnalyzer Analyzer;
+            public Task<AP.CompletionsResponse> Task;
+            public AP.CompletionsResponse Result;
         }
 
         public PythonNavigateToItemProvider(IServiceProvider serviceProvider, IGlyphService glyphService) {
             _serviceProvider = serviceProvider;
+            var solution = (IVsSolution)_serviceProvider.GetService(typeof(SVsSolution));
+            _analyzers = solution.EnumerateLoadedPythonProjects()
+                .Select(p => new AnalyzerInfo { Analyzer = p.GetAnalyzer(), ProjectName = p.Caption })
+                .Where(a => a.Analyzer != null)
+                .ToArray();
             _glyphService = glyphService;
-            var libraryManager = (LibraryManager)_serviceProvider.GetService(typeof(IPythonLibraryManager));
-            _library = libraryManager?.Library;
             var pyService = _serviceProvider.GetPythonToolsService();
             _matchMode = pyService?.AdvancedOptions.SearchMode ?? FuzzyMatchMode.FuzzyIgnoreLowerCase;
         }
 
         public async void StartSearch(INavigateToCallback callback, string searchValue) {
             CancellationTokenSource searchCts = null;
-
-            if (_library == null) {
-                callback.Done();
-                return;
-            }
 
             try {
                 searchCts = new CancellationTokenSource();
@@ -177,10 +82,7 @@ namespace Microsoft.PythonTools.Navigation.NavigateTo {
                     return;
                 }
 
-                await _library.VisitNodesAsync(
-                    new LibraryNodeVisitor(this, callback, searchValue, _matchMode),
-                    token
-                );
+                await FindMatchesAsync(callback, searchValue, token);
             } catch (OperationCanceledException) {
             } catch (Exception ex) when (!ex.IsCriticalException()) {
                 ex.ReportUnhandledException(_serviceProvider, GetType());
@@ -190,6 +92,81 @@ namespace Microsoft.PythonTools.Navigation.NavigateTo {
                     Interlocked.CompareExchange(ref _searchCts, null, searchCts);
                     searchCts.Dispose();
                 }
+            }
+        }
+
+        private async Task FindMatchesAsync(INavigateToCallback callback, string searchValue, CancellationToken token) {
+            var matchers = new List<Tuple<FuzzyStringMatcher, string, MatchKind>> {
+                    Tuple.Create(new FuzzyStringMatcher(FuzzyMatchMode.Prefix), searchValue, MatchKind.Prefix),
+                    Tuple.Create(new FuzzyStringMatcher(_matchMode), searchValue, MatchKind.Regular)
+                };
+
+            if (searchValue.Length > 2 && searchValue.StartsWith("/") && searchValue.EndsWith("/")) {
+                matchers.Insert(0, Tuple.Create(
+                    new FuzzyStringMatcher(FuzzyMatchMode.RegexIgnoreCase),
+                    searchValue.Substring(1, searchValue.Length - 2),
+                    MatchKind.Regular
+                ));
+            }
+
+            var opts = GetMemberOptions.NoMemberRecursion | GetMemberOptions.IntersectMultipleResults | GetMemberOptions.DetailedInformation;
+            foreach (var a in _analyzers) {
+                a.Task = a.Analyzer.SendRequestAsync(new AP.GetAllMembersRequest { options = opts });
+            }
+            foreach (var a in _analyzers) {
+                a.Result = await a.Task;
+            }
+            token.ThrowIfCancellationRequested();
+
+            int progress = 0;
+            int total = _analyzers.Sum(r => r.Result?.completions?.Length ?? 0);
+            foreach (var a in _analyzers) {
+                token.ThrowIfCancellationRequested();
+                if (a.Result?.completions?.Length == 0) {
+                    continue;
+                }
+
+                foreach (var res in FilterResults(a.ProjectName, a.Result.completions, matchers)) {
+                    callback.AddItem(res);
+                }
+
+                progress += a.Result.completions.Length;
+                callback.ReportProgress(progress, total);
+            }
+        }
+        private IEnumerable<NavigateToItem> FilterResults(
+            string projectName,
+            IEnumerable<AP.Completion> completions,
+            IEnumerable<Tuple<FuzzyStringMatcher, string, MatchKind>> matchers
+        ) {
+            foreach (var c in completions) {
+                MatchKind matchKind = MatchKind.None;
+                foreach (var m in matchers) {
+                    if (m.Item1.IsCandidateMatch(c.name, m.Item2)) {
+                        matchKind = m.Item3;
+                        break;
+                    }
+                }
+                if (matchKind == MatchKind.None) {
+                    continue;
+                }
+
+                var itemTag = new ItemTag {
+                    Site = _serviceProvider,
+                    Completion = c,
+                    GlyphService = _glyphService,
+                    ProjectName = projectName
+                };
+
+                yield return new NavigateToItem(
+                    c.name,
+                    c.memberType.ToString(),
+                    "Python",
+                    "",
+                    itemTag,
+                    matchKind,
+                    PythonNavigateToItemDisplayFactory.Instance
+                );
             }
         }
 


### PR DESCRIPTION
Partially fixes #2602 No navigate to results of object browser items
Switches to an analyzer command for Navigate To results. Object browser is still busted.