### PR TITLE
Fixes #2064 Analyzer null reference in queue worker

### DIFF
--- a/Python/Product/Analyzer/Intellisense/AnalysisQueue.cs
+++ b/Python/Product/Analyzer/Intellisense/AnalysisQueue.cs
@@ -206,17 +206,17 @@ namespace Microsoft.PythonTools.Intellisense {
                         _analyzer.ReportUnhandledException(ex);
                         _cancel.Cancel();
                     }
-                } else if (!_workEvent.WaitOne(500)) {
+                } else if (!_workEvent.WaitOne(50)) {
                     // Short wait for activity before raising the event.
                     _isAnalyzing = false;
-                    var evt = AnalysisComplete;
-                    if (evt != null) {
-                        ThreadPool.QueueUserWorkItem(_ => evt(this, EventArgs.Empty));
+                    var evt1 = AnalysisComplete;
+                    if (evt1 != null) {
+                        ThreadPool.QueueUserWorkItem(_ => evt1(this, EventArgs.Empty));
                     }
                     WaitHandle.SignalAndWait(_analyzer.QueueActivityEvent, _workEvent);
-                    evt = AnalysisStarted;
-                    if (evt != null) {
-                        ThreadPool.QueueUserWorkItem(_ => evt(this, EventArgs.Empty));
+                    var evt2 = AnalysisStarted;
+                    if (evt2 != null) {
+                        ThreadPool.QueueUserWorkItem(_ => evt2(this, EventArgs.Empty));
                     }
                     _isAnalyzing = true;
                 }


### PR DESCRIPTION
Fixes #2064 Analyzer null reference in queue worker
Stops changing the event handler reference in the closure.