### PR TITLE
Fixes a range of IntelliSense issues

### DIFF
--- a/Python/Product/Analysis/Interpreter/Ast/AstPythonType.cs
+++ b/Python/Product/Analysis/Interpreter/Ast/AstPythonType.cs
@@ -53,14 +53,16 @@ namespace Microsoft.PythonTools.Interpreter.Ast {
         }
 
         internal void AddMembers(IEnumerable<KeyValuePair<string, IMember>> members, bool overwrite) {
-            foreach (var kv in members) {
-                if (!overwrite) {
-                    IMember existing;
-                    if (_members.TryGetValue(kv.Key, out existing)) {
-                        continue;
+            lock (_members) {
+                foreach (var kv in members) {
+                    if (!overwrite) {
+                        IMember existing;
+                        if (_members.TryGetValue(kv.Key, out existing)) {
+                            continue;
+                        }
                     }
+                    _members[kv.Key] = kv.Value;
                 }
-                _members[kv.Key] = kv.Value;
             }
         }
 
@@ -76,14 +78,18 @@ namespace Microsoft.PythonTools.Interpreter.Ast {
 
         public IMember GetMember(IModuleContext context, string name) {
             IMember member;
-            _members.TryGetValue(name, out member);
+            lock (_members) {
+                _members.TryGetValue(name, out member);
+            }
             return member;
         }
 
         public IPythonFunction GetConstructors() => GetMember(null, "__init__") as IPythonFunction;
 
         public IEnumerable<string> GetMemberNames(IModuleContext moduleContext) {
-            return _members.Keys.ToArray();
+            lock (_members) {
+                return _members.Keys.ToArray();
+            }
         }
     }
 }

--- a/Python/Product/Analysis/PythonAnalyzer.cs
+++ b/Python/Product/Analysis/PythonAnalyzer.cs
@@ -921,6 +921,12 @@ namespace Microsoft.PythonTools.Analysis {
             if (value == null) {
                 return Types[BuiltinTypeId.NoneType];
             }
+
+            var astConst = value as IPythonConstant;
+            if (astConst != null) {
+                return Types[astConst.Type?.TypeId ?? BuiltinTypeId.Object] ?? Types[BuiltinTypeId.Object];
+            }
+
             switch (Type.GetTypeCode(value.GetType())) {
                 case TypeCode.Boolean: return Types[BuiltinTypeId.Bool];
                 case TypeCode.Double: return Types[BuiltinTypeId.Float];
@@ -939,7 +945,8 @@ namespace Microsoft.PythonTools.Analysis {
                     break;
             }
 
-            throw new InvalidOperationException();
+            Debug.Fail("unsupported constant type <{0}> value '{1}'".FormatInvariant(value.GetType().FullName, value));
+            return Types[BuiltinTypeId.Object];
         }
 
         internal BuiltinClassInfo MakeGenericType(IAdvancedPythonType clrType, params IPythonType[] clrIndexType) {

--- a/Python/Product/Analyzer/Intellisense/AnalysisQueue.cs
+++ b/Python/Product/Analyzer/Intellisense/AnalysisQueue.cs
@@ -222,9 +222,15 @@ namespace Microsoft.PythonTools.Intellisense {
                 }
             }
             _isAnalyzing = false;
+
+            if (_cancel.IsCancellationRequested) {
+                AnalysisAborted?.Invoke(this, EventArgs.Empty);
+            }
         }
 
         public event EventHandler AnalysisComplete;
+
+        public event EventHandler AnalysisAborted;
 
         sealed class GroupAnalysis : IAnalyzable {
             private readonly IGroupableAnalysisProject _project;

--- a/Python/Product/Analyzer/Intellisense/OutOfProcProjectAnalyzer.cs
+++ b/Python/Product/Analyzer/Intellisense/OutOfProcProjectAnalyzer.cs
@@ -76,6 +76,7 @@ namespace Microsoft.PythonTools.Intellisense {
         internal OutOfProcProjectAnalyzer(Stream writer, Stream reader) {
             _analysisQueue = new AnalysisQueue(this);
             _analysisQueue.AnalysisComplete += AnalysisQueue_Complete;
+            _analysisQueue.AnalysisAborted += AnalysisQueue_Aborted;
             _options = new AP.OptionsChangedEvent() {
                 indentation_inconsistency_severity = Severity.Ignore
             };
@@ -91,6 +92,11 @@ namespace Microsoft.PythonTools.Intellisense {
             _container = new CompositionContainer(_catalog);
             _container.ExportsChanged += ContainerExportsChanged;
         }
+
+        private void AnalysisQueue_Aborted(object sender, EventArgs e) {
+            _connection.Dispose();
+        }
+
 
         private void ContainerExportsChanged(object sender, ExportsChangeEventArgs e) {
             // figure out the new extensions...
@@ -193,10 +199,18 @@ namespace Microsoft.PythonTools.Intellisense {
         }
 
         internal void ReportUnhandledException(Exception ex) {
+            SendUnhandledException(ex);
+            // Allow some time for the other threads to write the event before
+            // we (probably) come crashing down.
+            Thread.Sleep(100);
+        }
+
+        private async void SendUnhandledException(Exception ex) {
             try {
-                _connection.SendEventAsync(
+                Debug.Fail(ex.ToString());
+                await _connection.SendEventAsync(
                     new AP.UnhandledExceptionEvent(ex)
-                ).Wait();
+                ).ConfigureAwait(false);
             } catch (Exception) {
                 // We're in pretty bad state, but nothing useful we can do about
                 // it.
@@ -1435,13 +1449,15 @@ namespace Microsoft.PythonTools.Intellisense {
             foreach (var entry in _projectFiles) {
                 var analysis = (entry.Value as IPythonProjectEntry)?.Analysis;
                 if (analysis != null) {
-                    members = members.Concat(analysis.GetAllAvailableMembers(SourceLocation.None, opts));
+                    members = members.Concat(analysis.GetAllAvailableMembers(SourceLocation.None, opts)
+                        .Where(mr => mr.Values.Any(v => v.DeclaringModule == entry.Value)));
                 }
             }
 
             if (!string.IsNullOrEmpty(req.prefix)) {
                 members = members.Where(mr => mr.Name.StartsWith(req.prefix));
             }
+            members = members.GroupBy(mr => mr.Name).Select(g => g.First());
 
             return new AP.CompletionsResponse() {
                 completions = ToCompletions(members.ToArray(), opts)

--- a/Python/Product/EnvironmentsList/ToolWindow.xaml.cs
+++ b/Python/Product/EnvironmentsList/ToolWindow.xaml.cs
@@ -50,7 +50,7 @@ namespace Microsoft.PythonTools.EnvironmentsList {
         private AnalyzerStatusListener _listener;
         private readonly object _listenerLock = new object();
         private int _listenerTimeToLive;
-        const int _listenerDefaultTimeToLive = 120;
+        const int _listenerDefaultTimeToLive = 1200;
 
         // lock(_environments) when accessing _currentlyRefreshing
         private readonly Dictionary<IPythonInterpreterFactory, AnalysisProgress> _currentlyRefreshing;

--- a/Python/Product/PythonTools/PythonTools/Navigation/DropDownBarClient.cs
+++ b/Python/Product/PythonTools/PythonTools/Navigation/DropDownBarClient.cs
@@ -221,10 +221,11 @@ namespace Microsoft.PythonTools.Navigation {
             lock (_navigationsLock) {
                 var cur = _navigations;
                 for (int i = 0; i < path.Length && cur != null; i++) {
-                    if (i < 0 || i >= cur.Children.Length) {
+                    int p = path[i];
+                    if (p < 0 || p >= cur.Children.Length) {
                         return null;
                     }
-                    cur = cur.Children[i];
+                    cur = cur.Children[p];
                 }
                 return cur;
             }


### PR DESCRIPTION
Fixes a range of IntelliSense issues
Fixes #1932 Navigate To probably crashing
Fixes #1547 Navigate To shows too many items
Fixes #1988 Navigation Bar does not navigate to classes
Prevents analyzers from getting stuck when they crash, and forces them to crash completely so we hear about it
Fixes some analyzer crashes that were preventing finding all tests in Azure SDK project
Prevents a race condition getting members from AST analysis
Prevents environments list from resetting the listener so often
Reduces duplication in Navigate To results