### PR TITLE
Prevent OnIdle initialization from occurring more than once.

### DIFF
--- a/Python/Product/PythonTools/PythonToolsService.cs
+++ b/Python/Product/PythonTools/PythonToolsService.cs
@@ -104,6 +104,8 @@ namespace Microsoft.PythonTools {
         private void OnIdleInitialization(object sender, ComponentManagerEventArgs e) {
             Site.AssertShellIsInitialized();
 
+            _idleManager.OnIdle -= OnIdleInitialization;
+
             _expansionCompletions = new ExpansionCompletionSource(Site);
             InitializeLogging();
         }


### PR DESCRIPTION
Fix #2066 devenv.exe ran out of memory

The initialization code that was called constantly was:
- enumerating snippets (using up some memory)
- logging events (which were ignored for memory logger, but not ignored for vs logger)

I'll have to repeat my experiment to ensure this resolves the leak I was seeing, but it's likely to be this, and even if not, this is bad enough that it needs to be fixed.

One regression with this fix:  If you import code snippets using the snippet manager, you won't see the updated snippet list in completions until you restart VS.  You can expand them by manually typing the name + TAB, but they don't appear in completion list.  I don't think that would be a common enough problem to worry about it, but I can file it.