### PR TITLE
Test fixes

### DIFF
--- a/Common/Tests/MockVsTests/MockVs.cs
+++ b/Common/Tests/MockVsTests/MockVs.cs
@@ -486,9 +486,12 @@ namespace Microsoft.VisualStudioTools.MockVsTests {
 
             AppDomain.CurrentDomain.AssemblyResolve += CurrentDomain_AssemblyResolve;
             try {
-                var _excludedAssemblies = new HashSet<string>(new[] {
-                    "VsLogger.dll",
+                var _excludedAssemblies = new HashSet<string>(new string[] {
+#if DEV14
+                    "Microsoft.PythonTools.Workspace.dll",
                     "Microsoft.VisualStudio.Workspace.dll",
+                    "Microsoft.VisualStudio.Workspace.Extensions.VS.dll",
+#endif
                 }, StringComparer.OrdinalIgnoreCase);
 
                 foreach (var file in Directory.GetFiles(runningLoc, "*.dll")) {

--- a/Common/Tests/Utilities/SharedProject/SolutionFile.cs
+++ b/Common/Tests/Utilities/SharedProject/SolutionFile.cs
@@ -64,6 +64,8 @@ namespace TestUtilities.SharedProject {
             System.IO.Directory.CreateDirectory(location);
 
             MSBuild.ProjectCollection collection = new MSBuild.ProjectCollection();
+            // VisualStudioVersion property may not be set in mock tests
+            collection.SetGlobalProperty("VisualStudioVersion", AssemblyVersionInfo.VSVersion);
             foreach (var project in toGenerate) {
                 projects.Add(project.Save(collection, location));
             }

--- a/Python/Product/PythonTools/PythonTools/Extensions.cs
+++ b/Python/Product/PythonTools/PythonTools/Extensions.cs
@@ -897,7 +897,10 @@ namespace Microsoft.PythonTools {
 
         internal static async Task RefreshVariableViews(this IServiceProvider serviceProvider) {
             serviceProvider.GetUIThread().MustBeCalledFromUIThread();
-            EnvDTE.Debugger debugger = serviceProvider.GetDTE().Debugger;
+            EnvDTE.Debugger debugger = serviceProvider.GetDTE()?.Debugger;
+            if (debugger == null) {
+                return;
+            }
             AD7Engine engine = AD7Engine.GetEngineForProcess(debugger.CurrentProcess);
             if (engine != null) {
                 await engine.RefreshThreadFrames(debugger.CurrentThread.ID);

--- a/Python/Product/PythonTools/PythonTools/Repl/PythonInteractiveEvaluator.CommandProcessorThread.cs
+++ b/Python/Product/PythonTools/PythonTools/Repl/PythonInteractiveEvaluator.CommandProcessorThread.cs
@@ -617,6 +617,8 @@ namespace Microsoft.PythonTools.Repl {
                     if (_completion != null) {
                         _completion.SetResult(ExecutionResult.Failure);
                         _completion = null;
+                    } else {
+                        Debug.Fail("No completion task");
                     }
                 }
             }
@@ -627,6 +629,8 @@ namespace Microsoft.PythonTools.Repl {
                     if (_completion != null) {
                         _completion.SetResult(ExecutionResult.Success);
                         _completion = null;
+                    } else {
+                        Debug.Fail("No completion task");
                     }
                 }
             }
@@ -669,7 +673,6 @@ namespace Microsoft.PythonTools.Repl {
                         }
                     }
                 }
-
                 var tcs = new TaskCompletionSource<ExecutionResult>();
                 lock (_completionLock) {
                     _completion = tcs;

--- a/Python/Product/PythonTools/PythonToolsService.cs
+++ b/Python/Product/PythonTools/PythonToolsService.cs
@@ -546,22 +546,27 @@ namespace Microsoft.PythonTools {
             var baseEnv = Environment.GetEnvironmentVariables();
             // Clear search paths from the global environment. The launch
             // configuration should include the existing value
-            baseEnv[config.Interpreter.PathEnvironmentVariable] = string.Empty;
+
+            var pathVar = config.Interpreter.PathEnvironmentVariable;
+            if (string.IsNullOrEmpty(pathVar)) {
+                pathVar = "PYTHONPATH";
+            }
+            baseEnv[pathVar] = string.Empty;
             var env = PathUtils.MergeEnvironments(
                 baseEnv.AsEnumerable<string, string>(),
                 config.GetEnvironmentVariables(),
-                "Path", config.Interpreter.PathEnvironmentVariable
+                "Path", pathVar
             );
             if (config.SearchPaths != null && config.SearchPaths.Any()) {
                 env = PathUtils.MergeEnvironments(
                     env,
                     new[] {
                         new KeyValuePair<string, string>(
-                            config.Interpreter.PathEnvironmentVariable,
+                            pathVar,
                             PathUtils.JoinPathList(config.SearchPaths)
                         )
                     },
-                    config.Interpreter.PathEnvironmentVariable
+                    pathVar
                 );
             }
             return env;

--- a/Python/Tests/Core.UI/PythonProjectProcessor.cs
+++ b/Python/Tests/Core.UI/PythonProjectProcessor.cs
@@ -14,7 +14,10 @@
 // See the Apache Version 2.0 License for specific language governing
 // permissions and limitations under the License.
 
+using System;
 using System.ComponentModel.Composition;
+using Microsoft.PythonTools;
+using Microsoft.PythonTools.Infrastructure;
 using TestUtilities.SharedProject;
 using MSBuild = Microsoft.Build.Evaluation;
 
@@ -26,6 +29,8 @@ namespace PythonToolsUITests {
             project.SetProperty("ProjectHome", ".");
             project.SetProperty("WorkingDirectory", ".");
 
+            var installPath = PathUtils.GetParent(PythonToolsInstallPath.GetFile("Microsoft.PythonTools.dll", typeof(PythonToolsPackage).Assembly));
+            project.SetProperty("_PythonToolsPath", installPath);
             project.Xml.AddImport(Microsoft.PythonTools.Project.PythonProjectFactory.PtvsTargets);
         }
 

--- a/Python/Tests/IronPython/ReplEvaluatorTests.cs
+++ b/Python/Tests/IronPython/ReplEvaluatorTests.cs
@@ -17,6 +17,7 @@
 using System.Diagnostics;
 using System.Linq;
 using System.Text.RegularExpressions;
+using System.Threading.Tasks;
 using Microsoft.IronPythonTools.Interpreter;
 using Microsoft.PythonTools.Analysis;
 using Microsoft.PythonTools.Intellisense;
@@ -158,20 +159,18 @@ namespace IronPythonTests {
         }
 
         [TestMethod, Priority(1)]
-        public void NoTraceFunction() {
+        public async Task NoTraceFunction() {
             // http://pytools.codeplex.com/workitem/662
             using (var replEval = Evaluator) {
                 var replWindow = new MockReplWindow(replEval);
-                replEval._Initialize(replWindow).Wait();
-                var execute = replEval.ExecuteText("import sys");
-                execute.Wait();
-                Assert.IsTrue(execute.Result.IsSuccessful);
+                await replEval._Initialize(replWindow);
+                var execute = await replEval.ExecuteText("import sys");
+                Assert.IsTrue(execute.IsSuccessful);
                 replWindow.ClearScreen();
 
-                execute = replEval.ExecuteText("sys.gettrace()");
-                execute.Wait();
+                await replEval.ExecuteText("print '[%s]' % sys.gettrace()");
                 AssertUtil.AreEqual(
-                    new Regex(@"\<bound method Thread.trace_func of \<Thread.+\>\>"),
+                    new Regex(@"\[\<bound method Thread.trace_func of \<Thread.+\>\>\]"),
                     replWindow.Output
                 );
                 replWindow.ClearScreen();

--- a/Python/Tests/PythonToolsMockTests/CompletionTests.cs
+++ b/Python/Tests/PythonToolsMockTests/CompletionTests.cs
@@ -677,7 +677,7 @@ lambda larg1, larg2: None";
                 TestQuickInfo(view, code.IndexOf("x = ") + 4, code.IndexOf("x = ") + 4 + 28, "\"ABCDEFGHIJKLMNOPQRSTUVWYXZ\": str");
 
                 // trailing new lines don't show up in quick info
-                TestQuickInfo(view, code.IndexOf("def f") + 4, code.IndexOf("def f") + 5, "f: def f()\r\nhelpful information");
+                TestQuickInfo(view, code.IndexOf("def f") + 4, code.IndexOf("def f") + 5, "f: def file.f()\r\nhelpful information");
 
                 // keywords don't show up in quick info
                 TestQuickInfo(view, code.IndexOf("while True:"), code.IndexOf("while True:") + 5);

--- a/Python/Tests/PythonToolsMockTests/ProjectTests.cs
+++ b/Python/Tests/PythonToolsMockTests/ProjectTests.cs
@@ -27,6 +27,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.VisualStudioTools;
 using Microsoft.VisualStudioTools.MockVsTests;
 using TestUtilities;
+using TestUtilities.Python;
 using TestUtilities.SharedProject;
 
 namespace PythonToolsMockTests {
@@ -37,6 +38,7 @@ namespace PythonToolsMockTests {
         [ClassInitialize]
         public static void Initialize(TestContext context) {
             AssertListener.Initialize();
+            PythonTestData.Deploy(includeTestData: false);
         }
 
         [TestMethod, Priority(1)]
@@ -112,8 +114,8 @@ namespace PythonToolsMockTests {
                     .GetService<IInterpreterRegistryService>()
                     .Interpreters;
                 
-                var v27 = interpreters.Where(x => x.Configuration.Id == "Global|PythonCore|2.7|x86").First();
-                var v34 = interpreters.Where(x => x.Configuration.Id == "Global|PythonCore|3.4|x86").First();
+                var v27 = interpreters.Where(x => x.Configuration.Id == "Global|PythonCore|2.7-32").First();
+                var v34 = interpreters.Where(x => x.Configuration.Id == "Global|PythonCore|3.4-32").First();
                 var interpOptions = (UIThreadBase)project.GetService(typeof(IComponentModel));
 
                 uiThread.Invoke(() => {

--- a/Python/Tests/Utilities.Python.Analysis/PythonPaths.cs
+++ b/Python/Tests/Utilities.Python.Analysis/PythonPaths.cs
@@ -75,7 +75,8 @@ namespace TestUtilities {
                                             res,
                                             Path.Combine(res, exeName),
                                             arch: x64 ? InterpreterArchitecture.x64 : InterpreterArchitecture.x86,
-                                            version: new Version(2, 7)
+                                            version: new Version(2, 7),
+                                            pathVar: "IRONPYTHONPATH"
                                         ),
                                         ironPython: true
                                     );
@@ -92,7 +93,8 @@ namespace TestUtilities {
                 "C:\\Program Files (x86)\\IronPython 2.7\\",
                 "C:\\Program Files (x86)\\IronPython 2.7\\" + exeName, 
                 arch: InterpreterArchitecture.x86,
-                version: new Version(2, 7)
+                version: new Version(2, 7),
+                pathVar: "IRONPYTHONPATH"
             ), ironPython: true);
             if (File.Exists(ver.InterpreterPath)) {
                 return ver;


### PR DESCRIPTION
Fixes a couple of tests.
Only product impact is defaulting to PYTHONPATH when no variable name is set. This should only affect tests, as we already default to PYTHONPATH elsewhere in the actual product.