### PR TITLE
Fixes #2046 REPL window unexpectedly disappears when opening new project

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Commands/ExecuteInReplCommand.cs
+++ b/Python/Product/PythonTools/PythonTools/Commands/ExecuteInReplCommand.cs
@@ -63,7 +63,7 @@ namespace Microsoft.PythonTools.Commands {
                         // We have an existing window, but it needs to be reset.
                         // Let's create a new one
                         window = provider.Create(projectId);
-                        project.AddActionOnClose(window, InteractiveWindowProvider.Close);
+                        project.AddActionOnClose(window, w => InteractiveWindowProvider.CloseIfEvaluatorMatches(w, projectId));
                     }
 
                     return window;
@@ -81,7 +81,7 @@ namespace Microsoft.PythonTools.Commands {
             // No window found, so let's create one
             if (!string.IsNullOrEmpty(projectId)) {
                 window = provider.Create(projectId);
-                project.AddActionOnClose(window, InteractiveWindowProvider.Close);
+                project.AddActionOnClose(window, w => InteractiveWindowProvider.CloseIfEvaluatorMatches(w, projectId));
             } else if (!string.IsNullOrEmpty(configId)) {
                 window = provider.Create(configId);
             } else {

--- a/Python/Product/PythonTools/PythonTools/Repl/InteractiveWindowProvider.cs
+++ b/Python/Product/PythonTools/PythonTools/Repl/InteractiveWindowProvider.cs
@@ -259,5 +259,12 @@ namespace Microsoft.PythonTools.Repl {
             var frame = ((obj as ToolWindowPane)?.Frame as IVsWindowFrame);
             frame?.CloseFrame((uint)__FRAMECLOSE.FRAMECLOSE_NoSave);
         }
+
+        internal static void CloseIfEvaluatorMatches(object obj, string evalId) {
+            var eval = (obj as IVsInteractiveWindow)?.InteractiveWindow.Evaluator as SelectableReplEvaluator;
+            if (eval?.CurrentEvaluator == evalId) {
+                Close(obj);
+            }
+        }
     }
 }

--- a/Python/Product/PythonTools/PythonTools/Repl/PythonDebugReplEvaluator.cs
+++ b/Python/Product/PythonTools/PythonTools/Repl/PythonDebugReplEvaluator.cs
@@ -152,11 +152,12 @@ namespace Microsoft.PythonTools.Repl {
         }
 
         public void AbortExecution() {
-            CurrentWindow.WriteError("Abort is not supported." + Environment.NewLine);
+            CurrentWindow.WriteErrorLine("Abort is not supported.");
         }
 
         public Task<ExecutionResult> Reset() {
-            throw new NotSupportedException();
+            CurrentWindow.WriteErrorLine("Reset is not supported.");
+            return ExecutionResult.Succeeded;
         }
 
         public string FormatClipboard() {


### PR DESCRIPTION
Fixes #2046 REPL window unexpectedly disappears when opening new project
Only closes interactive windows when they have not changed.

Fixes #2047 Debug interactive reset command brings down its REPL 
Display a message instead of throwing when reset is selected.