### PR TITLE
Fix build and update build tools.

### DIFF
--- a/Build/PreBuild.ps1
+++ b/Build/PreBuild.ps1
@@ -2,7 +2,7 @@ param ($vstarget, $source, [switch] $clean, [switch] $full)
 
 # This is the list of packages we require to build, and the version to use for each supported $vstarget
 $packages = @(
-    @{ name="Microsoft.VSSDK.BuildTools"; version=@{ "14.0"="14.2.25201"; "15.0"="15.0.25604-Preview4" }; required=$true },
+    @{ name="Microsoft.VSSDK.BuildTools"; version=@{ "14.0"="14.2.25201"; "15.0"="15.0.26124-RC3" }; required=$true },
     @{ name="Newtonsoft.Json"; version=@{ "14.0"="6.0.8"; "15.0"="8.0.3" }; required=$true },
     @{ name="MicroBuild.Core"; version=@{ "14.0"="0.2.0"; "15.0"="0.2.0" }; required=$false },
     @{ name="DataConnectionDialog"; version=@{ "14.0"="1.2.0"; "15.0"="1.2.0" }; required=$true },

--- a/Python/Product/Debugger/Debugger/DebugEngine/AD7Exceptions.cs
+++ b/Python/Product/Debugger/Debugger/DebugEngine/AD7Exceptions.cs
@@ -123,7 +123,7 @@ namespace Microsoft.PythonTools.Debugger.DebugEngine {
             return string.IsNullOrEmpty(_exception.ExceptionObjectExpression) ? VSConstants.S_FALSE : VSConstants.S_OK;
         }
 
-        int IDebugExceptionDetails.GetFormattedDescription(out string pbstrDescription) {
+        int IDebugExceptionDetails.GetFormattedDescription(IDebugStackFrame2 pStackFrameContext, out string pbstrDescription) {
             pbstrDescription = _exception.GetDescription(true);
             return VSConstants.S_OK;
         }


### PR DESCRIPTION
I'm on build 26130.1 and one of the debug interfaces has been changed. I updated the build tools while I was thinking of it, but it wasn't strictly necessary for it to build.

I suspect you'll want to update the build machine before merging this.