### PR TITLE
Fix cookiecutter git client

### DIFF
--- a/Python/Product/Cookiecutter/Model/GitClient.cs
+++ b/Python/Product/Cookiecutter/Model/GitClient.cs
@@ -148,8 +148,12 @@ namespace Microsoft.CookiecutterTools.Model {
         }
 
         private Dictionary<string, string> GetEnvironment() {
+            var path =
+                Path.GetDirectoryName(_gitExeFilePath) + ";" +
+                Environment.GetEnvironmentVariable("PATH");
+
             return new Dictionary<string, string>() {
-                { "PATH", Path.GetDirectoryName(_gitExeFilePath) },
+                { "PATH", path },
             };
         }
 

--- a/Python/Product/Cookiecutter/Model/GitClient.cs
+++ b/Python/Product/Cookiecutter/Model/GitClient.cs
@@ -150,7 +150,7 @@ namespace Microsoft.CookiecutterTools.Model {
         private Dictionary<string, string> GetEnvironment() {
             var path =
                 Path.GetDirectoryName(_gitExeFilePath) + ";" +
-                Environment.GetEnvironmentVariable("PATH");
+                Environment.GetEnvironmentVariable("PATH") ?? "";
 
             return new Dictionary<string, string>() {
                 { "PATH", path },

--- a/Python/Product/Cookiecutter/Model/GitClient.cs
+++ b/Python/Product/Cookiecutter/Model/GitClient.cs
@@ -52,7 +52,7 @@ namespace Microsoft.CookiecutterTools.Model {
             }
 
             var arguments = new string[] { "clone", repoUrl };
-            using (var output = ProcessOutput.Run(_gitExeFilePath, arguments, targetParentFolderPath, null, false, redirector)) {
+            using (var output = ProcessOutput.Run(_gitExeFilePath, arguments, targetParentFolderPath, GetEnvironment(), false, redirector)) {
                 await output;
 
                 var r = new ProcessOutputResult() {
@@ -84,7 +84,7 @@ namespace Microsoft.CookiecutterTools.Model {
 
         public async Task<string> GetRemoteOriginAsync(string repoFolderPath) {
             var arguments = new string[] { "remote", "-v" };
-            using (var output = ProcessOutput.Run(_gitExeFilePath, arguments, repoFolderPath, null, false, null)) {
+            using (var output = ProcessOutput.Run(_gitExeFilePath, arguments, repoFolderPath, GetEnvironment(), false, null)) {
                 await output;
                 foreach (var remote in output.StandardOutputLines) {
                     string origin;
@@ -102,7 +102,7 @@ namespace Microsoft.CookiecutterTools.Model {
                 arguments.Add(branch);
             }
 
-            using (var output = ProcessOutput.Run(_gitExeFilePath, arguments, repoFolderPath, null, false, null)) {
+            using (var output = ProcessOutput.Run(_gitExeFilePath, arguments, repoFolderPath, GetEnvironment(), false, null)) {
                 await output;
                 foreach (var line in output.StandardOutputLines) {
                     // Line with date starts with 'Date'. Example:
@@ -122,7 +122,7 @@ namespace Microsoft.CookiecutterTools.Model {
 
         public async Task FetchAsync(string repoFolderPath) {
             var arguments = new string[] { "fetch" };
-            using (var output = ProcessOutput.Run(_gitExeFilePath, arguments, repoFolderPath, null, false, null)) {
+            using (var output = ProcessOutput.Run(_gitExeFilePath, arguments, repoFolderPath, GetEnvironment(), false, null)) {
                 await output;
                 if (output.ExitCode < 0 || HasFatalError(output.StandardErrorLines)) {
                     throw new ProcessException(new ProcessOutputResult() {
@@ -137,7 +137,7 @@ namespace Microsoft.CookiecutterTools.Model {
 
         public async Task MergeAsync(string repoFolderPath) {
             var arguments = new string[] { "merge" };
-            using (var output = ProcessOutput.Run(_gitExeFilePath, arguments, repoFolderPath, null, false, _redirector)) {
+            using (var output = ProcessOutput.Run(_gitExeFilePath, arguments, repoFolderPath, GetEnvironment(), false, _redirector)) {
                 if (await output < 0) {
                     throw new ProcessException(new ProcessOutputResult() {
                         ExeFileName = _gitExeFilePath,
@@ -145,6 +145,12 @@ namespace Microsoft.CookiecutterTools.Model {
                     });
                 }
             }
+        }
+
+        private Dictionary<string, string> GetEnvironment() {
+            return new Dictionary<string, string>() {
+                { "PATH", Path.GetDirectoryName(_gitExeFilePath) },
+            };
         }
 
         private static bool HasFatalError(IEnumerable<string> standardErrorLines) {

--- a/Python/Product/Cookiecutter/Model/GitClientProvider.cs
+++ b/Python/Product/Cookiecutter/Model/GitClientProvider.cs
@@ -66,7 +66,7 @@ namespace Microsoft.CookiecutterTools.Model {
 
         private static string GetTeamExplorerGitFilePathFromIdeFolderPath(string ideFolderPath) {
             // git.exe is in a folder path with a symlink to the actual extension dir with random name
-            var gitFolder = Path.Combine(ideFolderPath, @"CommonExtensions\Microsoft\TeamFoundation\Team Explorer\Git\cmd");
+            var gitFolder = Path.Combine(ideFolderPath, @"CommonExtensions\Microsoft\TeamFoundation\Team Explorer\Git\mingw32\bin");
             var finalGitFolder = PathUtils.GetFinalPathName(gitFolder);
             var gitExe = Path.Combine(finalGitFolder, GitExecutableName);
             return gitExe;


### PR DESCRIPTION
Fix #2104 Cookiecutter clone broken in latest VS 2017 builds

Make sure that the dependent dlls can be found by adding the folder to the PATH. That seems safer than changing the working dir, which would also work but requires adding more params to the command line to tell git which folder to really work in.