### PR TITLE
Extract cookiecutter string resources

### DIFF
--- a/Python/Product/Cookiecutter/Attributes.cs
+++ b/Python/Product/Cookiecutter/Attributes.cs
@@ -1,0 +1,61 @@
+﻿// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABLITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System;
+using System.ComponentModel;
+
+namespace Microsoft.CookiecutterTools {
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Property | AttributeTargets.Field, Inherited = false, AllowMultiple = false)]
+    internal sealed class SRDisplayNameAttribute : DisplayNameAttribute {
+        private readonly string _name;
+
+        public SRDisplayNameAttribute(string name) {
+            _name = name;
+        }
+
+        public override string DisplayName => Strings.ResourceManager.GetString(_name);
+    }
+
+    [AttributeUsage(AttributeTargets.All)]
+    internal sealed class SRDescriptionAttribute : DescriptionAttribute {
+        private bool _replaced;
+
+        public SRDescriptionAttribute(string description)
+            : base(description) {
+        }
+
+        public override string Description {
+            get {
+                if (!_replaced) {
+                    _replaced = true;
+                    DescriptionValue = Strings.ResourceManager.GetString(base.Description);
+                }
+                return base.Description;
+            }
+        }
+    }
+
+    [AttributeUsage(AttributeTargets.All)]
+    internal sealed class SRCategoryAttribute : CategoryAttribute {
+        public SRCategoryAttribute(string category)
+            : base(category) {
+        }
+
+        protected override string GetLocalizedString(string value) {
+            return Strings.ResourceManager.GetString(value);
+        }
+    }
+}

--- a/Python/Product/Cookiecutter/Commands/CheckForUpdatesCommand.cs
+++ b/Python/Product/Cookiecutter/Commands/CheckForUpdatesCommand.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CookiecutterTools.Commands {
     /// Provides the command for opening the cookiecutter window.
     /// </summary>
     class CheckForUpdatesCommand : Command {
-        private CookiecutterToolWindow _window;
+        private readonly CookiecutterToolWindow _window;
 
         public CheckForUpdatesCommand(CookiecutterToolWindow window) {
             _window = window;
@@ -32,11 +32,6 @@ namespace Microsoft.CookiecutterTools.Commands {
             _window.CheckForUpdates();
         }
 
-        public string Description {
-            get {
-                return "Cookiecutter";
-            }
-        }
         public override EventHandler BeforeQueryStatus {
             get {
                 return (sender, args) => {

--- a/Python/Product/Cookiecutter/Commands/DeleteInstalledTemplateCommand.cs
+++ b/Python/Product/Cookiecutter/Commands/DeleteInstalledTemplateCommand.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CookiecutterTools.Commands {
     /// Provides the command for opening the cookiecutter window.
     /// </summary>
     class DeleteInstalledTemplateCommand : Command {
-        private CookiecutterToolWindow _window;
+        private readonly CookiecutterToolWindow _window;
 
         public DeleteInstalledTemplateCommand(CookiecutterToolWindow window) {
             _window = window;
@@ -31,12 +31,6 @@ namespace Microsoft.CookiecutterTools.Commands {
 
         public override void DoCommand(object sender, EventArgs args) {
             _window.DeleteSelection();
-        }
-
-        public string Description {
-            get {
-                return "Delete";
-            }
         }
 
         public override EventHandler BeforeQueryStatus {

--- a/Python/Product/Cookiecutter/Commands/GitHubHomeCommand.cs
+++ b/Python/Product/Cookiecutter/Commands/GitHubHomeCommand.cs
@@ -22,8 +22,8 @@ namespace Microsoft.CookiecutterTools.Commands {
     /// Provides the command for opening the cookiecutter window.
     /// </summary>
     class GitHubCommand : Command {
-        private CookiecutterToolWindow _window;
-        private int _commandId;
+        private readonly CookiecutterToolWindow _window;
+        private readonly int _commandId;
 
         public GitHubCommand(CookiecutterToolWindow window, int commandId) {
             _window = window;
@@ -32,12 +32,6 @@ namespace Microsoft.CookiecutterTools.Commands {
 
         public override void DoCommand(object sender, EventArgs args) {
             _window.NavigateToGitHub(_commandId);
-        }
-
-        public string Description {
-            get {
-                return "Cookiecutter";
-            }
         }
 
         public override EventHandler BeforeQueryStatus {

--- a/Python/Product/Cookiecutter/Commands/HomeCommand.cs
+++ b/Python/Product/Cookiecutter/Commands/HomeCommand.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CookiecutterTools.Commands {
     /// Provides the command for opening the cookiecutter window.
     /// </summary>
     class HomeCommand : Command {
-        private CookiecutterToolWindow _window;
+        private readonly CookiecutterToolWindow _window;
 
         public HomeCommand(CookiecutterToolWindow window) {
             _window = window;
@@ -30,12 +30,6 @@ namespace Microsoft.CookiecutterTools.Commands {
 
         public override void DoCommand(object sender, EventArgs args) {
             _window.Home();
-        }
-
-        public string Description {
-            get {
-                return "Cookiecutter";
-            }
         }
 
         public override int CommandId {

--- a/Python/Product/Cookiecutter/Commands/RunCommand.cs
+++ b/Python/Product/Cookiecutter/Commands/RunCommand.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CookiecutterTools.Commands {
     /// Provides the command for opening the cookiecutter window.
     /// </summary>
     class RunCommand : Command {
-        private CookiecutterToolWindow _window;
+        private readonly CookiecutterToolWindow _window;
 
         public RunCommand(CookiecutterToolWindow window) {
             _window = window;
@@ -30,12 +30,6 @@ namespace Microsoft.CookiecutterTools.Commands {
 
         public override void DoCommand(object sender, EventArgs args) {
             _window.RunSelection();
-        }
-
-        public string Description {
-            get {
-                return "Cookiecutter";
-            }
         }
 
         public override EventHandler BeforeQueryStatus {

--- a/Python/Product/Cookiecutter/Commands/UpdateCommand.cs
+++ b/Python/Product/Cookiecutter/Commands/UpdateCommand.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CookiecutterTools.Commands {
     /// Provides the command for opening the cookiecutter window.
     /// </summary>
     class UpdateCommand : Command {
-        private CookiecutterToolWindow _window;
+        private readonly CookiecutterToolWindow _window;
 
         public UpdateCommand(CookiecutterToolWindow window) {
             _window = window;
@@ -30,12 +30,6 @@ namespace Microsoft.CookiecutterTools.Commands {
 
         public override void DoCommand(object sender, EventArgs args) {
             _window.UpdateSelection();
-        }
-
-        public string Description {
-            get {
-                return "Cookiecutter";
-            }
         }
 
         public override EventHandler BeforeQueryStatus {

--- a/Python/Product/Cookiecutter/Cookiecutter.csproj
+++ b/Python/Product/Cookiecutter/Cookiecutter.csproj
@@ -270,7 +270,7 @@
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Strings.resx">
-      <Generator>ResXFileCodeGenerator</Generator>
+      <Generator>PublicResXFileCodeGenerator</Generator>
       <LastGenOutput>Strings.Designer.cs</LastGenOutput>
       <SubType>Designer</SubType>
     </EmbeddedResource>

--- a/Python/Product/Cookiecutter/Cookiecutter.csproj
+++ b/Python/Product/Cookiecutter/Cookiecutter.csproj
@@ -142,6 +142,8 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
+    <Compile Include="ProjectResources.cs" />
+    <Compile Include="Attributes.cs" />
     <Compile Include="Commands\DeleteInstalledTemplateCommand.cs" />
     <Compile Include="Commands\GitHubHomeCommand.cs" />
     <Compile Include="Commands\RunCommand.cs" />

--- a/Python/Product/Cookiecutter/Cookiecutter.vsct
+++ b/Python/Product/Cookiecutter/Cookiecutter.vsct
@@ -83,7 +83,8 @@
         <Strings>
           <ButtonText>&amp;Cookiecutter Explorer</ButtonText>
           <ToolTipText>Opens the Cookiecutter Explorer window.</ToolTipText>
-          <LocCanonicalName>.CookiecutterExplorer</LocCanonicalName>
+          <CanonicalName>.Cookiecutter.Explorer</CanonicalName>
+          <LocCanonicalName>.Cookiecutter.Explorer</LocCanonicalName>
         </Strings>
       </Button>
 
@@ -94,7 +95,8 @@
         <Strings>
           <ButtonText>From &amp;Cookiecutter...</ButtonText>
           <ToolTipText>Creates files using a Cookiecutter template.</ToolTipText>
-          <LocCanonicalName>.CreateFromCookiecutter</LocCanonicalName>
+          <CanonicalName>.Cookiecutter.CreateFrom</CanonicalName>
+          <LocCanonicalName>.Cookiecutter.CreateFrom</LocCanonicalName>
         </Strings>
       </Button>
 
@@ -106,7 +108,8 @@
         <Strings>
           <ButtonText>From &amp;Cookiecutter...</ButtonText>
           <ToolTipText>Adds files using a Cookiecutter template.</ToolTipText>
-          <LocCanonicalName>.AddFromCookiecutter</LocCanonicalName>
+          <CanonicalName>.Cookiecutter.AddFrom</CanonicalName>
+          <LocCanonicalName>.Cookiecutter.AddFrom</LocCanonicalName>
         </Strings>
       </Button>
 
@@ -117,6 +120,8 @@
         <Strings>
           <ButtonText>Home</ButtonText>
           <MenuText>&amp;Home</MenuText>
+          <CanonicalName>.Cookiecutter.Home</CanonicalName>
+          <LocCanonicalName>.Cookiecutter.Home</LocCanonicalName>
         </Strings>
       </Button>
 
@@ -127,6 +132,8 @@
         <Strings>
           <ButtonText>Run</ButtonText>
           <MenuText>&amp;Run</MenuText>
+          <CanonicalName>.Cookiecutter.RunTemplate</CanonicalName>
+          <LocCanonicalName>.Cookiecutter.RunTemplate</LocCanonicalName>
         </Strings>
       </Button>
 
@@ -137,6 +144,8 @@
         <Strings>
           <ButtonText>Check for Updates</ButtonText>
           <MenuText>&amp;Check for Updates</MenuText>
+          <CanonicalName>.Cookiecutter.CheckForUpdates</CanonicalName>
+          <LocCanonicalName>.Cookiecutter.CheckForUpdates</LocCanonicalName>
         </Strings>
       </Button>
 
@@ -147,6 +156,8 @@
         <Strings>
           <ButtonText>Update</ButtonText>
           <MenuText>&amp;Update</MenuText>
+          <CanonicalName>.Cookiecutter.UpdateTemplate</CanonicalName>
+          <LocCanonicalName>.Cookiecutter.UpdateTemplate</LocCanonicalName>
         </Strings>
       </Button>
 
@@ -157,6 +168,8 @@
         <Strings>
           <ButtonText>GitHub Home</ButtonText>
           <MenuText>&amp;GitHub Home</MenuText>
+          <CanonicalName>.Cookiecutter.GitHubHome</CanonicalName>
+          <LocCanonicalName>.Cookiecutter.GitHubHome</LocCanonicalName>
         </Strings>
       </Button>
 
@@ -167,6 +180,8 @@
         <Strings>
           <ButtonText>GitHub Issues</ButtonText>
           <MenuText>&amp;GitHub Issues</MenuText>
+          <CanonicalName>.Cookiecutter.GitHubIssues</CanonicalName>
+          <LocCanonicalName>.Cookiecutter.GitHubIssues</LocCanonicalName>
         </Strings>
       </Button>
 
@@ -177,6 +192,8 @@
         <Strings>
           <ButtonText>GitHub Wiki</ButtonText>
           <MenuText>&amp;GitHub Wiki</MenuText>
+          <CanonicalName>.Cookiecutter.GitHubWiki</CanonicalName>
+          <LocCanonicalName>.Cookiecutter.GitHubWiki</LocCanonicalName>
         </Strings>
       </Button>
 

--- a/Python/Product/Cookiecutter/CookiecutterOptionPage.cs
+++ b/Python/Product/Cookiecutter/CookiecutterOptionPage.cs
@@ -14,7 +14,6 @@
 // See the Apache Version 2.0 License for specific language governing
 // permissions and limitations under the License.
 
-using System;
 using System.ComponentModel;
 using System.Runtime.InteropServices;
 using Microsoft.VisualStudio.Shell;
@@ -29,25 +28,28 @@ namespace Microsoft.CookiecutterTools {
         public CookiecutterOptionPage() {
         }
 
-        [Category("General")]
-        [DisplayName("Show Help")]
-        [Description("Show the help information bar.")]
+        [SRCategory(SR.SettingsGeneralCategory)]
+        [SRDisplayName(SR.SettingsShowHelpName)]
+        [SRDescription(SR.SettingsShowHelpDescription)]
+        [DefaultValue(true)]
         public bool ShowHelp {
             get { return _showHelp; }
             set { _showHelp = value; }
         }
 
-        [Category("General")]
-        [DisplayName("Recommended Feed URL")]
-        [Description("Location of the feed. The contents of the feed consists of line separated URLs of template locations.")]
+        [SRCategory(SR.SettingsGeneralCategory)]
+        [SRDisplayName(SR.SettingsFeedUrlName)]
+        [SRDescription(SR.SettingsFeedUrlDescription)]
+        [DefaultValue(UrlConstants.DefaultRecommendedFeed)]
         public string FeedUrl {
             get { return _feedUrl; }
             set { _feedUrl = value; }
         }
 
-        [Category("General")]
-        [DisplayName("Check for Template Update")]
-        [Description("Automatically check online for updates to installed templates.")]
+        [SRCategory(SR.SettingsGeneralCategory)]
+        [SRDisplayName(SR.SettingsCheckForTemplateUpdateName)]
+        [SRDescription(SR.SettingsCheckForTemplateUpdateDescription)]
+        [DefaultValue(true)]
         public bool CheckForTemplateUpdate {
             get { return _checkForTemplateUpdate; }
             set { _checkForTemplateUpdate = value; }

--- a/Python/Product/Cookiecutter/Model/CookiecutterClient.cs
+++ b/Python/Product/Cookiecutter/Model/CookiecutterClient.cs
@@ -451,19 +451,19 @@ namespace Microsoft.CookiecutterTools.Model {
         }
 
         private void InvalidUrl(string url) {
-            _redirector.WriteErrorLine(string.Format("'{0}' from _visual_studio section in context file should be an absolute http or https url.", url));
+            _redirector.WriteErrorLine(Strings.CookiecutterClient_Invalidurl.FormatUI(url));
         }
 
         private void WrongJsonType(string name, JTokenType expected, JTokenType actual) {
-            _redirector.WriteErrorLine(string.Format("'{0}' from _visual_studio section in context file should be of type '{1}', instead of '{2}'.", name, expected, actual));
+            _redirector.WriteErrorLine(Strings.CookiecutterClient_WrongJsonType.FormatUI(name, expected, actual));
         }
 
         private void ReferenceNotFound(string name) {
-            _redirector.WriteErrorLine(string.Format("'{0}' is referenced from _visual_studio section in context file but was not found.", name));
+            _redirector.WriteErrorLine(Strings.CookiecutterClient_ReferenceNotFound.FormatUI(name));
         }
 
         private void MissingProperty(string objectName, string propertyName) {
-            _redirector.WriteErrorLine(string.Format("'{0}' property is required on '{1}'.", propertyName, objectName));
+            _redirector.WriteErrorLine(Strings.CookiecutterClient_MissingProperty.FormatUI(propertyName, objectName));
         }
 
         private static async Task<ProcessOutputResult> RunGenerateContextScript(Redirector redirector, string interpreterPath, string templateFolderPath, string userConfigFilePath) {
@@ -540,7 +540,7 @@ namespace Microsoft.CookiecutterTools.Model {
             if (subfolders.Length == 1) {
                 generatedFolder = subfolders[0];
             } else {
-                throw new InvalidOperationException("Cookiecutter generated files must have a templated folder.");
+                throw new InvalidOperationException(Strings.CookiecutterClient_MoveToDesiredFolderTemplatedFolderNotFound);
             }
 
             var res = await MoveFilesAndFoldersAsync(generatedFolder, desiredFolder);

--- a/Python/Product/Cookiecutter/Model/CookiecutterClient.cs
+++ b/Python/Product/Cookiecutter/Model/CookiecutterClient.cs
@@ -113,7 +113,7 @@ namespace Microsoft.CookiecutterTools.Model {
                             }
                             unrenderedContext.Items.Add(new ContextItem(prop.Name, Selectors.List, elements[0], elements.ToArray()));
                         } else {
-                            throw new InvalidOperationException(string.Format("Unsupported json element type in context file for property '{0}'.", prop.Name));
+                            throw new InvalidOperationException(Strings.CookiecutterClient_UnsupportedJsonElementTypeForPorperty.FormatUI(prop.Name));
                         }
                     } else if (prop.Name == "_visual_studio") {
                         vsExtrasProp = prop;
@@ -165,7 +165,7 @@ namespace Microsoft.CookiecutterTools.Model {
                             }
                             renderedContext.Items.Add(new ContextItem(prop.Name, Selectors.List, elements[0], elements.ToArray()));
                         } else {
-                            throw new InvalidOperationException(string.Format("Unsupported json element type in context file for property '{0}'.", prop.Name));
+                            throw new InvalidOperationException(Strings.CookiecutterClient_UnsupportedJsonElementTypeForPorperty.FormatUI(prop.Name));
                         }
                     } else if (prop.Name == "_visual_studio_post_cmds") {
                         // List of commands to run after the folder is opened,
@@ -468,12 +468,12 @@ namespace Microsoft.CookiecutterTools.Model {
 
         private static async Task<ProcessOutputResult> RunGenerateContextScript(Redirector redirector, string interpreterPath, string templateFolderPath, string userConfigFilePath) {
             var scriptPath = PythonToolsInstallPath.GetFile("cookiecutter_load.py");
-            return await RunPythonScript(redirector, interpreterPath, scriptPath, string.Format("\"{0}\" \"{1}\"", templateFolderPath, userConfigFilePath));
+            return await RunPythonScript(redirector, interpreterPath, scriptPath, "\"{0}\" \"{1}\"".FormatInvariant(templateFolderPath, userConfigFilePath));
         }
 
         private static async Task<ProcessOutputResult> RunRenderContextScript(Redirector redirector, string interpreterPath, string templateFolderPath, string userConfigFilePath, string outputFolderPath, string contextPath) {
             var scriptPath = PythonToolsInstallPath.GetFile("cookiecutter_render.py");
-            return await RunPythonScript(redirector, interpreterPath, scriptPath, string.Format("\"{0}\" \"{1}\" \"{2}\" \"{3}\"", templateFolderPath, userConfigFilePath, PathUtils.TrimEndSeparator(outputFolderPath), contextPath));
+            return await RunPythonScript(redirector, interpreterPath, scriptPath, "\"{0}\" \"{1}\" \"{2}\" \"{3}\"".FormatInvariant(templateFolderPath, userConfigFilePath, PathUtils.TrimEndSeparator(outputFolderPath), contextPath));
         }
 
         private static async Task<ProcessOutputResult> RunCheckScript(string interpreterPath) {
@@ -488,7 +488,7 @@ namespace Microsoft.CookiecutterTools.Model {
         }
 
         private static string GetRunArguments(string templateFolderPath, string userConfigFilePath, string outputFolderPath, string contextFilePath) {
-            return string.Format("\"{0}\" \"{1}\" \"{2}\" \"{3}\"", contextFilePath, templateFolderPath, outputFolderPath, userConfigFilePath);
+            return "\"{0}\" \"{1}\" \"{2}\" \"{3}\"".FormatInvariant(contextFilePath, templateFolderPath, outputFolderPath, userConfigFilePath);
         }
 
         private static async Task<ProcessOutputResult> RunPythonScript(Redirector redirector, string interpreterPath, string script, string parameters) {
@@ -496,7 +496,7 @@ namespace Microsoft.CookiecutterTools.Model {
             var errorLines = new List<string>();
 
             ProcessOutput output = null;
-            var arguments = string.Format("\"{0}\" {1}", script, parameters);
+            var arguments = "\"{0}\" {1}".FormatInvariant(script, parameters);
             var listRedirector = new ListRedirector(outputLines, errorLines);
             var outerRedirector = new TeeRedirector(redirector, listRedirector);
 

--- a/Python/Product/Cookiecutter/Model/FeedTemplateSource.cs
+++ b/Python/Product/Cookiecutter/Model/FeedTemplateSource.cs
@@ -22,7 +22,7 @@ using System.Threading.Tasks;
 
 namespace Microsoft.CookiecutterTools.Model {
     class FeedTemplateSource : ITemplateSource {
-        private Uri _feedLocation;
+        private readonly Uri _feedLocation;
         private List<Template> _cache;
 
         public FeedTemplateSource(Uri feedLocation) {

--- a/Python/Product/Cookiecutter/Model/GitClient.cs
+++ b/Python/Product/Cookiecutter/Model/GitClient.cs
@@ -169,7 +169,7 @@ namespace Microsoft.CookiecutterTools.Model {
             url = null;
 
             if (remote.StartsWith("origin")) {
-                int start = remote.IndexOf("https");
+                int start = remote.IndexOf("https", StringComparison.InvariantCultureIgnoreCase);
                 if (start >= 0) {
                     int end = remote.IndexOf(' ', start);
                     if (end >= 0) {

--- a/Python/Product/Cookiecutter/Model/GitHubClient.cs
+++ b/Python/Product/Cookiecutter/Model/GitHubClient.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Net;
 using System.Threading.Tasks;
+using static System.FormattableString;
 using Newtonsoft.Json;
 
 namespace Microsoft.CookiecutterTools.Model {
@@ -43,7 +44,7 @@ namespace Microsoft.CookiecutterTools.Model {
             }
 
             var q = string.Join("+", terms);
-            var queryUrl = string.Format("https://api.github.com/search/repositories?q={0}&sort=stars&order=desc&fork=false", q);
+            var queryUrl = Invariant($"https://api.github.com/search/repositories?q={q}&sort=stars&order=desc&fork=false");
             return await SearchRepositoriesAsync(queryUrl);
         }
 
@@ -57,14 +58,14 @@ namespace Microsoft.CookiecutterTools.Model {
             }
 
             var wc = CreateClient();
-            var queryUrl = string.Format("https://api.github.com/repos/{0}/{1}", owner, name);
+            var queryUrl = Invariant($"https://api.github.com/repos/{owner}/{name}");
             var json = await wc.DownloadStringTaskAsync(queryUrl);
             return JsonConvert.DeserializeObject<GitHubRepoSearchItem>(json);
         }
 
         public async Task<bool> FileExistsAsync(GitHubRepoSearchItem repo, string filePath) {
             var wc = new WebClient();
-            var url = $"https://raw.githubusercontent.com/{repo.FullName}/master/{filePath}";
+            var url = Invariant($"https://raw.githubusercontent.com/{repo.FullName}/master/{filePath}");
             try {
                 var json = await wc.DownloadDataTaskAsync(url);
                 return true;

--- a/Python/Product/Cookiecutter/Model/IGitClient.cs
+++ b/Python/Product/Cookiecutter/Model/IGitClient.cs
@@ -16,7 +16,6 @@
 
 using System;
 using System.Threading.Tasks;
-using Microsoft.CookiecutterTools.Infrastructure;
 
 namespace Microsoft.CookiecutterTools.Model {
     interface IGitClient {

--- a/Python/Product/Cookiecutter/Model/ILocalTemplateSource.cs
+++ b/Python/Product/Cookiecutter/Model/ILocalTemplateSource.cs
@@ -14,10 +14,7 @@
 // See the Apache Version 2.0 License for specific language governing
 // permissions and limitations under the License.
 
-using System;
-using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.CookiecutterTools.Infrastructure;
 
 namespace Microsoft.CookiecutterTools.Model {
     interface ILocalTemplateSource : ITemplateSource {

--- a/Python/Product/Cookiecutter/Model/LocalTemplateSource.cs
+++ b/Python/Product/Cookiecutter/Model/LocalTemplateSource.cs
@@ -24,8 +24,8 @@ using Microsoft.CookiecutterTools.Infrastructure;
 
 namespace Microsoft.CookiecutterTools.Model {
     class LocalTemplateSource : ILocalTemplateSource {
-        private string _installedFolderPath;
-        private IGitClient _gitClient;
+        private readonly string _installedFolderPath;
+        private readonly IGitClient _gitClient;
         private List<Template> _cache;
 
         public LocalTemplateSource(string installedFolderPath, IGitClient gitClient) {

--- a/Python/Product/Cookiecutter/Model/ProcessException.cs
+++ b/Python/Product/Cookiecutter/Model/ProcessException.cs
@@ -16,7 +16,6 @@
 
 using System;
 using System.Globalization;
-using System.Threading.Tasks;
 
 namespace Microsoft.CookiecutterTools.Model {
     [Serializable]

--- a/Python/Product/Cookiecutter/Model/ProcessOutputResult.cs
+++ b/Python/Product/Cookiecutter/Model/ProcessOutputResult.cs
@@ -14,9 +14,6 @@
 // See the Apache Version 2.0 License for specific language governing
 // permissions and limitations under the License.
 
-using System;
-using System.Threading.Tasks;
-
 namespace Microsoft.CookiecutterTools.Model {
     struct ProcessOutputResult {
         public string ExeFileName;

--- a/Python/Product/Cookiecutter/ProjectResources.cs
+++ b/Python/Product/Cookiecutter/ProjectResources.cs
@@ -14,10 +14,8 @@
 // See the Apache Version 2.0 License for specific language governing
 // permissions and limitations under the License.
 
-namespace Microsoft.CookiecutterTools
-{
-    internal class SR
-    {
+namespace Microsoft.CookiecutterTools {
+    internal class SR {
         internal const string SettingsGeneralCategory = "Settings_General_Category";
         internal const string SettingsShowHelpName = "Settings_ShowHelp_Name";
         internal const string SettingsShowHelpDescription = "Settings_ShowHelp_Description";

--- a/Python/Product/Cookiecutter/ProjectResources.cs
+++ b/Python/Product/Cookiecutter/ProjectResources.cs
@@ -1,0 +1,29 @@
+﻿// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABLITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+namespace Microsoft.CookiecutterTools
+{
+    internal class SR
+    {
+        internal const string SettingsGeneralCategory = "Settings_General_Category";
+        internal const string SettingsShowHelpName = "Settings_ShowHelp_Name";
+        internal const string SettingsShowHelpDescription = "Settings_ShowHelp_Description";
+        internal const string SettingsFeedUrlName = "Settings_FeedUrl_Name";
+        internal const string SettingsFeedUrlDescription = "Settings_FeedUrl_Description";
+        internal const string SettingsCheckForTemplateUpdateName = "Settings_CheckForTemplateUpdate_Name";
+        internal const string SettingsCheckForTemplateUpdateDescription = "Settings_CheckForTemplateUpdate_Description";
+    }
+}

--- a/Python/Product/Cookiecutter/Shared/Interpreters/IPythonInterpreterFactory.cs
+++ b/Python/Product/Cookiecutter/Shared/Interpreters/IPythonInterpreterFactory.cs
@@ -35,16 +35,5 @@ namespace Microsoft.CookiecutterTools.Interpreters {
         InterpreterConfiguration Configuration {
             get;
         }
-
-        /// <summary>
-        /// Creates an IPythonInterpreter instance.
-        /// </summary>
-        //IPythonInterpreter CreateInterpreter();
-
-        /// <summary>
-        /// Gets the associated package manager. This may be null,
-        /// and will not change after first access.
-        /// </summary>
-        //IPackageManager PackageManager { get; }
     }
 }

--- a/Python/Product/Cookiecutter/Shared/Interpreters/IPythonInterpreterFactoryProvider.cs
+++ b/Python/Product/Cookiecutter/Shared/Interpreters/IPythonInterpreterFactoryProvider.cs
@@ -57,17 +57,4 @@ namespace Microsoft.CookiecutterTools.Interpreters {
         /// of the property. Values will be compared by ordinal.</param>
         object GetProperty(string id, string propName);
     }
-
-    public static class PythonInterpreterExtensions {
-        public static bool IsAvailable(this InterpreterConfiguration configuration) {
-            // TODO: Differs from original by not checking for base interpreter
-            // configuration
-            return File.Exists(configuration.InterpreterPath) &&
-                File.Exists(configuration.WindowsInterpreterPath);
-        }
-
-        public static IEnumerable<IPythonInterpreterFactory> GetInterpreterFactories(this IPythonInterpreterFactoryProvider self) {
-            return self.GetInterpreterConfigurations().Select(x => self.GetInterpreterFactory(x.Id));
-        }
-    }
 }

--- a/Python/Product/Cookiecutter/Strings.Designer.cs
+++ b/Python/Product/Cookiecutter/Strings.Designer.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CookiecutterTools {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    internal class Strings {
+    public class Strings {
         
         private static global::System.Resources.ResourceManager resourceMan;
         
@@ -36,7 +36,7 @@ namespace Microsoft.CookiecutterTools {
         ///   Returns the cached ResourceManager instance used by this class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        internal static global::System.Resources.ResourceManager ResourceManager {
+        public static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
                     global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Microsoft.CookiecutterTools.Strings", typeof(Strings).Assembly);
@@ -51,7 +51,7 @@ namespace Microsoft.CookiecutterTools {
         ///   resource lookups using this strongly typed resource class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        internal static global::System.Globalization.CultureInfo Culture {
+        public static global::System.Globalization.CultureInfo Culture {
             get {
                 return resourceCulture;
             }
@@ -63,7 +63,7 @@ namespace Microsoft.CookiecutterTools {
         /// <summary>
         ///   Looks up a localized string similar to Files were successfully created, but there was an issue adding the files to your project.\n{0}.
         /// </summary>
-        internal static string AddToProjectError {
+        public static string AddToProjectError {
             get {
                 return ResourceManager.GetString("AddToProjectError", resourceCulture);
             }
@@ -72,7 +72,7 @@ namespace Microsoft.CookiecutterTools {
         /// <summary>
         ///   Looks up a localized string similar to ----- Check for template updates canceled -----.
         /// </summary>
-        internal static string CheckingForAllUpdatesCanceled {
+        public static string CheckingForAllUpdatesCanceled {
             get {
                 return ResourceManager.GetString("CheckingForAllUpdatesCanceled", resourceCulture);
             }
@@ -81,7 +81,7 @@ namespace Microsoft.CookiecutterTools {
         /// <summary>
         ///   Looks up a localized string similar to ----- Failed to check for template updates -----.
         /// </summary>
-        internal static string CheckingForAllUpdatesFailed {
+        public static string CheckingForAllUpdatesFailed {
             get {
                 return ResourceManager.GetString("CheckingForAllUpdatesFailed", resourceCulture);
             }
@@ -90,7 +90,7 @@ namespace Microsoft.CookiecutterTools {
         /// <summary>
         ///   Looks up a localized string similar to ----- Checking for template updates -----.
         /// </summary>
-        internal static string CheckingForAllUpdatesStarted {
+        public static string CheckingForAllUpdatesStarted {
             get {
                 return ResourceManager.GetString("CheckingForAllUpdatesStarted", resourceCulture);
             }
@@ -99,7 +99,7 @@ namespace Microsoft.CookiecutterTools {
         /// <summary>
         ///   Looks up a localized string similar to ----- Successfully checked for template updates -----.
         /// </summary>
-        internal static string CheckingForAllUpdatesSuccess {
+        public static string CheckingForAllUpdatesSuccess {
             get {
                 return ResourceManager.GetString("CheckingForAllUpdatesSuccess", resourceCulture);
             }
@@ -108,7 +108,7 @@ namespace Microsoft.CookiecutterTools {
         /// <summary>
         ///   Looks up a localized string similar to Error checking for an update..
         /// </summary>
-        internal static string CheckingTemplateUpdateError {
+        public static string CheckingTemplateUpdateError {
             get {
                 return ResourceManager.GetString("CheckingTemplateUpdateError", resourceCulture);
             }
@@ -117,7 +117,7 @@ namespace Microsoft.CookiecutterTools {
         /// <summary>
         ///   Looks up a localized string similar to An update is available..
         /// </summary>
-        internal static string CheckingTemplateUpdateFound {
+        public static string CheckingTemplateUpdateFound {
             get {
                 return ResourceManager.GetString("CheckingTemplateUpdateFound", resourceCulture);
             }
@@ -126,7 +126,7 @@ namespace Microsoft.CookiecutterTools {
         /// <summary>
         ///   Looks up a localized string similar to Could not determine if an update is available..
         /// </summary>
-        internal static string CheckingTemplateUpdateInconclusive {
+        public static string CheckingTemplateUpdateInconclusive {
             get {
                 return ResourceManager.GetString("CheckingTemplateUpdateInconclusive", resourceCulture);
             }
@@ -135,7 +135,7 @@ namespace Microsoft.CookiecutterTools {
         /// <summary>
         ///   Looks up a localized string similar to Template is already up-to-date..
         /// </summary>
-        internal static string CheckingTemplateUpdateNotFound {
+        public static string CheckingTemplateUpdateNotFound {
             get {
                 return ResourceManager.GetString("CheckingTemplateUpdateNotFound", resourceCulture);
             }
@@ -144,7 +144,7 @@ namespace Microsoft.CookiecutterTools {
         /// <summary>
         ///   Looks up a localized string similar to ----- Checking for update to template &apos;{0}&apos; from &apos;{1}&apos; -----.
         /// </summary>
-        internal static string CheckingTemplateUpdateStarted {
+        public static string CheckingTemplateUpdateStarted {
             get {
                 return ResourceManager.GetString("CheckingTemplateUpdateStarted", resourceCulture);
             }
@@ -155,7 +155,7 @@ namespace Microsoft.CookiecutterTools {
         ///
         ///Please delete the installed template and try again..
         /// </summary>
-        internal static string CloneCollisionMessage {
+        public static string CloneCollisionMessage {
             get {
                 return ResourceManager.GetString("CloneCollisionMessage", resourceCulture);
             }
@@ -164,7 +164,7 @@ namespace Microsoft.CookiecutterTools {
         /// <summary>
         ///   Looks up a localized string similar to ----- Failed to clone template &apos;{0}&apos; -----.
         /// </summary>
-        internal static string CloningTemplateFailed {
+        public static string CloningTemplateFailed {
             get {
                 return ResourceManager.GetString("CloningTemplateFailed", resourceCulture);
             }
@@ -173,7 +173,7 @@ namespace Microsoft.CookiecutterTools {
         /// <summary>
         ///   Looks up a localized string similar to ----- Cloning template &apos;{0}&apos; -----.
         /// </summary>
-        internal static string CloningTemplateStarted {
+        public static string CloningTemplateStarted {
             get {
                 return ResourceManager.GetString("CloningTemplateStarted", resourceCulture);
             }
@@ -182,7 +182,7 @@ namespace Microsoft.CookiecutterTools {
         /// <summary>
         ///   Looks up a localized string similar to ----- Successfully cloned template &apos;{0}&apos; to &apos;{1}&apos; -----.
         /// </summary>
-        internal static string CloningTemplateSuccess {
+        public static string CloningTemplateSuccess {
             get {
                 return ResourceManager.GetString("CloningTemplateSuccess", resourceCulture);
             }
@@ -191,7 +191,7 @@ namespace Microsoft.CookiecutterTools {
         /// <summary>
         ///   Looks up a localized string similar to The connection string appears to be in incorrect format. Would you like to re-create it?.
         /// </summary>
-        internal static string ConnectionStringFormatIncorrect {
+        public static string ConnectionStringFormatIncorrect {
             get {
                 return ResourceManager.GetString("ConnectionStringFormatIncorrect", resourceCulture);
             }
@@ -200,7 +200,7 @@ namespace Microsoft.CookiecutterTools {
         /// <summary>
         ///   Looks up a localized string similar to &apos;{0}&apos; from _visual_studio section in context file should be an absolute http or https url..
         /// </summary>
-        internal static string CookiecutterClient_Invalidurl {
+        public static string CookiecutterClient_Invalidurl {
             get {
                 return ResourceManager.GetString("CookiecutterClient_Invalidurl", resourceCulture);
             }
@@ -209,7 +209,7 @@ namespace Microsoft.CookiecutterTools {
         /// <summary>
         ///   Looks up a localized string similar to &apos;{0}&apos; property is required on &apos;{1}&apos;..
         /// </summary>
-        internal static string CookiecutterClient_MissingProperty {
+        public static string CookiecutterClient_MissingProperty {
             get {
                 return ResourceManager.GetString("CookiecutterClient_MissingProperty", resourceCulture);
             }
@@ -218,7 +218,7 @@ namespace Microsoft.CookiecutterTools {
         /// <summary>
         ///   Looks up a localized string similar to Cookiecutter generated files must have a templated folder..
         /// </summary>
-        internal static string CookiecutterClient_MoveToDesiredFolderTemplatedFolderNotFound {
+        public static string CookiecutterClient_MoveToDesiredFolderTemplatedFolderNotFound {
             get {
                 return ResourceManager.GetString("CookiecutterClient_MoveToDesiredFolderTemplatedFolderNotFound", resourceCulture);
             }
@@ -227,7 +227,7 @@ namespace Microsoft.CookiecutterTools {
         /// <summary>
         ///   Looks up a localized string similar to &apos;{0}&apos; is referenced from _visual_studio section in context file but was not found..
         /// </summary>
-        internal static string CookiecutterClient_ReferenceNotFound {
+        public static string CookiecutterClient_ReferenceNotFound {
             get {
                 return ResourceManager.GetString("CookiecutterClient_ReferenceNotFound", resourceCulture);
             }
@@ -236,7 +236,7 @@ namespace Microsoft.CookiecutterTools {
         /// <summary>
         ///   Looks up a localized string similar to &apos;{0}&apos; from _visual_studio section in context file should be of type &apos;{1}&apos;, instead of &apos;{2}&apos;..
         /// </summary>
-        internal static string CookiecutterClient_WrongJsonType {
+        public static string CookiecutterClient_WrongJsonType {
             get {
                 return ResourceManager.GetString("CookiecutterClient_WrongJsonType", resourceCulture);
             }
@@ -247,7 +247,7 @@ namespace Microsoft.CookiecutterTools {
         ///
         ///{0}.
         /// </summary>
-        internal static string DeleteConfirmation {
+        public static string DeleteConfirmation {
             get {
                 return ResourceManager.GetString("DeleteConfirmation", resourceCulture);
             }
@@ -256,7 +256,7 @@ namespace Microsoft.CookiecutterTools {
         /// <summary>
         ///   Looks up a localized string similar to ----- Failed to delete template &apos;{0}&apos; -----.
         /// </summary>
-        internal static string DeletingTemplateFailed {
+        public static string DeletingTemplateFailed {
             get {
                 return ResourceManager.GetString("DeletingTemplateFailed", resourceCulture);
             }
@@ -265,7 +265,7 @@ namespace Microsoft.CookiecutterTools {
         /// <summary>
         ///   Looks up a localized string similar to ----- Deleting template &apos;{0}&apos; -----.
         /// </summary>
-        internal static string DeletingTemplateStarted {
+        public static string DeletingTemplateStarted {
             get {
                 return ResourceManager.GetString("DeletingTemplateStarted", resourceCulture);
             }
@@ -274,7 +274,7 @@ namespace Microsoft.CookiecutterTools {
         /// <summary>
         ///   Looks up a localized string similar to ----- Successfully deleted template &apos;{0}&apos; -----.
         /// </summary>
-        internal static string DeletingTemplateSuccess {
+        public static string DeletingTemplateSuccess {
             get {
                 return ResourceManager.GetString("DeletingTemplateSuccess", resourceCulture);
             }
@@ -283,7 +283,7 @@ namespace Microsoft.CookiecutterTools {
         /// <summary>
         ///   Looks up a localized string similar to Could not retrieve results from feed.
         /// </summary>
-        internal static string FeedLoadError {
+        public static string FeedLoadError {
             get {
                 return ResourceManager.GetString("FeedLoadError", resourceCulture);
             }
@@ -292,7 +292,7 @@ namespace Microsoft.CookiecutterTools {
         /// <summary>
         ///   Looks up a localized string similar to Could not retrieve results from GitHub.
         /// </summary>
-        internal static string GitHubSearchError {
+        public static string GitHubSearchError {
             get {
                 return ResourceManager.GetString("GitHubSearchError", resourceCulture);
             }
@@ -301,7 +301,7 @@ namespace Microsoft.CookiecutterTools {
         /// <summary>
         ///   Looks up a localized string similar to Cookiecutter makes it easy to generate code from a template..
         /// </summary>
-        internal static string InfoBarMessage {
+        public static string InfoBarMessage {
             get {
                 return ResourceManager.GetString("InfoBarMessage", resourceCulture);
             }
@@ -310,7 +310,7 @@ namespace Microsoft.CookiecutterTools {
         /// <summary>
         ///   Looks up a localized string similar to Learn more..
         /// </summary>
-        internal static string InfoBarMessageLink {
+        public static string InfoBarMessageLink {
             get {
                 return ResourceManager.GetString("InfoBarMessageLink", resourceCulture);
             }
@@ -319,7 +319,7 @@ namespace Microsoft.CookiecutterTools {
         /// <summary>
         ///   Looks up a localized string similar to Install Git.
         /// </summary>
-        internal static string InstallGitInfoBarLink {
+        public static string InstallGitInfoBarLink {
             get {
                 return ResourceManager.GetString("InstallGitInfoBarLink", resourceCulture);
             }
@@ -328,7 +328,7 @@ namespace Microsoft.CookiecutterTools {
         /// <summary>
         ///   Looks up a localized string similar to ----- Failed to install cookiecutter -----.
         /// </summary>
-        internal static string InstallingCookiecutterFailed {
+        public static string InstallingCookiecutterFailed {
             get {
                 return ResourceManager.GetString("InstallingCookiecutterFailed", resourceCulture);
             }
@@ -337,7 +337,7 @@ namespace Microsoft.CookiecutterTools {
         /// <summary>
         ///   Looks up a localized string similar to ----- Installing cookiecutter -----.
         /// </summary>
-        internal static string InstallingCookiecutterStarted {
+        public static string InstallingCookiecutterStarted {
             get {
                 return ResourceManager.GetString("InstallingCookiecutterStarted", resourceCulture);
             }
@@ -346,7 +346,7 @@ namespace Microsoft.CookiecutterTools {
         /// <summary>
         ///   Looks up a localized string similar to ----- Successfully installed cookiecutter -----.
         /// </summary>
-        internal static string InstallingCookiecutterSuccess {
+        public static string InstallingCookiecutterSuccess {
             get {
                 return ResourceManager.GetString("InstallingCookiecutterSuccess", resourceCulture);
             }
@@ -355,7 +355,7 @@ namespace Microsoft.CookiecutterTools {
         /// <summary>
         ///   Looks up a localized string similar to Install Python 3.
         /// </summary>
-        internal static string InstallPythonInfoBarLink {
+        public static string InstallPythonInfoBarLink {
             get {
                 return ResourceManager.GetString("InstallPythonInfoBarLink", resourceCulture);
             }
@@ -364,7 +364,7 @@ namespace Microsoft.CookiecutterTools {
         /// <summary>
         ///   Looks up a localized string similar to Please enter a valid output folder in the &apos;Create To&apos; field..
         /// </summary>
-        internal static string InvalidOutputFolder {
+        public static string InvalidOutputFolder {
             get {
                 return ResourceManager.GetString("InvalidOutputFolder", resourceCulture);
             }
@@ -373,7 +373,7 @@ namespace Microsoft.CookiecutterTools {
         /// <summary>
         ///   Looks up a localized string similar to ----- Failed to load template &apos;{0}&apos; -----.
         /// </summary>
-        internal static string LoadingTemplateFailed {
+        public static string LoadingTemplateFailed {
             get {
                 return ResourceManager.GetString("LoadingTemplateFailed", resourceCulture);
             }
@@ -382,7 +382,7 @@ namespace Microsoft.CookiecutterTools {
         /// <summary>
         ///   Looks up a localized string similar to ----- Loading template &apos;{0}&apos; -----.
         /// </summary>
-        internal static string LoadingTemplateStarted {
+        public static string LoadingTemplateStarted {
             get {
                 return ResourceManager.GetString("LoadingTemplateStarted", resourceCulture);
             }
@@ -391,7 +391,7 @@ namespace Microsoft.CookiecutterTools {
         /// <summary>
         ///   Looks up a localized string similar to ----- Successfully loaded template &apos;{0}&apos; -----.
         /// </summary>
-        internal static string LoadingTemplateSuccess {
+        public static string LoadingTemplateSuccess {
             get {
                 return ResourceManager.GetString("LoadingTemplateSuccess", resourceCulture);
             }
@@ -400,7 +400,7 @@ namespace Microsoft.CookiecutterTools {
         /// <summary>
         ///   Looks up a localized string similar to Some external dependencies are missing. Click the links to install them..
         /// </summary>
-        internal static string MissingDependenciesInfoBarMessage {
+        public static string MissingDependenciesInfoBarMessage {
             get {
                 return ResourceManager.GetString("MissingDependenciesInfoBarMessage", resourceCulture);
             }
@@ -409,16 +409,142 @@ namespace Microsoft.CookiecutterTools {
         /// <summary>
         ///   Looks up a localized string similar to Would you like to open the generated folder in Solution Explorer?.
         /// </summary>
-        internal static string OpenInSolutionExplorerQuestion {
+        public static string OpenInSolutionExplorerQuestion {
             get {
                 return ResourceManager.GetString("OpenInSolutionExplorerQuestion", resourceCulture);
             }
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Files will be added to your project..
+        /// </summary>
+        public static string OptionsPage_AddingToProject {
+            get {
+                return ResourceManager.GetString("OptionsPage_AddingToProject", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Cookiecutter was invoked using the Add From Cookiecutter command. To return to the global mode where files are not added to an existing project, click on Cancel or Home..
+        /// </summary>
+        public static string OptionsPage_AddingToProjectTooltip {
+            get {
+                return ResourceManager.GetString("OptionsPage_AddingToProjectTooltip", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Add to Project.
+        /// </summary>
+        public static string OptionsPage_AddToProject {
+            get {
+                return ResourceManager.GetString("OptionsPage_AddToProject", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Cancel.
+        /// </summary>
+        public static string OptionsPage_Cancel {
+            get {
+                return ResourceManager.GetString("OptionsPage_Cancel", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Create.
+        /// </summary>
+        public static string OptionsPage_Create {
+            get {
+                return ResourceManager.GetString("OptionsPage_Create", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Create To.
+        /// </summary>
+        public static string OptionsPage_CreateTo {
+            get {
+                return ResourceManager.GetString("OptionsPage_CreateTo", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Folder location where the files will be created. Files may be replaced if the folder is not empty, but a backup of the existing files will be created as needed..
+        /// </summary>
+        public static string OptionsPage_CreateToTooltip {
+            get {
+                return ResourceManager.GetString("OptionsPage_CreateToTooltip", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to e.g. C:\Projects\Project1.
+        /// </summary>
+        public static string OptionsPage_CreateToWatermark {
+            get {
+                return ResourceManager.GetString("OptionsPage_CreateToWatermark", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Creating files....
+        /// </summary>
+        public static string OptionsPage_CreatingFiles {
+            get {
+                return ResourceManager.GetString("OptionsPage_CreatingFiles", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Error creating files. See output window for details..
+        /// </summary>
+        public static string OptionsPage_CreatingFilesError {
+            get {
+                return ResourceManager.GetString("OptionsPage_CreatingFilesError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Name.
+        /// </summary>
+        public static string OptionsPage_Name {
+            get {
+                return ResourceManager.GetString("OptionsPage_Name", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Options.
+        /// </summary>
+        public static string OptionsPage_Options {
+            get {
+                return ResourceManager.GetString("OptionsPage_Options", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Run additional tasks on completion.
+        /// </summary>
+        public static string OptionsPage_RunAdditionalTasks {
+            get {
+                return ResourceManager.GetString("OptionsPage_RunAdditionalTasks", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Template cloned successfully..
+        /// </summary>
+        public static string OptionsPage_TemplateCloneSuccessfully {
+            get {
+                return ResourceManager.GetString("OptionsPage_TemplateCloneSuccessfully", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to {0} returned an exit code of {1}..
         /// </summary>
-        internal static string ProcessExitCodeMessage {
+        public static string ProcessExitCodeMessage {
             get {
                 return ResourceManager.GetString("ProcessExitCodeMessage", resourceCulture);
             }
@@ -427,7 +553,7 @@ namespace Microsoft.CookiecutterTools {
         /// <summary>
         ///   Looks up a localized string similar to Cookiecutter.
         /// </summary>
-        internal static string ProductTitle {
+        public static string ProductTitle {
             get {
                 return ResourceManager.GetString("ProductTitle", resourceCulture);
             }
@@ -436,7 +562,7 @@ namespace Microsoft.CookiecutterTools {
         /// <summary>
         ///   Looks up a localized string similar to Project with unique name &apos;{0}&apos; was not found in the current solution..
         /// </summary>
-        internal static string ProjectNotFound {
+        public static string ProjectNotFound {
             get {
                 return ResourceManager.GetString("ProjectNotFound", resourceCulture);
             }
@@ -445,7 +571,7 @@ namespace Microsoft.CookiecutterTools {
         /// <summary>
         ///   Looks up a localized string similar to  - &apos;{0}&apos; was saved as &apos;{1}&apos;..
         /// </summary>
-        internal static string ReplacedFile {
+        public static string ReplacedFile {
             get {
                 return ResourceManager.GetString("ReplacedFile", resourceCulture);
             }
@@ -454,7 +580,7 @@ namespace Microsoft.CookiecutterTools {
         /// <summary>
         ///   Looks up a localized string similar to The following files were replaced, and a backup of the original file was created:.
         /// </summary>
-        internal static string ReplacedFilesHeader {
+        public static string ReplacedFilesHeader {
             get {
                 return ResourceManager.GetString("ReplacedFilesHeader", resourceCulture);
             }
@@ -463,7 +589,7 @@ namespace Microsoft.CookiecutterTools {
         /// <summary>
         ///   Looks up a localized string similar to ----- Failed to create files using template &apos;{0}&apos; -----.
         /// </summary>
-        internal static string RunningTemplateFailed {
+        public static string RunningTemplateFailed {
             get {
                 return ResourceManager.GetString("RunningTemplateFailed", resourceCulture);
             }
@@ -472,7 +598,7 @@ namespace Microsoft.CookiecutterTools {
         /// <summary>
         ///   Looks up a localized string similar to ----- Creating files using template &apos;{0}&apos; -----.
         /// </summary>
-        internal static string RunningTemplateStarted {
+        public static string RunningTemplateStarted {
             get {
                 return ResourceManager.GetString("RunningTemplateStarted", resourceCulture);
             }
@@ -481,9 +607,270 @@ namespace Microsoft.CookiecutterTools {
         /// <summary>
         ///   Looks up a localized string similar to ----- Successfully created files using template &apos;{0}&apos; into &apos;{1}&apos; -----.
         /// </summary>
-        internal static string RunningTemplateSuccess {
+        public static string RunningTemplateSuccess {
             get {
                 return ResourceManager.GetString("RunningTemplateSuccess", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Checking for updates....
+        /// </summary>
+        public static string SearchPage_CheckingUpdates {
+            get {
+                return ResourceManager.GetString("SearchPage_CheckingUpdates", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Check for updates completed..
+        /// </summary>
+        public static string SearchPage_CheckingUpdatesCompleted {
+            get {
+                return ResourceManager.GetString("SearchPage_CheckingUpdatesCompleted", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Cloning repository....
+        /// </summary>
+        public static string SearchPage_CloningRepository {
+            get {
+                return ResourceManager.GetString("SearchPage_CloningRepository", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to the creator.
+        /// </summary>
+        public static string SearchPage_Creator {
+            get {
+                return ResourceManager.GetString("SearchPage_Creator", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Enumerating templates. This may take a few seconds..
+        /// </summary>
+        public static string SearchPage_EnumeratingTemplatesTooltip {
+            get {
+                return ResourceManager.GetString("SearchPage_EnumeratingTemplatesTooltip", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Error checking for updates. See output window for details..
+        /// </summary>
+        public static string SearchPage_ErrorCheckingUpdates {
+            get {
+                return ResourceManager.GetString("SearchPage_ErrorCheckingUpdates", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Error cloning repository. See output window for details..
+        /// </summary>
+        public static string SearchPage_ErrorCloningRepository {
+            get {
+                return ResourceManager.GetString("SearchPage_ErrorCloningRepository", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Error installing cookiecutter. See output window for details..
+        /// </summary>
+        public static string SearchPage_ErrorInstallingCookiecutter {
+            get {
+                return ResourceManager.GetString("SearchPage_ErrorInstallingCookiecutter", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Error loading template. See output window for details..
+        /// </summary>
+        public static string SearchPage_ErrorLoadingTemplate {
+            get {
+                return ResourceManager.GetString("SearchPage_ErrorLoadingTemplate", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Files created successfully..
+        /// </summary>
+        public static string SearchPage_FilesCreatedSuccessfully {
+            get {
+                return ResourceManager.GetString("SearchPage_FilesCreatedSuccessfully", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to GitHub.
+        /// </summary>
+        public static string SearchPage_LinksGitHub {
+            get {
+                return ResourceManager.GetString("SearchPage_LinksGitHub", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Issues.
+        /// </summary>
+        public static string SearchPage_LinksGitHubIssues {
+            get {
+                return ResourceManager.GetString("SearchPage_LinksGitHubIssues", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Wiki.
+        /// </summary>
+        public static string SearchPage_LinksGitHubWiki {
+            get {
+                return ResourceManager.GetString("SearchPage_LinksGitHubWiki", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Loading....
+        /// </summary>
+        public static string SearchPage_LoadingSearchResults {
+            get {
+                return ResourceManager.GetString("SearchPage_LoadingSearchResults", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Loading template....
+        /// </summary>
+        public static string SearchPage_LoadingTemplate {
+            get {
+                return ResourceManager.GetString("SearchPage_LoadingTemplate", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Load more....
+        /// </summary>
+        public static string SearchPage_LoadMore {
+            get {
+                return ResourceManager.GetString("SearchPage_LoadMore", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to _Next.
+        /// </summary>
+        public static string SearchPage_NextButton {
+            get {
+                return ResourceManager.GetString("SearchPage_NextButton", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to No description available..
+        /// </summary>
+        public static string SearchPage_NoTemplateDescriptionAvailable {
+            get {
+                return ResourceManager.GetString("SearchPage_NoTemplateDescriptionAvailable", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Open in Solution Explorer.
+        /// </summary>
+        public static string SearchPage_OpenInSolutionExplorer {
+            get {
+                return ResourceManager.GetString("SearchPage_OpenInSolutionExplorer", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Preparing cookiecutter for first time use....
+        /// </summary>
+        public static string SearchPage_PreparingFirstTime {
+            get {
+                return ResourceManager.GetString("SearchPage_PreparingFirstTime", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Downloading and installing the cookiecutter package from the Python Package Index. This may take a few minutes..
+        /// </summary>
+        public static string SearchPage_PreparingFirstTimeTooltip {
+            get {
+                return ResourceManager.GetString("SearchPage_PreparingFirstTimeTooltip", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Search.
+        /// </summary>
+        public static string SearchPage_Search {
+            get {
+                return ResourceManager.GetString("SearchPage_Search", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Enter search terms or template location (git repository URL or path to local folder).
+        /// </summary>
+        public static string SearchPage_SearchTooltip {
+            get {
+                return ResourceManager.GetString("SearchPage_SearchTooltip", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Enter search terms or template location.
+        /// </summary>
+        public static string SearchPage_SearchWatermark {
+            get {
+                return ResourceManager.GetString("SearchPage_SearchWatermark", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to An update is available..
+        /// </summary>
+        public static string SearchPage_UpdateAvailableTooltip {
+            get {
+                return ResourceManager.GetString("SearchPage_UpdateAvailableTooltip", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Updating template....
+        /// </summary>
+        public static string SearchPage_UpdatingTemplate {
+            get {
+                return ResourceManager.GetString("SearchPage_UpdatingTemplate", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Template updated..
+        /// </summary>
+        public static string SearchPage_UpdatingTemplateCompleted {
+            get {
+                return ResourceManager.GetString("SearchPage_UpdatingTemplateCompleted", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Error updating template. See output window for details..
+        /// </summary>
+        public static string SearchPage_UpdatingTemplateError {
+            get {
+                return ResourceManager.GetString("SearchPage_UpdatingTemplateError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Visit {0} on GitHub.
+        /// </summary>
+        public static string SearchPage_VisitOwnerOnGitHub {
+            get {
+                return ResourceManager.GetString("SearchPage_VisitOwnerOnGitHub", resourceCulture);
             }
         }
         
@@ -492,7 +879,7 @@ namespace Microsoft.CookiecutterTools {
         ///
         ///You can get more information by running Visual Studio with the /log parameter on the command line, and then examining the file &apos;{0}&apos;, or by checking the Event Log..
         /// </summary>
-        internal static string SeeActivityLog {
+        public static string SeeActivityLog {
             get {
                 return ResourceManager.GetString("SeeActivityLog", resourceCulture);
             }
@@ -501,7 +888,7 @@ namespace Microsoft.CookiecutterTools {
         /// <summary>
         ///   Looks up a localized string similar to Custom.
         /// </summary>
-        internal static string TemplateCategoryCustom {
+        public static string TemplateCategoryCustom {
             get {
                 return ResourceManager.GetString("TemplateCategoryCustom", resourceCulture);
             }
@@ -510,7 +897,7 @@ namespace Microsoft.CookiecutterTools {
         /// <summary>
         ///   Looks up a localized string similar to GitHub.
         /// </summary>
-        internal static string TemplateCategoryGitHub {
+        public static string TemplateCategoryGitHub {
             get {
                 return ResourceManager.GetString("TemplateCategoryGitHub", resourceCulture);
             }
@@ -519,7 +906,7 @@ namespace Microsoft.CookiecutterTools {
         /// <summary>
         ///   Looks up a localized string similar to Installed.
         /// </summary>
-        internal static string TemplateCategoryInstalled {
+        public static string TemplateCategoryInstalled {
             get {
                 return ResourceManager.GetString("TemplateCategoryInstalled", resourceCulture);
             }
@@ -528,7 +915,7 @@ namespace Microsoft.CookiecutterTools {
         /// <summary>
         ///   Looks up a localized string similar to Recommended.
         /// </summary>
-        internal static string TemplateCategoryRecommended {
+        public static string TemplateCategoryRecommended {
             get {
                 return ResourceManager.GetString("TemplateCategoryRecommended", resourceCulture);
             }
@@ -537,7 +924,7 @@ namespace Microsoft.CookiecutterTools {
         /// <summary>
         ///   Looks up a localized string similar to Cookiecutter.
         /// </summary>
-        internal static string ToolWindowCaption {
+        public static string ToolWindowCaption {
             get {
                 return ResourceManager.GetString("ToolWindowCaption", resourceCulture);
             }
@@ -547,7 +934,7 @@ namespace Microsoft.CookiecutterTools {
         ///   Looks up a localized string similar to Unhandled exception in {3} ({1}:{2})
         ///{0}.
         /// </summary>
-        internal static string UnhandledException {
+        public static string UnhandledException {
             get {
                 return ResourceManager.GetString("UnhandledException", resourceCulture);
             }
@@ -556,7 +943,7 @@ namespace Microsoft.CookiecutterTools {
         /// <summary>
         ///   Looks up a localized string similar to ----- Failed to update template &apos;{0}&apos; -----.
         /// </summary>
-        internal static string UpdatingTemplateFailed {
+        public static string UpdatingTemplateFailed {
             get {
                 return ResourceManager.GetString("UpdatingTemplateFailed", resourceCulture);
             }
@@ -565,7 +952,7 @@ namespace Microsoft.CookiecutterTools {
         /// <summary>
         ///   Looks up a localized string similar to ----- Updating template &apos;{0}&apos; -----.
         /// </summary>
-        internal static string UpdatingTemplateStarted {
+        public static string UpdatingTemplateStarted {
             get {
                 return ResourceManager.GetString("UpdatingTemplateStarted", resourceCulture);
             }
@@ -574,7 +961,7 @@ namespace Microsoft.CookiecutterTools {
         /// <summary>
         ///   Looks up a localized string similar to ----- Successfully updated template &apos;{0}&apos; -----.
         /// </summary>
-        internal static string UpdatingTemplateSuccess {
+        public static string UpdatingTemplateSuccess {
             get {
                 return ResourceManager.GetString("UpdatingTemplateSuccess", resourceCulture);
             }

--- a/Python/Product/Cookiecutter/Strings.Designer.cs
+++ b/Python/Product/Cookiecutter/Strings.Designer.cs
@@ -895,6 +895,69 @@ namespace Microsoft.CookiecutterTools {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Automatically check online for updates to installed templates..
+        /// </summary>
+        public static string Settings_CheckForTemplateUpdate_Description {
+            get {
+                return ResourceManager.GetString("Settings_CheckForTemplateUpdate_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Check for Template Update.
+        /// </summary>
+        public static string Settings_CheckForTemplateUpdate_Name {
+            get {
+                return ResourceManager.GetString("Settings_CheckForTemplateUpdate_Name", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Location of the feed. The contents of the feed consists of line separated URLs of template locations..
+        /// </summary>
+        public static string Settings_FeedUrl_Description {
+            get {
+                return ResourceManager.GetString("Settings_FeedUrl_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Recommended Feed URL.
+        /// </summary>
+        public static string Settings_FeedUrl_Name {
+            get {
+                return ResourceManager.GetString("Settings_FeedUrl_Name", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to General.
+        /// </summary>
+        public static string Settings_General_Category {
+            get {
+                return ResourceManager.GetString("Settings_General_Category", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Show the help information bar..
+        /// </summary>
+        public static string Settings_ShowHelp_Description {
+            get {
+                return ResourceManager.GetString("Settings_ShowHelp_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Show Help.
+        /// </summary>
+        public static string Settings_ShowHelp_Name {
+            get {
+                return ResourceManager.GetString("Settings_ShowHelp_Name", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Custom.
         /// </summary>
         public static string TemplateCategoryCustom {

--- a/Python/Product/Cookiecutter/Strings.Designer.cs
+++ b/Python/Product/Cookiecutter/Strings.Designer.cs
@@ -234,6 +234,15 @@ namespace Microsoft.CookiecutterTools {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Unsupported json element type in context file for property &apos;{0}&apos;..
+        /// </summary>
+        public static string CookiecutterClient_UnsupportedJsonElementTypeForPorperty {
+            get {
+                return ResourceManager.GetString("CookiecutterClient_UnsupportedJsonElementTypeForPorperty", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to &apos;{0}&apos; from _visual_studio section in context file should be of type &apos;{1}&apos;, instead of &apos;{2}&apos;..
         /// </summary>
         public static string CookiecutterClient_WrongJsonType {

--- a/Python/Product/Cookiecutter/Strings.Designer.cs
+++ b/Python/Product/Cookiecutter/Strings.Designer.cs
@@ -198,6 +198,51 @@ namespace Microsoft.CookiecutterTools {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to &apos;{0}&apos; from _visual_studio section in context file should be an absolute http or https url..
+        /// </summary>
+        internal static string CookiecutterClient_Invalidurl {
+            get {
+                return ResourceManager.GetString("CookiecutterClient_Invalidurl", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &apos;{0}&apos; property is required on &apos;{1}&apos;..
+        /// </summary>
+        internal static string CookiecutterClient_MissingProperty {
+            get {
+                return ResourceManager.GetString("CookiecutterClient_MissingProperty", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Cookiecutter generated files must have a templated folder..
+        /// </summary>
+        internal static string CookiecutterClient_MoveToDesiredFolderTemplatedFolderNotFound {
+            get {
+                return ResourceManager.GetString("CookiecutterClient_MoveToDesiredFolderTemplatedFolderNotFound", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &apos;{0}&apos; is referenced from _visual_studio section in context file but was not found..
+        /// </summary>
+        internal static string CookiecutterClient_ReferenceNotFound {
+            get {
+                return ResourceManager.GetString("CookiecutterClient_ReferenceNotFound", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &apos;{0}&apos; from _visual_studio section in context file should be of type &apos;{1}&apos;, instead of &apos;{2}&apos;..
+        /// </summary>
+        internal static string CookiecutterClient_WrongJsonType {
+            get {
+                return ResourceManager.GetString("CookiecutterClient_WrongJsonType", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Are you sure you want to delete the template from this folder?
         ///
         ///{0}.

--- a/Python/Product/Cookiecutter/Strings.resx
+++ b/Python/Product/Cookiecutter/Strings.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -279,5 +279,20 @@ Please delete the installed template and try again.</value>
   </data>
   <data name="ConnectionStringFormatIncorrect" xml:space="preserve">
     <value>The connection string appears to be in incorrect format. Would you like to re-create it?</value>
+  </data>
+  <data name="CookiecutterClient_MoveToDesiredFolderTemplatedFolderNotFound" xml:space="preserve">
+    <value>Cookiecutter generated files must have a templated folder.</value>
+  </data>
+  <data name="CookiecutterClient_Invalidurl" xml:space="preserve">
+    <value>'{0}' from _visual_studio section in context file should be an absolute http or https url.</value>
+  </data>
+  <data name="CookiecutterClient_WrongJsonType" xml:space="preserve">
+    <value>'{0}' from _visual_studio section in context file should be of type '{1}', instead of '{2}'.</value>
+  </data>
+  <data name="CookiecutterClient_ReferenceNotFound" xml:space="preserve">
+    <value>'{0}' is referenced from _visual_studio section in context file but was not found.</value>
+  </data>
+  <data name="CookiecutterClient_MissingProperty" xml:space="preserve">
+    <value>'{0}' property is required on '{1}'.</value>
   </data>
 </root>

--- a/Python/Product/Cookiecutter/Strings.resx
+++ b/Python/Product/Cookiecutter/Strings.resx
@@ -295,6 +295,9 @@ Please delete the installed template and try again.</value>
   <data name="CookiecutterClient_MissingProperty" xml:space="preserve">
     <value>'{0}' property is required on '{1}'.</value>
   </data>
+  <data name="CookiecutterClient_UnsupportedJsonElementTypeForPorperty" xml:space="preserve">
+    <value>Unsupported json element type in context file for property '{0}'.</value>
+  </data>
   <data name="SearchPage_SearchWatermark" xml:space="preserve">
     <value>Enter search terms or template location</value>
   </data>
@@ -380,6 +383,12 @@ Please delete the installed template and try again.</value>
   <data name="SearchPage_LoadingSearchResults" xml:space="preserve">
     <value>Loading...</value>
   </data>
+  <data name="SearchPage_Creator" xml:space="preserve">
+    <value>the creator</value>
+  </data>
+  <data name="SearchPage_VisitOwnerOnGitHub" xml:space="preserve">
+    <value>Visit {0} on GitHub</value>
+  </data>
   <data name="OptionsPage_TemplateCloneSuccessfully" xml:space="preserve">
     <value>Template cloned successfully.</value>
   </data>
@@ -421,15 +430,6 @@ Please delete the installed template and try again.</value>
   </data>
   <data name="OptionsPage_Name" xml:space="preserve">
     <value>Name</value>
-  </data>
-  <data name="SearchPage_Creator" xml:space="preserve">
-    <value>the creator</value>
-  </data>
-  <data name="SearchPage_VisitOwnerOnGitHub" xml:space="preserve">
-    <value>Visit {0} on GitHub</value>
-  </data>
-  <data name="CookiecutterClient_UnsupportedJsonElementTypeForPorperty" xml:space="preserve">
-    <value>Unsupported json element type in context file for property '{0}'.</value>
   </data>
   <data name="Settings_General_Category" xml:space="preserve">
     <value>General</value>

--- a/Python/Product/Cookiecutter/Strings.resx
+++ b/Python/Product/Cookiecutter/Strings.resx
@@ -428,4 +428,7 @@ Please delete the installed template and try again.</value>
   <data name="SearchPage_VisitOwnerOnGitHub" xml:space="preserve">
     <value>Visit {0} on GitHub</value>
   </data>
+  <data name="CookiecutterClient_UnsupportedJsonElementTypeForPorperty" xml:space="preserve">
+    <value>Unsupported json element type in context file for property '{0}'.</value>
+  </data>
 </root>

--- a/Python/Product/Cookiecutter/Strings.resx
+++ b/Python/Product/Cookiecutter/Strings.resx
@@ -431,4 +431,25 @@ Please delete the installed template and try again.</value>
   <data name="CookiecutterClient_UnsupportedJsonElementTypeForPorperty" xml:space="preserve">
     <value>Unsupported json element type in context file for property '{0}'.</value>
   </data>
+  <data name="Settings_General_Category" xml:space="preserve">
+    <value>General</value>
+  </data>
+  <data name="Settings_ShowHelp_Name" xml:space="preserve">
+    <value>Show Help</value>
+  </data>
+  <data name="Settings_ShowHelp_Description" xml:space="preserve">
+    <value>Show the help information bar.</value>
+  </data>
+  <data name="Settings_FeedUrl_Name" xml:space="preserve">
+    <value>Recommended Feed URL</value>
+  </data>
+  <data name="Settings_FeedUrl_Description" xml:space="preserve">
+    <value>Location of the feed. The contents of the feed consists of line separated URLs of template locations.</value>
+  </data>
+  <data name="Settings_CheckForTemplateUpdate_Name" xml:space="preserve">
+    <value>Check for Template Update</value>
+  </data>
+  <data name="Settings_CheckForTemplateUpdate_Description" xml:space="preserve">
+    <value>Automatically check online for updates to installed templates.</value>
+  </data>
 </root>

--- a/Python/Product/Cookiecutter/Strings.resx
+++ b/Python/Product/Cookiecutter/Strings.resx
@@ -295,4 +295,137 @@ Please delete the installed template and try again.</value>
   <data name="CookiecutterClient_MissingProperty" xml:space="preserve">
     <value>'{0}' property is required on '{1}'.</value>
   </data>
+  <data name="SearchPage_SearchWatermark" xml:space="preserve">
+    <value>Enter search terms or template location</value>
+  </data>
+  <data name="SearchPage_SearchTooltip" xml:space="preserve">
+    <value>Enter search terms or template location (git repository URL or path to local folder)</value>
+  </data>
+  <data name="SearchPage_OpenInSolutionExplorer" xml:space="preserve">
+    <value>Open in Solution Explorer</value>
+  </data>
+  <data name="SearchPage_UpdateAvailableTooltip" xml:space="preserve">
+    <value>An update is available.</value>
+  </data>
+  <data name="SearchPage_EnumeratingTemplatesTooltip" xml:space="preserve">
+    <value>Enumerating templates. This may take a few seconds.</value>
+  </data>
+  <data name="SearchPage_LoadMore" xml:space="preserve">
+    <value>Load more...</value>
+  </data>
+  <data name="SearchPage_FilesCreatedSuccessfully" xml:space="preserve">
+    <value>Files created successfully.</value>
+  </data>
+  <data name="SearchPage_Search" xml:space="preserve">
+    <value>Search</value>
+  </data>
+  <data name="SearchPage_PreparingFirstTime" xml:space="preserve">
+    <value>Preparing cookiecutter for first time use...</value>
+  </data>
+  <data name="SearchPage_PreparingFirstTimeTooltip" xml:space="preserve">
+    <value>Downloading and installing the cookiecutter package from the Python Package Index. This may take a few minutes.</value>
+  </data>
+  <data name="SearchPage_ErrorInstallingCookiecutter" xml:space="preserve">
+    <value>Error installing cookiecutter. See output window for details.</value>
+  </data>
+  <data name="SearchPage_CloningRepository" xml:space="preserve">
+    <value>Cloning repository...</value>
+  </data>
+  <data name="SearchPage_ErrorCloningRepository" xml:space="preserve">
+    <value>Error cloning repository. See output window for details.</value>
+  </data>
+  <data name="SearchPage_LoadingTemplate" xml:space="preserve">
+    <value>Loading template...</value>
+  </data>
+  <data name="SearchPage_ErrorLoadingTemplate" xml:space="preserve">
+    <value>Error loading template. See output window for details.</value>
+  </data>
+  <data name="SearchPage_CheckingUpdates" xml:space="preserve">
+    <value>Checking for updates...</value>
+  </data>
+  <data name="SearchPage_CheckingUpdatesCompleted" xml:space="preserve">
+    <value>Check for updates completed.</value>
+  </data>
+  <data name="SearchPage_ErrorCheckingUpdates" xml:space="preserve">
+    <value>Error checking for updates. See output window for details.</value>
+  </data>
+  <data name="SearchPage_UpdatingTemplate" xml:space="preserve">
+    <value>Updating template...</value>
+  </data>
+  <data name="SearchPage_UpdatingTemplateCompleted" xml:space="preserve">
+    <value>Template updated.</value>
+  </data>
+  <data name="SearchPage_UpdatingTemplateError" xml:space="preserve">
+    <value>Error updating template. See output window for details.</value>
+  </data>
+  <data name="SearchPage_LinksGitHub" xml:space="preserve">
+    <value>GitHub</value>
+    <comment>Label for the link to the main GitHub page.</comment>
+  </data>
+  <data name="SearchPage_LinksGitHubIssues" xml:space="preserve">
+    <value>Issues</value>
+    <comment>Label for the link to the GitHub issues page</comment>
+  </data>
+  <data name="SearchPage_LinksGitHubWiki" xml:space="preserve">
+    <value>Wiki</value>
+    <comment>Label for the link to the GitHub wiki page.</comment>
+  </data>
+  <data name="SearchPage_NoTemplateDescriptionAvailable" xml:space="preserve">
+    <value>No description available.</value>
+  </data>
+  <data name="SearchPage_NextButton" xml:space="preserve">
+    <value>_Next</value>
+    <comment>Prefix accelerator key with underscore</comment>
+  </data>
+  <data name="SearchPage_LoadingSearchResults" xml:space="preserve">
+    <value>Loading...</value>
+  </data>
+  <data name="OptionsPage_TemplateCloneSuccessfully" xml:space="preserve">
+    <value>Template cloned successfully.</value>
+  </data>
+  <data name="OptionsPage_CreateTo" xml:space="preserve">
+    <value>Create To</value>
+  </data>
+  <data name="OptionsPage_CreateToWatermark" xml:space="preserve">
+    <value>e.g. C:\Projects\Project1</value>
+  </data>
+  <data name="OptionsPage_CreateToTooltip" xml:space="preserve">
+    <value>Folder location where the files will be created. Files may be replaced if the folder is not empty, but a backup of the existing files will be created as needed.</value>
+  </data>
+  <data name="OptionsPage_AddingToProject" xml:space="preserve">
+    <value>Files will be added to your project.</value>
+  </data>
+  <data name="OptionsPage_AddingToProjectTooltip" xml:space="preserve">
+    <value>Cookiecutter was invoked using the Add From Cookiecutter command. To return to the global mode where files are not added to an existing project, click on Cancel or Home.</value>
+  </data>
+  <data name="OptionsPage_RunAdditionalTasks" xml:space="preserve">
+    <value>Run additional tasks on completion</value>
+  </data>
+  <data name="OptionsPage_AddToProject" xml:space="preserve">
+    <value>Add to Project</value>
+  </data>
+  <data name="OptionsPage_Cancel" xml:space="preserve">
+    <value>Cancel</value>
+  </data>
+  <data name="OptionsPage_CreatingFiles" xml:space="preserve">
+    <value>Creating files...</value>
+  </data>
+  <data name="OptionsPage_CreatingFilesError" xml:space="preserve">
+    <value>Error creating files. See output window for details.</value>
+  </data>
+  <data name="OptionsPage_Create" xml:space="preserve">
+    <value>Create</value>
+  </data>
+  <data name="OptionsPage_Options" xml:space="preserve">
+    <value>Options</value>
+  </data>
+  <data name="OptionsPage_Name" xml:space="preserve">
+    <value>Name</value>
+  </data>
+  <data name="SearchPage_Creator" xml:space="preserve">
+    <value>the creator</value>
+  </data>
+  <data name="SearchPage_VisitOwnerOnGitHub" xml:space="preserve">
+    <value>Visit {0} on GitHub</value>
+  </data>
 </root>

--- a/Python/Product/Cookiecutter/Telemetry/CookiecutterTelemetry.cs
+++ b/Python/Product/Cookiecutter/Telemetry/CookiecutterTelemetry.cs
@@ -26,6 +26,7 @@ namespace Microsoft.CookiecutterTools.Telemetry {
         /// <summary>
         /// Area names show up as part of telemetry event names like:
         ///   VS/CookiecutterTools/[area]/[event]
+        /// </summary>
         internal static class TelemetryArea {
             public const string Prereqs = "Prereqs";
             public const string Search = "Search";

--- a/Python/Product/Cookiecutter/Telemetry/StringTelemetryRecorder.cs
+++ b/Python/Product/Cookiecutter/Telemetry/StringTelemetryRecorder.cs
@@ -26,7 +26,7 @@ namespace Microsoft.CookiecutterTools.Telemetry {
     /// VS telemetry Web service.
     /// </summary>
     internal sealed class StringTelemetryRecorder : ITelemetryRecorder, ITelemetryLog, IDisposable {
-        private StringBuilder _stringBuilder = new StringBuilder();
+        private readonly StringBuilder _stringBuilder = new StringBuilder();
 
         #region ITelemetryRecorder
         public bool IsEnabled {

--- a/Python/Product/Cookiecutter/Telemetry/TelemetryServiceBase.cs
+++ b/Python/Product/Cookiecutter/Telemetry/TelemetryServiceBase.cs
@@ -63,7 +63,6 @@ namespace Microsoft.CookiecutterTools.Telemetry {
         /// Either string/object dictionary or anonymous
         /// collection of string/object pairs.
         /// </param>
-        /// <summary>
         public void ReportEvent(string area, string eventName, object parameters = null) {
             if (string.IsNullOrEmpty(area)) {
                 throw new ArgumentException(nameof(area));

--- a/Python/Product/Cookiecutter/Telemetry/VsTelemetryRecorder.cs
+++ b/Python/Product/Cookiecutter/Telemetry/VsTelemetryRecorder.cs
@@ -23,8 +23,8 @@ namespace Microsoft.CookiecutterTools.Telemetry {
     /// Implements telemetry recording in Visual Studio environment
     /// </summary>
     internal sealed class VsTelemetryRecorder : ITelemetryRecorder {
-        private TelemetrySession _session;
-        private static Lazy<VsTelemetryRecorder> _instance = new Lazy<VsTelemetryRecorder>(() => new VsTelemetryRecorder());
+        private readonly TelemetrySession _session;
+        private static readonly Lazy<VsTelemetryRecorder> _instance = new Lazy<VsTelemetryRecorder>(() => new VsTelemetryRecorder());
 
         private VsTelemetryRecorder() {
             _session = TelemetryService.DefaultSession;

--- a/Python/Product/Cookiecutter/Telemetry/VsTelemetryService.cs
+++ b/Python/Product/Cookiecutter/Telemetry/VsTelemetryService.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CookiecutterTools.Telemetry {
         public static readonly string EventNamePrefixString = "VS/Cookiecutter/";
         public static readonly string PropertyNamePrefixString = "VS.Cookiecutter.";
 
-        private static Lazy<VsTelemetryService> _instance = new Lazy<VsTelemetryService>(() => new VsTelemetryService());
+        private static readonly Lazy<VsTelemetryService> _instance = new Lazy<VsTelemetryService>(() => new VsTelemetryService());
 
         public VsTelemetryService()
             : base(VsTelemetryService.EventNamePrefixString, VsTelemetryService.PropertyNamePrefixString, VsTelemetryRecorder.Current) {

--- a/Python/Product/Cookiecutter/View/CookiecutterOptionsPage.xaml
+++ b/Python/Product/Cookiecutter/View/CookiecutterOptionsPage.xaml
@@ -10,6 +10,7 @@
       xmlns:imaging="clr-namespace:Microsoft.VisualStudio.Imaging;assembly=Microsoft.VisualStudio.Imaging"
       xmlns:img="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Imaging"
       xmlns:imagecatalog="clr-namespace:Microsoft.VisualStudio.Imaging;assembly=Microsoft.VisualStudio.ImageCatalog"
+      xmlns:cct="clr-namespace:Microsoft.CookiecutterTools"
       xmlns:sys="clr-namespace:System;assembly=mscorlib"
       wpf:LambdaProperties.ImportedNamespaces="System.Windows Microsoft.CookiecutterTools Microsoft.CookiecutterTools.ViewModel Microsoft.CookiecutterTools.Model"
       mc:Ignorable="d" 
@@ -177,28 +178,18 @@
         <StackPanel Grid.Row="0" Margin="4" Orientation="Vertical">
             <StackPanel Margin="4 4 4 8" Orientation="Horizontal" Visibility="{Binding CloningStatus, Converter={StaticResource OperationStatusSucceededToVisibleOrCollapsed}}">
                 <imaging:CrispImage Width="16" Height="16" Moniker="{x:Static imagecatalog:KnownMonikers.StatusOK}"/>
-                <TextBlock Margin="4 0 0 0" Text="Template cloned successfully."/>
+                <TextBlock Margin="4 0 0 0" Text="{x:Static cct:Strings.OptionsPage_TemplateCloneSuccessfully}"/>
             </StackPanel>
-            <Label FontWeight="Bold">Name</Label>
+            <Label FontWeight="Bold" Content="{x:Static cct:Strings.OptionsPage_Name}"></Label>
             <TextBlock Margin="4 0 4 4" Text="{Binding Path=SelectedTemplate.DisplayName}"/>
-            <!--<Label FontWeight="Bold">Local path</Label>
-            <TextBlock Margin="4 0 4 4" Text="{Binding Path=SelectedTemplate.ClonedPath}"/>
-            <Label FontWeight="Bold">Remote url</Label>
-            <TextBlock Margin="4 0 4 4" Text="{Binding Path=SelectedTemplate.RemoteUrl}"/>
-            <Label FontWeight="Bold">Description</Label>
-            <TextBlock Margin="4 0 4 4" Text="{Binding Path=SelectedDescription}"/>-->
-            <Label FontWeight="Bold">Create To</Label>
+            <Label FontWeight="Bold" Content="{x:Static cct:Strings.OptionsPage_CreateTo}"></Label>
             <wpf:ConfigurationTextBoxWithHelp Margin="4 0 4 0"
                                               Text="{Binding Path=OutputFolderPath,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}"
                                               IsReadOnly="{Binding Path=FixedOutputFolder}"
-                                              Watermark="e.g. C:\Projects\Project1"
+                                              Watermark="{x:Static cct:Strings.OptionsPage_CreateToWatermark}"
                                               BrowseButtonStyle="{StaticResource BrowseFolderButton}"
-                                              AutomationProperties.Name="Output folder path">
-                <wpf:ConfigurationTextBoxWithHelp.HelpText>
-                    Folder location where the files will be created.
-                    Files may be replaced if the folder is not empty,
-                    but a backup of the existing files will be created as needed.
-                </wpf:ConfigurationTextBoxWithHelp.HelpText>
+                                              AutomationProperties.Name="Output folder path"
+                                              HelpText="{x:Static cct:Strings.OptionsPage_CreateToTooltip}">
                 <wpf:ConfigurationTextBoxWithHelp.Resources>
                     <Style TargetType="{x:Type Button}">
                         <Setter Property="Height" Value="12"/>
@@ -207,24 +198,19 @@
             </wpf:ConfigurationTextBoxWithHelp>
             <StackPanel Margin="4 4 4 8" Orientation="Horizontal" Visibility="{Binding FixedOutputFolder, Converter={StaticResource BoolToVisibleOrCollapsed}}">
                 <imaging:CrispImage Width="16" Height="16" Moniker="{x:Static imagecatalog:KnownMonikers.StatusInformation}"/>
-                <TextBlock Margin="4 0 0 0" Text="Files will be added to your project.">
-                    <TextBlock.ToolTip>
-                        Cookiecutter was invoked using the Add From Cookiecutter command.
-                        To return to the global mode where files are not added to
-                        an existing project, click on Cancel or Home.
-                    </TextBlock.ToolTip>
-                </TextBlock>
+                <TextBlock Margin="4 0 0 0"
+                           Text="{x:Static cct:Strings.OptionsPage_AddingToProject}"
+                           ToolTip="{x:Static cct:Strings.OptionsPage_AddingToProjectTooltip}"/>
             </StackPanel>
-            <Label FontWeight="Bold">Options</Label>
+            <Label FontWeight="Bold" Content="{x:Static cct:Strings.OptionsPage_Options}"/>
             <CheckBox Margin="8 4 4 4"
                       IsChecked="{Binding ShouldExecutePostCommands}"
-                      Visibility="{Binding HasPostCommands, Converter={StaticResource BoolToVisibleOrCollapsed}}">
-                Run additional tasks on completion
-            </CheckBox>
+                      Visibility="{Binding HasPostCommands, Converter={StaticResource BoolToVisibleOrCollapsed}}"
+                      Content="{x:Static cct:Strings.OptionsPage_RunAdditionalTasks}"/>
         </StackPanel>
         <ScrollViewer Grid.Row="1" Margin="4">
             <ItemsControl ItemsSource="{Binding Path=ContextItems}"
-                            ItemTemplateSelector="{StaticResource contextItemSelector}" />
+                          ItemTemplateSelector="{StaticResource contextItemSelector}" />
         </ScrollViewer>
         <StackPanel Grid.Row="2" Margin="4" Orientation="Vertical">
             <StackPanel Grid.Row="2" Orientation="Horizontal">
@@ -232,23 +218,24 @@
                         Command="{x:Static vm:CookiecutterViewModel.CreateFilesCommand}">
                     <Button.Style>
                         <Style TargetType="Button" BasedOn="{StaticResource {x:Type Button}}">
-                            <Setter Property="Content" Value="Create"/>
+                            <Setter Property="Content" Value="{x:Static cct:Strings.OptionsPage_Create}"/>
                             <Style.Triggers>
                                 <DataTrigger Binding="{Binding Path=TargetProjectLocation, Converter={StaticResource TargetProjectLocationUniqueProjectNameNotEmpty}}" Value="True">
-                                    <Setter Property="Content" Value="Add to Project"/>
+                                    <Setter Property="Content" Value="{x:Static cct:Strings.OptionsPage_AddToProject}"/>
                                 </DataTrigger>
                             </Style.Triggers>
                         </Style>
                     </Button.Style>
                 </Button>
                 <Button MinWidth="100"
-                        Command="{x:Static vm:CookiecutterViewModel.HomeCommand}">Cancel</Button>
+                        Command="{x:Static vm:CookiecutterViewModel.HomeCommand}"
+                        Content="{x:Static cct:Strings.OptionsPage_Cancel}"/>
             </StackPanel>
 
             <StackPanel Margin="4 4 4 8"
                         Orientation="Vertical"
                         Visibility="{Binding Path=CreatingStatus, Converter={StaticResource OperationStatusInProgressToVisibleOrCollapsed}}">
-                <TextBlock Text="Creating files..."/>
+                <TextBlock Text="{x:Static cct:Strings.OptionsPage_CreatingFiles}"/>
                 <ProgressBar Margin="4" IsIndeterminate="True"/>
             </StackPanel>
 
@@ -256,7 +243,9 @@
                         Orientation="Horizontal"
                         Visibility="{Binding Path=CreatingStatus, Converter={StaticResource OperationStatusFailedToVisibleOrCollapsed}}">
                 <imaging:CrispImage Width="16" Height="16" Moniker="{x:Static imagecatalog:KnownMonikers.StatusError}"/>
-                <TextBlock Margin="4 0 0 0" TextWrapping="Wrap" Text="Error creating files. See output window for details."/>
+                <TextBlock Margin="4 0 0 0"
+                           TextWrapping="Wrap"
+                           Text="{x:Static cct:Strings.OptionsPage_CreatingFilesError}"/>
             </StackPanel>
 
         </StackPanel>

--- a/Python/Product/Cookiecutter/View/CookiecutterSearchPage.xaml
+++ b/Python/Product/Cookiecutter/View/CookiecutterSearchPage.xaml
@@ -10,6 +10,7 @@
       xmlns:imaging="clr-namespace:Microsoft.VisualStudio.Imaging;assembly=Microsoft.VisualStudio.Imaging"
       xmlns:img="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Imaging"
       xmlns:imagecatalog="clr-namespace:Microsoft.VisualStudio.Imaging;assembly=Microsoft.VisualStudio.ImageCatalog"
+      xmlns:cct="clr-namespace:Microsoft.CookiecutterTools"
       wpf:LambdaProperties.ImportedNamespaces="System.Windows Microsoft.CookiecutterTools Microsoft.CookiecutterTools.ViewModel"
       mc:Ignorable="d" 
       d:DataContext="{Binding Source={d:DesignData Source=CookiecutterControlDesignData.xaml}}"
@@ -90,7 +91,9 @@
             <StackPanel Margin="4 4 4 8"
                         Orientation="Horizontal">
                 <imaging:CrispImage Width="16" Height="16" Moniker="{x:Static imagecatalog:KnownMonikers.StatusOK}"/>
-                <TextBlock Margin="4 0 0 0" TextWrapping="Wrap" Text="Files created successfully."/>
+                <TextBlock Margin="4 0 0 0"
+                           TextWrapping="Wrap"
+                           Text="{x:Static cct:Strings.SearchPage_FilesCreatedSuccessfully}"/>
             </StackPanel>
             <StackPanel Margin="4 4 4 8"
                         Orientation="Horizontal">
@@ -99,9 +102,8 @@
                         Margin="4 0 0 0"
                         Command="{x:Static vm:CookiecutterViewModel.OpenInExplorer}"
                         CommandParameter="{Binding Path=OpenInExplorerFolderPath,Mode=OneWay}"
-                        HorizontalAlignment="Left">
-                    Open in Solution Explorer
-                </Button>
+                        HorizontalAlignment="Left"
+                        Content="{x:Static cct:Strings.SearchPage_OpenInSolutionExplorer}"/>
             </StackPanel>
         </StackPanel>
 
@@ -111,7 +113,7 @@
                 <Grid.Resources>
                     <Style x:Key="SearchButtonStyle" TargetType="{x:Type Button}" BasedOn="{StaticResource {x:Type Button}}">
                         <Setter Property="Command" Value="{x:Static vm:CookiecutterViewModel.Search}" />
-                        <Setter Property="Content" Value="Search" />
+                        <Setter Property="Content" Value="{x:Static cct:Strings.SearchPage_Search}" />
                         <Setter Property="Padding" Value="6 4" />
                         <Setter Property="Margin" Value="3 0 0 0" />
                     </Style>
@@ -119,9 +121,9 @@
                 
                 <wpf:ConfigurationTextBoxWithHelp Margin="0 0 0 0"
                                                   Text="{Binding Path=SearchTerm, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                                                  HelpText="Enter search terms or template location (git repository URL or path to local folder)"
+                                                  HelpText="{x:Static cct:Strings.SearchPage_SearchTooltip}"
                                                   AutomationProperties.Name="Search terms"
-                                                  Watermark="Enter search terms or template location"
+                                                  Watermark="{x:Static cct:Strings.SearchPage_SearchWatermark}"
                                                   BrowseButtonStyle="{StaticResource SearchButtonStyle}"
                                                   KeyDown="TextBox_KeyDown" />
             </Grid>
@@ -148,7 +150,7 @@
                     </StackPanel>
                     <DataTemplate.Triggers>
                         <DataTrigger Binding="{Binding Path=IsUpdateAvailable}" Value="True">
-                            <Setter TargetName="Item" Property="ToolTip" Value="An update is available." />
+                            <Setter TargetName="Item" Property="ToolTip" Value="{x:Static cct:Strings.SearchPage_UpdateAvailableTooltip}" />
                             <Setter TargetName="Image" Property="Moniker" Value="{x:Static rc:ImageMonikers.CookiecutterTemplateUpdate}" />
                         </DataTrigger>
                     </DataTemplate.Triggers>
@@ -174,9 +176,10 @@
                                             Moniker="{x:Static imagecatalog:KnownMonikers.Refresh}">
                         </imaging:CrispImage>
                         <TextBlock Margin="3 3"
-                                   Text="Loading...">
+                                   Text="{x:Static cct:Strings.SearchPage_LoadingSearchResults}">
                             <TextBlock.ToolTip>
-                                <TextBlock TextWrapping="Wrap" Text="Enumerating templates. This may take a few seconds."/>
+                                <TextBlock TextWrapping="Wrap"
+                                           Text="{x:Static cct:Strings.SearchPage_EnumeratingTemplatesTooltip}"/>
                             </TextBlock.ToolTip>
                         </TextBlock>
                     </StackPanel>
@@ -193,9 +196,7 @@
                                 Command="{x:Static vm:CookiecutterViewModel.LoadMore}"
                                 CommandParameter="{Binding Path=ContinuationToken,Mode=OneWay}"
                                 HorizontalAlignment="Left">
-                            <TextBlock>
-                                Load more...
-                            </TextBlock>
+                            <TextBlock Text="{x:Static cct:Strings.SearchPage_LoadMore}"/>
                         </Button>
                     </StackPanel>
                 </DataTemplate>
@@ -215,17 +216,15 @@
             <Button Margin="4"
                 Command="{x:Static vm:CookiecutterViewModel.RunSelection}"
                 MinWidth="100"
-                HorizontalAlignment="Left">_Next</Button>
+                HorizontalAlignment="Left"
+                Content="{x:Static cct:Strings.SearchPage_NextButton}"/>
 
             <StackPanel Margin="4 4 4 8"
                         Orientation="Vertical"
                         Visibility="{Binding Path=InstallingStatus, Converter={StaticResource OperationStatusInProgressToVisibleOrCollapsed}}">
                 <Separator/>
-                <TextBlock Text="Preparing cookiecutter for first time use...">
-                    <TextBlock.ToolTip>
-                        Downloading and installing the cookiecutter package from the Python Package Index. This may take a few minutes.
-                    </TextBlock.ToolTip>
-                </TextBlock>
+                <TextBlock Text="{x:Static cct:Strings.SearchPage_PreparingFirstTime}"
+                           ToolTip="{x:Static cct:Strings.SearchPage_PreparingFirstTimeTooltip}"/>
                 <ProgressBar Margin="4" IsIndeterminate="True"/>
             </StackPanel>
 
@@ -233,14 +232,16 @@
                         Orientation="Horizontal"
                         Visibility="{Binding Path=InstallingStatus, Converter={StaticResource OperationStatusFailedToVisibleOrCollapsed}}">
                 <imaging:CrispImage Width="16" Height="16" Moniker="{x:Static imagecatalog:KnownMonikers.StatusError}"/>
-                <TextBlock Margin="4 0 0 0" TextWrapping="Wrap" Text="Error installing cookiecutter. See output window for details."/>
+                <TextBlock Margin="4 0 0 0"
+                           TextWrapping="Wrap"
+                           Text="{x:Static cct:Strings.SearchPage_ErrorInstallingCookiecutter}"/>
             </StackPanel>
 
             <StackPanel Margin="4 4 4 8"
                         Orientation="Vertical"
                         Visibility="{Binding Path=CloningStatus, Converter={StaticResource OperationStatusInProgressToVisibleOrCollapsed}}">
                 <Separator/>
-                <TextBlock Text="Cloning repository..."/>
+                <TextBlock Text="{x:Static cct:Strings.SearchPage_CloningRepository}"/>
                 <ProgressBar Margin="4" IsIndeterminate="True"/>
             </StackPanel>
 
@@ -248,14 +249,16 @@
                         Orientation="Horizontal"
                         Visibility="{Binding Path=CloningStatus, Converter={StaticResource OperationStatusFailedToVisibleOrCollapsed}}">
                 <imaging:CrispImage Width="16" Height="16" Moniker="{x:Static imagecatalog:KnownMonikers.StatusError}"/>
-                <TextBlock Margin="4 0 0 0" TextWrapping="Wrap" Text="Error cloning repository. See output window for details."/>
+                <TextBlock Margin="4 0 0 0"
+                           TextWrapping="Wrap"
+                           Text="{x:Static cct:Strings.SearchPage_ErrorCloningRepository}"/>
             </StackPanel>
 
             <StackPanel Margin="4 4 4 8"
                         Orientation="Vertical"
                         Visibility="{Binding Path=LoadingStatus, Converter={StaticResource OperationStatusInProgressToVisibleOrCollapsed}}">
                 <Separator/>
-                <TextBlock Text="Loading template..."/>
+                <TextBlock Text="{x:Static cct:Strings.SearchPage_LoadingTemplate}"/>
                 <ProgressBar Margin="4" IsIndeterminate="True"/>
             </StackPanel>
 
@@ -263,14 +266,16 @@
                         Orientation="Horizontal"
                         Visibility="{Binding Path=LoadingStatus, Converter={StaticResource OperationStatusFailedToVisibleOrCollapsed}}">
                 <imaging:CrispImage Width="16" Height="16" Moniker="{x:Static imagecatalog:KnownMonikers.StatusError}"/>
-                <TextBlock Margin="4 0 0 0" TextWrapping="Wrap" Text="Error loading template. See output window for details."/>
+                <TextBlock Margin="4 0 0 0"
+                           TextWrapping="Wrap"
+                           Text="{x:Static cct:Strings.SearchPage_ErrorLoadingTemplate}"/>
             </StackPanel>
 
             <StackPanel Margin="4 4 4 8"
                         Orientation="Vertical"
                         Visibility="{Binding Path=CheckingUpdateStatus, Converter={StaticResource OperationStatusInProgressToVisibleOrCollapsed}}">
                 <Separator/>
-                <TextBlock Text="Checking for updates..."/>
+                <TextBlock Text="{x:Static cct:Strings.SearchPage_CheckingUpdates}"/>
                 <ProgressBar Margin="4" Value="{Binding Path=CheckingUpdatePercentComplete,Mode=OneWay}" Maximum="100"/>
             </StackPanel>
 
@@ -278,21 +283,25 @@
                         Orientation="Horizontal"
                         Visibility="{Binding Path=CheckingUpdateStatus, Converter={StaticResource OperationStatusSucceededToVisibleOrCollapsed}}">
                 <imaging:CrispImage Width="16" Height="16" Moniker="{x:Static imagecatalog:KnownMonikers.StatusOK}"/>
-                <TextBlock Margin="4 0 0 0" TextWrapping="Wrap" Text="Check for updates completed."/>
+                <TextBlock Margin="4 0 0 0"
+                           TextWrapping="Wrap"
+                           Text="{x:Static cct:Strings.SearchPage_CheckingUpdatesCompleted}"/>
             </StackPanel>
 
             <StackPanel Margin="4 4 4 8"
                         Orientation="Horizontal"
                         Visibility="{Binding Path=CheckingUpdateStatus, Converter={StaticResource OperationStatusFailedToVisibleOrCollapsed}}">
                 <imaging:CrispImage Width="16" Height="16" Moniker="{x:Static imagecatalog:KnownMonikers.StatusError}"/>
-                <TextBlock Margin="4 0 0 0" TextWrapping="Wrap" Text="Error checking for updates. See output window for details."/>
+                <TextBlock Margin="4 0 0 0"
+                           TextWrapping="Wrap"
+                           Text="{x:Static cct:Strings.SearchPage_ErrorCheckingUpdates}"/>
             </StackPanel>
 
             <StackPanel Margin="4 4 4 8"
                         Orientation="Vertical"
                         Visibility="{Binding Path=UpdatingStatus, Converter={StaticResource OperationStatusInProgressToVisibleOrCollapsed}}">
                 <Separator/>
-                <TextBlock Text="Updating template..."/>
+                <TextBlock Text="{x:Static cct:Strings.SearchPage_UpdatingTemplate}"/>
                 <ProgressBar Margin="4" IsIndeterminate="True"/>
             </StackPanel>
 
@@ -300,14 +309,14 @@
                         Orientation="Horizontal"
                         Visibility="{Binding Path=UpdatingStatus, Converter={StaticResource OperationStatusSucceededToVisibleOrCollapsed}}">
                 <imaging:CrispImage Width="16" Height="16" Moniker="{x:Static imagecatalog:KnownMonikers.StatusOK}"/>
-                <TextBlock Margin="4 0 0 0" TextWrapping="Wrap" Text="Template updated."/>
+                <TextBlock Margin="4 0 0 0" TextWrapping="Wrap" Text="{x:Static cct:Strings.SearchPage_UpdatingTemplateCompleted}"/>
             </StackPanel>
 
             <StackPanel Margin="4 4 4 8"
                         Orientation="Horizontal"
                         Visibility="{Binding Path=UpdatingStatus, Converter={StaticResource OperationStatusFailedToVisibleOrCollapsed}}">
                 <imaging:CrispImage Width="16" Height="16" Moniker="{x:Static imagecatalog:KnownMonikers.StatusError}"/>
-                <TextBlock Margin="4 0 0 0" TextWrapping="Wrap" Text="Error updating template. See output window for details."/>
+                <TextBlock Margin="4 0 0 0" TextWrapping="Wrap" Text="{x:Static cct:Strings.SearchPage_UpdatingTemplateError}"/>
             </StackPanel>
 
             <Separator Margin="4"/>
@@ -326,14 +335,8 @@
                    Stretch="Uniform"
                    RenderOptions.BitmapScalingMode="HighQuality"
                    Cursor="Hand"
+                   ToolTip="{Binding SelectedTemplate.OwnerTooltip}"
                    MouseLeftButtonDown="Image_MouseLeftButtonDown">
-                <Image.ToolTip>
-                    <TextBlock>
-                        <Run>Visit</Run>
-                        <Run Text="{Binding SelectedTemplate.RepositoryOwner,FallbackValue='the creator',Mode=OneWay}" />
-                        <Run>on github</Run>
-                    </TextBlock>
-                </Image.ToolTip>
             </Image>
             <Grid Grid.Column="1">
                 <Grid.RowDefinitions>
@@ -352,7 +355,7 @@
                         <TextBlock Margin="8"
                             Visibility="{Binding SelectedDescription, Converter={StaticResource EmptyStringToVisibleOrCollapsed}}"
                             TextWrapping="Wrap"
-                            Text="No description available."/>
+                            Text="{x:Static cct:Strings.SearchPage_NoTemplateDescriptionAvailable}"/>
                     </Grid>
                 </ScrollViewer>
                 <StackPanel Grid.Row="1" Orientation="Horizontal" Visibility="{Binding Path=SelectedTemplate, Converter={StaticResource NullToNotVisible}}">
@@ -360,17 +363,20 @@
                             Command="{x:Static vm:CookiecutterViewModel.OpenInBrowser}"
                             CommandParameter="{Binding SelectedTemplate.GitHubHomeUrl,Mode=OneWay}"
                             ToolTip="{Binding SelectedTemplate.GitHubHomeUrl,Mode=OneWay}"
-                            Style="{StaticResource NavigationButton}">GitHub</Button>
+                            Style="{StaticResource NavigationButton}"
+                            Content="{x:Static cct:Strings.SearchPage_LinksGitHub}"/>
                     <Button Margin="8"
                             Command="{x:Static vm:CookiecutterViewModel.OpenInBrowser}"
                             CommandParameter="{Binding SelectedTemplate.GitHubIssuesUrl,Mode=OneWay}"
                             ToolTip="{Binding SelectedTemplate.GitHubIssuesUrl,Mode=OneWay}"
-                            Style="{StaticResource NavigationButton}">Issues</Button>
+                            Style="{StaticResource NavigationButton}"
+                            Content="{x:Static cct:Strings.SearchPage_LinksGitHubIssues}"/>
                     <Button Margin="8"
                             Command="{x:Static vm:CookiecutterViewModel.OpenInBrowser}"
                             CommandParameter="{Binding SelectedTemplate.GitHubWikiUrl,Mode=OneWay}"
                             ToolTip="{Binding SelectedTemplate.GitHubWikiUrl,Mode=OneWay}"
-                            Style="{StaticResource NavigationButton}">Wiki</Button>
+                            Style="{StaticResource NavigationButton}"
+                            Content="{x:Static cct:Strings.SearchPage_LinksGitHubWiki}"/>
                 </StackPanel>
             </Grid>
         </Grid>

--- a/Python/Product/Cookiecutter/ViewModel/ContextItemViewModel.cs
+++ b/Python/Product/Cookiecutter/ViewModel/ContextItemViewModel.cs
@@ -27,7 +27,7 @@ namespace Microsoft.CookiecutterTools.ViewModel {
         private string _url;
         private string _val;
         private string _default;
-        private List<string> _items;
+        private readonly List<string> _items;
 
         public event PropertyChangedEventHandler PropertyChanged;
 

--- a/Python/Product/Cookiecutter/ViewModel/ContinuationViewModel.cs
+++ b/Python/Product/Cookiecutter/ViewModel/ContinuationViewModel.cs
@@ -14,8 +14,6 @@
 // See the Apache Version 2.0 License for specific language governing
 // permissions and limitations under the License.
 
-using System.ComponentModel;
-
 namespace Microsoft.CookiecutterTools.ViewModel {
     class ContinuationViewModel {
         public ContinuationViewModel() :

--- a/Python/Product/Cookiecutter/ViewModel/ErrorViewModel.cs
+++ b/Python/Product/Cookiecutter/ViewModel/ErrorViewModel.cs
@@ -15,7 +15,6 @@
 // permissions and limitations under the License.
 
 using System.ComponentModel;
-using Microsoft.VisualStudio.Imaging.Interop;
 
 namespace Microsoft.CookiecutterTools.ViewModel {
     class ErrorViewModel : INotifyPropertyChanged {

--- a/Python/Product/Cookiecutter/ViewModel/TemplateViewModel.cs
+++ b/Python/Product/Cookiecutter/ViewModel/TemplateViewModel.cs
@@ -16,7 +16,6 @@
 
 using System.ComponentModel;
 using Microsoft.CookiecutterTools.Model;
-using Microsoft.VisualStudio.Imaging.Interop;
 
 namespace Microsoft.CookiecutterTools.ViewModel {
     class TemplateViewModel : INotifyPropertyChanged {

--- a/Python/Product/Cookiecutter/ViewModel/TemplateViewModel.cs
+++ b/Python/Product/Cookiecutter/ViewModel/TemplateViewModel.cs
@@ -158,7 +158,7 @@ namespace Microsoft.CookiecutterTools.ViewModel {
             }
         }
 
-        public string AvatarUrl{
+        public string AvatarUrl {
             get {
                 return _avatarUrl;
             }
@@ -176,8 +176,7 @@ namespace Microsoft.CookiecutterTools.ViewModel {
                 return _ownerUrl;
             }
 
-            set
-            {
+            set {
                 if (value != _ownerUrl) {
                     _ownerUrl = value;
                     PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(OwnerUrl)));

--- a/Python/Product/Cookiecutter/ViewModel/TemplateViewModel.cs
+++ b/Python/Product/Cookiecutter/ViewModel/TemplateViewModel.cs
@@ -15,6 +15,7 @@
 // permissions and limitations under the License.
 
 using System.ComponentModel;
+using Microsoft.CookiecutterTools.Infrastructure;
 using Microsoft.CookiecutterTools.Model;
 
 namespace Microsoft.CookiecutterTools.ViewModel {
@@ -22,6 +23,7 @@ namespace Microsoft.CookiecutterTools.ViewModel {
         private string _displayName;
         private string _remoteUrl;
         private string _ownerUrl;
+        private string _ownerTooltip;
         private string _clonedPath;
         private string _description;
         private string _avatarUrl;
@@ -125,6 +127,8 @@ namespace Microsoft.CookiecutterTools.ViewModel {
                     _remoteUrl = value;
                     PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(RemoteUrl)));
                 }
+
+                RefreshOwnerTooltip();
             }
         }
 
@@ -172,10 +176,24 @@ namespace Microsoft.CookiecutterTools.ViewModel {
                 return _ownerUrl;
             }
 
-            set {
+            set
+            {
                 if (value != _ownerUrl) {
                     _ownerUrl = value;
                     PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(OwnerUrl)));
+                }
+            }
+        }
+
+        public string OwnerTooltip {
+            get {
+                return _ownerTooltip;
+            }
+
+            set {
+                if (value != _ownerTooltip) {
+                    _ownerTooltip = value;
+                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(OwnerTooltip)));
                 }
             }
         }
@@ -204,6 +222,15 @@ namespace Microsoft.CookiecutterTools.ViewModel {
                     PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsUpdateAvailable)));
                 }
             }
+        }
+
+        private void RefreshOwnerTooltip() {
+            var owner = RepositoryOwner;
+            if (string.IsNullOrEmpty(owner)) {
+                owner = Strings.SearchPage_Creator;
+            }
+
+            OwnerTooltip = Strings.SearchPage_VisitOwnerOnGitHub.FormatUI(owner);
         }
     }
 }


### PR DESCRIPTION
Part 1 of localization work.

Also deleted some unused code, and turned some fields into readonly.

There's a few more strings in the Shared code that is copy/pasted between PTVS and Cookiecutter, I will take care of that in a subsequent PR.
