### PR TITLE
Fixes #2142: NullReferenceException when using lightbulb extract method

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Intellisense/ProjectAnalyzer.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/ProjectAnalyzer.cs
@@ -2082,8 +2082,12 @@ namespace Microsoft.PythonTools.Intellisense {
         }
 
         internal static void ApplyChanges(AP.ChangeInfo[] changes, ITextBuffer textBuffer, LocationTracker translator) {
+            if (translator == null) {
+                throw new ArgumentNullException(nameof(translator));
+            }
+
             using (var edit = textBuffer.CreateEdit()) {
-                foreach (var change in changes) {
+                foreach (var change in changes.MaybeEnumerate()) {
                     edit.Replace(
                         translator.TranslateForward(new Span(change.start, change.length)),
                         change.newText


### PR DESCRIPTION
Fixes #2142: NullReferenceException when using lightbulb extract method
Adds null checks.