### PR TITLE
Fixes #2110 Invalid call to GetPythonToolsService in SurveyNewsService

### DIFF
--- a/Common/Product/SharedProject/VsExtensions.cs
+++ b/Common/Product/SharedProject/VsExtensions.cs
@@ -106,6 +106,18 @@ namespace Microsoft.VisualStudioTools {
         }
 
         [Conditional("DEBUG")]
+        // Available on serviceProvider so we can avoid the GetUIThread call on release builds
+        public static void MustBeCalledFromUIThread(this IServiceProvider serviceProvider, string message = "Invalid cross-thread call") {
+            serviceProvider.GetUIThread().MustBeCalledFromUIThread(message);
+        }
+
+        [Conditional("DEBUG")]
+        // Available on serviceProvider so we can avoid the GetUIThread call on release builds
+        public static void MustNotBeCalledFromUIThread(this IServiceProvider serviceProvider, string message = "Invalid cross-thread call") {
+            serviceProvider.GetUIThread().MustNotBeCalledFromUIThread(message);
+        }
+
+        [Conditional("DEBUG")]
         public static void MustBeCalledFromUIThread(this UIThreadBase self, string message = "Invalid cross-thread call") {
             Debug.Assert(self is MockUIThreadBase || !self.InvokeRequired, message);
         }

--- a/Python/Product/PythonTools/PythonToolsService.cs
+++ b/Python/Product/PythonTools/PythonToolsService.cs
@@ -92,7 +92,7 @@ namespace Microsoft.PythonTools {
             _advancedOptions = new Lazy<AdvancedEditorOptions>(CreateAdvancedEditorOptions);
             _debuggerOptions = new Lazy<DebuggerOptions>(CreateDebuggerOptions);
             _generalOptions = new Lazy<GeneralOptions>(CreateGeneralOptions);
-            _surveyNews = new Lazy<SurveyNewsService>(() => new SurveyNewsService(container));
+            _surveyNews = new Lazy<SurveyNewsService>(() => new SurveyNewsService(this));
             _suppressDialogOptions = new Lazy<SuppressDialogOptions>(() => new SuppressDialogOptions(this));
             _interactiveOptions = new Lazy<PythonInteractiveOptions>(() => CreateInteractiveOptions("Interactive"));
             _debugInteractiveOptions = new Lazy<PythonInteractiveOptions>(() => CreateInteractiveOptions("Debug Interactive Window"));
@@ -475,10 +475,14 @@ namespace Microsoft.PythonTools {
 
         internal event EventHandler<ComponentManagerEventArgs> OnIdle {
             add {
-                _idleManager.OnIdle += value;
+                lock (_idleManager) {
+                    _idleManager.OnIdle += value;
+                }
             }
             remove {
-                _idleManager.OnIdle -= value;
+                lock (_idleManager) {
+                    _idleManager.OnIdle -= value;
+                }
             }
         }
 


### PR DESCRIPTION
Fixes #2110 Invalid call to GetPythonToolsService in SurveyNewsService
Ensures PythonToolsService is available and adds locking around event handling.