### PR TITLE
Fixes #2160 Custom commands cannot detect installed packages

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Project/CustomCommand.cs
+++ b/Python/Product/PythonTools/PythonTools/Project/CustomCommand.cs
@@ -386,7 +386,7 @@ namespace Microsoft.PythonTools.Project {
             var pm = interpFactory.PackageManager;
             if (pm != null) {
                 foreach (var pkg in startInfo.RequiredPackages) {
-                    if (!(await pm.GetInstalledPackageAsync(new PackageSpec(pkg), CancellationToken.None)).IsValid) {
+                    if (!(await pm.GetInstalledPackageAsync(PackageSpec.FromRequirement(pkg), CancellationToken.None)).IsValid) {
                         packagesToInstall.Add(pkg);
                     }
                 }


### PR DESCRIPTION
Fixes #2160 Custom commands cannot detect installed packages
Switches check to treat package specs as requirements rather than names.