### PR TITLE
Fixes #2111 RemoveNonDocument ordering issue

### DIFF
--- a/Common/Product/SharedProject/HierarchyNode.cs
+++ b/Common/Product/SharedProject/HierarchyNode.cs
@@ -986,8 +986,11 @@ namespace Microsoft.VisualStudioTools.Project {
             ProjectMgr.OnItemDeleted(this);
 
             // Remove child if any before removing from the hierarchy
-            for (HierarchyNode child = this.FirstChild; child != null; child = child.NextSibling) {
+            var child = FirstChild;
+            while (child != null) {
+                var next = child.NextSibling;
                 child.Remove(removeFromStorage);
+                child = next;
             }
 
             // the project node has no parentNode


### PR DESCRIPTION
Fixes #2111 RemoveNonDocument ordering issue
Correctly traverses the linked list while removing elements.

This was reported by NTVS team when they discovered a crash in their version of this file.