### PR TITLE
Fixes #2043 Intellisense performance issues

### DIFF
--- a/Python/Product/Common/Infrastructure/TaskExtensions.cs
+++ b/Python/Product/Common/Infrastructure/TaskExtensions.cs
@@ -29,9 +29,30 @@ namespace Microsoft.PythonTools.Infrastructure {
             await task;
         }
 
+        /// <summary>
+        /// Waits for a task to complete. If an exception occurs, the exception
+        /// will be unwrapped. If the timeout expires, the default value for
+        /// <b>T</b> will be returned.
+        /// </summary>
         public static T WaitOrDefault<T>(this Task<T> task, int milliseconds) {
-            if (task.Wait(milliseconds)) {
-                return task.Result;
+            return WaitOrDefault(task, TimeSpan.FromMilliseconds(milliseconds));
+        }
+
+        /// <summary>
+        /// Waits for a task to complete. If an exception occurs, the exception
+        /// will be unwrapped. If the timeout expires, the default value for
+        /// <b>T</b> will be returned.
+        /// </summary>
+        public static T WaitOrDefault<T>(this Task<T> task, TimeSpan timeout) {
+            try {
+                if (task.Wait(timeout)) {
+                    return task.Result;
+                }
+            } catch (AggregateException ae) {
+                if (ae.InnerException != null) {
+                    throw ae.InnerException;
+                }
+                throw;
             }
             return default(T);
         }

--- a/Python/Product/Django/Intellisense/AnalyzerExtensions.cs
+++ b/Python/Product/Django/Intellisense/AnalyzerExtensions.cs
@@ -19,18 +19,17 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Web.Script.Serialization;
 using Microsoft.PythonTools.Django.Analysis;
-using Microsoft.PythonTools.Infrastructure;
 using Microsoft.PythonTools.Intellisense;
 using Microsoft.PythonTools.Interpreter;
 
 namespace Microsoft.PythonTools.Django.Intellisense {
     static class AnalyzerExtensions {
         public static string[] GetTags(this VsProjectAnalyzer analyzer) {
-            var tags = analyzer.SendExtensionCommandAsync(
+            var tags = analyzer.WaitForRequest(analyzer.SendExtensionCommandAsync(
                 DjangoAnalyzer.Name,
                 DjangoAnalyzer.Commands.GetTags,
                 string.Empty
-            ).WaitOrDefault(1000);
+            ), "Django.GetTags");
 
             if (tags != null) {
                 return new JavaScriptSerializer().Deserialize<string[]>(tags);
@@ -40,11 +39,11 @@ namespace Microsoft.PythonTools.Django.Intellisense {
         }
 
         public static Dictionary<string, TagInfo> GetFilters(this VsProjectAnalyzer analyzer) {
-            var filtersRes = analyzer.SendExtensionCommandAsync(
+            var filtersRes = analyzer.WaitForRequest(analyzer.SendExtensionCommandAsync(
                 DjangoAnalyzer.Name,
                 DjangoAnalyzer.Commands.GetFilters,
                 string.Empty
-            ).WaitOrDefault(1000);
+            ), "Django.GetFilters");
 
 
             var res = new Dictionary<string, TagInfo>();
@@ -59,21 +58,21 @@ namespace Microsoft.PythonTools.Django.Intellisense {
 
         public static DjangoUrl[] GetUrls(this VsProjectAnalyzer analyzer)
         {
-            var urls = analyzer.SendExtensionCommandAsync(
+            var urls = analyzer.WaitForRequest(analyzer.SendExtensionCommandAsync(
                 DjangoAnalyzer.Name,
                 DjangoAnalyzer.Commands.GetUrls,
                 string.Empty
-            ).WaitOrDefault(1000);
+            ), "Django.GetUrls");
 
             return urls != null ? new JavaScriptSerializer().Deserialize<DjangoUrl[]>(urls) : Array.Empty<DjangoUrl>();
         }
 
         public static string[] GetVariableNames(this VsProjectAnalyzer analyzer, string file) {
-            var variables = analyzer.SendExtensionCommandAsync(
+            var variables = analyzer.WaitForRequest(analyzer.SendExtensionCommandAsync(
                 DjangoAnalyzer.Name,
                 DjangoAnalyzer.Commands.GetVariables,
                 file
-            ).WaitOrDefault(1000);
+            ), "Django.GetVariableNames");
 
             if (variables != null) {
                 return new JavaScriptSerializer().Deserialize<string[]>(variables);
@@ -85,11 +84,11 @@ namespace Microsoft.PythonTools.Django.Intellisense {
         public static Dictionary<string, PythonMemberType> GetMembers(this VsProjectAnalyzer analyzer, string file, string variable) {
             var serializer = new JavaScriptSerializer();
 
-            var members = analyzer.SendExtensionCommandAsync(
+            var members = analyzer.WaitForRequest(analyzer.SendExtensionCommandAsync(
                 DjangoAnalyzer.Name,
                 DjangoAnalyzer.Commands.GetMembers,
                 serializer.Serialize(new[] { file, variable })
-            ).WaitOrDefault(1000);
+            ), "Django.GetMembers");
 
             if (members != null) {
                 var res = serializer.Deserialize<Dictionary<string, string>>(members);

--- a/Python/Product/PythonTools/PythonTools/Intellisense/ExceptionCompletionAnalysis.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/ExceptionCompletionAnalysis.cs
@@ -75,7 +75,9 @@ namespace Microsoft.PythonTools.Intellisense {
                 analysis
             );
 
-            var completions = (analysis.Analyzer.GetAllAvailableMembersAsync(analysis, index, GetMemberOptions.None).WaitOrDefault(1000) ?? Enumerable.Empty<CompletionResult>())
+            var analyzer = analysis.Analyzer;
+            var completions = analyzer.WaitForRequest(analyzer.GetAllAvailableMembersAsync(analysis, index, GetMemberOptions.None), "GetCompletions")
+                .MaybeEnumerate()
                 .Where(IsExceptionType)
                 .Select(member => PythonCompletion(glyphService, member))
                 .OrderBy(completion => completion.DisplayText);

--- a/Python/Product/PythonTools/PythonTools/Intellisense/ExpansionCompletionSource.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/ExpansionCompletionSource.cs
@@ -34,17 +34,11 @@ namespace Microsoft.PythonTools.Intellisense {
             _snippets = GetAvailableSnippets();
         }
 
-        public IEnumerable<CompletionResult> GetCompletions(int timeout) {
-            var task = _snippets;
-            if (task == null) {
-                return null;
+        public async Task<IEnumerable<CompletionResult>> GetCompletionsAsync() {
+            if (_snippets.IsCompleted) {
+                return _snippets.Result;
             }
-
-            if (task.IsCompleted || task.Wait(timeout)) {
-                return task.Result;
-            }
-
-            return null;
+            return await _snippets;
         }
 
         private async Task<IReadOnlyList<CompletionResult>> GetAvailableSnippets() {

--- a/Python/Product/PythonTools/PythonTools/Intellisense/OVERRIDECOMPLETIONANALYSIS.CS
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/OVERRIDECOMPLETIONANALYSIS.CS
@@ -55,12 +55,12 @@ namespace Microsoft.PythonTools.Intellisense {
             var snapshot = TextBuffer.CurrentSnapshot;
             var pos = VsProjectAnalyzer.TranslateIndex(startPos, snapshot, analysis);
 
-            var completions = analysis.Analyzer.GetOverrideCompletionsAsync(
+            var completions = analysis.Analyzer.WaitForRequest(analysis.Analyzer.GetOverrideCompletionsAsync(
                 analysis,
                 TextBuffer,
                 pos,
                 indentation
-            ).WaitOrDefault(1000)?.overrides;
+            ), "OverrideCompletionAnalysis.GetOverrideCompletions")?.overrides;
 
             CompletionSet res;
             if (completions != null && completions.Any()) {

--- a/Python/Product/PythonTools/PythonTools/Logging/VsTelemetryLogger.cs
+++ b/Python/Product/PythonTools/PythonTools/Logging/VsTelemetryLogger.cs
@@ -15,10 +15,7 @@
 // permissions and limitations under the License.
 
 using System;
-using System.Collections.Generic;
 using System.ComponentModel.Composition;
-using System.Security.Cryptography;
-using System.Text;
 using Microsoft.VisualStudio.Telemetry;
 
 namespace Microsoft.PythonTools.Logging {

--- a/Python/Product/PythonTools/PythonTools/Navigation/EditFilter.cs
+++ b/Python/Product/PythonTools/PythonTools/Navigation/EditFilter.cs
@@ -136,14 +136,14 @@ namespace Microsoft.PythonTools.Language {
             UpdateStatusForIncompleteAnalysis();
 
             var caret = _textView.GetPythonCaret();
-            if (caret != null) {
-
-                var defs = await VsProjectAnalyzer.AnalyzeExpressionAsync(_serviceProvider, _textView, caret.Value);
+            var analysis = _textView.GetAnalysisAtCaret(_serviceProvider);
+            if (analysis != null && caret != null) {
+                var defs = await analysis.Analyzer.AnalyzeExpressionAsync(analysis, _textView, caret.Value);
                 if (defs == null) {
                     return;
                 }
                 Dictionary<AnalysisLocation, SimpleLocationInfo> references, definitions, values;
-                GetDefsRefsAndValues(_textView.GetAnalyzerAtCaret(_serviceProvider), _serviceProvider, defs.Expression, defs.Variables, out definitions, out references, out values);
+                GetDefsRefsAndValues(analysis.Analyzer, _serviceProvider, defs.Expression, defs.Variables, out definitions, out references, out values);
 
                 if ((values.Count + definitions.Count) == 1) {
                     if (values.Count != 0) {
@@ -208,13 +208,14 @@ namespace Microsoft.PythonTools.Language {
             UpdateStatusForIncompleteAnalysis();
 
             var caret = _textView.GetPythonCaret();
-            if (caret != null) {
-                var references = await VsProjectAnalyzer.AnalyzeExpressionAsync(_serviceProvider, _textView, caret.Value);
+            var analysis = _textView.GetAnalysisAtCaret(_serviceProvider);
+            if (analysis != null && caret != null) {
+                var references = await analysis.Analyzer.AnalyzeExpressionAsync(analysis, _textView, caret.Value);
                 if (references == null) {
                     return;
                 }
 
-                var locations = GetFindRefLocations(_textView.GetAnalyzerAtCaret(_serviceProvider), _serviceProvider, references.Expression, references.Variables);
+                var locations = GetFindRefLocations(analysis.Analyzer, _serviceProvider, references.Expression, references.Variables);
 
                 ShowFindSymbolsDialog(references.Expression, locations);
             }

--- a/Python/Product/PythonTools/PythonTools/Navigation/PythonFileLibraryNode.cs
+++ b/Python/Product/PythonTools/PythonTools/Navigation/PythonFileLibraryNode.cs
@@ -82,11 +82,11 @@ namespace Microsoft.PythonTools.Navigation {
 
                 if (analysis != null) {
                     string expr = criteria.szName.Substring(criteria.szName.LastIndexOf(':') + 1);
-                    var exprAnalysis = VsProjectAnalyzer.AnalyzeExpressionAsync(
+                    var exprAnalysis = analysis.Analyzer.WaitForRequest(analysis.Analyzer.AnalyzeExpressionAsync(
                         analysis,
                         criteria.szName.Substring(criteria.szName.LastIndexOf(':') + 1),
-                        new Parsing.SourceLocation(0, 1, 1)
-                    ).WaitOrDefault(1000);
+                        new SourceLocation(0, 1, 1)
+                    ), "PythonFileLibraryNode.DoSearch");
 
                     if (exprAnalysis != null) {
                         return EditFilter.GetFindRefLocations(analysis.Analyzer, _hierarchy.ProjectMgr.Site, expr, exprAnalysis.Variables);
@@ -205,11 +205,11 @@ namespace Microsoft.PythonTools.Navigation {
 
         protected override IEnumerable<CompletionResult> GetChildren() {
             var analysis = _hierarchy.GetAnalysisEntry();
-            var members = analysis.Analyzer.GetAllAvailableMembersAsync(
+            var members = analysis.Analyzer.WaitForRequest(analysis.Analyzer.GetAllAvailableMembersAsync(
                 analysis,
                 new SourceLocation(0, 1, 1),
                 GetMemberOptions.ExcludeBuiltins | GetMemberOptions.DetailedInformation
-            ).WaitOrDefault(1000);
+            ), "PythonFileChildren.GetChildren");
             return members;
         }
 
@@ -227,13 +227,13 @@ namespace Microsoft.PythonTools.Navigation {
 
         protected override IEnumerable<CompletionResult> GetChildren() {
             var analysis = _hierarchy.GetAnalysisEntry();
-            var members = analysis.Analyzer.GetMembersAsync(
+            var members = analysis.Analyzer.WaitForRequest(analysis.Analyzer.GetMembersAsync(
                 analysis,
                 _member,
                 new SourceLocation(0, 1, 1),
                 GetMemberOptions.ExcludeBuiltins | GetMemberOptions.DetailedInformation | GetMemberOptions.DeclaredOnly |
                 GetMemberOptions.NoMemberRecursion
-            ).WaitOrDefault(1000);
+            ), "MemberChildren.GetChildren");
             return members;
         }
 

--- a/Python/Product/PythonTools/PythonTools/Navigation/PythonLanguageInfo.cs
+++ b/Python/Product/PythonTools/PythonTools/Navigation/PythonLanguageInfo.cs
@@ -19,6 +19,7 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using Microsoft.PythonTools.Debugger.DebugEngine;
 using Microsoft.PythonTools.Infrastructure;
+using Microsoft.PythonTools.Intellisense;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.Editor;
@@ -94,7 +95,7 @@ namespace Microsoft.PythonTools.Navigation {
 
             var projFile = buffer.GetAnalysisEntry(_serviceProvider);
             if (projFile != null) {
-                var location = projFile.Analyzer.GetNameOfLocationAsync(projFile, buffer, iLine, iCol).WaitOrDefault(1000);
+                var location = projFile.Analyzer.WaitForRequest(projFile.Analyzer.GetNameOfLocationAsync(projFile, buffer, iLine, iCol), "PythonLanguageInfo.GetNameOfLocation");
                 if (location != null) {
                     pbstrName = location.name;
                     piLineOffset = location.lineOffset;
@@ -123,7 +124,7 @@ namespace Microsoft.PythonTools.Navigation {
 
             var projFile = buffer.GetAnalysisEntry(_serviceProvider);
             if (projFile != null) {
-                var names = projFile.Analyzer.GetProximityExpressionsAsync(projFile, buffer, iLine, iCol, cLines).WaitOrDefault(1000);
+                var names = projFile.Analyzer.WaitForRequest(projFile.Analyzer.GetProximityExpressionsAsync(projFile, buffer, iLine, iCol, cLines), "PythonLanguageInfo.GetProximityExpressions");
                 ppEnum = new EnumBSTR(names);
             } else {
                 ppEnum = new EnumBSTR(Enumerable.Empty<string>());

--- a/Python/Product/PythonTools/PythonTools/Navigation/PythonLibraryNode.cs
+++ b/Python/Product/PythonTools/PythonTools/Navigation/PythonLibraryNode.cs
@@ -181,11 +181,11 @@ namespace Microsoft.PythonTools.Navigation {
                 foreach (var value in _value.Values) {
                     foreach (var reference in value.locations) {
                         var entry = analyzer.GetAnalysisEntryFromPath(reference.file);
-                        var analysis = VsProjectAnalyzer.AnalyzeExpressionAsync(
+                        var analysis = analyzer.WaitForRequest(analyzer.AnalyzeExpressionAsync(
                             entry, 
                             Name, 
                             new SourceLocation(0, reference.line, reference.column)
-                        ).WaitOrDefault(1000);
+                        ), "PythonLibraryNode.AnalyzeExpression");
                         vars.AddRange(analysis.Variables);
                     }
                 }

--- a/Python/Product/PythonTools/PythonTools/Project/PythonNonCodeFileNode.cs
+++ b/Python/Product/PythonTools/PythonTools/Project/PythonNonCodeFileNode.cs
@@ -17,6 +17,7 @@
 using System;
 using System.IO;
 using Microsoft.PythonTools.Infrastructure;
+using Microsoft.PythonTools.Intellisense;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.Text;
@@ -52,26 +53,29 @@ namespace Microsoft.PythonTools.Project {
 
             public string[] FindMethods(string className, int? paramCount) {
                 var fileInfo = _node.GetAnalysisEntry();
-                return fileInfo.Analyzer.FindMethodsAsync(
+                return fileInfo.Analyzer.WaitForRequest(fileInfo.Analyzer.FindMethodsAsync(
                     fileInfo,
                     _node.GetTextBuffer(),
                     className,
                     paramCount
-                ).WaitOrDefault(1000);
+                ), "PythonNonCodeFileNode.FindMethods");
             }
 
             public InsertionPoint GetInsertionPoint(string className) {
                 var fileInfo = _node.GetAnalysisEntry();
-                return fileInfo.Analyzer.GetInsertionPointAsync(
+                return fileInfo.Analyzer.WaitForRequest(fileInfo.Analyzer.GetInsertionPointAsync(
                     fileInfo,
                     _node.GetTextBuffer(),
                     className
-                ).WaitOrDefault(1000);
+                ), "PythonNonCodeFileNode.GetInsertionPoint");
             }
 
             public MethodInformation GetMethodInfo(string className, string methodName) {
                 var fileInfo = _node.GetAnalysisEntry();
-                var info = fileInfo.Analyzer.GetMethodInfoAsync(fileInfo, _node.GetTextBuffer(), className, methodName).WaitOrDefault(1000);
+                var info = fileInfo.Analyzer.WaitForRequest(
+                    fileInfo.Analyzer.GetMethodInfoAsync(fileInfo, _node.GetTextBuffer(), className, methodName),
+                    "PythonNonCodeFileNode.GetMethodInfo"
+                );
                 if (info != null) {
                     return new MethodInformation(
                         info.start,

--- a/Python/Product/PythonTools/PythonTools/Refactoring/ExtractMethodRequestView.cs
+++ b/Python/Product/PythonTools/PythonTools/Refactoring/ExtractMethodRequestView.cs
@@ -18,6 +18,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Windows.Media;
@@ -256,9 +257,14 @@ namespace Microsoft.PythonTools.Refactoring {
         private void UpdatePreview() {
             var info = GetRequest();
             if (info != null) {
-                _previewer.GetExtractionResult(info).ContinueWith(
-                    x => PreviewText = x?.WaitOrDefault(1000)?.methodBody ?? Strings.ExtractMethod_FailedToGetPreview
-                ).DoNotWait();
+                _previewer.GetExtractionResult(info).ContinueWith(t => {
+                    try {
+                        PreviewText = t.Result.methodBody;
+                    } catch (Exception ex) {
+                        Debug.Fail(ex.ToUnhandledExceptionMessage(GetType()));
+                        PreviewText = Strings.ExtractMethod_FailedToGetPreview;
+                    }
+                }).DoNotWait();
             } else {
                 PreviewText = Strings.ExtractMethod_InvalidMethodName;
             }

--- a/Python/Product/PythonTools/PythonTools/Refactoring/VariableRenamer.cs
+++ b/Python/Product/PythonTools/PythonTools/Refactoring/VariableRenamer.cs
@@ -47,7 +47,12 @@ namespace Microsoft.PythonTools.Refactoring {
             }
 
             var caret = _view.GetPythonCaret();
-            var analysis = await VsProjectAnalyzer.AnalyzeExpressionAsync(_serviceProvider, _view, caret.Value);
+            var entry = _view.GetAnalysisAtCaret(_serviceProvider);
+            if (caret == null || entry == null) {
+                input.CannotRename(Strings.RenameVariable_UnableGetAnalysisCurrentTextView);
+                return;
+            }
+            var analysis = await entry.Analyzer.AnalyzeExpressionAsync(entry, _view, caret.Value);
             if (analysis == null) {
                 input.CannotRename(Strings.RenameVariable_UnableGetAnalysisCurrentTextView);
                 return;

--- a/Python/Product/VSCommon/Logging/PythonLogEvent.cs
+++ b/Python/Product/VSCommon/Logging/PythonLogEvent.cs
@@ -67,6 +67,10 @@ namespace Microsoft.PythonTools.Logging {
         /// <summary>
         /// The analysis process raised a warning
         /// </summary>
-        AnalysisWarning
+        AnalysisWarning,
+        /// <summary>
+        /// Information about how long requests to the out-of-proc analyzer take
+        /// </summary>
+        AnalysisRequestTiming
     }
 }

--- a/Python/Product/VSCommon/Logging/PythonToolsLoggerData.cs
+++ b/Python/Product/VSCommon/Logging/PythonToolsLoggerData.cs
@@ -79,4 +79,10 @@ namespace Microsoft.PythonTools.Logging {
         public bool IsWeb { get; set; }
         public string Version { get; set; }
     }
+
+    internal sealed class AnalysisTimingInfo : PythonToolsLoggerData {
+        public string RequestName { get; set; }
+        public int Milliseconds { get; set; }
+        public bool Timeout { get; set; }
+    }
 }

--- a/Python/Product/VSInterpreters/PythonRegistrySearch.cs
+++ b/Python/Product/VSInterpreters/PythonRegistrySearch.cs
@@ -102,6 +102,16 @@ namespace Microsoft.PythonTools.Interpreter {
                             if (_seenIds.Add(config.Id)) {
                                 var supportUrl = tagKey.GetValue("SupportUrl") as string ?? companySupportUrl;
 
+                                // We don't want to send people to http://python.org, even
+                                // if that's what is in the registry, so catch and fix it.
+                                if (!string.IsNullOrEmpty(supportUrl)) {
+                                    var url = supportUrl.TrimEnd('/');
+                                    if (url.Equals("http://www.python.org", StringComparison.OrdinalIgnoreCase) ||
+                                        url.Equals("http://python.org", StringComparison.OrdinalIgnoreCase)) {
+                                        supportUrl = PythonCoreSupportUrl;
+                                    }
+                                }
+
                                 var info = new PythonInterpreterInformation(config, companyDisplay, companySupportUrl, supportUrl);
                                 _info.Add(info);
                             }

--- a/Python/Tests/Core/ExtractMethodTests.cs
+++ b/Python/Tests/Core/ExtractMethodTests.cs
@@ -19,9 +19,9 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using AnalysisTests;
+using Microsoft.PythonTools;
 using Microsoft.PythonTools.Intellisense;
 using Microsoft.PythonTools.Interpreter;
-using Microsoft.PythonTools.Interpreter.Default;
 using Microsoft.PythonTools.Parsing;
 using Microsoft.PythonTools.Parsing.Ast;
 using Microsoft.PythonTools.Refactoring;
@@ -36,13 +36,13 @@ namespace PythonToolsTests {
 
     [TestClass]
     public class ExtractMethodTests {
-        private const string ErrorReturn = "When the selection contains a return statement, all code paths must be terminated by a return statement too.";
-        private const string ErrorYield = "Cannot extract code containing \"yield\" expression";
-        private const string ErrorContinue = "The selection contains a \"continue\" statement, but not the enclosing loop";
-        private const string ErrorBreak = "The selection contains a \"break\" statement, but not the enclosing loop";
-        private const string ErrorReturnWithOutputs = "Cannot extract method that assigns to variables and returns";
-        private const string ErrorImportStar = "Cannot extract method containing from ... import * statement";
-        private const string ErrorExtractFromClass = "Cannot extract statements from a class definition";
+        private static readonly string ErrorReturn = Strings.ExtractMethodSelectionContainsReturn;
+        private static readonly string ErrorYield = Strings.ExtractMethodContainsYieldExpression;
+        private static readonly string ErrorContinue = Strings.ExtractMethodSelectionContainsContinueButNotEnclosingLoop;
+        private static readonly string ErrorBreak = Strings.ExtractMethodSelectionContainsBreakButNotEnclosingLoop;
+        private static readonly string ErrorReturnWithOutputs = Strings.ExtractMethodAssignsVariablesAndReturns;
+        private static readonly string ErrorImportStar = Strings.ExtractMethodContainsFromImportStar;
+        private static readonly string ErrorExtractFromClass = Strings.ExtractMethodStatementsFromClassDefinition;
 
         [ClassInitialize]
         public static void DoDeployment(TestContext context) {

--- a/Python/Tests/PythonToolsMockTests/CompletionTests.cs
+++ b/Python/Tests/PythonToolsMockTests/CompletionTests.cs
@@ -1143,8 +1143,8 @@ async def g():
                 ITrackingSpan span;
                 QuickInfoSource.AugmentQuickInfoWorker(
                     quickInfo,
-                    VsProjectAnalyzer.GetQuickInfoAsync(
-                        view.VS.ServiceProvider,
+                    view.Analyzer.GetQuickInfoAsync(
+                        view.View.View.GetAnalysisEntry(snapshot.TextBuffer, view.VS.ServiceProvider),
                         view.View.TextView,
                         new SnapshotPoint(snapshot, start)
                     ).Result,

--- a/Python/Tests/PythonToolsMockTests/CompletionTests.cs
+++ b/Python/Tests/PythonToolsMockTests/CompletionTests.cs
@@ -938,7 +938,7 @@ def func(a):
                 var expected2 = string.Join(Environment.NewLine, docString.Take(15)).TrimStart() + Environment.NewLine + "...";
 
                 using (var view = new PythonEditor(code)) {
-                    TestQuickInfo(view, code.IndexOf("func"), code.IndexOf("func") + 4, "func: def func(a)\r\n" + expected1);
+                    TestQuickInfo(view, code.IndexOf("func"), code.IndexOf("func") + 4, "func: def file.func(a)\r\n" + expected1);
 
                     SignatureAnalysis sigs;
                     view.Text += "func(";
@@ -961,7 +961,7 @@ def func(a):
                     expected1 = string.Join(Environment.NewLine, docString.Take(15)) + Environment.NewLine + "...";
                     expected2 = string.Join(Environment.NewLine, docString.Take(8)).TrimStart() + Environment.NewLine + "...";
 
-                    TestQuickInfo(view, code.IndexOf("func"), code.IndexOf("func") + 4, "func: def func(a)\r\n" + expected1);
+                    TestQuickInfo(view, code.IndexOf("func"), code.IndexOf("func") + 4, "func: def file.func(a)\r\n" + expected1);
 
                     SignatureAnalysis sigs;
                     view.Text += "func(";
@@ -1165,16 +1165,15 @@ async def g():
 
             using (var view = new PythonEditor(code, version, vs)) {
                 var snapshot = view.CurrentSnapshot;
-                ExpressionAnalysis expr = null;
+                Task<ExpressionAnalysis> task = null;
                 vs.InvokeSync(() => {
-                    expr = vs.GetPyService().AnalyzeExpression(
-                        view.View.TextView,
-                        snapshot,
-                        snapshot.CreateTrackingSpan(location, location < snapshot.Length ? 1 : 0, SpanTrackingMode.EdgeInclusive),
-                        false
+                    task = view.Analyzer.AnalyzeExpressionAsync(
+                        view.View.TextView.GetAnalysisEntry(snapshot.TextBuffer, view.VS.ServiceProvider),
+                        view.View.View,
+                        new SnapshotPoint(snapshot, location)
                     );
                 });
-                return expr;
+                return task.Wait(10000) ? task.Result : null;
             }
         }
 
@@ -1208,15 +1207,16 @@ async def g():
         private static SignatureAnalysis GetSignatureAnalysis(PythonEditor view, int index) {
             var snapshot = view.CurrentSnapshot;
 
-            SignatureAnalysis sigs = null;
+            Task<SignatureAnalysis> task = null;
             view.VS.InvokeSync(() => {
-                sigs = view.VS.GetPyService().GetSignatures(
+                task = view.Analyzer.GetSignaturesAsync(
+                    view.View.View.GetAnalysisEntry(snapshot.TextBuffer, view.VS.ServiceProvider),
                     view.View.TextView,
                     snapshot,
                     snapshot.CreateTrackingSpan(index, 1, SpanTrackingMode.EdgeInclusive)
                 );
             });
-            return sigs;
+            return task.Wait(10000) ? task.Result : null;
         }
 
 

--- a/Python/Tests/PythonToolsMockTests/EditorTests.cs
+++ b/Python/Tests/PythonToolsMockTests/EditorTests.cs
@@ -333,14 +333,14 @@ namespace PythonToolsMockTests {
             AutoListTest("{a for a in b for c in d if x}", 1, -7, 12, -18, 23, 28);
             AutoListTest("(a for a in b for c in d if x)", 1, -7, 12, -18, 23, 28);
             AutoListTest("{a: b for a, b in b for c, d in e if x}", 1, 4, -10, -13, 18, 32, 37);
-            AutoListTest("x = [a for a in b for c in d if x]", -1, 5, -11, 16, -22, 27, 32);
+            AutoListTest("x = [a for a in b for c in d if x]", 0, 5, -11, 16, -22, 27, 32);
         }
 
         [TestMethod, Priority(1)]
         public void AutoListInStatements() {
-            AutoListTest("assert a", -6, 7);
-            AutoListTest("a += b", 5);
-            AutoListTest("del a", -3, 4);
+            AutoListTest("assert a", 0, 6, -6, 7);
+            AutoListTest("a += b", 0, 5);
+            AutoListTest("del a", 0, 3, -3, 4);
             AutoListTest("exec a", PythonLanguageVersion.V27, -4, 5);
             AutoListTest("for a in b", -3, -5, 9);
             AutoListTest("if a", -2, 3);

--- a/Python/Tests/PythonToolsMockTests/MockPythonToolsPackage.cs
+++ b/Python/Tests/PythonToolsMockTests/MockPythonToolsPackage.cs
@@ -86,9 +86,9 @@ namespace PythonToolsMockTests {
                 return null;
             }
             var errorProvider = container.GetComponentModel().GetService<IErrorProviderFactory>();
-            if (type == typeof(ErrorTaskProvider)) {
+            if (typeof(ErrorTaskProvider).IsEquivalentTo(type) || typeof(ErrorTaskProvider).GUID == type.GUID) {
                 return new ErrorTaskProvider(container, null, errorProvider);
-            } else if (type == typeof(CommentTaskProvider)) {
+            } else if (typeof(CommentTaskProvider).IsEquivalentTo(type) || typeof(CommentTaskProvider).GUID == type.GUID) {
                 return new CommentTaskProvider(container, null, errorProvider);
             } else {
                 return null;

--- a/Python/Tests/PythonToolsMockTests/RefactorRenameTests.cs
+++ b/Python/Tests/PythonToolsMockTests/RefactorRenameTests.cs
@@ -31,7 +31,7 @@ using TestUtilities.Python;
 namespace PythonToolsMockTests {
     [TestClass]
     public class RefactorRenameTests {
-        private const string ErrorModuleName = "Cannot rename a module name";
+        private static readonly string ErrorModuleName = Microsoft.PythonTools.Strings.RenameVariable_CannotRenameModuleName;
 
         [ClassInitialize]
         public static void DoDeployment(TestContext context) {

--- a/Python/Tests/PythonToolsMockTests/SquiggleTests.cs
+++ b/Python/Tests/PythonToolsMockTests/SquiggleTests.cs
@@ -131,6 +131,7 @@ namespace PythonToolsMockTests {
                 var tagger = errorProvider.GetErrorTagger(view.View.TextView.TextBuffer);
                 // Ensure all tasks have been updated
                 var taskProvider = (ErrorTaskProvider)view.VS.ServiceProvider.GetService(typeof(ErrorTaskProvider));
+                Assert.IsNotNull(taskProvider, "no ErrorTaskProvider available");
 
                 foreach (var testCase in testCases) {
                     view.Text = testCase.Item1;

--- a/Python/Tests/Utilities.Python/PythonToolsTestUtilities.cs
+++ b/Python/Tests/Utilities.Python/PythonToolsTestUtilities.cs
@@ -45,7 +45,7 @@ namespace TestUtilities.Python {
             var service = new MockContentTypeRegistryService();
             service.AddContentType(PythonCoreConstants.ContentType, new[] { "code" });
 
-            service.AddContentType("Python Interactive Command", new[] { "code" });
+            service.AddContentType("Interactive Command", new[] { "code" });
             return service;
         }
 


### PR DESCRIPTION
Fixes #2043 Intellisense performance issues

Broadly, this reduces the timeouts based on telemetry information, but the more significant change is consistency in how we wait for out-of-proc analysis messages and also adding telemetry points for these waits.

To do this, we need direct access to the analyzer earlier in the call, so this resulted in a few functions changing from static to instance methods.

As usual, all telemetry-only code is (or should be) protected by catch-all handlers that assert in debug builds. Telemetry failures should _never_ cause the product to break.