### PR TITLE
Fix #1289: PTVS Concord components should avoid using NoFilter in their .vsdconfigxml

### DIFF
--- a/Python/Product/Debugger/DkmDebugger/LocalComponent.vsdconfigxml
+++ b/Python/Product/Debugger/DkmDebugger/LocalComponent.vsdconfigxml
@@ -53,7 +53,7 @@ permissions and limitations under the License.
           <Interface Name="IDkmModuleSymbolsLoadedNotification"/>
         </InterfaceGroup>
 
-        <InterfaceGroup>
+        <InterfaceGroup CallOnlyWhenLoaded="true">
           <NoFilter/>
           <Interface Name="IDkmCallStackFilter"/>
         </InterfaceGroup>

--- a/Python/Product/Debugger/DkmDebugger/RemoteComponent.vsdconfigxml
+++ b/Python/Product/Debugger/DkmDebugger/RemoteComponent.vsdconfigxml
@@ -72,16 +72,15 @@ permissions and limitations under the License.
 
         <!-- AboveNormal is needed so that we get invoked before the standard exception manager, which swallows the notifications. -->
         <InterfaceGroup Priority="AboveNormal">
-          <!--<Filter>
+          <Filter>
             <EngineId RequiredValue="guidPythonEngineId"/>
-          </Filter>-->
-          <NoFilter/>
+          </Filter>
           <Interface Name="IDkmExceptionManager"/>
         </InterfaceGroup>
 
-        <InterfaceGroup>
+        <InterfaceGroup CallOnlyWhenLoaded="true">
           <NoFilter/>
-          <Interface Name="IDkmAsyncBreakCompleteReceived"/>
+          <Interface Name="IDkmAsyncBreakCompleteReceived" />
         </InterfaceGroup>
 
       </Implements>


### PR DESCRIPTION
Filter by EngineId, or use CallOnlyWhenLoaded, as appropriate.