### PR TITLE
Fixes #1542 Create virtual env dialog doesn't always come up via new project

### DIFF
--- a/Common/Product/SharedProject/Automation/OAProject.cs
+++ b/Common/Product/SharedProject/Automation/OAProject.cs
@@ -19,11 +19,12 @@ using System.Globalization;
 using System.Runtime.InteropServices;
 using EnvDTE;
 using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.OLE.Interop;
 using Microsoft.VisualStudio.Shell.Interop;
 
 namespace Microsoft.VisualStudioTools.Project.Automation {
     [ComVisible(true)]
-    public class OAProject : EnvDTE.Project, EnvDTE.ISupportVSProperties {
+    public class OAProject : EnvDTE.Project, EnvDTE.ISupportVSProperties, IOleCommandTarget {
         #region fields
         private ProjectNode project;
         EnvDTE.ConfigurationManager configurationManager;
@@ -406,7 +407,16 @@ namespace Microsoft.VisualStudioTools.Project.Automation {
             }
 
         }
+
         #endregion
+
+        public int QueryStatus(ref Guid pguidCmdGroup, uint cCmds, OLECMD[] prgCmds, IntPtr pCmdText) {
+            return ((IOleCommandTarget)project).QueryStatus(ref pguidCmdGroup, cCmds, prgCmds, pCmdText);
+        }
+
+        public int Exec(ref Guid pguidCmdGroup, uint nCmdID, uint nCmdexecopt, IntPtr pvaIn, IntPtr pvaOut) {
+            return ((IOleCommandTarget)project).Exec(ref pguidCmdGroup, nCmdID, nCmdexecopt, pvaIn, pvaOut);
+        }
     }
 
     /// <summary>

--- a/Python/Product/PythonTools/PythonTools/Project/PythonProjectNode.cs
+++ b/Python/Product/PythonTools/PythonTools/Project/PythonProjectNode.cs
@@ -1626,6 +1626,7 @@ namespace Microsoft.PythonTools.Project {
             var requirementsPath = GetStringArgument(variantIn) ?? "";
             requirementsPath = requirementsPath.Trim('"');
             if (!File.Exists(requirementsPath)) {
+                Debug.Fail("ProcessRequirementsTxt did not find '{0}'".FormatInvariant(requirementsPath));
                 return;
             }
 
@@ -1662,6 +1663,7 @@ namespace Microsoft.PythonTools.Project {
             }
 
             if (install == null && venv == null) {
+                Debug.Fail("ProcessRequirementsTxt found nowhere to install");
                 return;
             }
 

--- a/Python/Tests/Core.UI/PythonToolsUITests.csproj
+++ b/Python/Tests/Core.UI/PythonToolsUITests.csproj
@@ -118,8 +118,6 @@
     <Compile Include="ProjectHomeTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="PublishTest.cs" />
-    <Compile Include="PythonProjectProcessor.cs" />
-    <Compile Include="PythonTestDefinitions.cs" />
     <Compile Include="RemoveImportTests.cs" />
     <Compile Include="Resources.Designer.cs">
       <AutoGen>True</AutoGen>

--- a/Python/Tests/Core/PythonProjectProcessor.cs
+++ b/Python/Tests/Core/PythonProjectProcessor.cs
@@ -14,14 +14,13 @@
 // See the Apache Version 2.0 License for specific language governing
 // permissions and limitations under the License.
 
-using System;
 using System.ComponentModel.Composition;
 using Microsoft.PythonTools;
 using Microsoft.PythonTools.Infrastructure;
 using TestUtilities.SharedProject;
 using MSBuild = Microsoft.Build.Evaluation;
 
-namespace PythonToolsUITests {
+namespace PythonToolsTests {
     [Export(typeof(IProjectProcessor))]
     [ProjectExtension(".pyproj")]
     public class PythonProjectProcessor : IProjectProcessor {

--- a/Python/Tests/Core/PythonTestDefinitions.cs
+++ b/Python/Tests/Core/PythonTestDefinitions.cs
@@ -17,7 +17,7 @@
 using System.ComponentModel.Composition;
 using TestUtilities.SharedProject;
 
-namespace PythonToolsUITests {
+namespace PythonToolsTests {
     public sealed class PythonTestDefintions {
         [Export]
         [ProjectExtension(".pyproj")]

--- a/Python/Tests/Core/PythonToolsTests.csproj
+++ b/Python/Tests/Core/PythonToolsTests.csproj
@@ -119,7 +119,9 @@
     <Compile Include="ProjectUpgradeTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ProximityExpressionWalkerTests.cs" />
+    <Compile Include="PythonProjectProcessor.cs" />
     <Compile Include="PythonProjectTests.cs" />
+    <Compile Include="PythonTestDefinitions.cs" />
     <Compile Include="RegistryWatcherTest.cs" />
     <Compile Include="ReplEvaluatorTests.cs" />
   </ItemGroup>

--- a/Python/Tests/PythonToolsMockTests/ProjectTests.cs
+++ b/Python/Tests/PythonToolsMockTests/ProjectTests.cs
@@ -1,3 +1,4 @@
+extern alias pythontools;
 // Python Tools for Visual Studio
 // Copyright(c) Microsoft Corporation
 // All rights reserved.
@@ -23,9 +24,12 @@ using Microsoft.PythonTools;
 using Microsoft.PythonTools.Interpreter;
 using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.Language.Intellisense;
+using Microsoft.VisualStudio.OLE.Interop;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.VisualStudioTools;
 using Microsoft.VisualStudioTools.MockVsTests;
+using Microsoft.VisualStudioTools.Project.Automation;
+using pythontools::Microsoft.PythonTools.Project;
 using TestUtilities;
 using TestUtilities.Python;
 using TestUtilities.SharedProject;
@@ -140,5 +144,22 @@ namespace PythonToolsMockTests {
             }
         }
 
+        [TestMethod, Priority(0)]
+        public void OAProjectMustBeRightType() {
+            var sln = new ProjectDefinition(
+                "HelloWorld",
+                PythonProject,
+                Compile("server", "")
+            ).Generate();
+
+            using (var vs = sln.ToMockVs()) {
+                var proj = vs.GetProject("HelloWorld");
+                Assert.IsNotNull(proj);
+                Assert.IsInstanceOfType(proj, typeof(OAProject));
+                Assert.IsInstanceOfType(proj, typeof(IOleCommandTarget));
+                Assert.IsInstanceOfType(proj.Object, typeof(OAVSProject));
+                Assert.IsInstanceOfType(((OAProject)proj).Project, typeof(PythonProjectNode));
+            }
+        }
     }
 }


### PR DESCRIPTION
Fixes #1542 Create virtual env dialog doesn't always come up via new project
Exposes IOleCommandTarget via the DTE Project so we can invoke the command without going through DTE.
Adds test ensuring project has the right types exposed.
Fixes implicit circular dependency between PythonToolsTests and PythonToolsUITests.

Validated with manual testing:
* I found that creating Flask project, Django project, Flask project would somehow get VS stuck not showing the dialog
* After this change, I can no longer reproduce this
* Over 100 projects were created and deleted in the process of fixing this bug :)