### PR TITLE
Fix ptvsd stackless schedule_callback

### DIFF
--- a/Python/Product/PythonTools/visualstudio_py_debugger.py
+++ b/Python/Product/PythonTools/visualstudio_py_debugger.py
@@ -790,6 +790,7 @@ class Thread(object):
     def _stackless_attach(self):
         try:
             stackless.tasklet.trace_function
+            stackless.set_schedule_callback(self._stackless_schedule_cb)
         except AttributeError:
             # the tasklets need to be traced on a case by case basis
             # sys.trace needs to be called within their calling context


### PR DESCRIPTION
Stackless-only issue:
`stackless.set_schedule_callback` was missing and `_stackless_schedule_cb` never called