### PR TITLE
Fixes #1266 Deadlock invoking MSBuild internally

### DIFF
--- a/Common/Product/SharedProject/ProjectNode.cs
+++ b/Common/Product/SharedProject/ProjectNode.cs
@@ -2589,6 +2589,7 @@ namespace Microsoft.VisualStudioTools.Project {
             } else {
                 ((IDEBuildLogger)this.BuildLogger).OutputWindowPane = output;
             }
+            ((IDEBuildLogger)this.BuildLogger).ResetVerbosity();
         }
 
         /// <summary>

--- a/Common/Product/SharedProject/ProjectResources.cs
+++ b/Common/Product/SharedProject/ProjectResources.cs
@@ -157,6 +157,7 @@ namespace Microsoft.VisualStudioTools.Project {
         internal const string StartupFileDescription = "StartupFileDescription";
         internal const string StartWebBrowser = "StartWebBrowser";
         internal const string StartWebBrowserDescription = "StartWebBrowserDescription";
+        internal const string UnableToReadVerbosity = "UnableToReadVerbosity";
         internal const string UnableToRemoveFile = "UnableToRemoveFile";
         internal const string UnknownInParentheses = "UnknownInParentheses";
         internal const string URL = "URL";

--- a/Common/Product/SharedProject/ProjectResources.resx
+++ b/Common/Product/SharedProject/ProjectResources.resx
@@ -679,4 +679,10 @@ You can get more information by running Visual Studio with the /log parameter on
   <data name="UnableToRemoveFile" xml:space="preserve">
     <value>The file does not exist on disk but is present in your project and cannot be removed.  Please remove the item from the project before attempting to rename an item to a filename of the same name.</value>
   </data>
+  <data name="UnableToReadVerbosity" xml:space="preserve">
+    <value>Unable to read build verbosity setting.
+
+{0}</value>
+    <comment>{0} will be embedded exception text</comment>
+  </data>
 </root>


### PR DESCRIPTION
Fixes #1266 Deadlock invoking MSBuild internally
Ensures build settings are only retrieved while on the UI thread.
Also moves error message into resources.