### PR TITLE
Fixes #2319 Unexpected error dialog needs version number

### DIFF
--- a/Python/Product/Common/Strings.Designer.cs
+++ b/Python/Product/Common/Strings.Designer.cs
@@ -2647,6 +2647,15 @@ namespace Microsoft.PythonTools {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Hide &amp;details.
+        /// </summary>
+        public static string HideDetails {
+            get {
+                return ResourceManager.GetString("HideDetails", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Coverage XML (*.xml)|*.xml|All Files (*.*)|*.*.
         /// </summary>
         public static string ImportCoverageCommandFileFilter {
@@ -4649,6 +4658,15 @@ namespace Microsoft.PythonTools {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Show &amp;details.
+        /// </summary>
+        public static string ShowDetails {
+            get {
+                return ResourceManager.GetString("ShowDetails", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Python source analysis is not up to date.
         /// </summary>
         public static string SourceAnalysisNotUpToDate {
@@ -4818,6 +4836,33 @@ namespace Microsoft.PythonTools {
         public static string UnableToElevate {
             get {
                 return ResourceManager.GetString("UnableToElevate", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Please press Ctrl+C to copy the contents of this dialog and report this error..
+        /// </summary>
+        public static string UnexpectedError_Instruction {
+            get {
+                return ResourceManager.GetString("UnexpectedError_Instruction", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Please press Ctrl+C to copy the contents of this dialog and report this error to our &lt;a href=&quot;issuetracker&quot;&gt;issue tracker&lt;/a&gt;..
+        /// </summary>
+        public static string UnexpectedError_InstructionWithLink {
+            get {
+                return ResourceManager.GetString("UnexpectedError_InstructionWithLink", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to An unexpected error occurred.
+        /// </summary>
+        public static string UnexpectedError_Title {
+            get {
+                return ResourceManager.GetString("UnexpectedError_Title", resourceCulture);
             }
         }
         

--- a/Python/Product/Common/Strings.resx
+++ b/Python/Product/Common/Strings.resx
@@ -2019,4 +2019,20 @@ Expand selection to the full expression?</value>
   <data name="Analyzer_WaitingForStart" xml:space="preserve">
     <value>Waiting for another refresh to start.</value>
   </data>
+  <data name="HideDetails" xml:space="preserve">
+    <value>Hide &amp;details</value>
+  </data>
+  <data name="ShowDetails" xml:space="preserve">
+    <value>Show &amp;details</value>
+  </data>
+  <data name="UnexpectedError_Instruction" xml:space="preserve">
+    <value>Please press Ctrl+C to copy the contents of this dialog and report this error.</value>
+  </data>
+  <data name="UnexpectedError_InstructionWithLink" xml:space="preserve">
+    <value>Please press Ctrl+C to copy the contents of this dialog and report this error to our &lt;a href="issuetracker"&gt;issue tracker&lt;/a&gt;.</value>
+    <comment>'a href="issuetracker"' should not be localized.</comment>
+  </data>
+  <data name="UnexpectedError_Title" xml:space="preserve">
+    <value>An unexpected error occurred</value>
+  </data>
 </root>

--- a/Python/Product/VSCommon/Infrastructure/TaskDialog.cs
+++ b/Python/Product/VSCommon/Infrastructure/TaskDialog.cs
@@ -43,8 +43,8 @@ namespace Microsoft.PythonTools.Infrastructure {
             string issueTrackerUrl = null
         ) {
             string suffix = string.IsNullOrEmpty(issueTrackerUrl) ?
-                "Please press Ctrl+C to copy the contents of this dialog and report this error." :
-                "Please press Ctrl+C to copy the contents of this dialog and report this error to our <a href=\"issuetracker\">issue tracker</a>.";
+                Strings.UnexpectedError_Instruction :
+                Strings.UnexpectedError_InstructionWithLink;
 
             if (string.IsNullOrEmpty(message)) {
                 message = suffix;
@@ -53,12 +53,12 @@ namespace Microsoft.PythonTools.Infrastructure {
             }
             
             var td = new TaskDialog(provider) {
-                MainInstruction = "An unexpected error occurred",
+                MainInstruction = Strings.UnexpectedError_Title,
                 Content = message,
                 EnableHyperlinks = true,
-                CollapsedControlText = "Show &details",
-                ExpandedControlText = "Hide &details",
-                ExpandedInformation = "```{0}{1}{0}```".FormatUI(Environment.NewLine, exception)
+                CollapsedControlText = Strings.ShowDetails,
+                ExpandedControlText = Strings.HideDetails,
+                ExpandedInformation = "```{0}Build: {2}{0}{0}{1}{0}```".FormatUI(Environment.NewLine, exception, AssemblyVersionInfo.Version)
             };
             td.Buttons.Add(TaskDialogButton.Close);
             if (!string.IsNullOrEmpty(issueTrackerUrl)) {


### PR DESCRIPTION
Fixes #2319 Unexpected error dialog needs version number
Adds version number to details.
Moves strings to resource files so they will be localized.

Note that the details string is deliberately non-localized, since the intent is to send it back to the development team for review (and we all speak English right now).