### PR TITLE
Fixes #2320 Unknown interpreter ID keeps causing upgrades

### DIFF
--- a/Python/Product/Common/Strings.Designer.cs
+++ b/Python/Product/Common/Strings.Designer.cs
@@ -4993,6 +4993,15 @@ namespace Microsoft.PythonTools {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to An environment reference could not be upgraded. Please review the Python Environments item in Solution Explorer to select an environment for your project..
+        /// </summary>
+        public static string UpgradedInterpreterReferenceRemoved {
+            get {
+                return ResourceManager.GetString("UpgradedInterpreterReferenceRemoved", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to This project has had old build references removed and may no longer work with prior PTVS versions..
         /// </summary>
         public static string UpgradedRemoveCommonProps {

--- a/Python/Product/Common/Strings.resx
+++ b/Python/Product/Common/Strings.resx
@@ -2019,4 +2019,7 @@ Expand selection to the full expression?</value>
   <data name="Analyzer_WaitingForStart" xml:space="preserve">
     <value>Waiting for another refresh to start.</value>
   </data>
+  <data name="UpgradedInterpreterReferenceRemoved" xml:space="preserve">
+    <value>An environment reference could not be upgraded. Please review the Python Environments item in Solution Explorer to select an environment for your project.</value>
+  </data>
 </root>

--- a/Python/Tests/TestData/ProjectUpgrade/OldPythonTargets.pyproj
+++ b/Python/Tests/TestData/ProjectUpgrade/OldPythonTargets.pyproj
@@ -1,10 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <PropertyGroup>
-    <Name>DragDropCopyCutPaste</Name>
-    <RootNamespace>DragDropCopyCutPaste</RootNamespace>
-  </PropertyGroup>
-  <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>c4ab46b7-511c-4847-8af7-233d7846a08a</ProjectGuid>
@@ -14,7 +10,6 @@
     </SearchPath>
     <WorkingDirectory>.</WorkingDirectory>
     <OutputPath>.</OutputPath>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Python/Tests/TestData/ProjectUpgrade/UnknownInterpreterId.pyproj
+++ b/Python/Tests/TestData/ProjectUpgrade/UnknownInterpreterId.pyproj
@@ -3,19 +3,27 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <SchemaVersion>2.0</SchemaVersion>
-    <ProjectGuid>c4ab46b7-511c-4847-8af7-233d7846a08a</ProjectGuid>
+    <ProjectGuid>{12535e18-06da-4f15-b99e-8f492fe721e2}</ProjectGuid>
     <ProjectHome>.</ProjectHome>
-    <StartupFile>server.py</StartupFile>
+    <StartupFile>Program.py</StartupFile>
     <SearchPath>
     </SearchPath>
     <WorkingDirectory>.</WorkingDirectory>
+    <AssemblyName>HelloWorld</AssemblyName>
+    <Name>HelloWorld</Name>
+    <RootNamespace>HelloWorld</RootNamespace>
     <OutputPath>.</OutputPath>
+    <InterpreterId>{C4CC9160-8D8C-4B72-B2D2-794FE98BB67F}</InterpreterId>
+    <InterpreterVersion>3.5</InterpreterVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
     <DebugSymbols>true</DebugSymbols>
+    <EnableUnmanagedDebugging>false</EnableUnmanagedDebugging>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <DebugSymbols>true</DebugSymbols>
+    <EnableUnmanagedDebugging>false</EnableUnmanagedDebugging>
   </PropertyGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.Common.targets" />
+  <ItemGroup />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\Python Tools\Microsoft.PythonTools.targets" />
 </Project>

--- a/Python/Tests/TestData/ProjectUpgrade/UnknownInterpreterReference.pyproj
+++ b/Python/Tests/TestData/ProjectUpgrade/UnknownInterpreterReference.pyproj
@@ -3,19 +3,27 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <SchemaVersion>2.0</SchemaVersion>
-    <ProjectGuid>c4ab46b7-511c-4847-8af7-233d7846a08a</ProjectGuid>
+    <ProjectGuid>{12535e18-06da-4f15-b99e-8f492fe721e2}</ProjectGuid>
     <ProjectHome>.</ProjectHome>
-    <StartupFile>server.py</StartupFile>
+    <StartupFile>Program.py</StartupFile>
     <SearchPath>
     </SearchPath>
     <WorkingDirectory>.</WorkingDirectory>
+    <AssemblyName>HelloWorld</AssemblyName>
+    <Name>HelloWorld</Name>
+    <RootNamespace>HelloWorld</RootNamespace>
     <OutputPath>.</OutputPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
     <DebugSymbols>true</DebugSymbols>
+    <EnableUnmanagedDebugging>false</EnableUnmanagedDebugging>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <DebugSymbols>true</DebugSymbols>
+    <EnableUnmanagedDebugging>false</EnableUnmanagedDebugging>
   </PropertyGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.Common.targets" />
+  <ItemGroup>
+    <InterpreterReference Include="{1E11E0E1-F748-452B-BE80-31DA87B07EA0}\3.5" />
+  </ItemGroup>
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\Python Tools\Microsoft.PythonTools.targets" />
 </Project>


### PR DESCRIPTION
Fixes #2320 Unknown interpreter ID keeps causing upgrades
Removes unknown IDs rather than ignoring them