### PR TITLE
Fixes #2280 EnvironmentList ToolWindow crashes on invalid environment

### DIFF
--- a/Python/Product/EnvironmentsList/EnvironmentPathsExtension.xaml
+++ b/Python/Product/EnvironmentsList/EnvironmentPathsExtension.xaml
@@ -47,6 +47,7 @@
                             </Button>
                             <Label x:Name="IsDefaultMessage"
                                    Visibility="Collapsed"
+                                   Padding="0"
                                    AutomationProperties.Name="{x:Static l:Resources.EnvironmentPathsExtensionIsDefaultLabel}">
                                 <Grid>
                                     <Grid.ColumnDefinitions>

--- a/Python/Product/EnvironmentsList/EnvironmentView.cs
+++ b/Python/Product/EnvironmentsList/EnvironmentView.cs
@@ -45,11 +45,6 @@ namespace Microsoft.PythonTools.EnvironmentsList {
             new InterpreterConfiguration(AddNewEnvironmentViewId, AddNewEnvironmentViewId)
         };
 
-        public static readonly EnvironmentView OnlineHelpView = new EnvironmentView(
-            OnlineHelpViewId,
-            Resources.EnvironmentViewOnlineHelpLabel
-        );
-
         // Names of properties that will be requested from interpreter configurations
         internal const string CompanyKey = "Company";
         internal const string SupportUrlKey = "SupportUrl";
@@ -70,7 +65,8 @@ namespace Microsoft.PythonTools.EnvironmentsList {
 
         private EnvironmentView(string id, string localizedName) {
             Configuration = new InterpreterConfiguration(id, id);
-            LocalizedDisplayName = localizedName;
+            Description = LocalizedDisplayName = localizedName;
+            Extensions = new ObservableCollection<object>();
         }
 
         internal EnvironmentView(
@@ -134,6 +130,14 @@ namespace Microsoft.PythonTools.EnvironmentsList {
             ev.Extensions = new ObservableCollection<object>();
             ev.Extensions.Add(new ConfigurationExtensionProvider(service, alwaysCreateNew: true));
             return ev;
+        }
+
+        public static EnvironmentView CreateOnlineHelpEnvironmentView() {
+            return new EnvironmentView(OnlineHelpViewId, Resources.EnvironmentViewOnlineHelpLabel);
+        }
+
+        public static EnvironmentView CreateMissingEnvironmentView(string id, string description) {
+            return new EnvironmentView(id, description + Strings.MissingSuffix);
         }
 
         public static bool IsAddNewEnvironmentView(string id) => AddNewEnvironmentViewId.Equals(id);
@@ -227,7 +231,7 @@ namespace Microsoft.PythonTools.EnvironmentsList {
 
         #region Configuration Dependency Properties
 
-        private static readonly DependencyPropertyKey DescriptionPropertyKey = DependencyProperty.RegisterReadOnly("Description", typeof(string), typeof(EnvironmentView), new PropertyMetadata());
+        private static readonly DependencyPropertyKey DescriptionPropertyKey = DependencyProperty.RegisterReadOnly("Description", typeof(string), typeof(EnvironmentView), new PropertyMetadata(""));
         private static readonly DependencyPropertyKey PrefixPathPropertyKey = DependencyProperty.RegisterReadOnly("PrefixPath", typeof(string), typeof(EnvironmentView), new PropertyMetadata());
         private static readonly DependencyPropertyKey InterpreterPathPropertyKey = DependencyProperty.RegisterReadOnly("InterpreterPath", typeof(string), typeof(EnvironmentView), new PropertyMetadata());
         private static readonly DependencyPropertyKey WindowsInterpreterPathPropertyKey = DependencyProperty.RegisterReadOnly("WindowsInterpreterPath", typeof(string), typeof(EnvironmentView), new PropertyMetadata());
@@ -240,8 +244,8 @@ namespace Microsoft.PythonTools.EnvironmentsList {
         public static readonly DependencyProperty PathEnvironmentVariableProperty = PathEnvironmentVariablePropertyKey.DependencyProperty;
 
         public string Description {
-            get { return Factory == null ? string.Empty : (string)GetValue(DescriptionProperty); }
-            set { if (Factory != null) { SetValue(DescriptionPropertyKey, value); } }
+            get { return (string)GetValue(DescriptionProperty) ?? ""; }
+            set { SetValue(DescriptionPropertyKey, value ?? ""); }
         }
 
         public string PrefixPath {
@@ -268,20 +272,20 @@ namespace Microsoft.PythonTools.EnvironmentsList {
 
         #region Extra Information Dependency Properties
 
-        private static readonly DependencyPropertyKey CompanyPropertyKey = DependencyProperty.RegisterReadOnly("Company", typeof(string), typeof(EnvironmentView), new PropertyMetadata());
-        private static readonly DependencyPropertyKey SupportUrlPropertyKey = DependencyProperty.RegisterReadOnly("SupportUrl", typeof(string), typeof(EnvironmentView), new PropertyMetadata());
+        private static readonly DependencyPropertyKey CompanyPropertyKey = DependencyProperty.RegisterReadOnly("Company", typeof(string), typeof(EnvironmentView), new PropertyMetadata(""));
+        private static readonly DependencyPropertyKey SupportUrlPropertyKey = DependencyProperty.RegisterReadOnly("SupportUrl", typeof(string), typeof(EnvironmentView), new PropertyMetadata(""));
 
         public static readonly DependencyProperty CompanyProperty = CompanyPropertyKey.DependencyProperty;
         public static readonly DependencyProperty SupportUrlProperty = SupportUrlPropertyKey.DependencyProperty;
 
         public string Company {
-            get { return Factory == null ? string.Empty : (string)GetValue(CompanyProperty); }
-            set { if (Factory != null) { SetValue(CompanyPropertyKey, value); } }
+            get { return (string)GetValue(CompanyProperty) ?? ""; }
+            set { SetValue(CompanyPropertyKey, value ?? ""); }
         }
 
         public string SupportUrl {
-            get { return Factory == null ? string.Empty : (string)GetValue(SupportUrlProperty); }
-            set { if (Factory != null) { SetValue(SupportUrlPropertyKey, value); } }
+            get { return (string)GetValue(SupportUrlProperty) ?? ""; }
+            set { SetValue(SupportUrlPropertyKey, value ?? ""); }
         }
 
         #endregion

--- a/Python/Product/EnvironmentsList/PipExtensionProvider.cs
+++ b/Python/Product/EnvironmentsList/PipExtensionProvider.cs
@@ -56,7 +56,7 @@ namespace Microsoft.PythonTools.EnvironmentsList {
             string indexName = null
         ) {
             _factory = factory;
-            _packageManager = _factory.PackageManager;
+            _packageManager = _factory?.PackageManager;
             if (_packageManager == null) {
                 throw new NotSupportedException();
             }

--- a/Python/Product/EnvironmentsList/ToolWindow.xaml.cs
+++ b/Python/Product/EnvironmentsList/ToolWindow.xaml.cs
@@ -364,14 +364,19 @@ namespace Microsoft.PythonTools.EnvironmentsList {
                     select = selectView?.Configuration?.Id;
                 }
 
+                // We allow up to three retries at this process to handle race
+                // conditions where an interpreter disappears between the
+                // point where we enumerate known configuration IDs and convert
+                // them into a view. The first time that happens, we insert a
+                // stub entry, and on the subsequent pass it will be removed.
                 bool anyMissing = true;
                 for (int retries = 3; retries > 0 && anyMissing; --retries) {
-                    var configs = _interpreters.Configurations.Where(f => f.IsUIVisible());
+                    var configs = _interpreters.Configurations.Where(f => f.IsUIVisible()).ToList();
                     if (_onlineHelpView != null) {
-                        configs = configs.Concat(Enumerable.Repeat(_onlineHelpView.Configuration, 1));
+                        configs.Add(_onlineHelpView.Configuration);
                     }
                     if (_addNewEnvironmentView != null) {
-                        configs = configs.Concat(Enumerable.Repeat(_addNewEnvironmentView.Configuration, 1));
+                        configs.Add(_addNewEnvironmentView.Configuration);
                     }
 
                     anyMissing = false;

--- a/Python/Product/EnvironmentsList/ToolWindow.xaml.cs
+++ b/Python/Product/EnvironmentsList/ToolWindow.xaml.cs
@@ -46,6 +46,7 @@ namespace Microsoft.PythonTools.EnvironmentsList {
         private IServiceProvider _site;
 
         private EnvironmentView _addNewEnvironmentView;
+        private EnvironmentView _onlineHelpView;
 
         private AnalyzerStatusListener _listener;
         private readonly object _listenerLock = new object();
@@ -363,29 +364,46 @@ namespace Microsoft.PythonTools.EnvironmentsList {
                     select = selectView?.Configuration?.Id;
                 }
 
-                var configs = _interpreters.Configurations.Where(f => f.IsUIVisible());
-                configs = configs.Concat(Enumerable.Repeat(EnvironmentView.OnlineHelpView.Configuration, 1));
-                if (_addNewEnvironmentView != null) {
-                    configs = configs.Concat(Enumerable.Repeat(_addNewEnvironmentView.Configuration, 1));
-                }
+                bool anyMissing = true;
+                for (int retries = 3; retries > 0 && anyMissing; --retries) {
+                    var configs = _interpreters.Configurations.Where(f => f.IsUIVisible());
+                    if (_onlineHelpView != null) {
+                        configs = configs.Concat(Enumerable.Repeat(_onlineHelpView.Configuration, 1));
+                    }
+                    if (_addNewEnvironmentView != null) {
+                        configs = configs.Concat(Enumerable.Repeat(_addNewEnvironmentView.Configuration, 1));
+                    }
 
-                _environments.Merge(
-                    configs,
-                    ev => ev.Configuration,
-                    c => c,
-                    c => {
-                        if (EnvironmentView.IsAddNewEnvironmentView(c.Id)) {
-                            return _addNewEnvironmentView;
-                        } else if (EnvironmentView.IsOnlineHelpView(c.Id)) {
-                            return EnvironmentView.OnlineHelpView;
-                        }
-                        var view = new EnvironmentView(_service, _interpreters, _interpreters.FindInterpreter(c.Id), null);
-                        OnViewCreated(view);
-                        return view;
-                    },
-                    InterpreterConfigurationComparer.Instance,
-                    InterpreterConfigurationComparer.Instance
-                );
+                    anyMissing = false;
+                    _environments.Merge(
+                        configs,
+                        ev => ev.Configuration,
+                        c => c,
+                        c => {
+                            if (EnvironmentView.IsAddNewEnvironmentView(c.Id)) {
+                                return _addNewEnvironmentView;
+                            } else if (EnvironmentView.IsOnlineHelpView(c.Id)) {
+                                return _onlineHelpView;
+                            }
+                            var fact = _interpreters.FindInterpreter(c.Id);
+                            EnvironmentView view = null;
+                            try {
+                                if (fact != null) {
+                                    view = new EnvironmentView(_service, _interpreters, fact, null);
+                                }
+                            } catch (ArgumentException) {
+                            }
+                            if (view == null) {
+                                view = EnvironmentView.CreateMissingEnvironmentView(c.Id + "+Missing", c.Description);
+                                anyMissing = true;
+                            }
+                            OnViewCreated(view);
+                            return view;
+                        },
+                        InterpreterConfigurationComparer.Instance,
+                        InterpreterConfigurationComparer.Instance
+                    );
+                }
 
                 if (select != null) {
                     var selectView = _environments.FirstOrDefault(v => v.Factory != null &&
@@ -448,8 +466,10 @@ namespace Microsoft.PythonTools.EnvironmentsList {
                 if (_service != null) {
                     _service.DefaultInterpreterChanged += Service_DefaultInterpreterChanged;
                     _addNewEnvironmentView = EnvironmentView.CreateAddNewEnvironmentView(_service);
+                    _onlineHelpView = EnvironmentView.CreateOnlineHelpEnvironmentView();
                 } else {
                     _addNewEnvironmentView = null;
+                    _onlineHelpView = null;
                 }
                 if (_interpreters != null) {
                     Dispatcher.InvokeAsync(FirstUpdateEnvironments).Task.DoNotWait();

--- a/Python/Product/PythonTools/PythonTools/InterpreterList/InterpreterListToolWindow.cs
+++ b/Python/Product/PythonTools/PythonTools/InterpreterList/InterpreterListToolWindow.cs
@@ -226,6 +226,9 @@ namespace Microsoft.PythonTools.InterpreterList {
 
         private void List_ViewCreated(object sender, EnvironmentViewEventArgs e) {
             var view = e.View;
+            if (view.Factory == null) {
+                return;
+            }
 
             try {
                 var pep = new PipExtensionProvider(view.Factory);


### PR DESCRIPTION
Fixes #2280 EnvironmentList ToolWindow crashes on invalid environment
Handles errors creating a view for an environment, including retrying the entire update to exclude "bad" entries rather than leaving them visible and unusable
Improves handling on the online help item, to avoid static construction

Also fixes layout of "make default" label.