### PR TITLE
Reverts to old syntax to satisfy FxCop.

### DIFF
--- a/Python/Product/Debugger/Debugger/DebugConnection.cs
+++ b/Python/Product/Debugger/Debugger/DebugConnection.cs
@@ -246,7 +246,10 @@ namespace Microsoft.PythonTools.Debugger {
         }
 
         public void Dispose() {
-            _connection?.Dispose();
+            // Avoiding ?. syntax because FxCop doesn't understand it
+            if (_connection != null) {
+                _connection.Dispose();
+            }
             // The connection dispose above won't close the stream, because we don't give it ownership
             // Disposing of the stream will cause the message thread to stop, which causes the event thread to stop
             _stream?.Dispose();

--- a/Python/Product/Debugger/Debugger/PythonProcess.cs
+++ b/Python/Product/Debugger/Debugger/PythonProcess.cs
@@ -59,6 +59,7 @@ namespace Microsoft.PythonTools.Debugger {
         private ICollection<KeyValuePair<string, int>> _breakOn;
         private bool _handleEntryPointHit = true;
         private bool _handleEntryPointBreakpoint = true;
+        private bool _isDisposed;
 
         protected PythonProcess(int pid, PythonLanguageVersion languageVersion) {
             if (languageVersion < PythonLanguageVersion.V26 && !languageVersion.IsNone()) {
@@ -173,6 +174,11 @@ namespace Microsoft.PythonTools.Debugger {
         }
 
         protected virtual void Dispose(bool disposing) {
+            if (_isDisposed) {
+                return;
+            }
+            _isDisposed = true;
+
             DebugConnectionListener.UnregisterProcess(_processGuid);
 
             if (disposing) {
@@ -200,8 +206,13 @@ namespace Microsoft.PythonTools.Debugger {
                         _connection.Dispose();
                         _connection = null;
                     }
-                    _process?.Dispose();
+                    // Avoiding ?. syntax because FxCop doesn't understand it
+                    if (_process != null) {
+                        _process.Dispose();
+                    }
                 }
+
+                _connectedEvent.Dispose();
             }
         }
 


### PR DESCRIPTION
Reverts to old syntax to satisfy FxCop.
Disposes of readonly event.