### PR TITLE
Fix #2342 Crash during remote debugging. 

### DIFF
--- a/Python/Product/Ipc.Json/Connection.cs
+++ b/Python/Product/Ipc.Json/Connection.cs
@@ -430,8 +430,14 @@ namespace Microsoft.PythonTools.Ipc.Json {
                 return null;
             }
 
+            // ReadAsync may not read everything in one call, so keep reading
+            // until we have it all. This is triggered when going over tcp.
             char[] buffer = new char[contentLength];
-            await reader.ReadAsync(buffer, 0, contentLength).ConfigureAwait(false);
+            int totalReceived = 0;
+            while (totalReceived < contentLength) {
+                int received = await reader.ReadAsync(buffer, totalReceived, contentLength - totalReceived).ConfigureAwait(false);
+                totalReceived += received;
+            }
 
             return new string(buffer);
         }


### PR DESCRIPTION
The packet was only read partially before it was deserialized as JSON. This ensures that the whole packet is read first.

Example: content-length was around 1800 chars, but the first call to ReadAsync was only getting about 1400 chars.