### PR TITLE
Add better error handling around attach to debug repl

### DIFF
--- a/Python/Product/Debugger/Debugger/DebugConnection.cs
+++ b/Python/Product/Debugger/Debugger/DebugConnection.cs
@@ -124,11 +124,17 @@ namespace Microsoft.PythonTools.Debugger {
                         }
                     }
 
-                    return await _connection.SendRequestAsync(
-                        request,
-                        linkedSource.Token,
-                        postResponseAction
-                    );
+                    try {
+                        return await _connection.SendRequestAsync(
+                            request,
+                            linkedSource.Token,
+                            postResponseAction
+                        );
+                    } catch (IOException ex) {
+                        throw new OperationCanceledException(ex.Message, ex);
+                    } catch (ObjectDisposedException ex) {
+                        throw new OperationCanceledException(ex.Message, ex);
+                    }
                 } finally {
                     ProcessingMessagesEnded -= handler;
                 }

--- a/Python/Product/PythonTools/PythonTools/Repl/PythonInteractiveEvaluator.cs
+++ b/Python/Product/PythonTools/PythonTools/Repl/PythonInteractiveEvaluator.cs
@@ -371,7 +371,11 @@ namespace Microsoft.PythonTools.Repl {
                     }
                 }
 
-                thread = await ConnectAsync(default(CancellationToken));
+                try {
+                    thread = await ConnectAsync(default(CancellationToken));
+                } catch (OperationCanceledException) {
+                    thread = null;
+                }
 
                 var newerThread = Interlocked.CompareExchange(ref _thread, thread, null);
                 if (newerThread != null) {


### PR DESCRIPTION
Fix https://github.com/Microsoft/PTVS/issues/2357

Add error handling so that VS doesn't crash when attach to debug repl is refused or there's any other error around that request.

This will allow us to turn off the debug repl attach feature in attach_server.py, if necessary.