### PR TITLE
Accessibility fixes for environment window and profiling dialog

### DIFF
--- a/Common/Product/SharedProject/Wpf/ConfigurationControl.cs
+++ b/Common/Product/SharedProject/Wpf/ConfigurationControl.cs
@@ -26,6 +26,7 @@ namespace Microsoft.VisualStudioTools.Wpf {
         public static readonly DependencyProperty IsReadOnlyProperty = DependencyProperty.Register("IsReadOnly", typeof(bool), typeof(ConfigurationTextBoxWithHelp), new PropertyMetadata());
         public static readonly DependencyProperty BrowseButtonStyleProperty = DependencyProperty.Register("BrowseButtonStyle", typeof(Style), typeof(ConfigurationTextBoxWithHelp), new PropertyMetadata());
         public static readonly DependencyProperty BrowseCommandParameterProperty = DependencyProperty.Register("BrowseCommandParameter", typeof(object), typeof(ConfigurationTextBoxWithHelp), new PropertyMetadata());
+        public static readonly DependencyProperty BrowseAutomationNameProperty = DependencyProperty.Register("BrowseAutomationName", typeof(string), typeof(ConfigurationTextBoxWithHelp), new PropertyMetadata());
 
         public string Watermark {
             get { return (string)GetValue(WatermarkProperty); }
@@ -55,6 +56,11 @@ namespace Microsoft.VisualStudioTools.Wpf {
         public object BrowseCommandParameter {
             get { return (object)GetValue(BrowseCommandParameterProperty); }
             set { SetValue(BrowseCommandParameterProperty, value); }
+        }
+
+        public string BrowseAutomationName {
+            get { return (string)GetValue(BrowseAutomationNameProperty); }
+            set { SetValue(BrowseAutomationNameProperty, value); }
         }
     }
 

--- a/Common/Product/SharedProject/Wpf/Controls.xaml
+++ b/Common/Product/SharedProject/Wpf/Controls.xaml
@@ -1299,6 +1299,7 @@
                                  Style="{StaticResource {x:Type TextBox}}"
                                  AutomationProperties.Name="{TemplateBinding AutomationProperties.Name}"
                                  AutomationProperties.HelpText="{TemplateBinding HelpText}"
+                                 AutomationProperties.LabeledBy="{TemplateBinding AutomationProperties.LabeledBy}"
                                  IsReadOnly="{Binding IsReadOnly,Mode=OneWay,RelativeSource={RelativeSource TemplatedParent}}"
                                  Text="{Binding Text,Mode=TwoWay,RelativeSource={RelativeSource TemplatedParent},UpdateSourceTrigger=PropertyChanged}">
                             <TextBox.ToolTip>
@@ -1327,6 +1328,7 @@
                                 Margin="1 4 4 4"
                                 VerticalAlignment="Center"
                                 Style="{TemplateBinding BrowseButtonStyle}"
+                                AutomationProperties.Name="{TemplateBinding BrowseAutomationName}"
                                 CommandParameter="{TemplateBinding BrowseCommandParameter}"
                                 CommandTarget="{Binding ElementName=_TextBox}" />
                     </Grid>
@@ -1368,7 +1370,8 @@
                                   IsTextSearchEnabled="True"
                                   IsTextSearchCaseSensitive="False"
                                   AutomationProperties.Name="{TemplateBinding AutomationProperties.Name}"
-                                  AutomationProperties.HelpText="{TemplateBinding HelpText}">
+                                  AutomationProperties.HelpText="{TemplateBinding HelpText}"
+                                  AutomationProperties.LabeledBy="{TemplateBinding AutomationProperties.LabeledBy}">
                             <ComboBox.ToolTip>
                                 <ToolTip Placement="Bottom" Content="{TemplateBinding HelpText}">
                                     <ToolTip.ContentTemplate>

--- a/Python/Product/Cookiecutter/Shared/Wpf/ConfigurationControl.cs
+++ b/Python/Product/Cookiecutter/Shared/Wpf/ConfigurationControl.cs
@@ -26,6 +26,7 @@ namespace Microsoft.VisualStudioTools.Wpf {
         public static readonly DependencyProperty IsReadOnlyProperty = DependencyProperty.Register("IsReadOnly", typeof(bool), typeof(ConfigurationTextBoxWithHelp), new PropertyMetadata());
         public static readonly DependencyProperty BrowseButtonStyleProperty = DependencyProperty.Register("BrowseButtonStyle", typeof(Style), typeof(ConfigurationTextBoxWithHelp), new PropertyMetadata());
         public static readonly DependencyProperty BrowseCommandParameterProperty = DependencyProperty.Register("BrowseCommandParameter", typeof(object), typeof(ConfigurationTextBoxWithHelp), new PropertyMetadata());
+        public static readonly DependencyProperty BrowseAutomationNameProperty = DependencyProperty.Register("BrowseAutomationName", typeof(string), typeof(ConfigurationTextBoxWithHelp), new PropertyMetadata());
 
         public string Watermark {
             get { return (string)GetValue(WatermarkProperty); }
@@ -55,6 +56,11 @@ namespace Microsoft.VisualStudioTools.Wpf {
         public object BrowseCommandParameter {
             get { return (object)GetValue(BrowseCommandParameterProperty); }
             set { SetValue(BrowseCommandParameterProperty, value); }
+        }
+
+        public string BrowseAutomationName {
+            get { return (string)GetValue(BrowseAutomationNameProperty); }
+            set { SetValue(BrowseAutomationNameProperty, value); }
         }
     }
 

--- a/Python/Product/Cookiecutter/Shared/Wpf/Controls.xaml
+++ b/Python/Product/Cookiecutter/Shared/Wpf/Controls.xaml
@@ -1313,6 +1313,7 @@
                                  Style="{StaticResource {x:Type TextBox}}"
                                  AutomationProperties.Name="{TemplateBinding AutomationProperties.Name}"
                                  AutomationProperties.HelpText="{TemplateBinding HelpText}"
+                                 AutomationProperties.LabeledBy="{TemplateBinding AutomationProperties.LabeledBy}"
                                  IsReadOnly="{Binding IsReadOnly,Mode=OneWay,RelativeSource={RelativeSource TemplatedParent}}"
                                  Text="{Binding Text,Mode=TwoWay,RelativeSource={RelativeSource TemplatedParent},UpdateSourceTrigger=PropertyChanged}">
                             <TextBox.ToolTip>
@@ -1341,6 +1342,7 @@
                                 Margin="1 4 4 4"
                                 VerticalAlignment="Center"
                                 Style="{TemplateBinding BrowseButtonStyle}"
+                                AutomationProperties.Name="{TemplateBinding BrowseAutomationName}"
                                 CommandParameter="{TemplateBinding BrowseCommandParameter}"
                                 CommandTarget="{Binding ElementName=_TextBox}" />
                     </Grid>
@@ -1382,7 +1384,8 @@
                                   IsTextSearchEnabled="True"
                                   IsTextSearchCaseSensitive="False"
                                   AutomationProperties.Name="{TemplateBinding AutomationProperties.Name}"
-                                  AutomationProperties.HelpText="{TemplateBinding HelpText}">
+                                  AutomationProperties.HelpText="{TemplateBinding HelpText}"
+                                  AutomationProperties.LabeledBy="{TemplateBinding AutomationProperties.LabeledBy}">
                             <ComboBox.ToolTip>
                                 <ToolTip Placement="Bottom" Content="{TemplateBinding HelpText}">
                                     <ToolTip.ContentTemplate>

--- a/Python/Product/Cookiecutter/View/CookiecutterOptionsPage.xaml
+++ b/Python/Product/Cookiecutter/View/CookiecutterOptionsPage.xaml
@@ -210,7 +210,8 @@
         </StackPanel>
         <ScrollViewer Grid.Row="1" Margin="4">
             <ItemsControl ItemsSource="{Binding Path=ContextItems}"
-                          ItemTemplateSelector="{StaticResource contextItemSelector}" />
+                          ItemTemplateSelector="{StaticResource contextItemSelector}"
+                          IsTabStop="False"/>
         </ScrollViewer>
         <StackPanel Grid.Row="2" Margin="4" Orientation="Vertical">
             <StackPanel Grid.Row="2" Orientation="Horizontal">

--- a/Python/Product/EnvironmentsList/ConfigurationExtension.xaml
+++ b/Python/Product/EnvironmentsList/ConfigurationExtension.xaml
@@ -67,54 +67,78 @@
                     <RowDefinition Height="*" />
                 </Grid.RowDefinitions>
 
-                <Label Grid.Column="0" Grid.Row="0" Content="{x:Static l:Resources.ConfigurationExtensionDescriptionLabel}"/>
+                <Label Grid.Column="0" Grid.Row="0"
+                       Name="DescriptionLabel"
+                       Content="{x:Static l:Resources.ConfigurationExtensionDescriptionLabel}"/>
                 <wpf:ConfigurationTextBoxWithHelp Grid.Column="0" Grid.Row="1"
                                                   Text="{Binding Description,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}"
                                                   HelpText="{x:Static l:Resources.ConfigurationExtensionDescriptionHelp}"
-                                                  Watermark="{x:Static l:Resources.ConfigurationExtensionDescriptionWatermark}"/>
+                                                  Watermark="{x:Static l:Resources.ConfigurationExtensionDescriptionWatermark}"
+                                                  AutomationProperties.LabeledBy="{Binding ElementName=DescriptionLabel}"/>
 
-                <Label Grid.Column="0" Grid.Row="2" Content="{x:Static l:Resources.ConfigurationExtensionPrefixPathLabel}"/>
+                <Label Grid.Column="0" Grid.Row="2"
+                       Name="PrefixPathLabel"
+                       Content="{x:Static l:Resources.ConfigurationExtensionPrefixPathLabel}"/>
                 <wpf:ConfigurationTextBoxWithHelp Grid.Column="0" Grid.Row="3"
                                                   Text="{Binding PrefixPath,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}"
                                                   Watermark="{x:Static l:Resources.ConfigurationExtensionPrefixPathWatermark}"
                                                   HelpText="{x:Static l:Resources.ConfigurationExtensionPrefixPathHelp}"
-                                                  BrowseButtonStyle="{StaticResource BrowseFolderButton}"/>
+                                                  AutomationProperties.LabeledBy="{Binding ElementName=PrefixPathLabel}"
+                                                  BrowseButtonStyle="{StaticResource BrowseFolderButton}"
+                                                  BrowseAutomationName="{x:Static l:Resources.ConfigurationExtensionPrefixPathBrowseButton}"/>
 
-                <Label Grid.Column="0" Grid.Row="4" Content="{x:Static l:Resources.ConfigurationExtensionInterpreterPathLabel}"/>
+                <Label Grid.Column="0" Grid.Row="4"
+                       Name="InterpreterPathLabel"
+                       Content="{x:Static l:Resources.ConfigurationExtensionInterpreterPathLabel}"/>
                 <wpf:ConfigurationTextBoxWithHelp Grid.Column="0" Grid.Row="5"
                                                   Text="{Binding InterpreterPath,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}"
                                                   Watermark="{x:Static l:Resources.ConfigurationExtensionInterpreterPathWatermark}"
                                                   HelpText="{x:Static l:Resources.ConfigurationExtensionInterpreterPathHelp}"
+                                                  AutomationProperties.LabeledBy="{Binding ElementName=InterpreterPathLabel}"
                                                   BrowseButtonStyle="{StaticResource BrowseOpenFileButton}"
-                                                  BrowseCommandParameter="{x:Static l:Resources.ConfigurationExtensionInterpreterPathBrowseFilter}"/>
+                                                  BrowseCommandParameter="{x:Static l:Resources.ConfigurationExtensionInterpreterPathBrowseFilter}"
+                                                  BrowseAutomationName="{x:Static l:Resources.ConfigurationExtensionInterpreterPathBrowseButton}"/>
 
-                <Label Grid.Column="0" Grid.Row="6" Content="{x:Static l:Resources.ConfigurationExtensionWindowedInterpreterPathLabel}"/>
+                <Label Grid.Column="0" Grid.Row="6"
+                       Name="WindowedInterpreterPathLabel"
+                       Content="{x:Static l:Resources.ConfigurationExtensionWindowedInterpreterPathLabel}"/>
                 <wpf:ConfigurationTextBoxWithHelp Grid.Column="0" Grid.Row="7"
                                                   Text="{Binding WindowsInterpreterPath,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}"
                                                   Watermark="{x:Static l:Resources.ConfigurationExtensionWindowedInterpreterPathWatermark}"
                                                   HelpText="{x:Static l:Resources.ConfigurationExtensionWindowedInterpreterPathHelp}"
+                                                  AutomationProperties.LabeledBy="{Binding ElementName=WindowedInterpreterPathLabel}"
                                                   BrowseButtonStyle="{StaticResource BrowseOpenFileButton}"
-                                                  BrowseCommandParameter="{x:Static l:Resources.ConfigurationExtensionWindowedInterpreterPathBrowseFilter}"/>
+                                                  BrowseCommandParameter="{x:Static l:Resources.ConfigurationExtensionWindowedInterpreterPathBrowseFilter}"
+                                                  BrowseAutomationName="{x:Static l:Resources.ConfigurationExtensionWindowedInterpreterPathBrowseButton}"/>
 
-                <Label Grid.Column="0" Grid.Row="8" Content="{x:Static l:Resources.ConfigurationExtensionLanguageVersionLabel}"/>
+                <Label Grid.Column="0" Grid.Row="8"
+                       Name="LanguageVersionLabel"
+                       Content="{x:Static l:Resources.ConfigurationExtensionLanguageVersionLabel}"/>
                 <wpf:ConfigurationComboBoxWithHelp Grid.Column="0" Grid.Row="9"
                                                    Value="{Binding VersionName,Mode=TwoWay}"
                                                    Values="{Binding VersionNames}"
                                                    Watermark="{x:Static l:Resources.ConfigurationExtensionLanguageVersionWatermark}"
-                                                   HelpText="{x:Static l:Resources.ConfigurationExtensionLanguageVersionHelp}"/>
+                                                   HelpText="{x:Static l:Resources.ConfigurationExtensionLanguageVersionHelp}"
+                                                   AutomationProperties.LabeledBy="{Binding ElementName=LanguageVersionLabel}"/>
 
-                <Label Grid.Column="0" Grid.Row="10" Content="{x:Static l:Resources.ConfigurationExtensionArchitectureLabel}"/>
+                <Label Grid.Column="0" Grid.Row="10"
+                       Name="ArchitectureLabel"
+                       Content="{x:Static l:Resources.ConfigurationExtensionArchitectureLabel}"/>
                 <wpf:ConfigurationComboBoxWithHelp Grid.Column="0" Grid.Row="11"
                                                    Value="{Binding ArchitectureName,Mode=TwoWay}"
                                                    Values="{Binding ArchitectureNames}"
                                                    Watermark="{x:Static l:Resources.ConfigurationExtensionArchitectureWatermark}"
-                                                   HelpText="{x:Static l:Resources.ConfigurationExtensionArchitectureHelp}"/>
+                                                   HelpText="{x:Static l:Resources.ConfigurationExtensionArchitectureHelp}"
+                                                   AutomationProperties.LabeledBy="{Binding ElementName=ArchitectureLabel}"/>
 
-                <Label Grid.Column="0" Grid.Row="12" Content="{x:Static l:Resources.ConfigurationExtensionPathEnvVarLabel}"/>
+                <Label Grid.Column="0" Grid.Row="12"
+                       Name="PathEnvVarLabel"
+                       Content="{x:Static l:Resources.ConfigurationExtensionPathEnvVarLabel}"/>
                 <wpf:ConfigurationTextBoxWithHelp Grid.Column="0" Grid.Row="13"
                                                   Text="{Binding PathEnvironmentVariable,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}"
                                                   Watermark="{x:Static l:Resources.ConfigurationExtensionPathEnvVarWatermark}"
-                                                  HelpText="{x:Static l:Resources.ConfigurationExtensionPathEnvVarHelp}"/>
+                                                  HelpText="{x:Static l:Resources.ConfigurationExtensionPathEnvVarHelp}"
+                                                  AutomationProperties.LabeledBy="{Binding ElementName=PathEnvVarLabel}"/>
             </Grid>
         </ScrollViewer>
         

--- a/Python/Product/EnvironmentsList/EnvironmentPathsExtension.xaml
+++ b/Python/Product/EnvironmentsList/EnvironmentPathsExtension.xaml
@@ -39,7 +39,8 @@
                                     </Grid.ColumnDefinitions>
                                     <Control Grid.Column="0"
                                                     Margin="3 0"
-                                                    Style="{StaticResource PythonEnvironmentImage}" />
+                                                    Style="{StaticResource PythonEnvironmentImage}"
+                                             IsTabStop="False"/>
                                     <TextBlock Grid.Column="1"
                                                TextWrapping="WrapWithOverflow"
                                                Text="{x:Static l:Resources.EnvironmentPathsExtensionMakeDefaultLabel}"/>
@@ -57,7 +58,8 @@
 
                                     <ContentControl Grid.Column="0"
                                                     Margin="3 0"
-                                                    Style="{StaticResource ActiveEnvironmentImage}" />
+                                                    Style="{StaticResource ActiveEnvironmentImage}"
+                                                    IsTabStop="False"/>
                                     <TextBlock Grid.Column="1"
                                                TextWrapping="WrapWithOverflow"
                                                Text="{x:Static l:Resources.EnvironmentPathsExtensionIsDefaultLabel}"/>
@@ -75,7 +77,8 @@
                                     <ContentControl Grid.Column="0"
                                                     Margin="3 0"
                                                     Opacity="0.5"
-                                                    Style="{StaticResource PythonEnvironmentImage}" />
+                                                    Style="{StaticResource PythonEnvironmentImage}"
+                                                    IsTabStop="False"/>
                                     <TextBlock Grid.Column="1"
                                                TextWrapping="WrapWithOverflow"
                                                Text="{x:Static l:Resources.EnvironmentPathsExtensionCannotBeDefaultLabel}"/>
@@ -110,7 +113,8 @@
                                     </Grid.ColumnDefinitions>
                                     <Control Grid.Column="0"
                                              Margin="3 0"
-                                             Style="{StaticResource InteractiveWindowImage}" />
+                                             Style="{StaticResource InteractiveWindowImage}"
+                                             IsTabStop="False"/>
                                     <TextBlock Grid.Column="1"
                                                TextWrapping="WrapWithOverflow"
                                                Text="{x:Static l:Resources.EnvironmentPathsExtensionOpenInteractiveWindowLabel}"/>
@@ -130,7 +134,8 @@
                                     </Grid.ColumnDefinitions>
                                     <Control Grid.Column="0"
                                              Margin="3 0"
-                                             Style="{StaticResource SettingsImage}" />
+                                             Style="{StaticResource SettingsImage}"
+                                             IsTabStop="False"/>
                                     <TextBlock Grid.Column="1"
                                                TextWrapping="WrapWithOverflow"
                                                Text="{x:Static l:Resources.EnvironmentPathsExtensionOpenInteractiveScriptsLabel}"/>
@@ -156,7 +161,8 @@
                                     </Grid.ColumnDefinitions>
                                     <Control Grid.Column="0"
                                              Margin="3 0"
-                                             Style="{StaticResource CheckBoxUncheckedImage}" />
+                                             Style="{StaticResource CheckBoxUncheckedImage}"
+                                             IsTabStop="False"/>
                                     <TextBlock Grid.Column="1"
                                                TextWrapping="WrapWithOverflow"
                                                Text="{x:Static l:Resources.EnvironmentPathsExtensionEnableIPythonLabel}"/>
@@ -176,7 +182,8 @@
                                     </Grid.ColumnDefinitions>
                                     <Control Grid.Column="0"
                                              Margin="3 0"
-                                             Style="{StaticResource CheckBoxCheckedImage}" />
+                                             Style="{StaticResource CheckBoxCheckedImage}"
+                                             IsTabStop="False"/>
                                     <TextBlock Grid.Column="1"
                                                TextWrapping="WrapWithOverflow"
                                                Text="{x:Static l:Resources.EnvironmentPathsExtensionDisableIPythonLabel}"/>
@@ -197,7 +204,8 @@
                                     </Grid.ColumnDefinitions>
                                     <ContentControl Grid.Column="0"
                                                     Margin="3 0"
-                                                    Style="{StaticResource ConsoleImage}" />
+                                                    Style="{StaticResource ConsoleImage}"
+                                                    IsTabStop="False"/>
                                     <TextBlock Grid.Column="1"
                                                Text="{x:Static l:Resources.EnvironmentPathsExtensionOpenInPowerShell}"/>
                                 </Grid>
@@ -231,7 +239,8 @@
                                     </Grid.ColumnDefinitions>
                                     <ContentControl Grid.Column="0"
                                                     Margin="3 0"
-                                                    Style="{StaticResource SettingsImage}" />
+                                                    Style="{StaticResource SettingsImage}"
+                                                    IsTabStop="False"/>
                                     <TextBlock Grid.Column="1"
                                                TextWrapping="WrapWithOverflow"
                                                Text="{x:Static l:Resources.EnvironmentPathsExtensionConfigureEnvironmentLabel}"/>
@@ -253,7 +262,8 @@
                                     </Grid.ColumnDefinitions>
                                     <ContentControl Grid.Column="0"
                                                     Margin="3 0"
-                                                    Style="{StaticResource FolderClosedImage}" />
+                                                    Style="{StaticResource FolderClosedImage}"
+                                                    IsTabStop="False"/>
                                     <Label Grid.Column="1" Style="{StaticResource FileNameLabel}"
                                            Foreground="{Binding Foreground,RelativeSource={RelativeSource AncestorType=Button}}"
                                            Content="{Binding PrefixPath,Mode=OneWay}" />
@@ -288,7 +298,8 @@
                                     </Grid.ColumnDefinitions>
                                     <ContentControl Grid.Column="0"
                                                     Margin="3 0"
-                                                    Style="{StaticResource PythonConsoleApplicationImage}" />
+                                                    Style="{StaticResource PythonConsoleApplicationImage}"
+                                                    IsTabStop="False"/>
                                     <Label Grid.Column="1" Style="{StaticResource FileNameLabel}"
                                            Foreground="{Binding Foreground,RelativeSource={RelativeSource AncestorType=Button}}"
                                            Content="{Binding InterpreterPath,Mode=OneWay}" />
@@ -323,7 +334,8 @@
                                     </Grid.ColumnDefinitions>
                                     <ContentControl Grid.Column="0"
                                                     Margin="3 0"
-                                                    Style="{StaticResource PythonApplicationImage}" />
+                                                    Style="{StaticResource PythonApplicationImage}"
+                                                    IsTabStop="False"/>
                                     <Label Grid.Column="1" Style="{StaticResource FileNameLabel}"
                                            Foreground="{Binding Foreground,RelativeSource={RelativeSource AncestorType=Button}}"
                                            Content="{Binding WindowsInterpreterPath,Mode=OneWay}" />
@@ -369,7 +381,8 @@
                                     </Grid.ColumnDefinitions>
                                     <ContentControl Grid.Column="0"
                                                     Margin="3 0"
-                                                    Style="{StaticResource HelpImage}" />
+                                                    Style="{StaticResource HelpImage}"
+                                                    IsTabStop="False"/>
                                     <Label Grid.Column="1" Style="{StaticResource FileNameLabel}"
                                            Foreground="{Binding Foreground,RelativeSource={RelativeSource AncestorType=Button}}"
                                            Content="{x:Static l:Resources.EnvironmentPathsExtensionSupportInformationLabel}"/>

--- a/Python/Product/EnvironmentsList/EnvironmentPathsExtension.xaml
+++ b/Python/Product/EnvironmentsList/EnvironmentPathsExtension.xaml
@@ -38,8 +38,8 @@
                                         <ColumnDefinition />
                                     </Grid.ColumnDefinitions>
                                     <Control Grid.Column="0"
-                                                    Margin="3 0"
-                                                    Style="{StaticResource PythonEnvironmentImage}"
+                                             Margin="3 0"
+                                             Style="{StaticResource PythonEnvironmentImage}"
                                              IsTabStop="False"/>
                                     <TextBlock Grid.Column="1"
                                                TextWrapping="WrapWithOverflow"

--- a/Python/Product/EnvironmentsList/EnvironmentView.xaml
+++ b/Python/Product/EnvironmentsList/EnvironmentView.xaml
@@ -80,7 +80,7 @@
                             AutomationProperties.Name="{x:Static l:Resources.EnvironmentViewNeedRefreshAutomationName}"
                             AutomationProperties.HelpText="{x:Static l:Resources.EnvironmentViewNeedRefreshAutomationHelp}"
                             Visibility="Hidden">
-                        <Control Style="{StaticResource RefreshImage}" />
+                        <Control Style="{StaticResource RefreshImage}" IsTabStop="False" />
                     </Button>
 
                     <Button x:Name="InteractiveWindowButton"
@@ -92,7 +92,7 @@
                             CommandParameter="{Binding}"
                             ToolTip="{x:Static l:Resources.EnvironmentViewInteractiveWindowTooltip}"
                             AutomationProperties.Name="{x:Static l:Resources.EnvironmentViewInteractiveWindowAutomationName}">
-                        <Control Style="{StaticResource InteractiveWindowImage}" />
+                        <Control Style="{StaticResource InteractiveWindowImage}" IsTabStop="False" />
                     </Button>
                 </Grid>
 

--- a/Python/Product/EnvironmentsList/Resources.Designer.cs
+++ b/Python/Product/EnvironmentsList/Resources.Designer.cs
@@ -169,7 +169,7 @@ namespace Microsoft.PythonTools.EnvironmentsList {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Browse folder dialog for interpreter path.
+        ///   Looks up a localized string similar to Browse for interpreter path.
         /// </summary>
         public static string ConfigurationExtensionInterpreterPathBrowseButton {
             get {
@@ -268,7 +268,7 @@ namespace Microsoft.PythonTools.EnvironmentsList {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Browse folder dialog for prefix path.
+        ///   Looks up a localized string similar to Browse for prefix path.
         /// </summary>
         public static string ConfigurationExtensionPrefixPathBrowseButton {
             get {
@@ -340,7 +340,7 @@ namespace Microsoft.PythonTools.EnvironmentsList {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Browse folder dialog for windowed interpreter path.
+        ///   Looks up a localized string similar to Browse for windowed interpreter path.
         /// </summary>
         public static string ConfigurationExtensionWindowedInterpreterPathBrowseButton {
             get {

--- a/Python/Product/EnvironmentsList/Resources.Designer.cs
+++ b/Python/Product/EnvironmentsList/Resources.Designer.cs
@@ -169,7 +169,7 @@ namespace Microsoft.PythonTools.EnvironmentsList {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Browse for interpreter path.
+        ///   Looks up a localized string similar to Browse folder dialog for interpreter path.
         /// </summary>
         public static string ConfigurationExtensionInterpreterPathBrowseButton {
             get {
@@ -268,7 +268,7 @@ namespace Microsoft.PythonTools.EnvironmentsList {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Browse for prefix path.
+        ///   Looks up a localized string similar to Browse folder dialog for prefix path.
         /// </summary>
         public static string ConfigurationExtensionPrefixPathBrowseButton {
             get {
@@ -340,7 +340,7 @@ namespace Microsoft.PythonTools.EnvironmentsList {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Browse for windowed interpreter path.
+        ///   Looks up a localized string similar to Browse folder dialog for windowed interpreter path.
         /// </summary>
         public static string ConfigurationExtensionWindowedInterpreterPathBrowseButton {
             get {

--- a/Python/Product/EnvironmentsList/Resources.Designer.cs
+++ b/Python/Product/EnvironmentsList/Resources.Designer.cs
@@ -169,6 +169,15 @@ namespace Microsoft.PythonTools.EnvironmentsList {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Browse for interpreter path.
+        /// </summary>
+        public static string ConfigurationExtensionInterpreterPathBrowseButton {
+            get {
+                return ResourceManager.GetString("ConfigurationExtensionInterpreterPathBrowseButton", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Executable Files (*.exe)|*.exe|All Files (*.*)|*.*.
         /// </summary>
         public static string ConfigurationExtensionInterpreterPathBrowseFilter {
@@ -259,6 +268,15 @@ namespace Microsoft.PythonTools.EnvironmentsList {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Browse for prefix path.
+        /// </summary>
+        public static string ConfigurationExtensionPrefixPathBrowseButton {
+            get {
+                return ResourceManager.GetString("ConfigurationExtensionPrefixPathBrowseButton", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The prefix path specifies the directory containing all files needed for this environment. It may be used for searching installed libraries or deploying an environment to another machine..
         /// </summary>
         public static string ConfigurationExtensionPrefixPathHelp {
@@ -318,6 +336,15 @@ namespace Microsoft.PythonTools.EnvironmentsList {
         public static string ConfigurationExtensionResetTooltip {
             get {
                 return ResourceManager.GetString("ConfigurationExtensionResetTooltip", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Browse for windowed interpreter path.
+        /// </summary>
+        public static string ConfigurationExtensionWindowedInterpreterPathBrowseButton {
+            get {
+                return ResourceManager.GetString("ConfigurationExtensionWindowedInterpreterPathBrowseButton", resourceCulture);
             }
         }
         

--- a/Python/Product/EnvironmentsList/Resources.resx
+++ b/Python/Product/EnvironmentsList/Resources.resx
@@ -223,6 +223,9 @@
   <data name="ConfigurationExtensionPrefixPathLabel" xml:space="preserve">
     <value>Prefix path</value>
   </data>
+  <data name="ConfigurationExtensionPrefixPathBrowseButton" xml:space="preserve">
+    <value>Browse for prefix path</value>
+  </data>
   <data name="ConfigurationExtensionPrefixPathWatermark" xml:space="preserve">
     <value>e.g. C:\PythonXY</value>
   </data>
@@ -232,6 +235,9 @@
   <data name="ConfigurationExtensionInterpreterPathLabel" xml:space="preserve">
     <value>Interpreter path</value>
   </data>
+  <data name="ConfigurationExtensionInterpreterPathBrowseButton" xml:space="preserve">
+    <value>Browse for interpreter path</value>
+  </data>
   <data name="ConfigurationExtensionInterpreterPathWatermark" xml:space="preserve">
     <value>e.g. C:\PythonXY\python.exe</value>
   </data>
@@ -240,6 +246,9 @@
   </data>
   <data name="ConfigurationExtensionWindowedInterpreterPathLabel" xml:space="preserve">
     <value>Windowed interpreter</value>
+  </data>
+  <data name="ConfigurationExtensionWindowedInterpreterPathBrowseButton" xml:space="preserve">
+    <value>Browse for windowed interpreter path</value>
   </data>
   <data name="ConfigurationExtensionWindowedInterpreterPathWatermark" xml:space="preserve">
     <value>e.g. C:\PythonXY\pythonw.exe</value>

--- a/Python/Product/EnvironmentsList/Resources.resx
+++ b/Python/Product/EnvironmentsList/Resources.resx
@@ -224,7 +224,7 @@
     <value>Prefix path</value>
   </data>
   <data name="ConfigurationExtensionPrefixPathBrowseButton" xml:space="preserve">
-    <value>Browse folder dialog for prefix path</value>
+    <value>Browse for prefix path</value>
   </data>
   <data name="ConfigurationExtensionPrefixPathWatermark" xml:space="preserve">
     <value>e.g. C:\PythonXY</value>
@@ -236,7 +236,7 @@
     <value>Interpreter path</value>
   </data>
   <data name="ConfigurationExtensionInterpreterPathBrowseButton" xml:space="preserve">
-    <value>Browse folder dialog for interpreter path</value>
+    <value>Browse for interpreter path</value>
   </data>
   <data name="ConfigurationExtensionInterpreterPathWatermark" xml:space="preserve">
     <value>e.g. C:\PythonXY\python.exe</value>
@@ -248,7 +248,7 @@
     <value>Windowed interpreter</value>
   </data>
   <data name="ConfigurationExtensionWindowedInterpreterPathBrowseButton" xml:space="preserve">
-    <value>Browse folder dialog for windowed interpreter path</value>
+    <value>Browse for windowed interpreter path</value>
   </data>
   <data name="ConfigurationExtensionWindowedInterpreterPathWatermark" xml:space="preserve">
     <value>e.g. C:\PythonXY\pythonw.exe</value>

--- a/Python/Product/EnvironmentsList/Resources.resx
+++ b/Python/Product/EnvironmentsList/Resources.resx
@@ -224,7 +224,7 @@
     <value>Prefix path</value>
   </data>
   <data name="ConfigurationExtensionPrefixPathBrowseButton" xml:space="preserve">
-    <value>Browse for prefix path</value>
+    <value>Browse folder dialog for prefix path</value>
   </data>
   <data name="ConfigurationExtensionPrefixPathWatermark" xml:space="preserve">
     <value>e.g. C:\PythonXY</value>
@@ -236,7 +236,7 @@
     <value>Interpreter path</value>
   </data>
   <data name="ConfigurationExtensionInterpreterPathBrowseButton" xml:space="preserve">
-    <value>Browse for interpreter path</value>
+    <value>Browse folder dialog for interpreter path</value>
   </data>
   <data name="ConfigurationExtensionInterpreterPathWatermark" xml:space="preserve">
     <value>e.g. C:\PythonXY\python.exe</value>
@@ -248,7 +248,7 @@
     <value>Windowed interpreter</value>
   </data>
   <data name="ConfigurationExtensionWindowedInterpreterPathBrowseButton" xml:space="preserve">
-    <value>Browse for windowed interpreter path</value>
+    <value>Browse folder dialog for windowed interpreter path</value>
   </data>
   <data name="ConfigurationExtensionWindowedInterpreterPathWatermark" xml:space="preserve">
     <value>e.g. C:\PythonXY\pythonw.exe</value>

--- a/Python/Product/Profiling/Profiling/LaunchProfiling.xaml
+++ b/Python/Product/Profiling/Profiling/LaunchProfiling.xaml
@@ -31,8 +31,11 @@
                 <RowDefinition Height="auto" />
                 <RowDefinition Height="auto" />
             </Grid.RowDefinitions>
-                    
-            <Label Grid.Row="0" Content="{x:Static ui:Strings.LaunchProfiling_WhatToProfile}" Margin="6 12 6 0" FontWeight="Bold" />
+
+            <Label Grid.Row="0"
+                   Content="{x:Static ui:Strings.LaunchProfiling_WhatToProfile}"
+                   Margin="6 12 6 0"
+                   FontWeight="Bold"/>
 
             <RadioButton Grid.Row="1" Margin="12 12 12 4"
                          Content="{x:Static ui:Strings.LaunchProfiling_OpenProject}"
@@ -46,6 +49,7 @@
                       SelectedItem="{Binding Project}"
                       Margin="8 4" Padding="4 6" VerticalContentAlignment="Center"
                       DisplayMemberPath="Name"
+                      AutomationProperties.Name="{x:Static ui:Strings.LaunchProfiling_OpenProjectComboBoxDescription}"
                       AutomationProperties.AutomationId="Project" />
 
             <RadioButton Grid.Row="3" Margin="12 12 12 4"
@@ -67,17 +71,22 @@
                         <RowDefinition Height="auto" />
                         <RowDefinition Height="auto" />
                     </Grid.RowDefinitions>
-                    <Label Grid.Row="0" Grid.Column="0" Content="{x:Static ui:Strings.LaunchProfiling_PythonInterpreter}"
-                            Padding="0" VerticalAlignment="Center" />
+                    <Label Grid.Row="0" Grid.Column="0"
+                           Name="InterpreterLabel"
+                           Content="{x:Static ui:Strings.LaunchProfiling_PythonInterpreter}"
+                           Padding="0" VerticalAlignment="Center" />
                     <ComboBox Grid.Row="0" Grid.Column="1" Margin="4 4"
-                                ItemsSource="{Binding Standalone.AvailableInterpreters}"
-                                SelectedItem="{Binding Standalone.Interpreter,UpdateSourceTrigger=PropertyChanged}"
-                                IsEditable="False"
-                                DisplayMemberPath="Name"
-                                AutomationProperties.AutomationId="Standalone.Interpreter" />
+                              ItemsSource="{Binding Standalone.AvailableInterpreters}"
+                              SelectedItem="{Binding Standalone.Interpreter,UpdateSourceTrigger=PropertyChanged}"
+                              IsEditable="False"
+                              DisplayMemberPath="Name"
+                              AutomationProperties.LabeledBy="{Binding ElementName=InterpreterLabel}"
+                              AutomationProperties.AutomationId="Standalone.Interpreter" />
 
-                    <Label Grid.Row="1" Grid.Column="0" Content="{x:Static ui:Strings.LaunchProfiling_InterpreterPath}"
-                            Padding="0" VerticalAlignment="Center" />
+                    <Label Grid.Row="1" Grid.Column="0"
+                           Name="InterpreterPathLabel"
+                           Content="{x:Static ui:Strings.LaunchProfiling_InterpreterPath}"
+                           Padding="0" VerticalAlignment="Center" />
                     <Grid Grid.Row="1" Grid.Column="1" Margin="4"
                             IsEnabled="{Binding Standalone.CanSpecifyInterpreterPath}">
                         <Grid.ColumnDefinitions>
@@ -86,14 +95,18 @@
                         </Grid.ColumnDefinitions>
                         <TextBox Grid.Column="0" 
                                     Text="{Binding Standalone.InterpreterPath,UpdateSourceTrigger=PropertyChanged}"
+                                    AutomationProperties.LabeledBy="{Binding ElementName=InterpreterPathLabel}"
                                     AutomationProperties.AutomationId="Standalone.InterpreterPath" />
                         <Button Grid.Column="1" Margin="4 0 0 0" Content="{x:Static ui:Strings.LaunchProfiling_BrowseButton}"
                                 Click="FindInterpreterClick"
+                                AutomationProperties.Name="{x:Static ui:Strings.LaunchProfiling_InterpreterPathBrowseButtonDescription}"
                                 Width="{Binding RelativeSource={RelativeSource Self},Path=ActualHeight}" />
                     </Grid>
 
-                    <Label Grid.Row="2" Grid.Column="0" Content="{x:Static ui:Strings.LaunchProfiling_Script}"
-                            Padding="0" VerticalAlignment="Center" />
+                    <Label Grid.Row="2" Grid.Column="0"
+                           Name="ScriptLabel"
+                           Content="{x:Static ui:Strings.LaunchProfiling_Script}"
+                           Padding="0" VerticalAlignment="Center" />
                     <Grid Grid.Row="2" Grid.Column="1" Margin="4">
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="*" />
@@ -101,14 +114,18 @@
                         </Grid.ColumnDefinitions>
                         <TextBox Grid.Column="0" 
                                     Text="{Binding Standalone.ScriptPath,UpdateSourceTrigger=PropertyChanged}"
+                                    AutomationProperties.LabeledBy="{Binding ElementName=ScriptLabel}"
                                     AutomationProperties.AutomationId="Standalone.ScriptPath" />
                         <Button Grid.Column="1" Margin="4 0 0 0" Content="{x:Static ui:Strings.LaunchProfiling_BrowseButton}"
                                 Click="FindScriptClick"
+                                AutomationProperties.Name="{x:Static ui:Strings.LaunchProfiling_ScriptBrowseButtonDescription}"
                                 Width="{Binding RelativeSource={RelativeSource Self},Path=ActualHeight}" />
                     </Grid>
 
-                    <Label Grid.Row="3" Grid.Column="0" Content="{x:Static ui:Strings.LaunchProfiling_WorkingDirectory}"
-                            Padding="0" VerticalAlignment="Center" />
+                    <Label Grid.Row="3" Grid.Column="0"
+                           Name="WorkingDirectoryLabel"
+                           Content="{x:Static ui:Strings.LaunchProfiling_WorkingDirectory}"
+                           Padding="0" VerticalAlignment="Center" />
                     <Grid Grid.Row="3" Grid.Column="1" Margin="4">
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="*" />
@@ -116,16 +133,21 @@
                         </Grid.ColumnDefinitions>
                         <TextBox Grid.Column="0" 
                                     Text="{Binding Standalone.WorkingDirectory,UpdateSourceTrigger=PropertyChanged}" 
+                                    AutomationProperties.LabeledBy="{Binding ElementName=WorkingDirectoryLabel}"
                                     AutomationProperties.AutomationId="Standalone.WorkingDirectory" />
                         <Button Grid.Column="1" Margin="4 0 0 0" Content="{x:Static ui:Strings.LaunchProfiling_BrowseButton}" 
                                 Click="FindWorkingDirectoryClick"
+                                AutomationProperties.Name="{x:Static ui:Strings.LaunchProfiling_WorkingDirectoryBrowseButtonDescription}"
                                 Width="{Binding RelativeSource={RelativeSource Self},Path=ActualHeight}" />
                     </Grid>
 
-                    <Label Grid.Row="4" Grid.Column="0" Content="{x:Static ui:Strings.LaunchProfiling_CommandLineArguments}"
-                            Padding="0" VerticalAlignment="Center" />
+                    <Label Grid.Row="4" Grid.Column="0"
+                           Name="CommandLineArgumentsLabel"
+                           Content="{x:Static ui:Strings.LaunchProfiling_CommandLineArguments}"
+                           Padding="0" VerticalAlignment="Center" />
                     <TextBox Grid.Row="4" Grid.Column="1" Margin="4"
                                 Text="{Binding Standalone.Arguments,UpdateSourceTrigger=PropertyChanged}"
+                                AutomationProperties.LabeledBy="{Binding ElementName=CommandLineArgumentsLabel}"
                                 AutomationProperties.AutomationId="Standalone.Arguments" />
                 </Grid>
             </GroupBox>

--- a/Python/Product/Profiling/Strings.Designer.cs
+++ b/Python/Product/Profiling/Strings.Designer.cs
@@ -209,7 +209,7 @@ namespace Microsoft.PythonTools.Profiling {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Browse for interpreter path.
+        ///   Looks up a localized string similar to Browse file dialog for interpreter path.
         /// </summary>
         public static string LaunchProfiling_InterpreterPathBrowseButtonDescription {
             get {
@@ -236,7 +236,7 @@ namespace Microsoft.PythonTools.Profiling {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to List of projects.
+        ///   Looks up a localized string similar to Project to profile.
         /// </summary>
         public static string LaunchProfiling_OpenProjectComboBoxDescription {
             get {
@@ -272,7 +272,7 @@ namespace Microsoft.PythonTools.Profiling {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Browse for script.
+        ///   Looks up a localized string similar to Browse file dialog for script.
         /// </summary>
         public static string LaunchProfiling_ScriptBrowseButtonDescription {
             get {
@@ -335,7 +335,7 @@ namespace Microsoft.PythonTools.Profiling {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Browse for working directory.
+        ///   Looks up a localized string similar to Browse folder dialog for working directory.
         /// </summary>
         public static string LaunchProfiling_WorkingDirectoryBrowseButtonDescription {
             get {

--- a/Python/Product/Profiling/Strings.Designer.cs
+++ b/Python/Product/Profiling/Strings.Designer.cs
@@ -209,6 +209,15 @@ namespace Microsoft.PythonTools.Profiling {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Browse for interpreter path.
+        /// </summary>
+        public static string LaunchProfiling_InterpreterPathBrowseButtonDescription {
+            get {
+                return ResourceManager.GetString("LaunchProfiling_InterpreterPathBrowseButtonDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to _OK.
         /// </summary>
         public static string LaunchProfiling_OK {
@@ -223,6 +232,15 @@ namespace Microsoft.PythonTools.Profiling {
         public static string LaunchProfiling_OpenProject {
             get {
                 return ResourceManager.GetString("LaunchProfiling_OpenProject", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to List of projects.
+        /// </summary>
+        public static string LaunchProfiling_OpenProjectComboBoxDescription {
+            get {
+                return ResourceManager.GetString("LaunchProfiling_OpenProjectComboBoxDescription", resourceCulture);
             }
         }
         
@@ -250,6 +268,15 @@ namespace Microsoft.PythonTools.Profiling {
         public static string LaunchProfiling_Script {
             get {
                 return ResourceManager.GetString("LaunchProfiling_Script", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Browse for script.
+        /// </summary>
+        public static string LaunchProfiling_ScriptBrowseButtonDescription {
+            get {
+                return ResourceManager.GetString("LaunchProfiling_ScriptBrowseButtonDescription", resourceCulture);
             }
         }
         
@@ -304,6 +331,15 @@ namespace Microsoft.PythonTools.Profiling {
         public static string LaunchProfiling_WorkingDirectory {
             get {
                 return ResourceManager.GetString("LaunchProfiling_WorkingDirectory", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Browse for working directory.
+        /// </summary>
+        public static string LaunchProfiling_WorkingDirectoryBrowseButtonDescription {
+            get {
+                return ResourceManager.GetString("LaunchProfiling_WorkingDirectoryBrowseButtonDescription", resourceCulture);
             }
         }
         

--- a/Python/Product/Profiling/Strings.resx
+++ b/Python/Product/Profiling/Strings.resx
@@ -277,15 +277,15 @@ Error:
     <value>_Start</value>
   </data>
   <data name="LaunchProfiling_InterpreterPathBrowseButtonDescription" xml:space="preserve">
-    <value>Browse for interpreter path</value>
+    <value>Browse file dialog for interpreter path</value>
   </data>
   <data name="LaunchProfiling_OpenProjectComboBoxDescription" xml:space="preserve">
-    <value>List of projects</value>
+    <value>Project to profile</value>
   </data>
   <data name="LaunchProfiling_ScriptBrowseButtonDescription" xml:space="preserve">
-    <value>Browse for script</value>
+    <value>Browse file dialog for script</value>
   </data>
   <data name="LaunchProfiling_WorkingDirectoryBrowseButtonDescription" xml:space="preserve">
-    <value>Browse for working directory</value>
+    <value>Browse folder dialog for working directory</value>
   </data>
 </root>

--- a/Python/Product/Profiling/Strings.resx
+++ b/Python/Product/Profiling/Strings.resx
@@ -276,4 +276,16 @@ Error:
   <data name="LaunchProfiling_Start" xml:space="preserve">
     <value>_Start</value>
   </data>
+  <data name="LaunchProfiling_InterpreterPathBrowseButtonDescription" xml:space="preserve">
+    <value>Browse for interpreter path</value>
+  </data>
+  <data name="LaunchProfiling_OpenProjectComboBoxDescription" xml:space="preserve">
+    <value>List of projects</value>
+  </data>
+  <data name="LaunchProfiling_ScriptBrowseButtonDescription" xml:space="preserve">
+    <value>Browse for script</value>
+  </data>
+  <data name="LaunchProfiling_WorkingDirectoryBrowseButtonDescription" xml:space="preserve">
+    <value>Browse for working directory</value>
+  </data>
 </root>


### PR DESCRIPTION
Fixes #2234 No screen reader output when tabbing through New Environment Config Form UI
Fixes similar bug in the profiling dialog

This uses the AutomationProperties.LabeledBy attribute to associate a control with its label.  When tabbing to the control, the label is now read by narrator.

This also sets AutomationProperties.Name on the browse buttons so that for example narrator reads "Browse for interpreter path" followed by "button" instead of just reading "button" (because the button text is `...` which is not read).

Prevents options pane from receiving focus, as it's a container and non-interactive.

Prevent focus from going to images in labels and buttons in environments window.