### PR TITLE
Fixes #2381 VS crashed after new python project

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Intellisense/ProjectAnalyzer.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/ProjectAnalyzer.cs
@@ -728,6 +728,9 @@ namespace Microsoft.PythonTools.Intellisense {
             }
 
             string path = GetFilePath(textBuffer);
+            if (string.IsNullOrEmpty(path)) {
+                return null;
+            }
 
             AnalysisEntry entry;
             if (!_projectFiles.TryGetValue(path, out entry)) {
@@ -769,6 +772,9 @@ namespace Microsoft.PythonTools.Intellisense {
                 // We aren't able to analyze code, so don't create an entry.
                 return null;
             }
+            if (string.IsNullOrEmpty(path)) {
+                return null;
+            }
 
             AnalysisEntry res;
             if (!_projectFiles.TryGetValue(path, out res)) {
@@ -800,7 +806,9 @@ namespace Microsoft.PythonTools.Intellisense {
             AnalysisEntry[] res = new AnalysisEntry[paths.Length];
             for (int i = 0; i < paths.Length; ++i) {
                 AnalysisEntry existing;
-                if (_projectFiles.TryGetValue(paths[i], out existing)) {
+                if (string.IsNullOrEmpty(paths[i])) {
+                    res[i] = null;
+                } else if (_projectFiles.TryGetValue(paths[i], out existing)) {
                     res[i] = existing;
                 } else {
                     anyAdded = true;
@@ -816,7 +824,7 @@ namespace Microsoft.PythonTools.Intellisense {
                         AnalysisEntry entry = null;
                         var path = paths[i];
                         var id = response.fileId[i];
-                        if (id != -1 && !_projectFilesById.TryGetValue(id, out entry)) {
+                        if (!string.IsNullOrEmpty(path) && id != -1 && !_projectFilesById.TryGetValue(id, out entry)) {
                             entry = _projectFilesById[id] = _projectFiles[path] = new AnalysisEntry(this, path, id);
                             entry.AnalysisCookie = new FileCookie(path);
                         }
@@ -831,7 +839,7 @@ namespace Microsoft.PythonTools.Intellisense {
 
         internal AnalysisEntry GetAnalysisEntryFromPath(string path) {
             AnalysisEntry res;
-            if (_projectFiles.TryGetValue(path, out res)) {
+            if (!string.IsNullOrEmpty(path) && _projectFiles.TryGetValue(path, out res)) {
                 return res;
             }
             return null;


### PR DESCRIPTION
Fixes #2381 VS crashed after new python project
Ensures strings are not null or empty before using as dictionary keys.