### PR TITLE
Fixes #2395 VSHPROPID_Name should not return caption

### DIFF
--- a/Common/Product/SharedProject/FileNode.cs
+++ b/Common/Product/SharedProject/FileNode.cs
@@ -177,9 +177,11 @@ namespace Microsoft.VisualStudioTools.Project {
             }
         }
 
-#endregion
+        public override string Name => CommonUtils.GetFileOrDirectoryName(ItemNode.Url);
 
-#region ctor
+        #endregion
+
+        #region ctor
 #if !DEV14_OR_LATER
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1810:InitializeReferenceTypeStaticFieldsInline")]
         static FileNode() {

--- a/Common/Product/SharedProject/FolderNode.cs
+++ b/Common/Product/SharedProject/FolderNode.cs
@@ -60,6 +60,8 @@ namespace Microsoft.VisualStudioTools.Project {
             }
         }
 
+        public override string Name => CommonUtils.GetFileOrDirectoryName(ItemNode.Url);
+
         public override int SortPriority {
             get { return DefaultSortOrderNode.FolderNode; }
         }

--- a/Common/Product/SharedProject/HierarchyNode.cs
+++ b/Common/Product/SharedProject/HierarchyNode.cs
@@ -74,6 +74,8 @@ namespace Microsoft.VisualStudioTools.Project {
             get;
         }
 
+        public virtual string Name => Caption;
+
         /// <summary>
         /// The Caption of the node.
         /// </summary>
@@ -591,7 +593,7 @@ namespace Microsoft.VisualStudioTools.Project {
                     break;
 
                 case __VSHPROPID.VSHPROPID_Name:
-                    result = this.Caption;
+                    result = Name;
                     break;
 
                 case __VSHPROPID.VSHPROPID_ExpandByDefault:


### PR DESCRIPTION
Fixes #2395 VSHPROPID_Name should not return caption
Adds Name property to allow overriding node names.
Override name by default for files and folders.