### PR TITLE
Fixes and tests for IPC JSON

### DIFF
--- a/Python/Product/Ipc.Json/Ipc.Json.csproj
+++ b/Python/Product/Ipc.Json/Ipc.Json.csproj
@@ -59,6 +59,7 @@
     <Compile Include="Request.cs" />
     <Compile Include="RequestArgs.cs" />
     <Compile Include="Response.cs" />
+    <Compile Include="ProtocolReader.cs" />
   </ItemGroup>
   <Import Project="..\ProjectAfter.settings" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/Python/Product/Ipc.Json/Properties/AssemblyInfo.cs
+++ b/Python/Product/Ipc.Json/Properties/AssemblyInfo.cs
@@ -15,6 +15,7 @@
 // permissions and limitations under the License.
 
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 [assembly: AssemblyTitle("Visual Studio - Python JSON interprocess communication")]
@@ -22,3 +23,5 @@ using System.Runtime.InteropServices;
 
 [assembly: ComVisible(false)]
 [assembly: Guid("e1e1613d-0c96-42f9-9f2d-052c72533297")]
+
+[assembly: InternalsVisibleTo("IpcJsonTests, PublicKey=002400000480000094000000060200000024000052534131000400000100010007d1fa57c4aed9f0a32e84aa0faefd0de9e8fd6aec8f87fb03766c834c99921eb23be79ad9d5dcc1dd9ad236132102900b723cf980957fc4e177108fc607774f29e8320e92ea05ece4e821c0a5efe8f1645c4c0c93c1ab99285d622caa652c1dfad63d745d6f2de5f17e5eaf0fc4963d261c8a12436518206dc093344d5ad293")]

--- a/Python/Product/Ipc.Json/ProtocolReader.cs
+++ b/Python/Product/Ipc.Json/ProtocolReader.cs
@@ -1,0 +1,121 @@
+﻿// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABLITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.PythonTools.Ipc.Json {
+    class ProtocolReader {
+        private Stream _stream;
+        private List<byte> _buffer = new List<byte>();
+
+        public ProtocolReader(Stream stream) {
+            if (stream == null) {
+                throw new ArgumentNullException(nameof(stream));
+            }
+            _stream = stream;
+        }
+
+        /// <summary>
+        /// Reads an ASCII encoded header line asynchronously from the current stream
+        /// and returns the data as a string. Line termination chars are '\r\n' and
+        /// are excluded from the return value. Keeps reading until it finds it, even
+        /// when there is no data no the stream. The only way to unblock it is to
+        /// dispose of the stream.
+        /// </summary>
+        public async Task<string> ReadHeaderLineAsync() {
+            // Keep reading into the buffer until it contains the '\r\n'.
+            int searchStartPos = 0;
+            int newLineIndex;
+            while ((newLineIndex = IndexOfNewLineInBuffer(searchStartPos)) < 0) {
+                searchStartPos = Math.Max(0, _buffer.Count - 1);
+
+                // Keep reading until we get data
+                int readCount;
+                while ((readCount = await ReadIntoBuffer()) == 0) {
+                }
+            }
+
+            var line = _buffer.Take(newLineIndex).ToArray();
+            _buffer.RemoveRange(0, newLineIndex + 2);
+            var text = Encoding.ASCII.GetString(line);
+            return text;
+        }
+
+        /// <summary>
+        /// Reads all bytes from the current position to the end of the
+        /// stream asynchronously.
+        /// </summary>
+        public async Task<byte[]> ReadToEndAsync() {
+            int read;
+            while ((read = await ReadIntoBuffer()) > 0) {
+            }
+
+            var all = _buffer.ToArray();
+            _buffer.Clear();
+            return all;
+        }
+
+        /// <summary>
+        /// Reads a number of bytes asynchronously from the current stream.
+        /// </summary>
+        /// <param name="byteCount">Number of bytes to read.</param>
+        /// <remarks>
+        /// May return fewer bytes than requested.
+        /// </remarks>
+        public async Task<byte[]> ReadContentAsync(int byteCount) {
+            if (byteCount < 0) {
+                throw new ArgumentOutOfRangeException(nameof(byteCount), byteCount, "Value cannot be negative.");
+            }
+
+            while (_buffer.Count < byteCount) {
+                var addedByteCount = await ReadIntoBuffer();
+                if (addedByteCount == 0) {
+                    break;
+                }
+            }
+
+            var actualCount = Math.Min(byteCount, _buffer.Count);
+            var result = _buffer.Take(actualCount).ToArray();
+            _buffer.RemoveRange(0, actualCount);
+            return result;
+        }
+
+        private int IndexOfNewLineInBuffer(int searchStartPos) {
+            for (int i = searchStartPos; i < _buffer.Count - 1; i++) {
+                if (_buffer[i] == 13 && _buffer[i + 1] == 10) {
+                    return i;
+                }
+            }
+            return -1;
+        }
+
+        /// <summary>
+        /// Reads bytes from the stream into the buffer, in chunks.
+        /// </summary>
+        /// <returns>Number of bytes that were added to the buffer.</returns>
+        private async Task<int> ReadIntoBuffer() {
+            var temp = new byte[1024];
+            var read = await _stream.ReadAsync(temp, 0, temp.Length);
+            _buffer.AddRange(temp.Take(read).ToArray());
+            return read;
+        }
+    }
+}

--- a/Python/Product/TestAdapter/visualstudio_py_testlauncher.py
+++ b/Python/Product/TestAdapter/visualstudio_py_testlauncher.py
@@ -36,6 +36,7 @@ if sys.version_info[0] < 3:
     else:
         from io import open
 
+import visualstudio_py_ipcjson as _vsipc
 
 class _TestOutput(object):
     """file like object which redirects output to the repl window."""
@@ -101,23 +102,9 @@ class _TestOutputBuffer(object):
     def seek(self, pos, whence = 0):
         return self.buffer.seek(pos, whence)
 
-class _IpcChannel(object):
+class _IpcChannel(_vsipc.SocketIO, _vsipc.IpcChannel):
     def __init__(self, socket):
-        self.socket = socket
-        self.seq = 0
-        self.lock = thread.allocate_lock()
-
-    def close(self):
-        self.socket.close()
-
-    def send_event(self, name, **args):
-        with self.lock:
-            body = {'type': 'event', 'seq': self.seq, 'event':name, 'body':args}
-            self.seq += 1
-            content = json.dumps(body).encode('utf-8')
-            headers = ('Content-Length: %d\r\n\r\n' % (len(content), )).encode('ascii')
-            self.socket.send(headers)
-            self.socket.send(content)
+        super(_IpcChannel, self).__init__(socket=socket)
 
 _channel = None
 

--- a/Python/Product/TestAdapter/visualstudio_py_testlauncher.py
+++ b/Python/Product/TestAdapter/visualstudio_py_testlauncher.py
@@ -114,8 +114,8 @@ class _IpcChannel(object):
         with self.lock:
             body = {'type': 'event', 'seq': self.seq, 'event':name, 'body':args}
             self.seq += 1
-            content = json.dumps(body).encode('utf8')
-            headers = ('Content-Length: %d\n\n' % (len(content), )).encode('utf8')
+            content = json.dumps(body).encode('utf-8')
+            headers = ('Content-Length: %d\r\n\r\n' % (len(content), )).encode('ascii')
             self.socket.send(headers)
             self.socket.send(content)
 

--- a/Python/Tests/IpcJsonTests/IpcJsonTests.csproj
+++ b/Python/Tests/IpcJsonTests/IpcJsonTests.csproj
@@ -47,8 +47,13 @@
       <RequiredTargetFramework>3.5</RequiredTargetFramework>
     </Reference>
     <Reference Include="System.XML" />
+    <Reference Include="Newtonsoft.Json">
+      <HintPath>$(PackagesPath)\Newtonsoft.Json\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="PacketReadTests.cs" />
     <Compile Include="IpcJsonTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/Python/Tests/IpcJsonTests/PacketReadTests.cs
+++ b/Python/Tests/IpcJsonTests/PacketReadTests.cs
@@ -1,4 +1,4 @@
-// Python Tools for Visual Studio
+﻿// Python Tools for Visual Studio
 // Copyright(c) Microsoft Corporation
 // All rights reserved.
 //
@@ -24,27 +24,137 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace IpcJsonTests {
     [TestClass]
     public class PacketReadTests {
-        [TestMethod, Priority(1)]
-        public async Task ReadPacket() {
-            string data = @"Content-Length: 135
+        private const string validJson1 = @"{'request_seq':1,'success':true,'command':'initialize','message':null,'body':{'failedLoads':[],'error':null},'type':'response','seq':2}";
+        private const string validJson2 = @"{'event':'childFileAnalyzed','body':{'filename':'C:\\Projects\\RemoteDebugApp\\RemoteDebugApp.py','fileId':1,'isTemporaryFile':false,'suppressErrorList':false},'type':'event','seq':5}";
+        private const string validUtf8Json1 = @"{'event':'childFileAnalyzed','body':{'filename':'C:\\Projects\\RemoteDebugApp\\この文は、テストです。私はこれがうまく願っています。.py','fileId':1,'isTemporaryFile':false,'suppressErrorList':false},'type':'event','seq':5}";
+        private const string validUtf8Json2 = @"{'event':'childFileAnalyzed','body':{'filename':'C:\\Projects\\RemoteDebugApp\\é.py','fileId':1,'isTemporaryFile':false,'suppressErrorList':false},'type':'event','seq':5}";
 
-{'request_seq':1,'success':true,'command':'initialize','message':null,'body':{'failedLoads':[],'error':null},'type':'response','seq':2}";
-            using (var stream = new MemoryStream(UTF8Encoding.Default.GetBytes(data)))
-            using (var reader = new StreamReader(stream)) {
-                var packet = await Connection.ReadPacketAsJObject(reader);
+        [TestMethod, Priority(1)]
+        public async Task ValidPackets() {
+            await ReadValidPacket(MakePacketFromJson(validJson1));
+            await ReadValidPacket(MakePacketFromJson(validJson2));
+        }
+
+        [TestMethod, Priority(1)]
+        public async Task ValidUnicodePackets() {
+            await ReadValidPacket(MakePacketFromJson(validUtf8Json1));
+            await ReadValidPacket(MakePacketFromJson(validUtf8Json2));
+        }
+
+        [TestMethod, Priority(1)]
+        public async Task TruncatedJson() {
+            // Valid packet, but the json is invalid because it's truncated
+            for (int i = 1; i < validJson1.Length; i++) {
+                await ReadInvalidPacket(MakePacketFromJson(validJson1.Substring(0, validJson1.Length - i)));
             }
         }
 
-        //{"request_seq":1,"success":true,"command":"initialize","message":null,"body":{"failedLoads":[],"error":null},"type":"response","seq":2}
-        //{"event":"childFileAnalyzed","body":{"filename":"C:\\Users\\huvalo\\RemoteDebugApp\\RemoteDebugApp.py","fileId":1,"isTemporaryFile":false,"suppressErrorList":false},"type":"event","seq":5}
+        [TestMethod, Priority(1)]
+        public async Task IncorrectContentLengthUnderread() {
+            // Full json is in the stream, but the header was corrupted and the
+            // Content-Length value is SMALLER than it should be, so the packet body
+            // will miss parts of the json at the end.
+            for (int i = 1; i < validJson1.Length; i++) {
+                var json = MakeBody(validJson1);
+                var headers = MakeHeaders(i);
+                await ReadInvalidPacket(MakePacket(headers, json));
+            }
+        }
 
-        private static byte[] MakeValidPacket(string json) {
-            var encoded = UTF8Encoding.Default.GetBytes(json);
-            var header = UTF8Encoding.Default.GetBytes(string.Format("Content-Length: {0}", encoded.Length));
-            var packet = new byte[header.Length + encoded.Length];
-            Array.Copy(header, packet, header.Length);
-            Array.Copy(encoded, 0, packet, header.Length, encoded.Length);
-            return packet;
+        [TestMethod, Priority(1)]
+        public async Task IncorrectContentLengthOverread() {
+            // Full json is in the stream, but the header was corrupted and the
+            // Content-Length value is LARGER than it should be, so the packet body
+            // will include junk at the end from the next message.
+            var endJunk = MakeHeaders(5);
+            for (int i = 1; i < endJunk.Length; i++) {
+                var json = MakeBody(validJson1);
+                var headers = MakeHeaders(json.Length + i);
+                await ReadInvalidPacket(MakePacket(headers, json, endJunk));
+            }
+        }
+
+        [TestMethod, Priority(1)]
+        public async Task IncorrectContentLengthOverreadEndOfStream() {
+            // Full json is in the stream, but the header was corrupted and the
+            // Content-Length value is LARGER than it should be, and there's no
+            // more data in the stream after this.
+            for (int i = 1; i < 5; i++) {
+                var json = MakeBody(validJson1);
+                var headers = MakeHeaders(json.Length + i);
+                await ReadInvalidPacket(MakePacket(headers, json));
+            }
+        }
+
+        [TestMethod, Priority(1)]
+        public async Task InvalidContentLengthType() {
+            var body = MakeBody(validJson1);
+            await ReadInvalidPacket(MakePacket(Encoding.UTF8.GetBytes("Content-Length: 2147483649\r\n\r\n"), body));
+            await ReadInvalidPacket(MakePacket(Encoding.UTF8.GetBytes("Content-Length: -1\r\n\r\n"), body));
+            await ReadInvalidPacket(MakePacket(Encoding.UTF8.GetBytes("Content-Length: BAD\r\n\r\n"), body));
+        }
+
+        [TestMethod, Priority(1)]
+        public async Task MissingContentLength() {
+            var body = MakeBody(validJson1);
+            await ReadInvalidPacket(MakePacket(Encoding.UTF8.GetBytes("From: Test\r\n\r\n"), body));
+        }
+
+        [TestMethod, Priority(1)]
+        public async Task MalformedHeader() {
+            var body = MakeBody(validJson1);
+            await ReadInvalidPacket(MakePacket(Encoding.UTF8.GetBytes("Content-Length\r\n\r\n"), body));
+        }
+
+        [TestMethod, Priority(1)]
+        public async Task AdditionalHeaders() {
+            // Other headers are fine, we only care that Content-Length is there and valid
+            var body = MakeBody(validJson1);
+            await ReadValidPacket(MakePacket(Encoding.UTF8.GetBytes(string.Format("From: Test\r\nContent-Length:{0}\r\nTo: You\r\n\r\n", body.Length)), body));
+        }
+
+        private static async Task ReadValidPacket(Stream stream) {
+            var reader = new ProtocolReader(stream);
+            var packet = await Connection.ReadPacketAsJObject(reader);
+            Assert.IsNotNull(packet);
+        }
+
+        private static async Task ReadInvalidPacket(Stream stream) {
+            var reader = new ProtocolReader(stream);
+            try {
+                var packet = await Connection.ReadPacketAsJObject(reader);
+                Assert.IsNotNull(packet);
+                Assert.Fail("Failed to raise InvalidDataException.");
+            } catch (InvalidDataException) {
+            }
+        }
+
+        private static Stream MakePacketFromJson(string json) {
+            var encoded = MakeBody(json);
+            var headers = MakeHeaders(encoded.Length);
+
+            return MakePacket(headers, encoded);
+        }
+
+        private static Stream MakePacket(byte[] headers, byte[] encoded, byte[] endJunk = null) {
+            var stream = new MemoryStream();
+            stream.Write(headers, 0, headers.Length);
+            stream.Write(encoded, 0, encoded.Length);
+            if (endJunk != null) {
+                stream.Write(endJunk, 0, endJunk.Length);
+            }
+            stream.Flush();
+            stream.Seek(0, SeekOrigin.Begin);
+
+            return stream;
+        }
+
+        private static byte[] MakeBody(string json) {
+            return Encoding.UTF8.GetBytes(json);
+        }
+
+        private static byte[] MakeHeaders(int contentLength) {
+            return Encoding.ASCII.GetBytes(string.Format("Content-Length: {0}\r\n\r\n", contentLength));
         }
     }
 }

--- a/Python/Tests/IpcJsonTests/PacketReadTests.cs
+++ b/Python/Tests/IpcJsonTests/PacketReadTests.cs
@@ -1,0 +1,50 @@
+// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABLITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.PythonTools.Ipc.Json;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace IpcJsonTests {
+    [TestClass]
+    public class PacketReadTests {
+        [TestMethod, Priority(1)]
+        public async Task ReadPacket() {
+            string data = @"Content-Length: 135
+
+{'request_seq':1,'success':true,'command':'initialize','message':null,'body':{'failedLoads':[],'error':null},'type':'response','seq':2}";
+            using (var stream = new MemoryStream(UTF8Encoding.Default.GetBytes(data)))
+            using (var reader = new StreamReader(stream)) {
+                var packet = await Connection.ReadPacketAsJObject(reader);
+            }
+        }
+
+        //{"request_seq":1,"success":true,"command":"initialize","message":null,"body":{"failedLoads":[],"error":null},"type":"response","seq":2}
+        //{"event":"childFileAnalyzed","body":{"filename":"C:\\Users\\huvalo\\RemoteDebugApp\\RemoteDebugApp.py","fileId":1,"isTemporaryFile":false,"suppressErrorList":false},"type":"event","seq":5}
+
+        private static byte[] MakeValidPacket(string json) {
+            var encoded = UTF8Encoding.Default.GetBytes(json);
+            var header = UTF8Encoding.Default.GetBytes(string.Format("Content-Length: {0}", encoded.Length));
+            var packet = new byte[header.Length + encoded.Length];
+            Array.Copy(header, packet, header.Length);
+            Array.Copy(encoded, 0, packet, header.Length, encoded.Length);
+            return packet;
+        }
+    }
+}

--- a/Python/Tests/TestData/Ipc.Json/socket_handle_request.py
+++ b/Python/Tests/TestData/Ipc.Json/socket_handle_request.py
@@ -15,6 +15,7 @@ class SocketIpcChannel(_ipc.SocketIO, _ipc.IpcChannel):
             request,
             success=True,
             message='',
+            requestText=args['dataText'],
             responseText='test response text'
         )
 


### PR DESCRIPTION
Add lower-level tests for the reading of packets on C# side, fix issues discovered and refactor as necessary for tests.

Change the protocol to be closer to the VSC base protocol (ascii headers, `\r\n` separators).

The new reading code no longer allocates a char array based on the value of Content-Length, which could have caused out of memory errors if that value was incorrect.  In the new code an incorrect large value won't cause as much damage.

Fixes https://github.com/Microsoft/PTVS/issues/2402
