### PR TITLE
Some accessibility fixes for pip package view

### DIFF
--- a/Python/Product/EnvironmentsList/PipExtension.xaml
+++ b/Python/Product/EnvironmentsList/PipExtension.xaml
@@ -41,7 +41,7 @@
 
                             <Button Grid.Column="2"
                                     VerticalAlignment="Center"
-                                    Focusable="False"
+                                    Focusable="True"
                                     Margin="4"
                                     Cursor="Hand"
                                     Command="{x:Static l:PipExtension.UpgradePackage}"
@@ -87,7 +87,7 @@
 
                             <Button Grid.Column="3"
                                     VerticalAlignment="Center"
-                                    Focusable="False"
+                                    Focusable="True"
                                     Margin="4"
                                     Cursor="Hand"
                                     Command="{x:Static l:PipExtension.UninstallPackage}"

--- a/Python/Product/EnvironmentsList/PipExtension.xaml
+++ b/Python/Product/EnvironmentsList/PipExtension.xaml
@@ -29,7 +29,8 @@
                             
                             <Control Grid.Column="0"
                                      Margin="4 2 2 2"
-                                     Style="{StaticResource PythonPackageImage}" />
+                                     Style="{StaticResource PythonPackageImage}"
+                                     Focusable="False"/>
                             
                             <Grid Grid.Column="1"
                                   Margin="2"
@@ -222,7 +223,8 @@
                          Margin="2"
                          Background="Transparent"
                          BorderBrush="Transparent"
-                         Text="{Binding SearchQuery,UpdateSourceTrigger=PropertyChanged}">
+                         Text="{Binding SearchQuery,UpdateSourceTrigger=PropertyChanged}"
+                         AutomationProperties.Name="{x:Static l:Resources.PipExtensionSearchPyPILabel}">
                     <TextBox.InputBindings>
                         <KeyBinding Key="Escape" Command="ApplicationCommands.Delete" CommandTarget="{Binding ElementName=SearchQueryText}" />
                         <KeyBinding Key="Return" Command="{x:Static l:PipExtension.InstallPackage}" CommandParameter="{Binding Text,ElementName=SearchQueryText}" />
@@ -278,7 +280,8 @@
                 <ListBox ItemsSource="{Binding InstalledPackages}" />
                 <ContentControl Content="{Binding InstallCommand}"
                                 HorizontalAlignment="Stretch"
-                                PreviewMouseWheel="ForwardMouseWheel" />
+                                PreviewMouseWheel="ForwardMouseWheel"
+                                Focusable="False"/>
                 <ListBox ItemsSource="{Binding InstallablePackages}" />
             </StackPanel>
         </ScrollViewer>


### PR DESCRIPTION
404497 Accessibility : MAS40B : INSPECT : Python+ Python Environments : Name property for the Search edit in Packages window is null
404519 Accessibility : MAS36 : Keyboard : 'Delete(X)' and 'Upgrade To set up tools(Up Arrow mark) buttons are not accessible in Packages window of Python Environment
