### PR TITLE
Fixes #2352 Intellisense hangs VS when interacting with filepath that contains many files

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Intellisense/IntellisenseController.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/IntellisenseController.cs
@@ -258,9 +258,10 @@ namespace Microsoft.PythonTools.Intellisense {
                 var sigHelpSession = Volatile.Read(ref _sigHelpSession);
                 var literalSpan = GetStringLiteralSpan();
                 if (literalSpan.HasValue &&
-                    ShouldTriggerStringCompletionSession(prefs, literalSpan.Value) &&
+                    // UNDONE: Do not automatically trigger file path completions github#2352
+                    //ShouldTriggerStringCompletionSession(prefs, literalSpan.Value) &&
                     (session?.IsDismissed ?? true)) {
-                    TriggerCompletionSession(false);
+                    //TriggerCompletionSession(false);
                     return;
                 }
 


### PR DESCRIPTION
Fixes #2352 Intellisense hangs VS when interacting with filepath that contains many files
Filters by partial name once items exceed 10000
Since the completion is synchronous and the disk IO causes the hang, we also disable automatic triggering for paths. You now need to Ctrl+Space/J to trigger completions in a string literal.