### PR TITLE
Fixes #2447 Opening the Python Environments tab causes VS 2017 to crash

### DIFF
--- a/Python/Product/Common/Infrastructure/PathUtils.cs
+++ b/Python/Product/Common/Infrastructure/PathUtils.cs
@@ -60,6 +60,9 @@ namespace Microsoft.PythonTools.Infrastructure {
         /// <summary>
         /// Normalizes and returns the provided path.
         /// </summary>
+        /// <exception cref="ArgumentException">
+        /// If the provided path contains invalid characters.
+        /// </exception>
         public static string NormalizePath(string path) {
             if (string.IsNullOrEmpty(path)) {
                 return string.Empty;

--- a/Python/Product/PythonTools/PythonTools/Repl/PythonInteractiveEvaluator.cs
+++ b/Python/Product/PythonTools/PythonTools/Repl/PythonInteractiveEvaluator.cs
@@ -459,14 +459,19 @@ namespace Microsoft.PythonTools.Repl {
             // TODO: Allow customizing the scripts path
             //var root = _serviceProvider.GetPythonToolsService().InteractiveOptions.ScriptsPath;
             string root;
-            if (!provider.TryGetShellProperty((__VSSPROPID)__VSSPROPID2.VSSPROPID_VisualStudioDir, out root)) {
-                root = PathUtils.GetAbsoluteDirectoryPath(
-                    Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments),
-                    "Visual Studio {0}".FormatInvariant(AssemblyVersionInfo.VSName)
-                );
-            }
+            try {
+                if (!provider.TryGetShellProperty((__VSSPROPID)__VSSPROPID2.VSSPROPID_VisualStudioDir, out root)) {
+                    root = PathUtils.GetAbsoluteDirectoryPath(
+                        Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments),
+                        "Visual Studio {0}".FormatInvariant(AssemblyVersionInfo.VSName)
+                    );
+                }
 
-            root = PathUtils.GetAbsoluteDirectoryPath(root, "Python Scripts");
+                root = PathUtils.GetAbsoluteDirectoryPath(root, "Python Scripts");
+            } catch (ArgumentException ex) {
+                ex.ReportUnhandledException(provider, typeof(PythonInteractiveEvaluator));
+                return null;
+            }
 
             string candidate;
             if (!string.IsNullOrEmpty(displayName)) {

--- a/Python/Product/VSInterpreters/PythonRegistrySearch.cs
+++ b/Python/Product/VSInterpreters/PythonRegistrySearch.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -136,9 +137,15 @@ namespace Microsoft.PythonTools.Interpreter {
                 return null;
             }
 
-            var prefixPath = PathUtils.NormalizePath(installKey.GetValue(null) as string);
-            var exePath = PathUtils.NormalizePath(installKey.GetValue("ExecutablePath") as string);
-            var exewPath = PathUtils.NormalizePath(installKey.GetValue("WindowedExecutablePath") as string);
+            string prefixPath, exePath, exewPath;
+            try {
+                prefixPath = PathUtils.NormalizePath(installKey.GetValue(null) as string);
+                exePath = PathUtils.NormalizePath(installKey.GetValue("ExecutablePath") as string);
+                exewPath = PathUtils.NormalizePath(installKey.GetValue("WindowedExecutablePath") as string);
+            } catch (ArgumentException ex) {
+                Debug.Fail(ex.ToUnhandledExceptionMessage(GetType()));
+                return null;
+            }
             if (pythonCoreCompatibility && !string.IsNullOrEmpty(prefixPath)) {
                 if (string.IsNullOrEmpty(exePath)) {
                     exePath = PathUtils.GetAbsoluteFilePath(prefixPath, CPythonInterpreterFactoryConstants.ConsoleExecutable);


### PR DESCRIPTION
Fixes #2447 Opening the Python Environments tab causes VS 2017 to crash
Handles error due to invalid path rather than crashing.

Also fixes unhandled NormalizePath failure.