### PR TITLE
Cookiecutter accessibility fixes

### DIFF
--- a/Python/Product/Cookiecutter/Cookiecutter.csproj
+++ b/Python/Product/Cookiecutter/Cookiecutter.csproj
@@ -161,6 +161,7 @@
     <Compile Include="Model\ILocalTemplateSource.cs" />
     <Compile Include="Model\TemplateContext.cs" />
     <Compile Include="Model\DteCommand.cs" />
+    <Compile Include="ViewModel\TreeItemViewModel.cs" />
     <Compile Include="View\LoadingPage.xaml.cs">
       <DependentUpon>LoadingPage.xaml</DependentUpon>
     </Compile>

--- a/Python/Product/Cookiecutter/View/CookiecutterContainerPage.xaml
+++ b/Python/Product/Cookiecutter/View/CookiecutterContainerPage.xaml
@@ -6,7 +6,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              mc:Ignorable="d" 
              d:DesignHeight="300" d:DesignWidth="300" MouseRightButtonUp="UserControl_MouseRightButtonUp" KeyUp="UserControl_KeyUp">
-    <Grid>
+    <Grid KeyboardNavigation.TabNavigation="Cycle">
         <Frame Content="{Binding PageSequence.CurrentItem}"
                NavigationUIVisibility="Hidden"
                Focusable="False" IsTabStop="False"

--- a/Python/Product/Cookiecutter/View/CookiecutterSearchPage.xaml
+++ b/Python/Product/Cookiecutter/View/CookiecutterSearchPage.xaml
@@ -140,6 +140,7 @@
                   Margin="4 4 0 8"
                   ItemsSource="{Binding Path=SearchResults}"
                   Focusable="True"
+                  IsTabStop="True"
                   SelectedItemChanged="TreeView_SelectedItemChanged">
             <TreeView.Resources>
                 <HierarchicalDataTemplate DataType="{x:Type vm:CategorizedViewModel}" ItemsSource="{Binding Path=Templates}">
@@ -202,7 +203,8 @@
                                 Margin="3 3"
                                 Command="{x:Static vm:CookiecutterViewModel.LoadMore}"
                                 CommandParameter="{Binding Path=ContinuationToken,Mode=OneWay}"
-                                HorizontalAlignment="Left">
+                                HorizontalAlignment="Left"
+                                IsTabStop="False">
                             <TextBlock Text="{x:Static cct:Strings.SearchPage_LoadMore}"/>
                         </Button>
                     </StackPanel>
@@ -213,6 +215,7 @@
                     <Setter Property="IsExpanded" Value="True" />
                     <EventSetter Event="MouseDoubleClick" Handler="OnItemMouseDoubleClick" />
                     <EventSetter Event="TreeViewItem.PreviewMouseRightButtonDown" Handler="OnItemPreviewMouseRightButtonDown"/>
+                    <EventSetter Event="PreviewKeyDown" Handler="OnItemPreviewKeyDown"/>
                 </Style>
             </TreeView.ItemContainerStyle>
         </TreeView>

--- a/Python/Product/Cookiecutter/View/CookiecutterSearchPage.xaml
+++ b/Python/Product/Cookiecutter/View/CookiecutterSearchPage.xaml
@@ -213,6 +213,7 @@
             <TreeView.ItemContainerStyle>
                 <Style TargetType="{x:Type TreeViewItem}" BasedOn="{StaticResource {x:Type TreeViewItem}}">
                     <Setter Property="IsExpanded" Value="True" />
+                    <Setter Property="IsSelected" Value="{Binding Path=IsSelected, Mode=TwoWay}"/>
                     <EventSetter Event="MouseDoubleClick" Handler="OnItemMouseDoubleClick" />
                     <EventSetter Event="TreeViewItem.PreviewMouseRightButtonDown" Handler="OnItemPreviewMouseRightButtonDown"/>
                     <EventSetter Event="PreviewKeyDown" Handler="OnItemPreviewKeyDown"/>

--- a/Python/Product/Cookiecutter/View/CookiecutterSearchPage.xaml.cs
+++ b/Python/Product/Cookiecutter/View/CookiecutterSearchPage.xaml.cs
@@ -107,18 +107,10 @@ namespace Microsoft.CookiecutterTools.View {
 
         private void OnItemMouseDoubleClick(object sender, MouseButtonEventArgs args) {
             var item = sender as TreeViewItem;
-            if (item != null) {
-                if (item.IsSelected) {
-                    var template = item.DataContext as TemplateViewModel;
-                    if (template != null) {
-                        if (template != ViewModel.SelectedTemplate) {
-                            ViewModel.SelectedTemplate = template;
-                        }
-
-                        if (ViewModel.CanLoadSelectedTemplate) {
-                            LoadTemplate();
-                        }
-                    }
+            if (item != null && item.IsSelected) {
+                var template = item.DataContext as TemplateViewModel;
+                if (template != null) {
+                    LoadTemplate(template);
                 }
             }
         }
@@ -136,14 +128,30 @@ namespace Microsoft.CookiecutterTools.View {
 
         private void OnItemPreviewKeyDown(object sender, KeyEventArgs e) {
             var item = sender as TreeViewItem;
-            if (item != null) {
+            if (item != null && item.IsSelected) {
                 if (e.Key == Key.Enter) {
                     var continuation = item.DataContext as ContinuationViewModel;
                     if (continuation != null) {
                         e.Handled = true;
                         ViewModel.LoadMoreTemplatesAsync(continuation.ContinuationToken).DoNotWait();
+                    } else {
+                        var template = item.DataContext as TemplateViewModel;
+                        if (template != null) {
+                            e.Handled = true;
+                            LoadTemplate(template);
+                        }
                     }
                 }
+            }
+        }
+
+        private void LoadTemplate(TemplateViewModel template) {
+            if (template != ViewModel.SelectedTemplate) {
+                ViewModel.SelectedTemplate = template;
+            }
+
+            if (ViewModel.CanLoadSelectedTemplate) {
+                LoadTemplate();
             }
         }
 

--- a/Python/Product/Cookiecutter/View/CookiecutterSearchPage.xaml.cs
+++ b/Python/Product/Cookiecutter/View/CookiecutterSearchPage.xaml.cs
@@ -134,6 +134,19 @@ namespace Microsoft.CookiecutterTools.View {
             }
         }
 
+        private void OnItemPreviewKeyDown(object sender, KeyEventArgs e) {
+            var item = sender as TreeViewItem;
+            if (item != null) {
+                if (e.Key == Key.Enter) {
+                    var continuation = item.DataContext as ContinuationViewModel;
+                    if (continuation != null) {
+                        e.Handled = true;
+                        ViewModel.LoadMoreTemplatesAsync(continuation.ContinuationToken).DoNotWait();
+                    }
+                }
+            }
+        }
+
         public void LoadTemplate() {
             TemplateViewModel collidingTemplate;
             if (ViewModel.IsCloneNeeded(ViewModel.SelectedTemplate) && ViewModel.IsCloneCollision(ViewModel.SelectedTemplate, out collidingTemplate)) {

--- a/Python/Product/Cookiecutter/ViewModel/CategorizedViewModel.cs
+++ b/Python/Product/Cookiecutter/ViewModel/CategorizedViewModel.cs
@@ -18,7 +18,7 @@ using System.Collections.ObjectModel;
 using System.ComponentModel;
 
 namespace Microsoft.CookiecutterTools.ViewModel {
-    class CategorizedViewModel : INotifyPropertyChanged {
+    class CategorizedViewModel : TreeItemViewModel {
         private string _displayName;
 
         /// <summary>
@@ -42,14 +42,12 @@ namespace Microsoft.CookiecutterTools.ViewModel {
             set {
                 if (value != _displayName) {
                     _displayName = value;
-                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(DisplayName)));
+                    OnPropertyChanged(new PropertyChangedEventArgs(nameof(DisplayName)));
                 }
             }
         }
 
         public ObservableCollection<object> Templates { get; } = new ObservableCollection<object>();
-
-        public event PropertyChangedEventHandler PropertyChanged;
 
         public override string ToString() => _displayName;
     }

--- a/Python/Product/Cookiecutter/ViewModel/ContinuationViewModel.cs
+++ b/Python/Product/Cookiecutter/ViewModel/ContinuationViewModel.cs
@@ -15,7 +15,7 @@
 // permissions and limitations under the License.
 
 namespace Microsoft.CookiecutterTools.ViewModel {
-    class ContinuationViewModel {
+    class ContinuationViewModel : TreeItemViewModel {
         public ContinuationViewModel() :
             this(null) {
         }
@@ -27,5 +27,7 @@ namespace Microsoft.CookiecutterTools.ViewModel {
         public bool Selectable => false;
 
         public string ContinuationToken { get; set; }
+
+        public override string ToString() => Strings.SearchPage_LoadMore;
     }
 }

--- a/Python/Product/Cookiecutter/ViewModel/CookiecutterViewModel.cs
+++ b/Python/Product/Cookiecutter/ViewModel/CookiecutterViewModel.cs
@@ -476,11 +476,16 @@ namespace Microsoft.CookiecutterTools.ViewModel {
             SearchResults.Add(Recommended);
             SearchResults.Add(GitHub);
 
-            var recommendedTask = AddFromSourceAsync(_recommendedSource, searchTerm, Recommended, ct);
-            var installedTask = AddFromSourceAsync(_installedSource, searchTerm, Installed, ct);
-            var githubTask = AddFromSourceAsync(_githubSource, searchTerm, GitHub, ct);
+            var recommendedTask = AddFromSourceAsync(_recommendedSource, searchTerm, Recommended, false, ct);
+            var installedTask = AddFromSourceAsync(_installedSource, searchTerm, Installed, false, ct);
+            var githubTask = AddFromSourceAsync(_githubSource, searchTerm, GitHub, false, ct);
 
             await Task.WhenAll(recommendedTask, installedTask, githubTask);
+
+            var first = SearchResults.FirstOrDefault();
+            if (first != null) {
+                first.IsSelected = true;
+            }
         }
 
         public async Task DeleteTemplateAsync(TemplateViewModel template) {
@@ -579,7 +584,7 @@ namespace Microsoft.CookiecutterTools.ViewModel {
                     _templateRefreshCancelTokenSource = new CancellationTokenSource();
                     try {
                         Installed.Templates.Clear();
-                        await AddFromSourceAsync(_installedSource, SearchTerm, Installed, CancellationToken.None);
+                        await AddFromSourceAsync(_installedSource, SearchTerm, Installed, false, CancellationToken.None);
                     } catch (OperationCanceledException) {
                     }
 
@@ -894,7 +899,7 @@ namespace Microsoft.CookiecutterTools.ViewModel {
                 try {
                     GitHub.Templates.Remove(last);
                     ReportEvent(CookiecutterTelemetry.TelemetryArea.Search, CookiecutterTelemetry.SearchEvents.More);
-                    await AddFromSourceAsync(_githubSource, null, GitHub, _templateRefreshCancelTokenSource.Token, continuationToken);
+                    await AddFromSourceAsync(_githubSource, null, GitHub, true, _templateRefreshCancelTokenSource.Token, continuationToken);
                 } catch (OperationCanceledException) {
                 }
             }
@@ -937,12 +942,16 @@ namespace Microsoft.CookiecutterTools.ViewModel {
             ITemplateSource source,
             string searchTerm,
             CategorizedViewModel parent,
+            bool alterSelection,
             CancellationToken ct,
             string continuationToken = null,
             VisualStudio.Imaging.Interop.ImageMoniker? updateableImage = null
         ) {
             var loading = new LoadingViewModel();
             parent.Templates.Add(loading);
+            if (alterSelection) {
+                loading.IsSelected = true;
+            }
 
             try {
                 var result = await source.GetTemplatesAsync(searchTerm, continuationToken, ct);
@@ -963,7 +972,8 @@ namespace Microsoft.CookiecutterTools.ViewModel {
                 ct.ThrowIfCancellationRequested();
 
                 if (result.ContinuationToken != null) {
-                    parent.Templates.Add(new ContinuationViewModel(result.ContinuationToken));
+                    var loadMore = new ContinuationViewModel(result.ContinuationToken);
+                    parent.Templates.Add(loadMore);
                 }
             } catch (TemplateEnumerationException ex) {
                 var template = new ErrorViewModel() {
@@ -972,7 +982,17 @@ namespace Microsoft.CookiecutterTools.ViewModel {
                 };
                 parent.Templates.Add(template);
             } finally {
+                // Check if the loading item is still selected before we remove it, the user
+                // may have selected something else while we were loading results.
+                bool loadingStillSelected = loading.IsSelected;
                 parent.Templates.Remove(loading);
+                if (alterSelection && loadingStillSelected) {
+                    // Loading was still selected, so select something else.
+                    var newLast = GitHub.Templates.LastOrDefault() as TreeItemViewModel;
+                    if (newLast != null) {
+                        newLast.IsSelected = true;
+                    }
+                }
             }
         }
 

--- a/Python/Product/Cookiecutter/ViewModel/CookiecutterViewModel.cs
+++ b/Python/Product/Cookiecutter/ViewModel/CookiecutterViewModel.cs
@@ -988,7 +988,7 @@ namespace Microsoft.CookiecutterTools.ViewModel {
                 parent.Templates.Remove(loading);
                 if (alterSelection && loadingStillSelected) {
                     // Loading was still selected, so select something else.
-                    var newLast = GitHub.Templates.LastOrDefault() as TreeItemViewModel;
+                    var newLast = parent.Templates.LastOrDefault() as TreeItemViewModel;
                     if (newLast != null) {
                         newLast.IsSelected = true;
                     }

--- a/Python/Product/Cookiecutter/ViewModel/ErrorViewModel.cs
+++ b/Python/Product/Cookiecutter/ViewModel/ErrorViewModel.cs
@@ -17,11 +17,9 @@
 using System.ComponentModel;
 
 namespace Microsoft.CookiecutterTools.ViewModel {
-    class ErrorViewModel : INotifyPropertyChanged {
+    class ErrorViewModel : TreeItemViewModel {
         private string _errorDescription;
         private string _errorDetails;
-
-        public event PropertyChangedEventHandler PropertyChanged;
 
         public ErrorViewModel() {
         }
@@ -36,7 +34,7 @@ namespace Microsoft.CookiecutterTools.ViewModel {
             set {
                 if (value != _errorDescription) {
                     _errorDescription = value;
-                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(ErrorDescription)));
+                    OnPropertyChanged(new PropertyChangedEventArgs(nameof(ErrorDescription)));
                 }
             }
         }
@@ -49,7 +47,7 @@ namespace Microsoft.CookiecutterTools.ViewModel {
             set {
                 if (value != _errorDetails) {
                     _errorDetails = value;
-                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(ErrorDetails)));
+                    OnPropertyChanged(new PropertyChangedEventArgs(nameof(ErrorDetails)));
                 }
             }
         }

--- a/Python/Product/Cookiecutter/ViewModel/TemplateViewModel.cs
+++ b/Python/Product/Cookiecutter/ViewModel/TemplateViewModel.cs
@@ -19,7 +19,7 @@ using Microsoft.CookiecutterTools.Infrastructure;
 using Microsoft.CookiecutterTools.Model;
 
 namespace Microsoft.CookiecutterTools.ViewModel {
-    class TemplateViewModel : INotifyPropertyChanged {
+    class TemplateViewModel : TreeItemViewModel {
         private string _displayName;
         private string _remoteUrl;
         private string _ownerUrl;
@@ -29,8 +29,6 @@ namespace Microsoft.CookiecutterTools.ViewModel {
         private string _avatarUrl;
         private bool _isSearchTerm;
         private bool _isUpdateAvailable;
-
-        public event PropertyChangedEventHandler PropertyChanged;
 
         public TemplateViewModel() {
         }
@@ -112,7 +110,7 @@ namespace Microsoft.CookiecutterTools.ViewModel {
             set {
                 if (value != _displayName) {
                     _displayName = value;
-                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(DisplayName)));
+                    OnPropertyChanged(new PropertyChangedEventArgs(nameof(DisplayName)));
                 }
             }
         }
@@ -125,7 +123,7 @@ namespace Microsoft.CookiecutterTools.ViewModel {
             set {
                 if (value != _remoteUrl) {
                     _remoteUrl = value;
-                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(RemoteUrl)));
+                    OnPropertyChanged(new PropertyChangedEventArgs(nameof(RemoteUrl)));
                 }
 
                 RefreshOwnerTooltip();
@@ -140,7 +138,7 @@ namespace Microsoft.CookiecutterTools.ViewModel {
             set {
                 if (value != _clonedPath) {
                     _clonedPath = value;
-                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(ClonedPath)));
+                    OnPropertyChanged(new PropertyChangedEventArgs(nameof(ClonedPath)));
                 }
             }
         }
@@ -153,7 +151,7 @@ namespace Microsoft.CookiecutterTools.ViewModel {
             set {
                 if (value != _description) {
                     _description = value;
-                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Description)));
+                    OnPropertyChanged(new PropertyChangedEventArgs(nameof(Description)));
                 }
             }
         }
@@ -166,7 +164,7 @@ namespace Microsoft.CookiecutterTools.ViewModel {
             set {
                 if (value != _avatarUrl) {
                     _avatarUrl = value;
-                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(AvatarUrl)));
+                    OnPropertyChanged(new PropertyChangedEventArgs(nameof(AvatarUrl)));
                 }
             }
         }
@@ -179,7 +177,7 @@ namespace Microsoft.CookiecutterTools.ViewModel {
             set {
                 if (value != _ownerUrl) {
                     _ownerUrl = value;
-                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(OwnerUrl)));
+                    OnPropertyChanged(new PropertyChangedEventArgs(nameof(OwnerUrl)));
                 }
             }
         }
@@ -192,7 +190,7 @@ namespace Microsoft.CookiecutterTools.ViewModel {
             set {
                 if (value != _ownerTooltip) {
                     _ownerTooltip = value;
-                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(OwnerTooltip)));
+                    OnPropertyChanged(new PropertyChangedEventArgs(nameof(OwnerTooltip)));
                 }
             }
         }
@@ -205,7 +203,7 @@ namespace Microsoft.CookiecutterTools.ViewModel {
             set {
                 if (value != _isSearchTerm) {
                     _isSearchTerm = value;
-                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsSearchTerm)));
+                    OnPropertyChanged(new PropertyChangedEventArgs(nameof(IsSearchTerm)));
                 }
             }
         }
@@ -218,7 +216,7 @@ namespace Microsoft.CookiecutterTools.ViewModel {
             set {
                 if (value != _isUpdateAvailable) {
                     _isUpdateAvailable = value;
-                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsUpdateAvailable)));
+                    OnPropertyChanged(new PropertyChangedEventArgs(nameof(IsUpdateAvailable)));
                 }
             }
         }

--- a/Python/Product/Cookiecutter/ViewModel/TreeItemViewModel.cs
+++ b/Python/Product/Cookiecutter/ViewModel/TreeItemViewModel.cs
@@ -14,13 +14,35 @@
 // See the Apache Version 2.0 License for specific language governing
 // permissions and limitations under the License.
 
+using System.ComponentModel;
+
 namespace Microsoft.CookiecutterTools.ViewModel {
-    class LoadingViewModel : TreeItemViewModel {
-        public LoadingViewModel() {
+    class TreeItemViewModel : INotifyPropertyChanged {
+        private bool _isSelected;
+
+        /// <summary>
+        /// Constructor for design view.
+        /// </summary>
+        public TreeItemViewModel() {
         }
 
-        public bool Selectable => false;
+        public bool IsSelected {
+            get {
+                return _isSelected;
+            }
 
-        public override string ToString() => Strings.SearchPage_LoadingTemplate;
+            set {
+                if (value != _isSelected) {
+                    _isSelected = value;
+                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsSelected)));
+                }
+            }
+        }
+
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        protected void OnPropertyChanged(PropertyChangedEventArgs ea) {
+            PropertyChanged?.Invoke(this, ea);
+        }
     }
 }


### PR DESCRIPTION
More reasonable TAB and SHIFT-TAB behavior
- Cycles through all controls forward and backward, no longer takes you to the toolbar
- Load more is no longer a tab stop, just go to the tree node by navigating the tree with arrow keys

Focus now remains in the tree view after clicking load more, instead of going to the output window.

Toolbar is accessed with Shift-Alt (standard in VS)

405000 Accessibility : MAS05 : Keyboard : Python + Cookiecutter : Focus order improper for tool-bar in Cookie cutter window
403507 Accessibility : MAS05 : Keyboard : Python + Cookiecutter : Focus order improper in CookieCutter window after refreshing or loading the page
404511 Accessibility : MAS07 : Keyboard : Python+Cookiecutter : Keyboard trap found over 'Search' edit box when perfoming reverse tab (Shift +Tab) in CookieCutter window
403505 Accessibility : MAS36 : Keyboard : Python + Cookiecutter : 'Load more' is not accessible through reverse tab (Shift + TAB) in CookieCutter window
