### PR TITLE
Fixes #2481 No AnalysisEntryService in tests

### DIFF
--- a/Python/Tests/Utilities.Python/PythonToolsTestUtilities.cs
+++ b/Python/Tests/Utilities.Python/PythonToolsTestUtilities.cs
@@ -78,6 +78,10 @@ namespace TestUtilities.Python {
             serviceProvider.ComponentModel.AddExtension<IInterpreterRegistryService>(() => optService.Value);
             serviceProvider.ComponentModel.AddExtension<IInterpreterOptionsService>(() => optService.Value);
 
+            var analysisEntryServiceCreator = new Lazy<AnalysisEntryService>(() => new AnalysisEntryService(serviceProvider));
+            serviceProvider.ComponentModel.AddExtension<IAnalysisEntryService>(() => analysisEntryServiceCreator.Value);
+            serviceProvider.ComponentModel.AddExtension(() => analysisEntryServiceCreator.Value);
+
             if (suppressTaskProvider) {
                 serviceProvider.AddService(typeof(ErrorTaskProvider), null, true);
                 serviceProvider.AddService(typeof(CommentTaskProvider), null, true);


### PR DESCRIPTION
Fixes #2481 No AnalysisEntryService in tests
Ensures the entry service is added to the mock component model.