### PR TITLE
Fixes #2464 Create Azure Cloud Service project error

### DIFF
--- a/Python/Product/ProjectWizards/CloudServiceWizard.cs
+++ b/Python/Product/ProjectWizards/CloudServiceWizard.cs
@@ -67,7 +67,10 @@ namespace Microsoft.PythonTools.ProjectWizards {
 
         private static bool AreToolsInstalled(IServiceProvider provider) {
             var setupService = provider.GetService(typeof(SVsSetupCompositionService)) as IVsSetupCompositionService;
-            return setupService.IsPackageInstalled(RequiredPackage);
+            // If we fail to get the setup service, we're probably in a whole lot of trouble
+            // Likely the "install" step will fail too, but at least we'll have given users a
+            // hint and they might go to Setup and repair things.
+            return setupService?.IsPackageInstalled(RequiredPackage) ?? false;
         }
 
         private static void InstallTools(IServiceProvider provider) {

--- a/Python/Product/ProjectWizards/CloudServiceWizard.cs
+++ b/Python/Product/ProjectWizards/CloudServiceWizard.cs
@@ -18,11 +18,10 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.Linq;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using Microsoft.PythonTools.Infrastructure;
 using Microsoft.VisualStudio;
-using Microsoft.VisualStudio.Settings;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.TemplateWizard;
 using Project = EnvDTE.Project;
@@ -30,138 +29,54 @@ using ProjectItem = EnvDTE.ProjectItem;
 
 namespace Microsoft.PythonTools.ProjectWizards {
     public sealed class CloudServiceWizard : IWizard {
+        private const string RequiredPackage = "Microsoft.VisualStudio.Component.Azure.Waverton";
+
         private IWizard _wizard;
 
-#if DEV14
-        private readonly bool _recommendUpgrade;
-        const string AzureToolsDownload = "http://go.microsoft.com/fwlink/?linkid=518003";
-#elif DEV15_OR_LATER
-#else
-#error Unsupported VS version
-#endif
-
-        const string DontShowUpgradeDialogAgainProperty = "SuppressUpgradeAzureTools";
-
-#if DEV14
-        private static bool ShouldRecommendUpgrade(Assembly asm) {
-            var attr = asm.GetCustomAttributes(typeof(AssemblyFileVersionAttribute), false)
-                .OfType<AssemblyFileVersionAttribute>()
-                .FirstOrDefault();
-
-            Version ver;
-            if (attr != null && Version.TryParse(attr.Version, out ver)) {
-                Debug.WriteLine(ver);
-                // 2.4 is where we added integration, so we should recommend it
-                // to people who don't have it.
-                return ver < new Version(2, 4);
-            }
-            return false;
-        }
-#endif
-
-        public CloudServiceWizard() {
-            try {
-                // If we fail to find the wizard, we will redirect the user to
-                // the WebPI download.
-                var asm = Assembly.Load("Microsoft.VisualStudio.CloudService.Wizard,Version=1.0.0.0,Culture=neutral,PublicKeyToken=b03f5f7f11d50a3a");
-
-#if DEV14
-                _recommendUpgrade = ShouldRecommendUpgrade(asm);
-#endif
-
-                var type = asm.GetType("Microsoft.VisualStudio.CloudService.Wizard.CloudServiceWizard");
-                _wizard = type.InvokeMember(null, BindingFlags.CreateInstance, null, null, new object[0]) as IWizard;
-            } catch (ArgumentException) {
-            } catch (BadImageFormatException) {
-            } catch (IOException) {
-            } catch (MemberAccessException) {
+        [Conditional("DEBUG")]
+        private void AssertWizard([CallerMemberName] string caller = null) {
+            if (_wizard == null) {
+                Debug.Fail($"{caller ?? "Function"} called with no wizard");
             }
         }
 
         public void BeforeOpeningFile(ProjectItem projectItem) {
-            if (_wizard != null) {
-                _wizard.BeforeOpeningFile(projectItem);
-            }
+            AssertWizard();
+            _wizard?.BeforeOpeningFile(projectItem);
         }
 
         public void ProjectFinishedGenerating(Project project) {
-            if (_wizard != null) {
-                _wizard.ProjectFinishedGenerating(project);
-            }
+            AssertWizard();
+            _wizard?.ProjectFinishedGenerating(project);
         }
 
         public void ProjectItemFinishedGenerating(ProjectItem projectItem) {
-            if (_wizard != null) {
-                _wizard.ProjectItemFinishedGenerating(projectItem);
-            }
+            AssertWizard();
+            _wizard?.ProjectItemFinishedGenerating(projectItem);
         }
 
         public void RunFinished() {
-            if (_wizard != null) {
-                _wizard.RunFinished();
-            }
+            AssertWizard();
+            _wizard?.RunFinished();
         }
 
         public bool ShouldAddProjectItem(string filePath) {
-            if (_wizard != null) {
-                return _wizard.ShouldAddProjectItem(filePath);
-            }
-            return false;
+            AssertWizard();
+            return _wizard?.ShouldAddProjectItem(filePath) ?? false;
         }
 
-#if DEV14
-        private void StartDownload(IServiceProvider provider) {
-            Process.Start(new ProcessStartInfo(AzureToolsDownload));
+        private static bool AreToolsInstalled(IServiceProvider provider) {
+            var setupService = provider.GetService(typeof(SVsSetupCompositionService)) as IVsSetupCompositionService;
+            return setupService.IsPackageInstalled(RequiredPackage);
         }
 
-        private void OfferUpgrade(IServiceProvider provider) {
-            if (!_recommendUpgrade) {
-                return;
-            }
-
-            var sm = SettingsManagerCreator.GetSettingsManager(provider);
-            var store = sm.GetReadOnlySettingsStore(SettingsScope.UserSettings);
-
-            if (!store.CollectionExists(PythonConstants.DontShowUpgradeDialogAgainCollection) ||
-                !store.GetBoolean(PythonConstants.DontShowUpgradeDialogAgainCollection, DontShowUpgradeDialogAgainProperty, false)) {
-                var dlg = new TaskDialog(provider) {
-                    Title = Strings.ProductTitle,
-                    MainInstruction = Strings.AzureToolsUpgradeRecommended,
-                    Content = Strings.AzureToolsUpgradeInstructions,
-                    AllowCancellation = true,
-                    VerificationText = Strings.DontShowAgain
-                };
-                var download = new TaskDialogButton(Strings.DownloadAndInstall);
-                dlg.Buttons.Add(download);
-                var cont = new TaskDialogButton(Strings.ContinueWithoutAzureToolsUpgrade);
-                dlg.Buttons.Add(cont);
-                dlg.Buttons.Add(TaskDialogButton.Cancel);
-
-                var response = dlg.ShowModal();
-
-                if (dlg.SelectedVerified) {
-                    var rwStore = sm.GetWritableSettingsStore(SettingsScope.UserSettings);
-                    rwStore.CreateCollection(PythonConstants.DontShowUpgradeDialogAgainCollection);
-                    rwStore.SetBoolean(PythonConstants.DontShowUpgradeDialogAgainCollection, DontShowUpgradeDialogAgainProperty, true);
-                }
-
-                if (response == download) {
-                    Process.Start(new ProcessStartInfo(AzureToolsDownload));
-                    throw new WizardCancelledException();
-                } else if (response == TaskDialogButton.Cancel) {
-                    // User cancelled, so go back to the New Project dialog
-                    throw new WizardBackoutException();
-                }
-            }
-        }
-#else
-        private void StartDownload(IServiceProvider provider) {
+        private static void InstallTools(IServiceProvider provider) {
             var svc = (IVsTrackProjectRetargeting2)provider.GetService(typeof(SVsTrackProjectRetargeting));
             if (svc != null) {
                 IVsProjectAcquisitionSetupDriver driver;
                 if (ErrorHandler.Succeeded(svc.GetSetupDriver(VSConstants.SetupDrivers.SetupDriver_VS, out driver)) &&
                     driver != null) {
-                    var task = driver.Install("Microsoft.VisualStudio.Component.Azure.Waverton");
+                    var task = driver.Install(RequiredPackage);
                     if (task != null) {
                         task.Start();
                         throw new WizardCancelledException();
@@ -170,12 +85,22 @@ namespace Microsoft.PythonTools.ProjectWizards {
             }
         }
 
-        private void OfferUpgrade(IServiceProvider provider) {
-        }
-#endif
-
         public void RunStarted(object automationObject, Dictionary<string, string> replacementsDictionary, WizardRunKind runKind, object[] customParams) {
             var provider = WizardHelpers.GetProvider(automationObject);
+
+            try {
+                if (AreToolsInstalled(provider)) {
+                    // If we fail to find the wizard, we will redirect the user to
+                    // install the required packages.
+                    var asm = Assembly.Load("Microsoft.VisualStudio.CloudService.Wizard,Version=1.0.0.0,Culture=neutral,PublicKeyToken=b03f5f7f11d50a3a");
+                    var type = asm.GetType("Microsoft.VisualStudio.CloudService.Wizard.CloudServiceWizard");
+                    _wizard = type.InvokeMember(null, BindingFlags.CreateInstance, null, null, new object[0]) as IWizard;
+                }
+            } catch (ArgumentException) {
+            } catch (BadImageFormatException) {
+            } catch (IOException) {
+            } catch (MemberAccessException) {
+            }
 
             if (_wizard == null) {
                 try {
@@ -196,15 +121,13 @@ namespace Microsoft.PythonTools.ProjectWizards {
                 dlg.Buttons.Insert(0, download);
 
                 if (dlg.ShowModal() == download) {
-                    StartDownload(provider);
+                    InstallTools(provider);
                     throw new WizardCancelledException();
                 }
 
                 // User cancelled, so go back to the New Project dialog
                 throw new WizardBackoutException();
             }
-
-            OfferUpgrade(provider);
 
             // Run the original wizard to get the right replacements
             _wizard.RunStarted(automationObject, replacementsDictionary, runKind, customParams);

--- a/Python/Product/ProjectWizards/ProjectWizards.csproj
+++ b/Python/Product/ProjectWizards/ProjectWizards.csproj
@@ -60,6 +60,9 @@
     <Reference Include="Microsoft.VisualStudio.Shell.Interop.12.0, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <EmbedInteropTypes>True</EmbedInteropTypes>
     </Reference>
+    <Reference Include="Microsoft.VisualStudio.Shell.Interop.15.0.DesignTime, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <EmbedInteropTypes>True</EmbedInteropTypes>
+    </Reference>
     <Reference Include="Microsoft.VisualStudio.TemplateWizardInterface, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="System" />
     <Reference Include="System.Core" />


### PR DESCRIPTION
Fixes #2464 Create Azure Cloud Service project error
Explicitly checks for an installed package rather than inferring it from a loadable type.
Removes dead code