### PR TITLE
More cookiecutter accessibility fixes

### DIFF
--- a/Python/Product/Cookiecutter/Strings.Designer.cs
+++ b/Python/Product/Cookiecutter/Strings.Designer.cs
@@ -497,11 +497,20 @@ namespace Microsoft.CookiecutterTools {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Output folder path.
+        ///   Looks up a localized string similar to Output folder path for created files.
         /// </summary>
         public static string OptionsPage_CreateToAutomationName {
             get {
                 return ResourceManager.GetString("OptionsPage_CreateToAutomationName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Browse for output folder path.
+        /// </summary>
+        public static string OptionsPage_CreateToBrowseAutomationName {
+            get {
+                return ResourceManager.GetString("OptionsPage_CreateToBrowseAutomationName", resourceCulture);
             }
         }
         
@@ -547,6 +556,15 @@ namespace Microsoft.CookiecutterTools {
         public static string OptionsPage_Name {
             get {
                 return ResourceManager.GetString("OptionsPage_Name", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Browse for database connection.
+        /// </summary>
+        public static string OptionsPage_OdbcConnectionBrowseAutomationName {
+            get {
+                return ResourceManager.GetString("OptionsPage_OdbcConnectionBrowseAutomationName", resourceCulture);
             }
         }
         

--- a/Python/Product/Cookiecutter/Strings.resx
+++ b/Python/Product/Cookiecutter/Strings.resx
@@ -429,7 +429,7 @@ Please delete the installed template and try again.</value>
     <value>Folder location where the files will be created. Files may be replaced if the folder is not empty, but a backup of the existing files will be created as needed.</value>
   </data>
   <data name="OptionsPage_CreateToAutomationName" xml:space="preserve">
-    <value>Output folder path</value>
+    <value>Output folder path for created files</value>
   </data>
   <data name="OptionsPage_AddingToProject" xml:space="preserve">
     <value>Files will be added to your project.</value>
@@ -487,5 +487,11 @@ Please delete the installed template and try again.</value>
   </data>
   <data name="MissingDependenciesPage_Message" xml:space="preserve">
     <value>Please install Python 3.5 or later and restart Visual Studio to use this feature.</value>
+  </data>
+  <data name="OptionsPage_CreateToBrowseAutomationName" xml:space="preserve">
+    <value>Browse for output folder path</value>
+  </data>
+  <data name="OptionsPage_OdbcConnectionBrowseAutomationName" xml:space="preserve">
+    <value>Browse for database connection</value>
   </data>
 </root>

--- a/Python/Product/Cookiecutter/View/CookiecutterContainerPage.xaml.cs
+++ b/Python/Product/Cookiecutter/View/CookiecutterContainerPage.xaml.cs
@@ -291,7 +291,7 @@ namespace Microsoft.CookiecutterTools.View {
         }
 
         private void UserControl_KeyUp(object sender, KeyEventArgs e) {
-            if (e.Key == Key.Apps) {
+            if (e.Key == Key.Apps || (e.SystemKey == Key.F10 && (Keyboard.Modifiers & ModifierKeys.Shift) == ModifierKeys.Shift)) {
                 var element = (FrameworkElement)sender;
                 var point = element.PointToScreen(new Point(0, 0));
 

--- a/Python/Product/Cookiecutter/View/CookiecutterOptionsPage.xaml
+++ b/Python/Product/Cookiecutter/View/CookiecutterOptionsPage.xaml
@@ -97,6 +97,7 @@
                                                               HelpText="{Binding Description}"
                                                               Watermark="{Binding Default}"
                                                               BrowseButtonStyle="{StaticResource BrowseOdbcButton}"
+                                                              BrowseAutomationName="{x:Static cct:Strings.OptionsPage_OdbcConnectionBrowseAutomationName}"
                                                               AutomationProperties.Name="{Binding Label}"/>
                         </StackPanel>
                         <DataTemplate.Triggers>
@@ -189,6 +190,7 @@
                                               Watermark="{x:Static cct:Strings.OptionsPage_CreateToWatermark}"
                                               BrowseButtonStyle="{StaticResource BrowseFolderButton}"
                                               AutomationProperties.Name="{x:Static cct:Strings.OptionsPage_CreateToAutomationName}"
+                                              BrowseAutomationName="{x:Static cct:Strings.OptionsPage_CreateToBrowseAutomationName}"
                                               HelpText="{x:Static cct:Strings.OptionsPage_CreateToTooltip}">
                 <wpf:ConfigurationTextBoxWithHelp.Resources>
                     <Style TargetType="{x:Type Button}">

--- a/Python/Product/Cookiecutter/View/CookiecutterSearchPage.xaml
+++ b/Python/Product/Cookiecutter/View/CookiecutterSearchPage.xaml
@@ -125,7 +125,7 @@
                     </Style>
                 </Grid.Resources>
                 
-                <wpf:ConfigurationTextBoxWithHelp Margin="0 0 0 0"
+                <wpf:ConfigurationTextBoxWithHelp Margin="0 0 -4 0"
                                                   Text="{Binding Path=SearchTerm, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                                                   HelpText="{x:Static cct:Strings.SearchPage_SearchTooltip}"
                                                   AutomationProperties.HelpText="{x:Static cct:Strings.SearchPage_SearchAutomationName}"

--- a/Python/Product/Cookiecutter/ViewModel/CategorizedViewModel.cs
+++ b/Python/Product/Cookiecutter/ViewModel/CategorizedViewModel.cs
@@ -47,7 +47,7 @@ namespace Microsoft.CookiecutterTools.ViewModel {
             }
         }
 
-        public ObservableCollection<object> Templates { get; } = new ObservableCollection<object>();
+        public ObservableCollection<TreeItemViewModel> Templates { get; } = new ObservableCollection<TreeItemViewModel>();
 
         public override string ToString() => _displayName;
     }

--- a/Python/Product/Cookiecutter/ViewModel/CookiecutterViewModel.cs
+++ b/Python/Product/Cookiecutter/ViewModel/CookiecutterViewModel.cs
@@ -476,16 +476,20 @@ namespace Microsoft.CookiecutterTools.ViewModel {
             SearchResults.Add(Recommended);
             SearchResults.Add(GitHub);
 
+            // Ensure that there's a selection, to avoid focus issues
+            // when tabbing to the search results.
+            if (SearchResults.Where(cat => cat.IsSelected).Count() == 0) {
+                var first = SearchResults.FirstOrDefault();
+                if (first != null) {
+                    first.IsSelected = true;
+                }
+            }
+
             var recommendedTask = AddFromSourceAsync(_recommendedSource, searchTerm, Recommended, false, ct);
             var installedTask = AddFromSourceAsync(_installedSource, searchTerm, Installed, false, ct);
             var githubTask = AddFromSourceAsync(_githubSource, searchTerm, GitHub, false, ct);
 
             await Task.WhenAll(recommendedTask, installedTask, githubTask);
-
-            var first = SearchResults.FirstOrDefault();
-            if (first != null) {
-                first.IsSelected = true;
-            }
         }
 
         public async Task DeleteTemplateAsync(TemplateViewModel template) {

--- a/Python/Product/Cookiecutter/ViewModel/CookiecutterViewModel.cs
+++ b/Python/Product/Cookiecutter/ViewModel/CookiecutterViewModel.cs
@@ -478,7 +478,7 @@ namespace Microsoft.CookiecutterTools.ViewModel {
 
             // Ensure that there's a selection, to avoid focus issues
             // when tabbing to the search results.
-            if (SearchResults.Where(cat => cat.IsSelected).Count() == 0) {
+            if (!SearchResults.Any(cat => cat.IsSelected)) {
                 var first = SearchResults.FirstOrDefault();
                 if (first != null) {
                     first.IsSelected = true;


### PR DESCRIPTION
Bug 410725: Usability : Unable to invoke the context menu in Cookie cutter window using Shift key + F10
Bug 404076: Accessibility : MAS40B : INSPECT : Python + Cookiecutter : Name property is inappropriate for the interactive elements in Templates present in Cookiecutter window

Fixes alignment of search text box / button.
Prevents changing the selection if there's already a node that is selected.
