### PR TITLE
Fixes #2420 REPL analyzer processes do not exit

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Repl/SelectableReplEvaluator.cs
+++ b/Python/Product/PythonTools/PythonTools/Repl/SelectableReplEvaluator.cs
@@ -267,6 +267,8 @@ namespace Microsoft.PythonTools.Repl {
 
         private void InteractiveWindow_Closed(object sender, EventArgs e) {
             ClearPersistedEvaluator();
+            AbortExecution();
+            Dispose();
         }
 
         #region Multiple Scope Support


### PR DESCRIPTION
Fixes #2420 REPL analyzer processes do not exit
Disposes the evaluator when the associated window closes.