### PR TITLE
Fixes #2495 InvalidOperationException when pip is not installed

### DIFF
--- a/Python/Product/EnvironmentsList/PipExtension.xaml
+++ b/Python/Product/EnvironmentsList/PipExtension.xaml
@@ -187,6 +187,7 @@
 
         <Grid.Resources>
             <wpf:Lambda x:Key="Visibility">(bool b) => b ? Visibility.Visible : Visibility.Collapsed</wpf:Lambda>
+            <wpf:Lambda x:Key="VisibilityIfAll"><![CDATA[(bool b, bool c) => b && c ? Visibility.Visible : Visibility.Collapsed]]></wpf:Lambda>
             <wpf:Lambda x:Key="VisibilityOrHidden">(bool b) => b ? Visibility.Visible : Visibility.Hidden</wpf:Lambda>
             <wpf:Lambda x:Key="Hidden">(bool b) => b ? Visibility.Hidden : Visibility.Visible</wpf:Lambda>
             <wpf:Lambda x:Key="Collapsed">(bool b) => b ? Visibility.Collapsed : Visibility.Visible</wpf:Lambda>
@@ -223,6 +224,7 @@
                          Margin="2"
                          Background="Transparent"
                          BorderBrush="Transparent"
+                         IsEnabled="{Binding IsPipInstalled,Mode=OneWay}"
                          Text="{Binding SearchQuery,UpdateSourceTrigger=PropertyChanged}"
                          AutomationProperties.Name="{x:Static l:Resources.PipExtensionSearchPyPILabel}">
                     <TextBox.InputBindings>
@@ -239,8 +241,14 @@
                    Margin="8 2"
                    IsHitTestVisible="False"
                    Foreground="{DynamicResource {x:Static wpf:Controls.GrayTextKey}}"
-                   Visibility="{Binding Text.IsEmpty,ElementName=SearchQueryText,Converter={StaticResource Visibility}}"
-                   Text="{x:Static l:Resources.PipExtensionSearchPyPILabel}"/>
+                   Text="{x:Static l:Resources.PipExtensionSearchPyPILabel}">
+            <TextBlock.Visibility>
+                <MultiBinding Converter="{StaticResource VisibilityIfAll}">
+                    <Binding Path="IsPipInstalled" Mode="OneWay"  />
+                    <Binding ElementName="SearchQueryText" Path="Text.IsEmpty" />
+                </MultiBinding>
+            </TextBlock.Visibility>
+        </TextBlock>
 
         <ProgressBar Grid.Row="1"
                      IsIndeterminate="True"

--- a/Python/Product/EnvironmentsList/PipExtension.xaml.cs
+++ b/Python/Product/EnvironmentsList/PipExtension.xaml.cs
@@ -123,7 +123,9 @@ namespace Microsoft.PythonTools.EnvironmentsList {
         }
 
         private void InstallPackage_CanExecute(object sender, CanExecuteRoutedEventArgs e) {
-            e.CanExecute = _provider.CanExecute && !string.IsNullOrEmpty(e.Parameter as string);
+            e.CanExecute = _provider.CanExecute &&
+                !string.IsNullOrEmpty(e.Parameter as string) &&
+                (_provider.IsPipInstalled ?? false);
             e.Handled = true;
         }
 
@@ -200,6 +202,8 @@ namespace Microsoft.PythonTools.EnvironmentsList {
             _provider.OperationFinished += PipExtensionProvider_UpdateComplete;
             _provider.IsPipInstalledChanged += PipExtensionProvider_IsPipInstalledChanged;
             _provider.InstalledPackagesChanged += PipExtensionProvider_InstalledPackagesChanged;
+
+            IsPipInstalled = _provider.IsPipInstalled ?? true;
 
             _installCommandView = new InstallPackageView(this);
 


### PR DESCRIPTION
Fixes #2495 InvalidOperationException when pip is not installed
Prevents installing packages when pip is not available
Ensures "Download and install pip" is correctly shown
Disables search box when pip is not installed