### PR TITLE
Fixes #2492 Empty code cells prevent code cells being collapsible

### DIFF
--- a/Common/Tests/Utilities/Mocks/MockTextBuffer.cs
+++ b/Common/Tests/Utilities/Mocks/MockTextBuffer.cs
@@ -31,6 +31,7 @@ namespace TestUtilities.Mocks {
         private PropertyCollection _properties;
 
         public MockTextBuffer(string content) {
+            _snapshot = new MockTextSnapshot(this, content);
         }
 
         public MockTextBuffer(string content, string contentType, string filename = null) {

--- a/Python/Product/PythonTools/PythonTools/OutliningTaggerProvider.cs
+++ b/Python/Product/PythonTools/PythonTools/OutliningTaggerProvider.cs
@@ -172,9 +172,9 @@ namespace Microsoft.PythonTools {
                             break;
                         }
                     } else {
+                        previousCellStart = cellStart.LineNumber;
                         var cellEnd = CodeCellAnalysis.FindEndOfCell(cellStart, line);
                         if (cellEnd.LineNumber > cellStart.LineNumber) {
-                            previousCellStart = cellStart.LineNumber;
                             yield return GetTagSpan(snapshot, cellStart.Start, cellEnd.End);
                         }
                         if (cellEnd.LineNumber + 1 < snapshot.LineCount) {

--- a/Python/Tests/Core/CodeCellTests.cs
+++ b/Python/Tests/Core/CodeCellTests.cs
@@ -1,0 +1,257 @@
+﻿// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABLITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.PythonTools;
+using Microsoft.PythonTools.Infrastructure;
+using Microsoft.PythonTools.Intellisense;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.VisualStudio.Text;
+using TestUtilities;
+using TestUtilities.Mocks;
+
+namespace PythonToolsTests {
+    using CCA = CodeCellAnalysis;
+
+    [TestClass]
+    public class CodeCellTests {
+        private static string ShowWhitespace(string s) {
+            return s.Replace(' ', '\u00B7').Replace('\t', '\u2409');
+        }
+
+        [TestMethod, Priority(0)]
+        public void CodeCellMarkers() {
+            foreach (var trueMarker in new[] {
+                "#%%",
+                "#%% Comment",
+                "# In[1]:",
+                "# In[abcdefg]:comment after",
+                "#In[1043540398340162312]:"
+            }) {
+                foreach (var ws in new[] { "", " ", "\t", "  \t  " }) {
+                    Assert.IsTrue(CCA.IsCellMarker(ws + trueMarker), ShowWhitespace(ws + trueMarker));
+                    Assert.IsTrue(CCA.IsCellMarker(trueMarker + ws), ShowWhitespace(trueMarker + ws));
+                    Assert.IsTrue(CCA.IsCellMarker(ws + trueMarker + ws), ShowWhitespace(ws + trueMarker + ws));
+                }
+            }
+
+            foreach (var falseMarker in new[] {
+                "",
+                "#",
+                "'''#%%'''",
+                "# In[abcdefg]",
+                "# In[abcdefg] :"
+            }) {
+                Assert.IsFalse(CCA.IsCellMarker(falseMarker), ShowWhitespace(falseMarker));
+            }
+        }
+
+        private static void AssertCellStart(ITextBuffer buffer, int startFromLine, int expectedLine) {
+            var found = CCA.FindStartOfCell(buffer.CurrentSnapshot.GetLineFromLineNumber(startFromLine));
+            if (expectedLine < 0) {
+                Assert.IsNull(found, "Actually found: " + found?.GetText() ?? "(null)");
+            } else {
+                Assert.IsNotNull(found, "Actually found: (null)\r\n\r\nExpected: " + buffer.CurrentSnapshot.GetLineFromLineNumber(expectedLine).GetText());
+                Assert.AreEqual(expectedLine, found.LineNumber, "Actually found: " + found.GetText());
+            }
+        }
+
+        private static void AssertCellEnd(ITextBuffer buffer, int startFromLine, int expectedLine, bool withWhitespace = false) {
+            var cellStart = CCA.FindStartOfCell(buffer.CurrentSnapshot.GetLineFromLineNumber(startFromLine));
+            var found = CCA.FindEndOfCell(cellStart, buffer.CurrentSnapshot.GetLineFromLineNumber(startFromLine), withWhitespace);
+            if (expectedLine < 0) {
+                Assert.IsNull(found, "Actually found: " + found?.GetText() ?? "(null)");
+            } else {
+                Assert.IsNotNull(found, "Actually found: (null)\r\n\r\nExpected: " + buffer.CurrentSnapshot.GetLineFromLineNumber(expectedLine).GetText());
+                Assert.AreEqual(expectedLine, found.LineNumber, "Actually found: " + found.GetText());
+            }
+        }
+
+        [TestMethod, Priority(0)]
+        public void FindStartOfCodeCell() {
+            var code = new MockTextBuffer(@"x
+# ...
+x
+#%% cell here
+x
+
+#%% cell here
+x
+");
+
+            AssertCellStart(code, 0, -1);
+            AssertCellStart(code, 2, -1);
+            AssertCellStart(code, 3, 3);
+            AssertCellStart(code, 5, 3);
+            AssertCellStart(code, 6, 6);
+            AssertCellStart(code, 8, 6);
+        }
+
+        [TestMethod, Priority(0)]
+        public void FindEndOfCodeCell() {
+            var code = new MockTextBuffer(@"x
+# ...
+x
+#%% cell here
+x
+
+#%% cell here
+x
+");
+
+            AssertCellEnd(code, 0, 0);
+            AssertCellEnd(code, 2, 2);
+            AssertCellEnd(code, 3, 4);
+            AssertCellEnd(code, 5, 4);  // Start in whitespace finds previous cell
+            AssertCellEnd(code, 5, 5, withWhitespace: true);
+            AssertCellEnd(code, 6, 7);
+            AssertCellEnd(code, 8, 7);  // Start in whitespace finds previous cell
+            AssertCellEnd(code, 8, 8, withWhitespace: true);
+        }
+
+        [TestMethod, Priority(0)]
+        public void FindStartOfCodeCellWithComment() {
+            var code = new MockTextBuffer(@"
+# Preceding comment
+#
+# and whitespace
+
+#%% cell here
+x
+
+# Next preceding commint
+
+#%% cell here
+x
+");
+
+            AssertCellStart(code, 0, 1);
+            AssertCellStart(code, 1, 1);
+            AssertCellStart(code, 4, 1);
+            AssertCellStart(code, 6, 1);
+            AssertCellStart(code, 7, 8);
+            AssertCellStart(code, 11, 8);
+            AssertCellStart(code, 12, 8);
+        }
+
+        [TestMethod, Priority(0)]
+        public void FindEndOfCodeCellWithComment() {
+            var code = new MockTextBuffer(@"
+# Preceding comment
+#
+# and whitespace
+
+#%% cell here
+x
+
+# Next preceding comment
+
+#%% cell here
+x
+");
+
+            AssertCellEnd(code, 0, 6);
+            AssertCellEnd(code, 1, 6);
+            AssertCellEnd(code, 4, 6);
+            AssertCellEnd(code, 4, 7, withWhitespace: true);
+            AssertCellEnd(code, 6, 6);
+            AssertCellEnd(code, 7, 11);
+            AssertCellEnd(code, 11, 11);
+            AssertCellEnd(code, 11, 12, withWhitespace: true);
+            AssertCellEnd(code, 12, 11);
+        }
+
+        [TestMethod, Priority(0)]
+        public void FindStartOfEmptyCodeCell() {
+            var code = new MockTextBuffer(@"
+#%% empty cell here
+
+#%% cell after empty cell
+
+");
+
+            AssertCellStart(code, 1, 1);
+            AssertCellStart(code, 2, 1);
+            AssertCellStart(code, 3, 3);
+            AssertCellStart(code, 4, 3);
+        }
+
+        [TestMethod, Priority(0)]
+        public void FindEndOfEmptyCodeCell() {
+            var code = new MockTextBuffer(@"
+#%% empty cell here
+
+#%% cell after empty cell
+
+");
+
+            AssertCellEnd(code, 1, 1);
+            AssertCellEnd(code, 1, 2, withWhitespace: true);
+            AssertCellEnd(code, 3, 3);
+            AssertCellEnd(code, 3, 5, withWhitespace: true);
+        }
+
+        private static void AssertTags(ITextBuffer buffer, params string[] spans) {
+            var tags = OutliningTaggerProvider.OutliningTagger.ProcessCellTags(
+                buffer.CurrentSnapshot,
+                CancellationTokens.After1s
+            ).ToList();
+
+            AssertUtil.AreEqual(tags.Select(t => t.Span.Span.ToString()), spans);
+        }
+
+        [TestMethod, Priority(0)]
+        public void OutlineCodeCell() {
+            AssertTags(new MockTextBuffer(@"#%% cell 1
+
+x
+
+# comment
+
+#%% cell 2
+
+y
+
+"), "[10..15)", "[28..47)");
+
+            // No tags, but should not time out
+            AssertTags(new MockTextBuffer(@"#%% empty cell here
+
+#%% cell after empty cell
+
+"));
+
+            AssertTags(new MockTextBuffer(@"#%% cell here
+
+x
+#%% empty cell
+
+"), "[13..18)");
+
+            AssertTags(new MockTextBuffer(@"#%% empty cell here
+
+# comment before
+#%% cell after empty cell
+
+"), "[39..66)");
+        }
+    }
+}

--- a/Python/Tests/Core/PythonToolsTests.csproj
+++ b/Python/Tests/Core/PythonToolsTests.csproj
@@ -103,6 +103,7 @@
       <Link>DebugExtensions.cs</Link>
     </Compile>
     <Compile Include="BuildTasksTests.cs" />
+    <Compile Include="CodeCellTests.cs" />
     <Compile Include="CoverageTests.cs" />
     <Compile Include="EditorTests.cs" />
     <Compile Include="CodeFormatterTests.cs" />


### PR DESCRIPTION
Fixes #2492 Empty code cells prevent code cells being collapsible
Fixes OutliningTaggerProvider to prevent getting stuck in infinite loops
Fixes FindEndOfCell to correctly exclude comments while including whitespace
Adds tests for code cells