### PR TITLE
Fix add/remove import tests noticed on test machine

### DIFF
--- a/Python/Tests/Core.UI/AddImportTests.cs
+++ b/Python/Tests/Core.UI/AddImportTests.cs
@@ -19,6 +19,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using TestUtilities;
 using TestUtilities.Python;
 using TestUtilities.UI;
+using TestUtilities.UI.Python;
 
 namespace PythonToolsUITests {
     [TestClass]
@@ -285,6 +286,8 @@ sub_package";
                 var point = doc.TextView.TextBuffer.CurrentSnapshot.GetLineFromLineNumber(line - 1).Start.Add(column - 1);
                 doc.TextView.Caret.MoveTo(point);
             });
+
+            doc.WaitForAnalyzerAtCaret();
 
             if (expectedActions.Length > 0) {
                 using (var sh = doc.StartSmartTagSession()) {

--- a/Python/Tests/Core.UI/RemoveImportTests.cs
+++ b/Python/Tests/Core.UI/RemoveImportTests.cs
@@ -14,12 +14,11 @@
 // See the Apache Version 2.0 License for specific language governing
 // permissions and limitations under the License.
 
-using System.Threading;
-using EnvDTE;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using TestUtilities;
 using TestUtilities.Python;
 using TestUtilities.UI;
+using TestUtilities.UI.Python;
 
 namespace PythonToolsUITests {
     [TestClass]
@@ -342,6 +341,8 @@ def f():
                     var point = doc.TextView.TextBuffer.CurrentSnapshot.GetLineFromLineNumber(line - 1).Start.Add(column - 1);
                     doc.TextView.Caret.MoveTo(point);
                 });
+
+                doc.WaitForAnalyzerAtCaret();
 
                 if (allScopes) {
                     app.ExecuteCommand("EditorContextMenus.CodeWindow.RemoveImports.AllScopes");

--- a/Python/Tests/Utilities.Python/EditorWindowExtensions.cs
+++ b/Python/Tests/Utilities.Python/EditorWindowExtensions.cs
@@ -1,0 +1,35 @@
+// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABLITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using Microsoft.PythonTools;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.VisualStudioTools.VSTestHost;
+
+namespace TestUtilities.UI.Python {
+    static class EditorWindowExtensions {
+        public static void WaitForAnalyzerAtCaret(this EditorWindow doc) {
+            for (int i = 0; i < 100; i++) {
+                var analyzer = doc.TextView.GetAnalyzerAtCaret(VSTestContext.ServiceProvider);
+                if (analyzer != null) {
+                    return;
+                }
+                System.Threading.Thread.Sleep(100);
+            }
+
+            Assert.Fail("Timed out waiting for analyzer");
+        }
+    }
+}

--- a/Python/Tests/Utilities.Python/TestUtilities.Python.csproj
+++ b/Python/Tests/Utilities.Python/TestUtilities.Python.csproj
@@ -113,6 +113,7 @@
     <Compile Include="PythonProjectTest.cs" />
     <Compile Include="PythonReplWindowProxySettings.cs" />
     <Compile Include="PythonToolsTestUtilities.cs" />
+    <Compile Include="EditorWindowExtensions.cs" />
     <Compile Include="PythonVisualStudioApp.cs" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
'Remove import' tests failures were easy to repro on my machine, and adding the wait for analyzer makes them succeed consistently.
'Add import' tests were not failing on my machine. On test machine they fail waiting for the lightbulb session, so adding a wait on the analyzer makes some sense.