### PR TITLE
Fixes #2510 REPL SyntaxError when sending/typing only comments

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Repl/PythonInteractiveEvaluator.cs
+++ b/Python/Product/PythonTools/PythonTools/Repl/PythonInteractiveEvaluator.cs
@@ -319,7 +319,10 @@ namespace Microsoft.PythonTools.Repl {
         }
 
         public bool CanExecuteCode(string text) {
-            if (text.EndsWith("\n") || string.IsNullOrEmpty(text)) {
+            if (string.IsNullOrEmpty(text)) {
+                return true;
+            }
+            if (string.IsNullOrWhiteSpace(text) && text.EndsWith("\n")) {
                 return true;
             }
 
@@ -327,7 +330,10 @@ namespace Microsoft.PythonTools.Repl {
             using (var parser = Parser.CreateParser(new StringReader(text), LanguageVersion)) {
                 ParseResult pr;
                 parser.ParseInteractiveCode(out pr);
-                if (pr == ParseResult.Empty || pr == ParseResult.IncompleteToken || pr == ParseResult.IncompleteStatement) {
+                if (pr == ParseResult.IncompleteStatement) {
+                    return text.EndsWith("\n");
+                }
+                if (pr == ParseResult.Empty || pr == ParseResult.IncompleteToken) {
                     return false;
                 }
             }

--- a/Python/Tests/Core/ReplEvaluatorTests.cs
+++ b/Python/Tests/Core/ReplEvaluatorTests.cs
@@ -103,6 +103,7 @@ namespace PythonToolsTests {
                 Assert.IsFalse(evaluator.CanExecuteCode("# Comment"));
                 Assert.IsTrue(evaluator.CanExecuteCode("\r\n"));
                 Assert.IsFalse(evaluator.CanExecuteCode("\r\n#Comment"));
+                Assert.IsFalse(evaluator.CanExecuteCode("# hello\r\n#world\r\n"));
             }
         }
 


### PR DESCRIPTION
Fixes #2510 REPL SyntaxError when sending/typing only comments
Improves logic for identifying non-executable statements
Adds test for problematic code