### PR TITLE
Fix ipc json unicode tests failures

### DIFF
--- a/Python/Tests/TestData/Ipc.Json/parsing_test.py
+++ b/Python/Tests/TestData/Ipc.Json/parsing_test.py
@@ -36,7 +36,6 @@ def main():
     channel = TestChannel(port = opts.result_port)
     try:
         msg = channel.process_one_message()
-        print(msg)
     finally:
         channel.close()
 


### PR DESCRIPTION
Don't print the message, as it may contain unicode chars that cannot be printed to the console.

I was testing an unrelated code page issue on my desktop machine at the time I wrote the test, and ended up with a false positive because of it.

The intention with printing the message was that the test could validate the message read. It only checks if the message was read and deserialized successfully. If we ever want to validate more than that, we could print in base64, or write to a file.
