### PR TITLE
Fixes #2493 Execute File in Interactive executes wrong file

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Commands/ExecuteInReplCommand.cs
+++ b/Python/Product/PythonTools/PythonTools/Commands/ExecuteInReplCommand.cs
@@ -143,9 +143,10 @@ namespace Microsoft.PythonTools.Commands {
 
             if (!string.IsNullOrEmpty(scriptName) && pyProj != null) {
                 if (pyProj.FindNodeByFullPath(scriptName) == null) {
-                    // Starting a script that isn't in the project,
-                    // so don't use the project settings.
-                    pyProj = null;
+                    // Starting a script that isn't in the project.
+                    // Try and find the project. If we fail, we will
+                    // use the default environment.
+                    pyProj = _serviceProvider.GetProjectFromFile(scriptName);
                 }
             }
 

--- a/Python/Product/PythonTools/PythonTools/Extensions.cs
+++ b/Python/Product/PythonTools/PythonTools/Extensions.cs
@@ -413,7 +413,12 @@ namespace Microsoft.PythonTools {
             }
             var project = hierarchy.GetProject();
             if (project != null) {
-                return project.GetPythonProject();
+                var pyProj = project.GetPythonProject();
+                var node = pyProj?.FindNodeByFullPath(filename);
+                if (node == null || !node.IsVisible) {
+                    return null;
+                }
+                return pyProj;
             }
 
             object projectObj;


### PR DESCRIPTION
Now ignores the project if the file is not in it (or is not visible), and selects the right project if it's not in the startup project.