### PR TITLE
Fix build

### DIFF
--- a/Common/Tests/SharedProjectUITests/BasicProjectTests.cs
+++ b/Common/Tests/SharedProjectUITests/BasicProjectTests.cs
@@ -1743,11 +1743,17 @@ namespace Microsoft.VisualStudioTools.SharedProjectTests {
                             uint itemid;
 
                             Console.WriteLine(relativeName);
-                            ThreadHelper.Generic.Invoke(() => ErrorHandler.ThrowOnFailure(project.IsDocumentInProject(relativeName, out found, priority, out itemid)));
+                            ThreadHelper.JoinableTaskFactory.Run(async () => {
+                                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                                ErrorHandler.ThrowOnFailure(project.IsDocumentInProject(relativeName, out found, priority, out itemid));
+                            });
                             Assert.AreNotEqual(0, found);
 
                             Console.WriteLine(absoluteName);
-                            ThreadHelper.Generic.Invoke(() => ErrorHandler.ThrowOnFailure(project.IsDocumentInProject(absoluteName, out found, priority, out itemid)));
+                            ThreadHelper.JoinableTaskFactory.Run(async() => {
+                                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                                ErrorHandler.ThrowOnFailure(project.IsDocumentInProject(absoluteName, out found, priority, out itemid));
+                            });
                             Assert.AreNotEqual(0, found);
                         }
                     }

--- a/Common/Tests/SharedProjectUITests/SharedProjectUITests.csproj
+++ b/Common/Tests/SharedProjectUITests/SharedProjectUITests.csproj
@@ -40,6 +40,9 @@
     <Reference Include="Microsoft.VisualStudio.Text.UI, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.VisualStudio.Text.UI.Wpf, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.VisualStudio.TextManager.Interop, Version=7.1.40304.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+    <Reference Include="Microsoft.VisualStudio.Threading, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="System" />
@@ -60,20 +63,6 @@
     </Reference>
     <Reference Include="WindowsBase" />
   </ItemGroup>
-  <Choose>
-    <When Condition="$(VSTarget) == '15.0'">
-      <ItemGroup>
-        <Reference Include="Microsoft.VisualStudio.Threading, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-          <SpecificVersion>False</SpecificVersion>
-        </Reference>
-      </ItemGroup>
-    </When>
-    <Otherwise>
-      <ItemGroup>
-        <Reference Include="Microsoft.VisualStudio.Threading, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-      </ItemGroup>
-    </Otherwise>
-  </Choose>
   <ItemGroup>
     <Compile Include="BasicProjectTests.cs" />
     <Compile Include="DragDropCopyCutPaste.cs" />

--- a/Common/Tests/SharedProjectUITests/SharedProjectUITests.csproj
+++ b/Common/Tests/SharedProjectUITests/SharedProjectUITests.csproj
@@ -60,6 +60,18 @@
     </Reference>
     <Reference Include="WindowsBase" />
   </ItemGroup>
+  <Choose>
+    <When Condition="$(VSTarget) == '15.0'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.Threading, Version=15.3.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.Threading, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
   <ItemGroup>
     <Compile Include="BasicProjectTests.cs" />
     <Compile Include="DragDropCopyCutPaste.cs" />

--- a/Common/Tests/SharedProjectUITests/SharedProjectUITests.csproj
+++ b/Common/Tests/SharedProjectUITests/SharedProjectUITests.csproj
@@ -63,7 +63,9 @@
   <Choose>
     <When Condition="$(VSTarget) == '15.0'">
       <ItemGroup>
-        <Reference Include="Microsoft.VisualStudio.Threading, Version=15.3.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+        <Reference Include="Microsoft.VisualStudio.Threading, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+          <SpecificVersion>False</SpecificVersion>
+        </Reference>
       </ItemGroup>
     </When>
     <Otherwise>

--- a/Common/Tests/Utilities.UI/TestUtilities.UI.csproj
+++ b/Common/Tests/Utilities.UI/TestUtilities.UI.csproj
@@ -78,7 +78,9 @@
   <Choose>
     <When Condition="$(VSTarget) == '15.0'">
       <ItemGroup>
-        <Reference Include="Microsoft.VisualStudio.Threading, Version=15.3.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+        <Reference Include="Microsoft.VisualStudio.Threading, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+          <SpecificVersion>False</SpecificVersion>
+        </Reference>
       </ItemGroup>
     </When>
     <Otherwise>

--- a/Common/Tests/Utilities.UI/TestUtilities.UI.csproj
+++ b/Common/Tests/Utilities.UI/TestUtilities.UI.csproj
@@ -63,6 +63,9 @@
     <Reference Include="Microsoft.VisualStudio.TextManager.Interop, Version=7.1.40304.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
     <Reference Include="Microsoft.VisualStudio.TextManager.Interop.8.0, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
     <Reference Include="Microsoft.VisualStudio.TextManager.Interop.9.0, Version=9.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+    <Reference Include="Microsoft.VisualStudio.Threading, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="System" />
@@ -75,20 +78,6 @@
     <Reference Include="UIAutomationTypes" />
     <Reference Include="WindowsBase" />
   </ItemGroup>
-  <Choose>
-    <When Condition="$(VSTarget) == '15.0'">
-      <ItemGroup>
-        <Reference Include="Microsoft.VisualStudio.Threading, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-          <SpecificVersion>False</SpecificVersion>
-        </Reference>
-      </ItemGroup>
-    </When>
-    <Otherwise>
-      <ItemGroup>
-        <Reference Include="Microsoft.VisualStudio.Threading, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-      </ItemGroup>
-    </Otherwise>
-  </Choose>
   <ItemGroup>
     <Compile Include="..\..\Product\SharedProject\ExceptionExtensions.cs">
       <Link>ExceptionExtensions.cs</Link>

--- a/Common/Tests/Utilities.UI/TestUtilities.UI.csproj
+++ b/Common/Tests/Utilities.UI/TestUtilities.UI.csproj
@@ -75,6 +75,18 @@
     <Reference Include="UIAutomationTypes" />
     <Reference Include="WindowsBase" />
   </ItemGroup>
+  <Choose>
+    <When Condition="$(VSTarget) == '15.0'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.Threading, Version=15.3.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.Threading, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
   <ItemGroup>
     <Compile Include="..\..\Product\SharedProject\ExceptionExtensions.cs">
       <Link>ExceptionExtensions.cs</Link>

--- a/Common/Tests/Utilities.UI/UI/TestExtensions.cs
+++ b/Common/Tests/Utilities.UI/UI/TestExtensions.cs
@@ -54,7 +54,9 @@ namespace TestUtilities.UI {
         public static bool GetNodeState(this EnvDTE.Project project, string item, __VSHIERARCHYITEMSTATE state) {
             IVsHierarchy hier = null;
             uint id = 0;
-            ThreadHelper.Generic.Invoke((Action)(() => {
+            ThreadHelper.JoinableTaskFactory.RunAsync(async () => {
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
                 hier = ((dynamic)project).Project as IVsHierarchy;
                 object projectDir;
                 ErrorHandler.ThrowOnFailure(
@@ -71,7 +73,7 @@ namespace TestUtilities.UI {
                         hier.ParseCanonicalName(itemPath + "\\", out id)
                     );
                 }
-            }));
+            });
 
             // make sure we're still expanded.
             var solutionWindow = UIHierarchyUtilities.GetUIHierarchyWindow(

--- a/Common/Tests/Utilities.UI/UI/VisualStudioInstance.cs
+++ b/Common/Tests/Utilities.UI/UI/VisualStudioInstance.cs
@@ -46,7 +46,11 @@ namespace TestUtilities.UI {
             _app = new VisualStudioApp();
             Project = _app.OpenProject(solution.Filename);
 
-            ThreadHelper.Generic.Invoke(Keyboard.Reset);
+            ThreadHelper.JoinableTaskFactory.Run(async () => {
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                Keyboard.Reset();
+            });
+
             _solutionExplorer = _app.OpenSolutionExplorer();
             SelectSolutionNode();
         }

--- a/Python/Product/Cookiecutter/Cookiecutter.csproj
+++ b/Python/Product/Cookiecutter/Cookiecutter.csproj
@@ -135,7 +135,9 @@
     <When Condition="$(VSTarget) == '15.0'">
       <ItemGroup>
         <Reference Include="Microsoft.VisualStudio.Shell.Framework, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-        <Reference Include="Microsoft.VisualStudio.Threading, Version=15.3.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+        <Reference Include="Microsoft.VisualStudio.Threading, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+          <SpecificVersion>False</SpecificVersion>
+        </Reference>
       </ItemGroup>
     </When>
     <Otherwise>

--- a/Python/Product/Cookiecutter/Cookiecutter.csproj
+++ b/Python/Product/Cookiecutter/Cookiecutter.csproj
@@ -101,6 +101,9 @@
     <Reference Include="Microsoft.VisualStudio.Shell.Interop.14.0.DesignTime, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <EmbedInteropTypes>True</EmbedInteropTypes>
     </Reference>
+    <Reference Include="Microsoft.VisualStudio.Threading, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
     <Reference Include="Microsoft.VisualStudio.Utilities, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.Build, Version=$(MicrosoftBuildAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
     <Reference Include="PresentationCore" />
@@ -135,16 +138,12 @@
     <When Condition="$(VSTarget) == '15.0'">
       <ItemGroup>
         <Reference Include="Microsoft.VisualStudio.Shell.Framework, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-        <Reference Include="Microsoft.VisualStudio.Threading, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-          <SpecificVersion>False</SpecificVersion>
-        </Reference>
       </ItemGroup>
     </When>
     <Otherwise>
       <ItemGroup>
         <Reference Include="Microsoft.VisualStudio.Shell.Immutable.10.0, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
         <Reference Include="Microsoft.VisualStudio.Shell.Immutable.11.0, Version=11.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" Condition="'$(VSTarget)' != '10.0'" />
-        <Reference Include="Microsoft.VisualStudio.Threading, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
       </ItemGroup>
     </Otherwise>
   </Choose>

--- a/Python/Product/Cookiecutter/Cookiecutter.csproj
+++ b/Python/Product/Cookiecutter/Cookiecutter.csproj
@@ -102,7 +102,6 @@
       <EmbedInteropTypes>True</EmbedInteropTypes>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Utilities, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
-    <Reference Include="Microsoft.VisualStudio.Threading, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.Build, Version=$(MicrosoftBuildAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
@@ -136,12 +135,14 @@
     <When Condition="$(VSTarget) == '15.0'">
       <ItemGroup>
         <Reference Include="Microsoft.VisualStudio.Shell.Framework, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+        <Reference Include="Microsoft.VisualStudio.Threading, Version=15.3.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
       </ItemGroup>
     </When>
     <Otherwise>
       <ItemGroup>
         <Reference Include="Microsoft.VisualStudio.Shell.Immutable.10.0, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
         <Reference Include="Microsoft.VisualStudio.Shell.Immutable.11.0, Version=11.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" Condition="'$(VSTarget)' != '10.0'" />
+        <Reference Include="Microsoft.VisualStudio.Threading, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
       </ItemGroup>
     </Otherwise>
   </Choose>

--- a/Python/Product/Debugger/Debugger.csproj
+++ b/Python/Product/Debugger/Debugger.csproj
@@ -85,7 +85,9 @@
     <When Condition="$(VSTarget) == '15.0'">
       <ItemGroup>
         <Reference Include="Microsoft.VisualStudio.Shell.Framework, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-        <Reference Include="Microsoft.VisualStudio.Threading, Version=15.3.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+        <Reference Include="Microsoft.VisualStudio.Threading, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+          <SpecificVersion>False</SpecificVersion>
+        </Reference>
       </ItemGroup>
     </When>
     <Otherwise>

--- a/Python/Product/Debugger/Debugger.csproj
+++ b/Python/Product/Debugger/Debugger.csproj
@@ -72,6 +72,9 @@
     <Reference Include="Microsoft.VisualStudio.Shell.$(VsTarget)">
       <Aliases>global</Aliases>
     </Reference>
+    <Reference Include="Microsoft.VisualStudio.Threading, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
     <Reference Include="System.XML" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="WindowsBase" />
@@ -85,16 +88,12 @@
     <When Condition="$(VSTarget) == '15.0'">
       <ItemGroup>
         <Reference Include="Microsoft.VisualStudio.Shell.Framework, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-        <Reference Include="Microsoft.VisualStudio.Threading, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-          <SpecificVersion>False</SpecificVersion>
-        </Reference>
       </ItemGroup>
     </When>
     <Otherwise>
       <ItemGroup>
         <Reference Include="Microsoft.VisualStudio.Shell.Immutable.14.0, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
         <Reference Include="Microsoft.VisualStudio.Shell.Immutable.10.0, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
-        <Reference Include="Microsoft.VisualStudio.Threading, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
       </ItemGroup>
     </Otherwise>
   </Choose>

--- a/Python/Product/Debugger/Debugger.csproj
+++ b/Python/Product/Debugger/Debugger.csproj
@@ -56,7 +56,6 @@
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Shell.Interop.8.0, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
     <Reference Include="Microsoft.VisualStudio.Shell.Interop.9.0, Version=9.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-    <Reference Include="Microsoft.VisualStudio.Threading, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Core" />
@@ -86,12 +85,14 @@
     <When Condition="$(VSTarget) == '15.0'">
       <ItemGroup>
         <Reference Include="Microsoft.VisualStudio.Shell.Framework, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+        <Reference Include="Microsoft.VisualStudio.Threading, Version=15.3.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
       </ItemGroup>
     </When>
     <Otherwise>
       <ItemGroup>
         <Reference Include="Microsoft.VisualStudio.Shell.Immutable.14.0, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
         <Reference Include="Microsoft.VisualStudio.Shell.Immutable.10.0, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+        <Reference Include="Microsoft.VisualStudio.Threading, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
       </ItemGroup>
     </Otherwise>
   </Choose>

--- a/Python/Product/Profiling/Profiling.csproj
+++ b/Python/Product/Profiling/Profiling.csproj
@@ -96,7 +96,9 @@
     <When Condition="$(VSTarget) == '15.0'">
       <ItemGroup>
         <Reference Include="Microsoft.VisualStudio.Shell.Framework, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-        <Reference Include="Microsoft.VisualStudio.Threading, Version=15.3.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+        <Reference Include="Microsoft.VisualStudio.Threading, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+          <SpecificVersion>False</SpecificVersion>
+        </Reference>
       </ItemGroup>
     </When>
     <Otherwise>

--- a/Python/Product/Profiling/Profiling.csproj
+++ b/Python/Product/Profiling/Profiling.csproj
@@ -96,11 +96,13 @@
     <When Condition="$(VSTarget) == '15.0'">
       <ItemGroup>
         <Reference Include="Microsoft.VisualStudio.Shell.Framework, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+        <Reference Include="Microsoft.VisualStudio.Threading, Version=15.3.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
       </ItemGroup>
     </When>
     <Otherwise>
       <ItemGroup>
         <Reference Include="Microsoft.VisualStudio.Shell.Immutable.10.0, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+        <Reference Include="Microsoft.VisualStudio.Threading, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
       </ItemGroup>
     </Otherwise>
   </Choose>

--- a/Python/Product/Profiling/Profiling.csproj
+++ b/Python/Product/Profiling/Profiling.csproj
@@ -79,6 +79,9 @@
       <EmbedInteropTypes>True</EmbedInteropTypes>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Utilities, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+    <Reference Include="Microsoft.VisualStudio.Threading, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
     <Reference Include="envdte, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <EmbedInteropTypes>False</EmbedInteropTypes>
     </Reference>
@@ -96,15 +99,11 @@
     <When Condition="$(VSTarget) == '15.0'">
       <ItemGroup>
         <Reference Include="Microsoft.VisualStudio.Shell.Framework, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-        <Reference Include="Microsoft.VisualStudio.Threading, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-          <SpecificVersion>False</SpecificVersion>
-        </Reference>
       </ItemGroup>
     </When>
     <Otherwise>
       <ItemGroup>
         <Reference Include="Microsoft.VisualStudio.Shell.Immutable.10.0, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
-        <Reference Include="Microsoft.VisualStudio.Threading, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
       </ItemGroup>
     </Otherwise>
   </Choose>

--- a/Python/Product/Profiling/PythonProfilingPackage.cs
+++ b/Python/Product/Profiling/PythonProfilingPackage.cs
@@ -192,7 +192,9 @@ namespace Microsoft.PythonTools.Profiling {
         }
 
         internal SessionNode ProfileTarget(ProfilingTarget target, bool openReport = true) {
-            return ThreadHelper.Generic.Invoke(() => {
+            return ThreadHelper.JoinableTaskFactory.Run(async () => {
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
                 bool save;
                 string name = target.GetProfilingName(this, out save);
                 var session = ShowPerformanceExplorer().Sessions.AddTarget(target, name, save);
@@ -203,7 +205,9 @@ namespace Microsoft.PythonTools.Profiling {
         }
 
         internal void StartProfiling(ProfilingTarget target, SessionNode session, bool openReport = true) {
-            ThreadHelper.Generic.Invoke(() => {
+            ThreadHelper.JoinableTaskFactory.Run(async () => {
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
                 if (!Utilities.SaveDirtyFiles()) {
                     // Abort
                     return;

--- a/Python/Product/ProjectWizards/CloudServiceWizard.cs
+++ b/Python/Product/ProjectWizards/CloudServiceWizard.cs
@@ -66,11 +66,15 @@ namespace Microsoft.PythonTools.ProjectWizards {
         }
 
         private static bool AreToolsInstalled(IServiceProvider provider) {
+#if DEV15_OR_LATER
             var setupService = provider.GetService(typeof(SVsSetupCompositionService)) as IVsSetupCompositionService;
             // If we fail to get the setup service, we're probably in a whole lot of trouble
             // Likely the "install" step will fail too, but at least we'll have given users a
             // hint and they might go to Setup and repair things.
             return setupService?.IsPackageInstalled(RequiredPackage) ?? false;
+#else
+            return true;
+#endif
         }
 
         private static void InstallTools(IServiceProvider provider) {

--- a/Python/Product/PythonTools/PythonTools.csproj
+++ b/Python/Product/PythonTools/PythonTools.csproj
@@ -108,7 +108,6 @@
     <Reference Include="Microsoft.VisualStudio.InteractiveWindow" />
     <Reference Include="Microsoft.VisualStudio.VsInteractiveWindow" />
     <Reference Include="Microsoft.VisualStudio.Telemetry" />
-    <Reference Include="Microsoft.VisualStudio.Threading, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Accessibility">
@@ -238,12 +237,14 @@
     <When Condition="$(VSTarget) == '15.0'">
       <ItemGroup>
         <Reference Include="Microsoft.VisualStudio.Shell.Framework, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+        <Reference Include="Microsoft.VisualStudio.Threading, Version=15.3.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
       </ItemGroup>
     </When>
     <Otherwise>
       <ItemGroup>
         <Reference Include="Microsoft.VisualStudio.Shell.Immutable.10.0, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
         <Reference Include="Microsoft.VisualStudio.Shell.Immutable.11.0, Version=11.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" Condition="'$(VSTarget)' != '10.0'" />
+        <Reference Include="Microsoft.VisualStudio.Threading, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
       </ItemGroup>
     </Otherwise>
   </Choose>

--- a/Python/Product/PythonTools/PythonTools.csproj
+++ b/Python/Product/PythonTools/PythonTools.csproj
@@ -237,7 +237,9 @@
     <When Condition="$(VSTarget) == '15.0'">
       <ItemGroup>
         <Reference Include="Microsoft.VisualStudio.Shell.Framework, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-        <Reference Include="Microsoft.VisualStudio.Threading, Version=15.3.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+        <Reference Include="Microsoft.VisualStudio.Threading, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+          <SpecificVersion>False</SpecificVersion>
+        </Reference>
       </ItemGroup>
     </When>
     <Otherwise>

--- a/Python/Product/PythonTools/PythonTools.csproj
+++ b/Python/Product/PythonTools/PythonTools.csproj
@@ -232,21 +232,20 @@
     <Reference Include="Microsoft.VisualStudio.Settings.$(VSTarget), Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=x86">
       <Private>false</Private>
     </Reference>
+    <Reference Include="Microsoft.VisualStudio.Threading, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
   </ItemGroup>
   <Choose>
     <When Condition="$(VSTarget) == '15.0'">
       <ItemGroup>
         <Reference Include="Microsoft.VisualStudio.Shell.Framework, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-        <Reference Include="Microsoft.VisualStudio.Threading, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-          <SpecificVersion>False</SpecificVersion>
-        </Reference>
       </ItemGroup>
     </When>
     <Otherwise>
       <ItemGroup>
         <Reference Include="Microsoft.VisualStudio.Shell.Immutable.10.0, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
         <Reference Include="Microsoft.VisualStudio.Shell.Immutable.11.0, Version=11.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" Condition="'$(VSTarget)' != '10.0'" />
-        <Reference Include="Microsoft.VisualStudio.Threading, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
       </ItemGroup>
     </Otherwise>
   </Choose>

--- a/Python/Product/TestAdapter/TestAdapter.csproj
+++ b/Python/Product/TestAdapter/TestAdapter.csproj
@@ -92,7 +92,9 @@
     <When Condition="$(VSTarget) == '15.0'">
       <ItemGroup>
         <Reference Include="Microsoft.VisualStudio.Shell.Framework, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-        <Reference Include="Microsoft.VisualStudio.Threading, Version=15.3.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+        <Reference Include="Microsoft.VisualStudio.Threading, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+          <SpecificVersion>False</SpecificVersion>
+        </Reference>
       </ItemGroup>
     </When>
     <Otherwise>

--- a/Python/Product/TestAdapter/TestAdapter.csproj
+++ b/Python/Product/TestAdapter/TestAdapter.csproj
@@ -71,7 +71,6 @@
     <Reference Include="Microsoft.VisualStudio.ComponentModelHost, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.VisualStudio.CoreUtility, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
     <Reference Include="Microsoft.VisualStudio.OLE.Interop" />
-    <Reference Include="Microsoft.VisualStudio.Threading, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="System" />
@@ -93,11 +92,13 @@
     <When Condition="$(VSTarget) == '15.0'">
       <ItemGroup>
         <Reference Include="Microsoft.VisualStudio.Shell.Framework, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+        <Reference Include="Microsoft.VisualStudio.Threading, Version=15.3.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
       </ItemGroup>
     </When>
     <Otherwise>
       <ItemGroup>
         <Reference Include="Microsoft.VisualStudio.Shell.Immutable.10.0, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+        <Reference Include="Microsoft.VisualStudio.Threading, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
       </ItemGroup>
     </Otherwise>
   </Choose>

--- a/Python/Product/TestAdapter/TestAdapter.csproj
+++ b/Python/Product/TestAdapter/TestAdapter.csproj
@@ -87,20 +87,19 @@
     <Reference Include="Microsoft.VisualStudio.Settings.$(VSTarget), Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=x86">
       <Private>false</Private>
     </Reference>
+    <Reference Include="Microsoft.VisualStudio.Threading, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
   </ItemGroup>
   <Choose>
     <When Condition="$(VSTarget) == '15.0'">
       <ItemGroup>
         <Reference Include="Microsoft.VisualStudio.Shell.Framework, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-        <Reference Include="Microsoft.VisualStudio.Threading, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-          <SpecificVersion>False</SpecificVersion>
-        </Reference>
       </ItemGroup>
     </When>
     <Otherwise>
       <ItemGroup>
         <Reference Include="Microsoft.VisualStudio.Shell.Immutable.10.0, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
-        <Reference Include="Microsoft.VisualStudio.Threading, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
       </ItemGroup>
     </Otherwise>
   </Choose>

--- a/Python/Product/Uwp/Uwp.csproj
+++ b/Python/Product/Uwp/Uwp.csproj
@@ -134,20 +134,19 @@
     <Reference Include="WindowsBase" />
     <Reference Include="Microsoft.VisualStudio.Debugger.Engine, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.VisualStudio.Web.HTML, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+    <Reference Include="Microsoft.VisualStudio.Threading, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
   </ItemGroup>
   <Choose>
     <When Condition="$(VSTarget) == '15.0'">
       <ItemGroup>
         <Reference Include="Microsoft.VisualStudio.Shell.Framework, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-        <Reference Include="Microsoft.VisualStudio.Threading, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-          <SpecificVersion>False</SpecificVersion>
-        </Reference>
       </ItemGroup>
     </When>
     <Otherwise>
       <ItemGroup>
         <Reference Include="Microsoft.VisualStudio.Shell.Immutable.10.0, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
-        <Reference Include="Microsoft.VisualStudio.Threading, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
       </ItemGroup>
     </Otherwise>
   </Choose>

--- a/Python/Product/Uwp/Uwp.csproj
+++ b/Python/Product/Uwp/Uwp.csproj
@@ -108,7 +108,6 @@
     <Reference Include="Microsoft.VisualStudio.TextManager.Interop.8.0, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
     <Reference Include="Microsoft.VisualStudio.TextManager.Interop.9.0, Version=9.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
     <Reference Include="Microsoft.Build, Version=$(MicrosoftBuildAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-    <Reference Include="Microsoft.VisualStudio.Threading, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="PresentationUI, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
@@ -140,11 +139,13 @@
     <When Condition="$(VSTarget) == '15.0'">
       <ItemGroup>
         <Reference Include="Microsoft.VisualStudio.Shell.Framework, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+        <Reference Include="Microsoft.VisualStudio.Threading, Version=15.3.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
       </ItemGroup>
     </When>
     <Otherwise>
       <ItemGroup>
         <Reference Include="Microsoft.VisualStudio.Shell.Immutable.10.0, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+        <Reference Include="Microsoft.VisualStudio.Threading, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
       </ItemGroup>
     </Otherwise>
   </Choose>

--- a/Python/Product/Uwp/Uwp.csproj
+++ b/Python/Product/Uwp/Uwp.csproj
@@ -139,7 +139,9 @@
     <When Condition="$(VSTarget) == '15.0'">
       <ItemGroup>
         <Reference Include="Microsoft.VisualStudio.Shell.Framework, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-        <Reference Include="Microsoft.VisualStudio.Threading, Version=15.3.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+        <Reference Include="Microsoft.VisualStudio.Threading, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+          <SpecificVersion>False</SpecificVersion>
+        </Reference>
       </ItemGroup>
     </When>
     <Otherwise>

--- a/Python/Product/Workspace/Workspace.csproj
+++ b/Python/Product/Workspace/Workspace.csproj
@@ -90,21 +90,20 @@
     <Reference Include="Microsoft.VisualStudio.Workspace" />
     <Reference Include="Microsoft.VisualStudio.Workspace.Extensions" />
     <Reference Include="Microsoft.VisualStudio.Workspace.Extensions.VS" />
+    <Reference Include="Microsoft.VisualStudio.Threading, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
   </ItemGroup>
   <Choose>
     <When Condition="$(VSTarget) == '15.0'">
       <ItemGroup>
         <Reference Include="Microsoft.VisualStudio.Shell.Framework, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-        <Reference Include="Microsoft.VisualStudio.Threading, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-          <SpecificVersion>False</SpecificVersion>
-        </Reference>
       </ItemGroup>
     </When>
     <Otherwise>
       <ItemGroup>
         <Reference Include="Microsoft.VisualStudio.Shell.Immutable.10.0, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
         <Reference Include="Microsoft.VisualStudio.Shell.Immutable.11.0, Version=11.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" Condition="'$(VSTarget)' != '10.0'" />
-        <Reference Include="Microsoft.VisualStudio.Threading, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
       </ItemGroup>
     </Otherwise>
   </Choose>

--- a/Python/Product/Workspace/Workspace.csproj
+++ b/Python/Product/Workspace/Workspace.csproj
@@ -95,7 +95,9 @@
     <When Condition="$(VSTarget) == '15.0'">
       <ItemGroup>
         <Reference Include="Microsoft.VisualStudio.Shell.Framework, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-        <Reference Include="Microsoft.VisualStudio.Threading, Version=15.3.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+        <Reference Include="Microsoft.VisualStudio.Threading, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+          <SpecificVersion>False</SpecificVersion>
+        </Reference>
       </ItemGroup>
     </When>
     <Otherwise>

--- a/Python/Product/Workspace/Workspace.csproj
+++ b/Python/Product/Workspace/Workspace.csproj
@@ -90,20 +90,19 @@
     <Reference Include="Microsoft.VisualStudio.Workspace" />
     <Reference Include="Microsoft.VisualStudio.Workspace.Extensions" />
     <Reference Include="Microsoft.VisualStudio.Workspace.Extensions.VS" />
-    <Reference Include="Microsoft.VisualStudio.Threading, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <HintPath Condition="$(VSTarget) == '14.0'">References\Microsoft.VisualStudio.Threading.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <Choose>
     <When Condition="$(VSTarget) == '15.0'">
       <ItemGroup>
         <Reference Include="Microsoft.VisualStudio.Shell.Framework, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+        <Reference Include="Microsoft.VisualStudio.Threading, Version=15.3.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
       </ItemGroup>
     </When>
     <Otherwise>
       <ItemGroup>
         <Reference Include="Microsoft.VisualStudio.Shell.Immutable.10.0, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
         <Reference Include="Microsoft.VisualStudio.Shell.Immutable.11.0, Version=11.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" Condition="'$(VSTarget)' != '10.0'" />
+        <Reference Include="Microsoft.VisualStudio.Threading, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
       </ItemGroup>
     </Otherwise>
   </Choose>

--- a/Python/Product/Wsl/Wsl.csproj
+++ b/Python/Product/Wsl/Wsl.csproj
@@ -127,21 +127,10 @@
     </Reference>
     <Reference Include="WindowsBase" />
     <Reference Include="Microsoft.VisualStudio.Shell.Framework, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+    <Reference Include="Microsoft.VisualStudio.Threading, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
   </ItemGroup>
-  <Choose>
-    <When Condition="$(VSTarget) == '15.0'">
-      <ItemGroup>
-        <Reference Include="Microsoft.VisualStudio.Threading, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-          <SpecificVersion>False</SpecificVersion>
-        </Reference>
-      </ItemGroup>
-    </When>
-    <Otherwise>
-      <ItemGroup>
-        <Reference Include="Microsoft.VisualStudio.Threading, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-      </ItemGroup>
-    </Otherwise>
-  </Choose>
   <ItemGroup>
     <Compile Include="Debugger\WslLauncher.cs" />
     <Compile Include="NativeMethods.cs" />

--- a/Python/Product/Wsl/Wsl.csproj
+++ b/Python/Product/Wsl/Wsl.csproj
@@ -131,7 +131,9 @@
   <Choose>
     <When Condition="$(VSTarget) == '15.0'">
       <ItemGroup>
-        <Reference Include="Microsoft.VisualStudio.Threading, Version=15.3.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+        <Reference Include="Microsoft.VisualStudio.Threading, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+          <SpecificVersion>False</SpecificVersion>
+        </Reference>
       </ItemGroup>
     </When>
     <Otherwise>

--- a/Python/Product/Wsl/Wsl.csproj
+++ b/Python/Product/Wsl/Wsl.csproj
@@ -103,7 +103,6 @@
       <EmbedInteropTypes>True</EmbedInteropTypes>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Utilities, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
-    <Reference Include="Microsoft.VisualStudio.Threading, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.Build, Version=$(MicrosoftBuildAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
@@ -129,6 +128,18 @@
     <Reference Include="WindowsBase" />
     <Reference Include="Microsoft.VisualStudio.Shell.Framework, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   </ItemGroup>
+  <Choose>
+    <When Condition="$(VSTarget) == '15.0'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.Threading, Version=15.3.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.Threading, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
   <ItemGroup>
     <Compile Include="Debugger\WslLauncher.cs" />
     <Compile Include="NativeMethods.cs" />

--- a/Python/Tests/Core.UI/AddImportTests.cs
+++ b/Python/Tests/Core.UI/AddImportTests.cs
@@ -285,9 +285,8 @@ sub_package";
             doc.Invoke(() => {
                 var point = doc.TextView.TextBuffer.CurrentSnapshot.GetLineFromLineNumber(line - 1).Start.Add(column - 1);
                 doc.TextView.Caret.MoveTo(point);
+                doc.WaitForAnalyzerAtCaret();
             });
-
-            doc.WaitForAnalyzerAtCaret();
 
             if (expectedActions.Length > 0) {
                 using (var sh = doc.StartSmartTagSession()) {

--- a/Python/Tests/Core.UI/RemoveImportTests.cs
+++ b/Python/Tests/Core.UI/RemoveImportTests.cs
@@ -340,9 +340,8 @@ def f():
                 doc.Invoke(() => {
                     var point = doc.TextView.TextBuffer.CurrentSnapshot.GetLineFromLineNumber(line - 1).Start.Add(column - 1);
                     doc.TextView.Caret.MoveTo(point);
+                    doc.WaitForAnalyzerAtCaret();
                 });
-
-                doc.WaitForAnalyzerAtCaret();
 
                 if (allScopes) {
                     app.ExecuteCommand("EditorContextMenus.CodeWindow.RemoveImports.AllScopes");

--- a/Python/Tests/Django.UI/DjangoEditingTests.cs
+++ b/Python/Tests/Django.UI/DjangoEditingTests.cs
@@ -1254,7 +1254,8 @@ namespace DjangoUITests {
 
         private static bool SetBraceCompletion(VisualStudioApp app, bool value) {
             bool oldValue = false;
-            ThreadHelper.Generic.Invoke(() => {
+            ThreadHelper.JoinableTaskFactory.Run(async () => {
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
                 HtmlSettings.InsertMatchingBraces = false;
                 HtmlSettings.InsertEndTags = false;
             });

--- a/Python/Tests/Django.UI/DjangoUITests.csproj
+++ b/Python/Tests/Django.UI/DjangoUITests.csproj
@@ -93,6 +93,18 @@
       <HintPath>$(DevEnvDir)Microsoft.VisualStudio.Web.Html.dll</HintPath>
     </Reference>
   </ItemGroup>
+  <Choose>
+    <When Condition="$(VSTarget) == '15.0'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.Threading, Version=15.3.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.Threading, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
   <ItemGroup>
     <Compile Include="DjangoAzureTests.cs" />
     <Compile Include="DjangoDebugProjectTests.cs" />

--- a/Python/Tests/Django.UI/DjangoUITests.csproj
+++ b/Python/Tests/Django.UI/DjangoUITests.csproj
@@ -96,7 +96,9 @@
   <Choose>
     <When Condition="$(VSTarget) == '15.0'">
       <ItemGroup>
-        <Reference Include="Microsoft.VisualStudio.Threading, Version=15.3.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+        <Reference Include="Microsoft.VisualStudio.Threading, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+          <SpecificVersion>False</SpecificVersion>
+        </Reference>
       </ItemGroup>
     </When>
     <Otherwise>

--- a/Python/Tests/Django.UI/DjangoUITests.csproj
+++ b/Python/Tests/Django.UI/DjangoUITests.csproj
@@ -92,21 +92,10 @@
     <Reference Include="Microsoft.VisualStudio.Web.HTML, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>$(DevEnvDir)Microsoft.VisualStudio.Web.Html.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.VisualStudio.Threading, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
   </ItemGroup>
-  <Choose>
-    <When Condition="$(VSTarget) == '15.0'">
-      <ItemGroup>
-        <Reference Include="Microsoft.VisualStudio.Threading, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-          <SpecificVersion>False</SpecificVersion>
-        </Reference>
-      </ItemGroup>
-    </When>
-    <Otherwise>
-      <ItemGroup>
-        <Reference Include="Microsoft.VisualStudio.Threading, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-      </ItemGroup>
-    </Otherwise>
-  </Choose>
   <ItemGroup>
     <Compile Include="DjangoAzureTests.cs" />
     <Compile Include="DjangoDebugProjectTests.cs" />


### PR DESCRIPTION
I made the mistake of being the first to upgrade to 15.3 ;)

I've updated the ThreadHelper deprecated code according to the guidelines in Andrew's email.

Microsoft.VisualStudio.Threading assembly is now version 15.3.  I don't know how careful we want to be, my changes removes the version check only on Dev15, but we could simplify it by making it ignore the version unconditionally ie. no need for choose element.

I fixed the Dev14 build while I was there.