### PR TITLE
Accessibility fixes for environment window

### DIFF
--- a/Python/Product/EnvironmentsList/EnvironmentPathsExtension.xaml
+++ b/Python/Product/EnvironmentsList/EnvironmentPathsExtension.xaml
@@ -144,52 +144,14 @@
                             </Button>
 
                             <!--
-                            This command is not expected to remain long-term,
+                            This is not expected to remain long-term,
                             but should be replaced with a more general startup
                             script tool.
                             -->
-                            <Button Command="{x:Static l:EnvironmentView.EnableIPythonInteractive}"
-                                    CommandParameter="{Binding}"
-                                    Style="{StaticResource NavigationButton}"
-                                    Margin="12 6 6 6"
-                                    HorizontalAlignment="Left"
-                                    Visibility="{Binding IsEnabled,RelativeSource={RelativeSource Self},Converter={StaticResource VisibleIfEnabled}}"
-                                    AutomationProperties.Name="{x:Static l:Resources.EnvironmentPathsExtensionEnableIPythonAutomationName}">
-                                <Grid Background="Transparent">
-                                    <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="auto" />
-                                        <ColumnDefinition />
-                                    </Grid.ColumnDefinitions>
-                                    <Control Grid.Column="0"
-                                             Margin="3 0"
-                                             Style="{StaticResource CheckBoxUncheckedImage}"
-                                             IsTabStop="False"/>
-                                    <TextBlock Grid.Column="1"
-                                               TextWrapping="WrapWithOverflow"
-                                               Text="{x:Static l:Resources.EnvironmentPathsExtensionEnableIPythonLabel}"/>
-                                </Grid>
-                            </Button>
-                            <Button Command="{x:Static l:EnvironmentView.DisableIPythonInteractive}"
-                                    CommandParameter="{Binding}"
-                                    Style="{StaticResource NavigationButton}"
-                                    Margin="12 6 6 6"
-                                    HorizontalAlignment="Left"
-                                    Visibility="{Binding IsEnabled,RelativeSource={RelativeSource Self},Converter={StaticResource VisibleIfEnabled}}"
-                                    AutomationProperties.Name="{x:Static l:Resources.EnvironmentPathsExtensionDisableIPythonAutomationName}">
-                                <Grid Background="Transparent">
-                                    <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="auto" />
-                                        <ColumnDefinition />
-                                    </Grid.ColumnDefinitions>
-                                    <Control Grid.Column="0"
-                                             Margin="3 0"
-                                             Style="{StaticResource CheckBoxCheckedImage}"
-                                             IsTabStop="False"/>
-                                    <TextBlock Grid.Column="1"
-                                               TextWrapping="WrapWithOverflow"
-                                               Text="{x:Static l:Resources.EnvironmentPathsExtensionDisableIPythonLabel}"/>
-                                </Grid>
-                            </Button>
+                            <CheckBox Margin="12 6 6 6"
+                                      IsChecked="{Binding IsIPythonModeEnabled}"
+                                      Content="{x:Static l:Resources.EnvironmentPathsExtensionEnableIPythonLabel}"
+                                      AutomationProperties.Name="{x:Static l:Resources.EnvironmentPathsExtensionEnableIPythonAutomationName}"/>
 
                             <Button Command="{x:Static l:EnvironmentView.OpenInPowerShell}"
                                     CommandParameter="{Binding Mode=OneWay}"

--- a/Python/Product/EnvironmentsList/EnvironmentView.cs
+++ b/Python/Product/EnvironmentsList/EnvironmentView.cs
@@ -34,9 +34,6 @@ namespace Microsoft.PythonTools.EnvironmentsList {
         public static readonly RoutedCommand MakeGlobalDefault = new RoutedCommand();
         public static readonly RoutedCommand MakeActiveInCurrentProject = new RoutedCommand();
 
-        public static readonly RoutedCommand EnableIPythonInteractive = new RoutedCommand();
-        public static readonly RoutedCommand DisableIPythonInteractive = new RoutedCommand();
-
         private const string AddNewEnvironmentViewId = "__AddNewEnvironmentView";
         private const string OnlineHelpViewId = "__OnlineHelpView";
 
@@ -289,6 +286,20 @@ namespace Microsoft.PythonTools.EnvironmentsList {
         }
 
         #endregion
+
+        public static readonly DependencyProperty IsIPythonModeEnabledProperty = DependencyProperty.Register("IsIPythonModeEnabled", typeof(bool), typeof(EnvironmentView), new FrameworkPropertyMetadata(OnIsIPythonModeEnabledChanged));
+
+        public bool IsIPythonModeEnabled {
+            get { return (bool)GetValue(IsIPythonModeEnabledProperty); }
+            set { SetValue(IsIPythonModeEnabledProperty, value); }
+        }
+
+        public Action<EnvironmentView, bool> IPythonModeEnabledSetter { get; set; }
+
+        private static void OnIsIPythonModeEnabledChanged(DependencyObject d, DependencyPropertyChangedEventArgs e) {
+            var view = (EnvironmentView)d;
+            view.IPythonModeEnabledSetter?.Invoke(view, (bool)e.NewValue);
+        }
     }
 
     public sealed class EnvironmentViewTemplateSelector : DataTemplateSelector {

--- a/Python/Product/EnvironmentsList/Resources.Designer.cs
+++ b/Python/Product/EnvironmentsList/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.PythonTools.EnvironmentsList {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Resources {
@@ -462,24 +462,6 @@ namespace Microsoft.PythonTools.EnvironmentsList {
         public static string EnvironmentPathsExtensionConfigureEnvironmentLabel {
             get {
                 return ResourceManager.GetString("EnvironmentPathsExtensionConfigureEnvironmentLabel", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Disable IPython interactive mode.
-        /// </summary>
-        public static string EnvironmentPathsExtensionDisableIPythonAutomationName {
-            get {
-                return ResourceManager.GetString("EnvironmentPathsExtensionDisableIPythonAutomationName", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Use IPython interactive mode.
-        /// </summary>
-        public static string EnvironmentPathsExtensionDisableIPythonLabel {
-            get {
-                return ResourceManager.GetString("EnvironmentPathsExtensionDisableIPythonLabel", resourceCulture);
             }
         }
         

--- a/Python/Product/EnvironmentsList/Resources.resx
+++ b/Python/Product/EnvironmentsList/Resources.resx
@@ -358,9 +358,6 @@
   <data name="EnvironmentPathsExtensionEnableIPythonLabel" xml:space="preserve">
     <value>Use IPython interactive mode</value>
   </data>
-  <data name="EnvironmentPathsExtensionDisableIPythonLabel" xml:space="preserve">
-    <value>Use IPython interactive mode</value>
-  </data>
   <data name="EnvironmentPathsExtensionOpenInPowerShell" xml:space="preserve">
     <value>Open in PowerShell</value>
   </data>
@@ -403,9 +400,6 @@
   </data>
   <data name="StandardLibraryModuleListItem" xml:space="preserve">
     <value>(Standard Library)</value>
-  </data>
-  <data name="EnvironmentPathsExtensionDisableIPythonAutomationName" xml:space="preserve">
-    <value>Disable IPython interactive mode</value>
   </data>
   <data name="EnvironmentPathsExtensionEnableIPythonAutomationName" xml:space="preserve">
     <value>Enable IPython interactive mode</value>

--- a/Python/Product/EnvironmentsListHost/MainWindow.xaml
+++ b/Python/Product/EnvironmentsListHost/MainWindow.xaml
@@ -16,17 +16,9 @@
         <CommandBinding Command="{x:Static el:EnvironmentView.OpenInCommandPrompt}"
                         CanExecute="OpenConsole_CanExecute"
                         Executed="OpenConsole_Executed" />
-
         <CommandBinding Command="{x:Static el:EnvironmentView.OpenInteractiveScripts}"
                         CanExecute="OpenInteractiveScripts_CanExecute"
                         Executed="OpenInteractiveScripts_Executed" />
-        <CommandBinding Command="{x:Static el:EnvironmentView.EnableIPythonInteractive}"
-                        CanExecute="EnableIPythonInteractive_CanExecute"
-                        Executed="EnableIPythonInteractive_Executed" />
-        <CommandBinding Command="{x:Static el:EnvironmentView.DisableIPythonInteractive}"
-                        CanExecute="DisableIPythonInteractive_CanExecute"
-                        Executed="DisableIPythonInteractive_Executed" />
-
         <CommandBinding Command="{x:Static el:EnvironmentPathsExtension.OpenInBrowser}"
                         CanExecute="OpenInBrowser_CanExecute"
                         Executed="OpenInBrowser_Executed" />

--- a/Python/Product/EnvironmentsListHost/MainWindow.xaml.cs
+++ b/Python/Product/EnvironmentsListHost/MainWindow.xaml.cs
@@ -49,6 +49,8 @@ namespace Microsoft.PythonTools.EnvironmentsList.Host {
             if (withDb != null && !string.IsNullOrEmpty(withDb.DatabasePath)) {
                 e.View.Extensions.Add(new DBExtensionProvider(withDb));
             }
+            e.View.IPythonModeEnabledSetter = SetIPythonEnabled;
+            e.View.IsIPythonModeEnabled = QueryIPythonEnabled(e.View);
         }
 
 
@@ -123,14 +125,13 @@ namespace Microsoft.PythonTools.EnvironmentsList.Host {
             e.Handled = true;
         }
 
-        private void EnableIPythonInteractive_CanExecute(object sender, CanExecuteRoutedEventArgs e) {
-            var path = GetScriptsPath(e.Parameter as EnvironmentView);
-            e.CanExecute = !string.IsNullOrEmpty(path) && !File.Exists(Path.Combine(path, "__test_mode.txt"));
-            e.Handled = true;
+        private bool QueryIPythonEnabled(EnvironmentView view) {
+            var path = GetScriptsPath(view);
+            return !string.IsNullOrEmpty(path) && !File.Exists(Path.Combine(path, "__test_mode.txt"));
         }
 
-        private void EnableIPythonInteractive_Executed(object sender, ExecutedRoutedEventArgs e) {
-            var path = GetScriptsPath(e.Parameter as EnvironmentView);
+        private void SetIPythonEnabled(EnvironmentView view, bool enable) {
+            var path = GetScriptsPath(view);
             if (string.IsNullOrEmpty(path)) {
                 return;
             }
@@ -139,24 +140,12 @@ namespace Microsoft.PythonTools.EnvironmentsList.Host {
                 Directory.CreateDirectory(path);
             }
 
-            File.WriteAllText(Path.Combine(path, "__test_mode.txt"), "# Contents of the file");
-        }
-
-        private void DisableIPythonInteractive_CanExecute(object sender, CanExecuteRoutedEventArgs e) {
-            var path = GetScriptsPath(e.Parameter as EnvironmentView);
-            e.CanExecute = !string.IsNullOrEmpty(path) && File.Exists(Path.Combine(path, "__test_mode.txt"));
-            e.Handled = true;
-        }
-
-        private void DisableIPythonInteractive_Executed(object sender, ExecutedRoutedEventArgs e) {
-            var path = GetScriptsPath(e.Parameter as EnvironmentView);
-            if (string.IsNullOrEmpty(path)) {
-                return;
-            }
-
-            path = Path.Combine(path, "__test_mode.txt");
-            if (File.Exists(path)) {
-                File.Delete(path);
+            if (enable) {
+                File.WriteAllText(Path.Combine(path, "__test_mode.txt"), "# Contents of the file");
+            } else {
+                if (File.Exists(path)) {
+                    File.Delete(path);
+                }
             }
         }
 


### PR DESCRIPTION
Make the 2 buttons for enable IPython mode into a real checkbox.

404495 Accessibility : MAS40B : INSPECT : Python+ Python Environments : Control type is incorrect for the checkbox in Python Environments window
403510 Accessibility : MAS05 : Keyboard : Python + Python Environment : Focus order improper in Python Environment Window
