### PR TITLE
Accessibility fixes

### DIFF
--- a/Common/Product/SharedProject/Wpf/Controls.xaml
+++ b/Common/Product/SharedProject/Wpf/Controls.xaml
@@ -585,6 +585,7 @@
 
                         <ToggleButton x:Name="ExpanderButton" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" IsTabStop="False"
                                       IsChecked="{Binding IsExpanded,Mode=TwoWay,RelativeSource={RelativeSource TemplatedParent}}"
+                                      Focusable="False"
                                       Foreground="{TemplateBinding Foreground}">
                             <ToggleButton.Template>
                                 <ControlTemplate TargetType="ToggleButton">

--- a/Python/Product/Cookiecutter/Shared/Wpf/Controls.xaml
+++ b/Python/Product/Cookiecutter/Shared/Wpf/Controls.xaml
@@ -601,6 +601,7 @@
 
                         <ToggleButton x:Name="ExpanderButton" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" IsTabStop="False"
                                       IsChecked="{Binding IsExpanded,Mode=TwoWay,RelativeSource={RelativeSource TemplatedParent}}"
+                                      Focusable="False"
                                       Foreground="{TemplateBinding Foreground}">
                             <ToggleButton.Template>
                                 <ControlTemplate TargetType="ToggleButton">

--- a/Python/Product/EnvironmentsList/DBExtension.xaml
+++ b/Python/Product/EnvironmentsList/DBExtension.xaml
@@ -37,12 +37,14 @@
                                      x:Name="IsUpToDate"
                                      Margin="2"
                                      Style="{StaticResource CheckMarkImage}"
+                                     Focusable="False"
                                      ToolTip="{x:Static l:Resources.DBExtensionIsUpToDateToolTip}"/>
                             <Control Grid.Column="0"
                                      x:Name="IsNotUpToDate"
                                      Visibility="Hidden"
                                      Margin="2"
                                      Style="{StaticResource ExclamationPointImage}"
+                                     Focusable="False"
                                      ToolTip="{x:Static l:Resources.DBExtensionIsNotUpToDateToolTip}"/>
                         </Grid>
                         <DataTemplate.Triggers>
@@ -71,6 +73,7 @@
                                     </Grid.ColumnDefinitions>
                                     <Control Grid.Column="0"
                                              Margin="3"
+                                             Focusable="False"
                                              Style="{StaticResource RefreshImage}" />
                                     <AccessText Grid.Column="1"
                                                 VerticalAlignment="Center"

--- a/Python/Product/EnvironmentsList/DBExtension.xaml.cs
+++ b/Python/Product/EnvironmentsList/DBExtension.xaml.cs
@@ -200,7 +200,7 @@ namespace Microsoft.PythonTools.EnvironmentsList {
             _isUpToDate = true;
         }
 
-        public override string ToString() => Name;
+        public override string ToString() => Resources.DBExtensionModuleAutomationName.FormatUI(Name, TotalModules);
 
         public static IEnumerable<DBPackageView> FromModuleList(
             IList<string> modules,

--- a/Python/Product/EnvironmentsList/Resources.Designer.cs
+++ b/Python/Product/EnvironmentsList/Resources.Designer.cs
@@ -421,6 +421,15 @@ namespace Microsoft.PythonTools.EnvironmentsList {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to {0} ({1} modules).
+        /// </summary>
+        public static string DBExtensionModuleAutomationName {
+            get {
+                return ResourceManager.GetString("DBExtensionModuleAutomationName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to ({0} modules).
         /// </summary>
         public static string DBExtensionModuleCountLabel {

--- a/Python/Product/EnvironmentsList/Resources.resx
+++ b/Python/Product/EnvironmentsList/Resources.resx
@@ -138,6 +138,10 @@
   <data name="DBExtensionModuleCountLabel" xml:space="preserve">
     <value>({0} modules)</value>
   </data>
+  <data name="DBExtensionModuleAutomationName" xml:space="preserve">
+    <value>{0} ({1} modules)</value>
+    <comment>{0} is the package name, {1} is the module count.</comment>
+  </data>
   <data name="DBExtensionIsUpToDateToolTip" xml:space="preserve">
     <value>This package is up to date in the completion DB.</value>
   </data>


### PR DESCRIPTION
405004: Accessibility : MAS40B : INSPECT : Python+Python Environments : Name property for the items in the database does not contain the number of modules
404512: Accessibility : MAS36 : Keyboard : Python+Cookiecutter : 'Installed/Recommended/GitHub' expand collapse buttons are not accessible in CookieCutter window

Also prevents some images from getting focus.