### PR TITLE
Cookiecutter accessibility fixes

### DIFF
--- a/Python/Product/Cookiecutter/Cookiecutter.csproj
+++ b/Python/Product/Cookiecutter/Cookiecutter.csproj
@@ -164,6 +164,7 @@
     <Compile Include="Model\TemplateContext.cs" />
     <Compile Include="Model\DteCommand.cs" />
     <Compile Include="ViewModel\TreeItemViewModel.cs" />
+    <Compile Include="View\CookiecutterTreeView.cs" />
     <Compile Include="View\LoadingPage.xaml.cs">
       <DependentUpon>LoadingPage.xaml</DependentUpon>
     </Compile>

--- a/Python/Product/Cookiecutter/View/CookiecutterSearchPage.xaml
+++ b/Python/Product/Cookiecutter/View/CookiecutterSearchPage.xaml
@@ -11,6 +11,7 @@
       xmlns:img="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Imaging"
       xmlns:imagecatalog="clr-namespace:Microsoft.VisualStudio.Imaging;assembly=Microsoft.VisualStudio.ImageCatalog"
       xmlns:cct="clr-namespace:Microsoft.CookiecutterTools"
+      xmlns:ccv="clr-namespace:Microsoft.CookiecutterTools.View"
       wpf:LambdaProperties.ImportedNamespaces="System.Windows Microsoft.CookiecutterTools Microsoft.CookiecutterTools.ViewModel"
       mc:Ignorable="d" 
       d:DataContext="{Binding Source={d:DesignData Source=CookiecutterControlDesignData.xaml}}"
@@ -136,13 +137,13 @@
         </StackPanel>
 
         <!-- Results -->
-        <TreeView Grid.Row="2"
+        <ccv:CookiecutterTreeView Grid.Row="2"
                   Margin="4 4 0 8"
                   ItemsSource="{Binding Path=SearchResults}"
                   Focusable="True"
                   IsTabStop="True"
-                  SelectedItemChanged="TreeView_SelectedItemChanged">
-            <TreeView.Resources>
+                  SelectedItemChanged="TreeView_SelectedItemChanged" InvokeItem="OnInvokeTemplate">
+            <ccv:CookiecutterTreeView.Resources>
                 <HierarchicalDataTemplate DataType="{x:Type vm:CategorizedViewModel}" ItemsSource="{Binding Path=Templates}">
                     <TextBlock Margin="0 4 0 4"
                                FontWeight="Bold"
@@ -209,8 +210,8 @@
                         </Button>
                     </StackPanel>
                 </DataTemplate>
-            </TreeView.Resources>
-            <TreeView.ItemContainerStyle>
+            </ccv:CookiecutterTreeView.Resources>
+            <ccv:CookiecutterTreeView.ItemContainerStyle>
                 <Style TargetType="{x:Type TreeViewItem}" BasedOn="{StaticResource {x:Type TreeViewItem}}">
                     <Setter Property="IsExpanded" Value="True" />
                     <Setter Property="IsSelected" Value="{Binding Path=IsSelected, Mode=TwoWay}"/>
@@ -218,8 +219,8 @@
                     <EventSetter Event="TreeViewItem.PreviewMouseRightButtonDown" Handler="OnItemPreviewMouseRightButtonDown"/>
                     <EventSetter Event="PreviewKeyDown" Handler="OnItemPreviewKeyDown"/>
                 </Style>
-            </TreeView.ItemContainerStyle>
-        </TreeView>
+            </ccv:CookiecutterTreeView.ItemContainerStyle>
+        </ccv:CookiecutterTreeView>
 
         <!-- Next + Status -->
         <StackPanel Grid.Row="3" Orientation="Vertical">

--- a/Python/Product/Cookiecutter/View/CookiecutterSearchPage.xaml.cs
+++ b/Python/Product/Cookiecutter/View/CookiecutterSearchPage.xaml.cs
@@ -130,19 +130,30 @@ namespace Microsoft.CookiecutterTools.View {
             var item = sender as TreeViewItem;
             if (item != null && item.IsSelected) {
                 if (e.Key == Key.Enter) {
-                    var continuation = item.DataContext as ContinuationViewModel;
-                    if (continuation != null) {
+                    if (DoInvoke(item.DataContext)) {
                         e.Handled = true;
-                        ViewModel.LoadMoreTemplatesAsync(continuation.ContinuationToken).DoNotWait();
-                    } else {
-                        var template = item.DataContext as TemplateViewModel;
-                        if (template != null) {
-                            e.Handled = true;
-                            LoadTemplate(template);
-                        }
                     }
                 }
             }
+        }
+
+        private void OnInvokeTemplate(object sender, InvokeEventArgs e) {
+            DoInvoke(e.Item);
+        }
+
+        private bool DoInvoke(object item) {
+            var continuation = item as ContinuationViewModel;
+            if (continuation != null) {
+                ViewModel.LoadMoreTemplatesAsync(continuation.ContinuationToken).DoNotWait();
+                return true;
+            } else {
+                var template = item as TemplateViewModel;
+                if (template != null) {
+                    LoadTemplate(template);
+                    return true;
+                }
+            }
+            return false;
         }
 
         private void LoadTemplate(TemplateViewModel template) {

--- a/Python/Product/Cookiecutter/View/CookiecutterTreeView.cs
+++ b/Python/Product/Cookiecutter/View/CookiecutterTreeView.cs
@@ -1,0 +1,147 @@
+﻿// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABLITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows;
+using System.Windows.Automation.Peers;
+using System.Windows.Automation.Provider;
+using System.Windows.Controls;
+using Microsoft.CookiecutterTools.ViewModel;
+
+namespace Microsoft.CookiecutterTools.View {
+    /// <summary>
+    /// TreeView that provides a clean hierarchy of automation peers, with a
+    /// 1 to 1 mapping for each tree item - automation peer.
+    /// Additional controls, such as the expander, are discarded.
+    /// This results in a clear parent-children relationship, and fixes an issue
+    /// with narrator where it would report an inaccurate item count.
+    /// </summary>
+    class CookiecutterTreeView : TreeView {
+        public event EventHandler<InvokeEventArgs> InvokeItem;
+
+        protected override DependencyObject GetContainerForItemOverride() {
+            return new CookiecutterTreeViewItem(this);
+        }
+
+        protected override AutomationPeer OnCreateAutomationPeer() {
+            return new CookiecutterTreeViewAutomationPeer(this);
+        }
+
+        public void DoInvoke(TreeItemViewModel item) {
+            InvokeItem?.Invoke(this, new InvokeEventArgs(item));
+        }
+
+        class CookiecutterTreeViewItem : TreeViewItem {
+            private CookiecutterTreeView _treeView;
+
+            public CookiecutterTreeViewItem(CookiecutterTreeView treeView) {
+                _treeView = treeView;
+            }
+
+            protected override DependencyObject GetContainerForItemOverride() {
+                return new CookiecutterTreeViewItem(_treeView);
+            }
+
+            protected override AutomationPeer OnCreateAutomationPeer() {
+                return new CookiecutterItemAutomationPeer(_treeView, this);
+            }
+        }
+
+        class CookiecutterTreeViewAutomationPeer : TreeViewAutomationPeer {
+            public CookiecutterTreeViewAutomationPeer(CookiecutterTreeView owner)
+                : base(owner) {
+            }
+
+            protected override ItemAutomationPeer CreateItemAutomationPeer(object item) {
+                return new CookiecutterDataItemAutomationPeer((CookiecutterTreeView)Owner, item, this, null);
+            }
+        }
+
+        class CookiecutterItemAutomationPeer : TreeViewItemAutomationPeer {
+            private CookiecutterTreeView _treeView;
+
+            public CookiecutterItemAutomationPeer(CookiecutterTreeView treeView, TreeViewItem owner)
+                : base(owner) {
+                _treeView = treeView;
+            }
+
+            protected override List<AutomationPeer> GetChildrenCore() {
+                var originalChildren = base.GetChildrenCore();
+                if (originalChildren == null) {
+                    return null;
+                }
+                return originalChildren.Where(peer => peer is CookiecutterDataItemAutomationPeer).ToList();
+            }
+
+            protected override ItemAutomationPeer CreateItemAutomationPeer(object item) {
+                if (item is ContinuationViewModel || item is TemplateViewModel) {
+                    return new CookiecutterInvokableDataItemAutomationPeer(_treeView, item, this, null);
+                } else {
+                    return new CookiecutterDataItemAutomationPeer(_treeView, item, this, null);
+                }
+            }
+        }
+
+        class CookiecutterDataItemAutomationPeer : TreeViewDataItemAutomationPeer {
+            protected CookiecutterTreeView _treeView;
+
+            public CookiecutterDataItemAutomationPeer(CookiecutterTreeView treeView, object item, ItemsControlAutomationPeer itemsControlAutomationPeer, TreeViewDataItemAutomationPeer parentDataItemAutomationPeer)
+                : base(item, itemsControlAutomationPeer, parentDataItemAutomationPeer) {
+                _treeView = treeView;
+            }
+
+            protected override List<AutomationPeer> GetChildrenCore() {
+                var originalChildren = base.GetChildrenCore();
+                if (originalChildren == null) {
+                    return null;
+                }
+                return originalChildren.Where(peer => peer is CookiecutterDataItemAutomationPeer).ToList();
+            }
+        }
+
+        /// <summary>
+        /// Automation peer for a tree item which supports the invoke pattern.
+        /// </summary>
+        class CookiecutterInvokableDataItemAutomationPeer : CookiecutterDataItemAutomationPeer, IInvokeProvider {
+            public CookiecutterInvokableDataItemAutomationPeer(CookiecutterTreeView treeView, object item, ItemsControlAutomationPeer itemsControlAutomationPeer, TreeViewDataItemAutomationPeer parentDataItemAutomationPeer)
+                : base(treeView, item, itemsControlAutomationPeer, parentDataItemAutomationPeer) {
+            }
+
+            public override object GetPattern(PatternInterface patternInterface) {
+                switch (patternInterface) {
+                    case PatternInterface.Invoke:
+                        return this;
+                    default:
+                        return base.GetPattern(patternInterface);
+                }
+            }
+
+            public void Invoke() {
+                _treeView.DoInvoke((TreeItemViewModel)Item);
+            }
+        }
+    }
+
+    class InvokeEventArgs : EventArgs {
+        public InvokeEventArgs(TreeItemViewModel item) {
+            Item = item;
+        }
+
+        public TreeItemViewModel Item { get; }
+    }
+}


### PR DESCRIPTION
Bug 404069: Accessibility : MAS40B : INSPECT : Python + Cookiecutter : Inspect properties are incorrect for the tree items in Cookie cutter window

Fix automation peers for the cookiecutter tree view so that there's only one peer per tree view item. This makes the parent-children relationship more clear, and narrator now correctly reports item count.

Make the peers for templates and continuation support the invoke pattern so that hitting 'enter' is accessible through automation.

This is the result:
![image](https://cloud.githubusercontent.com/assets/1696845/26513072/69c5c67a-421e-11e7-8a7f-79926581f590.png)
