### PR TITLE
Build and test fix

### DIFF
--- a/Common/Tests/SccPackage/TestSccPackage.csproj
+++ b/Common/Tests/SccPackage/TestSccPackage.csproj
@@ -90,6 +90,7 @@
     <When Condition="$(VSTarget) == '15.0'">
       <ItemGroup>
         <Reference Include="Microsoft.VisualStudio.Shell.Framework, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+        <Reference Include="Microsoft.VisualStudio.Shell.Interop.15.3.DesignTime, Version=15.3.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
       </ItemGroup>
     </When>
     <Otherwise>

--- a/Python/Product/Cookiecutter/Cookiecutter.csproj
+++ b/Python/Product/Cookiecutter/Cookiecutter.csproj
@@ -138,6 +138,7 @@
     <When Condition="$(VSTarget) == '15.0'">
       <ItemGroup>
         <Reference Include="Microsoft.VisualStudio.Shell.Framework, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+        <Reference Include="Microsoft.VisualStudio.Shell.Interop.15.3.DesignTime, Version=15.3.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
       </ItemGroup>
     </When>
     <Otherwise>

--- a/Python/Product/Django/Django.csproj
+++ b/Python/Product/Django/Django.csproj
@@ -150,6 +150,7 @@
     <When Condition="$(VSTarget) == '15.0'">
       <ItemGroup>
         <Reference Include="Microsoft.VisualStudio.Shell.Framework, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+        <Reference Include="Microsoft.VisualStudio.Shell.Interop.15.3.DesignTime, Version=15.3.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
       </ItemGroup>
     </When>
     <Otherwise>

--- a/Python/Product/Profiling/Profiling.csproj
+++ b/Python/Product/Profiling/Profiling.csproj
@@ -111,6 +111,7 @@
     <When Condition="$(VSTarget) == '15.0'">
       <ItemGroup>
         <Reference Include="Microsoft.VisualStudio.Shell.Framework, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+        <Reference Include="Microsoft.VisualStudio.Shell.Interop.15.3.DesignTime, Version=15.3.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
       </ItemGroup>
     </When>
   </Choose>

--- a/Python/Product/PythonTools/PythonTools.csproj
+++ b/Python/Product/PythonTools/PythonTools.csproj
@@ -240,6 +240,7 @@
     <When Condition="$(VSTarget) == '15.0'">
       <ItemGroup>
         <Reference Include="Microsoft.VisualStudio.Shell.Framework, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+        <Reference Include="Microsoft.VisualStudio.Shell.Interop.15.3.DesignTime, Version=15.3.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
       </ItemGroup>
     </When>
     <Otherwise>

--- a/Python/Product/PythonTools/PythonTools/Extensions.cs
+++ b/Python/Product/PythonTools/PythonTools/Extensions.cs
@@ -696,7 +696,8 @@ namespace Microsoft.PythonTools {
 
         internal static bool TryGetShellProperty<T>(this IServiceProvider provider, __VSSPROPID propId, out T value) {
             object obj;
-            if (ErrorHandler.Failed(provider.GetShell().GetProperty((int)propId, out obj))) {
+            var shell = provider.GetShell();
+            if (shell == null || ErrorHandler.Failed(shell.GetProperty((int)propId, out obj))) {
                 value = default(T);
                 return false;
             }

--- a/Python/Product/Uwp/Uwp.csproj
+++ b/Python/Product/Uwp/Uwp.csproj
@@ -142,6 +142,7 @@
     <When Condition="$(VSTarget) == '15.0'">
       <ItemGroup>
         <Reference Include="Microsoft.VisualStudio.Shell.Framework, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+        <Reference Include="Microsoft.VisualStudio.Shell.Interop.15.3.DesignTime, Version=15.3.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
       </ItemGroup>
     </When>
     <Otherwise>


### PR DESCRIPTION
I upgraded a machine from 15.3 build 26507 to 26526, and it required adding a referenced assembly.  It still builds on the older build even with these changes (the 'new' assembly was there before).

Also fixes a REPL test (I forgot which one) which was failing with NRE.