### PR TITLE
Fix ExtractMethodTests

### DIFF
--- a/Common/Tests/Utilities/Mocks/MockTextImageVersion.cs
+++ b/Common/Tests/Utilities/Mocks/MockTextImageVersion.cs
@@ -1,0 +1,46 @@
+﻿// Visual Studio Shared Project
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABLITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System;
+using Microsoft.VisualStudio.Text;
+
+namespace TestUtilities.Mocks {
+    public class MockTextImageVersion : ITextImageVersion {
+        private readonly ITextVersion _source;
+
+        public MockTextImageVersion(ITextVersion source) {
+            _source = source;
+        }
+
+        public ITextImageVersion Next => (_source.Next != null) ? (ITextImageVersion)(new MockTextImageVersion(_source.Next)) : null;
+
+        public int Length => _source.Length;
+
+        public INormalizedTextChangeCollection Changes => _source.Changes;
+
+        public int VersionNumber => _source.VersionNumber;
+
+        public object Identifier => _source.TextBuffer;
+
+        public int TrackTo(VersionedPosition other, PointTrackingMode mode) {
+            throw new NotSupportedException();
+        }
+
+        public Span TrackTo(VersionedSpan span, SpanTrackingMode mode) {
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/Common/Tests/Utilities/Mocks/MockTextVersion.cs
+++ b/Common/Tests/Utilities/Mocks/MockTextVersion.cs
@@ -18,8 +18,9 @@ using System;
 using Microsoft.VisualStudio.Text;
 
 namespace TestUtilities.Mocks {
-    public class MockTextVersion : ITextVersion {
+    public class MockTextVersion : ITextVersion2 {
         private readonly int _version;
+        private readonly MockTextImageVersion _imageVersion;
         internal readonly MockTextSnapshot _snapshot;
         private MockTextVersion _nextVersion;
         private INormalizedTextChangeCollection _changes;
@@ -27,16 +28,13 @@ namespace TestUtilities.Mocks {
         public MockTextVersion(int version, MockTextSnapshot snapshot) {
             _version = version;
             _snapshot = snapshot;
+            _imageVersion = new MockTextImageVersion(this);
         }
 
         /// <summary>
         /// changes to get to the next version
         /// </summary>
-        public INormalizedTextChangeCollection Changes {
-            get {
-                return _changes;
-            }
-        }
+        public INormalizedTextChangeCollection Changes => _changes;
 
         public ITrackingSpan CreateCustomTrackingSpan(Span span, TrackingFidelityMode trackingFidelity, object customState, CustomTrackToVersion behavior) {
             throw new NotImplementedException();
@@ -66,25 +64,17 @@ namespace TestUtilities.Mocks {
             throw new NotImplementedException();
         }
 
-        public int Length {
-            get { return _snapshot.Length; }
-        }
+        public int Length => _snapshot.Length;
 
-        public ITextVersion Next {
-            get { return _nextVersion; }
-        }
+        public ITextVersion Next => _nextVersion;
 
-        public int ReiteratedVersionNumber {
-            get { throw new NotImplementedException(); }
-        }
+        public int ReiteratedVersionNumber => throw new NotImplementedException();
 
-        public ITextBuffer TextBuffer {
-            get { return _snapshot.TextBuffer; }
-        }
+        public ITextBuffer TextBuffer => _snapshot.TextBuffer;
 
-        public int VersionNumber {
-            get { return _version; }
-        }
+        public int VersionNumber => _version;
+
+        public ITextImageVersion ImageVersion => _imageVersion;
 
         internal void SetNext(MockTextVersion nextVersion, params ITextChange[] changes) {
             _nextVersion = nextVersion;

--- a/Common/Tests/Utilities/TestUtilities.csproj
+++ b/Common/Tests/Utilities/TestUtilities.csproj
@@ -98,6 +98,7 @@
     <Compile Include="MessageBoxButton.cs" />
     <Compile Include="Mocks\IClassificationTypeDefinitionMetadata.cs" />
     <Compile Include="Mocks\MockClassificationTypeRegistryService.cs" />
+    <Compile Include="Mocks\MockTextImageVersion.cs" />
     <Compile Include="Mocks\MockTextViewModel.cs" />
     <Compile Include="Mocks\MockVsShell.cs" />
     <Compile Include="ProcessScope.cs" />


### PR DESCRIPTION
TestComprehensions was failing with this error:
```
Test method PythonToolsTests.ExtractMethodTests.TestComprehensions threw exception: 

System.AggregateException: One or more errors occurred. ---> System.InvalidCastException: Unable to cast object of type 'TestUtilities.Mocks.MockTextVersion' to type 'Microsoft.VisualStudio.Text.ITextVersion2'.
```
