### PR TITLE
Add binding redirect for Microsoft.VisualStudio.Validation.

### DIFF
--- a/Python/Tests/PythonToolsMockTests/App.config
+++ b/Python/Tests/PythonToolsMockTests/App.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.VisualStudio.Validation" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="15.0.0.0-15.3.0.0" newVersion="15.3.0.0"/>
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/Python/Tests/PythonToolsMockTests/PythonToolsMockTests.csproj
+++ b/Python/Tests/PythonToolsMockTests/PythonToolsMockTests.csproj
@@ -177,5 +177,8 @@
       <Name>VSCommon</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+  </ItemGroup>
   <Import Project="..\TestProjectAfter.settings" />
 </Project>


### PR DESCRIPTION
Fixes https://github.com/Microsoft/PTVS/issues/2610

On 15.3, all tests from PythonToolsMockTests were failing trying to load an older version of Microsoft.VisualStudio.Validation. Now a lot of the tests are passing again, and those who don't are failing for a different reason.

Note that we do not directly reference that assembly from our projects.