### PR TITLE
Adds workaround for building against stable VS.

### DIFF
--- a/Common/Tests/Utilities/Mocks/TextVersionWorkaround.cs
+++ b/Common/Tests/Utilities/Mocks/TextVersionWorkaround.cs
@@ -1,0 +1,24 @@
+﻿// Visual Studio Shared Project
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABLITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using Microsoft.VisualStudio.Text;
+
+namespace TestUtilities.Mocks {
+    public interface ITextImageVersion { }
+    public interface ITextVersion2 : ITextVersion { }
+    public struct VersionedPosition { }
+    public struct VersionedSpan { }
+}

--- a/Common/Tests/Utilities/TestUtilities.csproj
+++ b/Common/Tests/Utilities/TestUtilities.csproj
@@ -101,6 +101,7 @@
     <Compile Include="Mocks\MockTextImageVersion.cs" />
     <Compile Include="Mocks\MockTextViewModel.cs" />
     <Compile Include="Mocks\MockVsShell.cs" />
+    <Compile Include="Mocks\TextVersionWorkaround.cs" />
     <Compile Include="ProcessScope.cs" />
     <Compile Include="SessionHolder.cs" />
     <Compile Include="SharedProject\SymbolicLinkItem.cs" />


### PR DESCRIPTION
This will keep us building with the current version of VS while we figure out how to deal with the brokenness in the next update.

We'll just have to ignore the failed tests for now until we can get all the build machines upgraded properly (which they probably won't do for us, so we're back to maintaining our own build infrastructure...)