### PR TITLE
Fixes #2240 Screen reader does not read what template section

### DIFF
--- a/Python/Product/Cookiecutter/Strings.Designer.cs
+++ b/Python/Product/Cookiecutter/Strings.Designer.cs
@@ -668,6 +668,24 @@ namespace Microsoft.CookiecutterTools {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Category: {0}..
+        /// </summary>
+        public static string SearchPage_CategoryHelpTextNoUpdate {
+            get {
+                return ResourceManager.GetString("SearchPage_CategoryHelpTextNoUpdate", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Category: {0}. Update is available.
+        /// </summary>
+        public static string SearchPage_CategoryHelpTextUpdate {
+            get {
+                return ResourceManager.GetString("SearchPage_CategoryHelpTextUpdate", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Checking for updates....
         /// </summary>
         public static string SearchPage_CheckingUpdates {

--- a/Python/Product/Cookiecutter/Strings.resx
+++ b/Python/Product/Cookiecutter/Strings.resx
@@ -494,4 +494,12 @@ Please delete the installed template and try again.</value>
   <data name="OptionsPage_OdbcConnectionBrowseAutomationName" xml:space="preserve">
     <value>Browse for database connection</value>
   </data>
+  <data name="SearchPage_CategoryHelpTextNoUpdate" xml:space="preserve">
+    <value>Category: {0}.</value>
+    <comment>{0} is a category name</comment>
+  </data>
+  <data name="SearchPage_CategoryHelpTextUpdate" xml:space="preserve">
+    <value>Category: {0}. Update is available</value>
+    <comment>{0} is a category name</comment>
+  </data>
 </root>

--- a/Python/Product/Cookiecutter/View/CookiecutterSearchPage.xaml
+++ b/Python/Product/Cookiecutter/View/CookiecutterSearchPage.xaml
@@ -215,6 +215,8 @@
                 <Style TargetType="{x:Type TreeViewItem}" BasedOn="{StaticResource {x:Type TreeViewItem}}">
                     <Setter Property="IsExpanded" Value="True" />
                     <Setter Property="IsSelected" Value="{Binding Path=IsSelected, Mode=TwoWay}"/>
+                    <Setter Property="AutomationProperties.Name" Value="{Binding AutomationName, Mode=OneWay}" />
+                    <Setter Property="AutomationProperties.HelpText" Value="{Binding AutomationHelpText, Mode=OneWay}" />
                     <EventSetter Event="MouseDoubleClick" Handler="OnItemMouseDoubleClick" />
                     <EventSetter Event="TreeViewItem.PreviewMouseRightButtonDown" Handler="OnItemPreviewMouseRightButtonDown"/>
                     <EventSetter Event="PreviewKeyDown" Handler="OnItemPreviewKeyDown"/>

--- a/Python/Product/Cookiecutter/ViewModel/CookiecutterViewModel.cs
+++ b/Python/Product/Cookiecutter/ViewModel/CookiecutterViewModel.cs
@@ -460,12 +460,14 @@ namespace Microsoft.CookiecutterTools.ViewModel {
                 if (searchTerm.StartsWith("http")) {
                     searchTermTemplate.DisplayName = searchTerm;
                     searchTermTemplate.RemoteUrl = searchTerm;
+                    searchTermTemplate.Category = Custom.DisplayName;
                     Custom.Templates.Add(searchTermTemplate);
                     SearchResults.Add(Custom);
                     return;
                 } else if (Directory.Exists(searchTerm)) {
                     searchTermTemplate.DisplayName = searchTerm;
                     searchTermTemplate.ClonedPath = searchTerm;
+                    searchTermTemplate.Category = Custom.DisplayName;
                     Custom.Templates.Add(searchTermTemplate);
                     SearchResults.Add(Custom);
                     return;
@@ -969,6 +971,7 @@ namespace Microsoft.CookiecutterTools.ViewModel {
                     vm.OwnerUrl = t.OwnerUrl;
                     vm.RemoteUrl = t.RemoteUrl;
                     vm.ClonedPath = t.LocalFolderPath;
+                    vm.Category = parent.DisplayName;
                     vm.IsUpdateAvailable = t.UpdateAvailable == true;
                     parent.Templates.Add(vm);
                 }

--- a/Python/Product/Cookiecutter/ViewModel/TemplateViewModel.cs
+++ b/Python/Product/Cookiecutter/ViewModel/TemplateViewModel.cs
@@ -27,6 +27,7 @@ namespace Microsoft.CookiecutterTools.ViewModel {
         private string _clonedPath;
         private string _description;
         private string _avatarUrl;
+        private string _category;
         private bool _isSearchTerm;
         private bool _isUpdateAvailable;
 
@@ -111,6 +112,7 @@ namespace Microsoft.CookiecutterTools.ViewModel {
                 if (value != _displayName) {
                     _displayName = value;
                     OnPropertyChanged(new PropertyChangedEventArgs(nameof(DisplayName)));
+                    OnPropertyChanged(new PropertyChangedEventArgs(nameof(AutomationName)));
                 }
             }
         }
@@ -217,9 +219,27 @@ namespace Microsoft.CookiecutterTools.ViewModel {
                 if (value != _isUpdateAvailable) {
                     _isUpdateAvailable = value;
                     OnPropertyChanged(new PropertyChangedEventArgs(nameof(IsUpdateAvailable)));
+                    OnPropertyChanged(new PropertyChangedEventArgs(nameof(AutomationHelpText)));
                 }
             }
         }
+
+        public string Category {
+            get {
+                return _category;
+            }
+            set {
+                if (value != _category) {
+                    _category = value;
+                    OnPropertyChanged(new PropertyChangedEventArgs(nameof(Category)));
+                    OnPropertyChanged(new PropertyChangedEventArgs(nameof(AutomationHelpText)));
+                }
+            }
+        }
+
+        public override string AutomationHelpText =>
+            (IsUpdateAvailable ? Strings.SearchPage_CategoryHelpTextUpdate : Strings.SearchPage_CategoryHelpTextNoUpdate)
+                .FormatUI(Category);
 
         private void RefreshOwnerTooltip() {
             var owner = RepositoryOwner;

--- a/Python/Product/Cookiecutter/ViewModel/TreeItemViewModel.cs
+++ b/Python/Product/Cookiecutter/ViewModel/TreeItemViewModel.cs
@@ -39,6 +39,9 @@ namespace Microsoft.CookiecutterTools.ViewModel {
             }
         }
 
+        public virtual string AutomationName => ToString();
+        public virtual string AutomationHelpText => null;
+
         public event PropertyChangedEventHandler PropertyChanged;
 
         protected void OnPropertyChanged(PropertyChangedEventArgs ea) {


### PR DESCRIPTION
Fixes #2240 Screen reader does not read what template section a selected cookiecutter template is in

Enhances help text for templates.