### PR TITLE
Fixes #2398 Paste adds extra whitespaces at the end

### DIFF
--- a/Python/Product/Common/Strings.Designer.cs
+++ b/Python/Product/Common/Strings.Designer.cs
@@ -4089,6 +4089,15 @@ namespace Microsoft.PythonTools {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Remove Interactive Prompts.
+        /// </summary>
+        public static string RemoveReplPrompts {
+            get {
+                return ResourceManager.GetString("RemoveReplPrompts", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to _Cancel.
         /// </summary>
         public static string RenameVariable_Cancel {

--- a/Python/Product/Common/Strings.resx
+++ b/Python/Product/Common/Strings.resx
@@ -2088,4 +2088,7 @@ Expand selection to the full expression?</value>
   <data name="PythonInteractive_Yellow" xml:space="preserve">
     <value>Python Interactive - yellow</value>
   </data>
+  <data name="RemoveReplPrompts" xml:space="preserve">
+    <value>Remove Interactive Prompts</value>
+  </data>
 </root>

--- a/Python/Product/PythonTools/PythonTools.csproj
+++ b/Python/Product/PythonTools/PythonTools.csproj
@@ -261,6 +261,7 @@
     <Compile Include="PythonTools\Commands\ImportCoverageCommand.cs" />
     <Compile Include="PythonTools\Commands\OpenWebUrlCommand.cs" />
     <Compile Include="PythonTools\Debugger\DebugLaunchHelper.cs" />
+    <Compile Include="PythonTools\Editor\ReplPromptHelpers.cs" />
     <Compile Include="PythonTools\Intellisense\AbnormalAnalysisExitEventArgs.cs" />
     <Compile Include="PythonTools\Intellisense\AnalysisLocation.cs" />
     <Compile Include="PythonTools\Intellisense\AnalysisVariable.cs" />

--- a/Python/Product/PythonTools/PythonTools/Editor/ReplPromptHelpers.cs
+++ b/Python/Product/PythonTools/PythonTools/Editor/ReplPromptHelpers.cs
@@ -1,0 +1,132 @@
+﻿// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABLITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Microsoft.VisualStudio.Text;
+
+namespace Microsoft.PythonTools.Editor {
+    internal static class ReplPromptHelpers {
+        internal static readonly Regex PromptRegex = new Regex(
+            @"^(
+                \>\>\>(\s|\s*$)
+              | \.\.\.(\s|\s*$)
+              | \s*In\s*\[.*?\]\s*:(\s|\s*$)
+              | \s*\.\.\.:(\s|\s*$)
+               )",
+            RegexOptions.CultureInvariant | RegexOptions.IgnorePatternWhitespace,
+            TimeSpan.FromSeconds(0.5)
+        );
+
+        /// <summary>
+        /// Given two snapshots, finds any inserted REPL prompts and removes
+        /// them in a single edit.
+        /// </summary>
+        /// <returns>True if any changes were made.</returns>
+        public static bool RemovePastedPrompts(ITextSnapshot before, ITextSnapshot after) {
+            if (before == null) {
+                throw new ArgumentNullException(nameof(before));
+            }
+            if (after == null) {
+                throw new ArgumentNullException(nameof(after));
+            }
+            if (before.TextBuffer != after.TextBuffer) {
+                throw new ArgumentException("'before' and 'after' must belong to the same buffer");
+            }
+
+            bool changeMade = false;
+
+            using (var edit = after.TextBuffer.CreateEdit()) {
+                foreach (var change in EnumerateLineChanges(before.Version, after.Version)) {
+                    int len = GetPromptLength(change.Value);
+                    if (len > 0) {
+                        edit.Replace(new Span(change.Key.Start, len), "");
+                        changeMade = true;
+                    }
+                }
+                if (changeMade) {
+                    edit.Apply();
+                }
+            }
+
+            return changeMade;
+        }
+
+        /// <summary>
+        /// Given a block of text, removes all REPL prompts and
+        /// optionally normalizes newlines.
+        /// </summary>
+        /// <param name="text">The text to remove prompts from.</param>
+        /// <param name="newline">
+        /// The newline to normalize to. If null or empty, newlines
+        /// are not normalized.
+        /// </param>
+        public static string RemovePrompts(string text, string newline) {
+            if (string.IsNullOrEmpty(text)) {
+                return text;
+            }
+
+            if (string.IsNullOrEmpty(newline)) {
+                var lines = text.Split('\n')
+                    .Select(l => l.Substring(GetPromptLength(l)));
+
+                return string.Join("\n", lines);
+            } else {
+                var lines = text.Split('\n')
+                    .Select(l => l.LastOrDefault() != '\r' ? l : l.Remove(l.Length - 1))
+                    .Select(l => l.Substring(GetPromptLength(l)));
+
+                return string.Join(newline, lines);
+            }
+        }
+
+
+
+        private static int GetPromptLength(string line) {
+            Match m;
+            try {
+                m = PromptRegex.Match(line);
+            } catch (RegexMatchTimeoutException) {
+                return 0;
+            }
+            return m.Success ? m.Length : 0;
+        }
+
+        private static IEnumerable<KeyValuePair<Span, string>> EnumerateLineChanges(ITextVersion v1, ITextVersion v2) {
+            while (v1 != null && v1 != v2 && v1.VersionNumber < v2.VersionNumber) {
+                foreach (var c in v1.Changes) {
+                    int start = 0, next = c.NewText.IndexOf('\n');
+                    while (next > start) {
+                        yield return new KeyValuePair<Span, string>(
+                            new Span(c.NewPosition + start, next - start + 1),
+                            c.NewText.Substring(start, next - start + 1)
+                        );
+                        start = next + 1;
+                        next = c.NewText.IndexOf('\n', start);
+                    }
+                    yield return new KeyValuePair<Span, string>(
+                        new Span(c.NewPosition + start, c.NewText.Length - start),
+                        c.NewText.Substring(start)
+                    );
+                }
+                v1 = v1.Next;
+            }
+        }
+
+    }
+}

--- a/Python/Product/PythonTools/PythonTools/Repl/PythonInteractiveEvaluator.cs
+++ b/Python/Product/PythonTools/PythonTools/Repl/PythonInteractiveEvaluator.cs
@@ -24,6 +24,7 @@ using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Forms;
+using Microsoft.PythonTools.Editor;
 using Microsoft.PythonTools.Infrastructure;
 using Microsoft.PythonTools.Intellisense;
 using Microsoft.PythonTools.Interpreter;
@@ -582,9 +583,15 @@ namespace Microsoft.PythonTools.Repl {
                     return res.ToString();
                 }
             }
-            return EditFilter.RemoveReplPrompts(
-                _serviceProvider.GetPythonToolsService(),
-                Clipboard.GetText(),
+
+            var txt = Clipboard.GetText();
+            if (!_serviceProvider.GetPythonToolsService().AdvancedOptions.PasteRemovesReplPrompts) {
+                return txt;
+            }
+
+
+            return ReplPromptHelpers.RemovePrompts(
+                txt,
                 _window.TextView.Options.GetNewLineCharacter()
             );
         }

--- a/Python/Tests/Core/EditorTests.cs
+++ b/Python/Tests/Core/EditorTests.cs
@@ -20,6 +20,7 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using Microsoft.PythonTools;
+using Microsoft.PythonTools.Editor;
 using Microsoft.PythonTools.Infrastructure;
 using Microsoft.PythonTools.Intellisense;
 using Microsoft.PythonTools.Parsing;
@@ -409,6 +410,61 @@ string'''";
         }
 
         #endregion Outlining Statements
+
+        #region REPL prompt removal
+
+        [TestMethod, Priority(0)]
+        public void RemoveReplPrompts() {
+            Assert.AreEqual("", ReplPromptHelpers.RemovePrompts("", null));
+            Assert.AreEqual("", ReplPromptHelpers.RemovePrompts(">>>", null));
+            Assert.AreEqual("", ReplPromptHelpers.RemovePrompts(">>> ", null));
+            Assert.AreEqual("    ", ReplPromptHelpers.RemovePrompts(">>>     ", null));
+            Assert.AreEqual("pass", ReplPromptHelpers.RemovePrompts(">>> pass", null));
+            Assert.AreEqual(" pass", ReplPromptHelpers.RemovePrompts(">>>  pass", null));
+            Assert.AreEqual("", ReplPromptHelpers.RemovePrompts("...", null));
+            Assert.AreEqual("", ReplPromptHelpers.RemovePrompts("... ", null));
+            Assert.AreEqual("    ", ReplPromptHelpers.RemovePrompts("...     ", null));
+            Assert.AreEqual("pass", ReplPromptHelpers.RemovePrompts("... pass", null));
+            Assert.AreEqual(" pass", ReplPromptHelpers.RemovePrompts("...  pass", null));
+            Assert.AreEqual("", ReplPromptHelpers.RemovePrompts("In[1]:", null));
+            Assert.AreEqual("    ", ReplPromptHelpers.RemovePrompts("In [ 2 ]  :     ", null));
+            Assert.AreEqual("pass", ReplPromptHelpers.RemovePrompts("In [ 2 ]  : pass", null));
+            Assert.AreEqual(" pass", ReplPromptHelpers.RemovePrompts("In [ 2 ]  :  pass", null));
+            Assert.AreEqual("", ReplPromptHelpers.RemovePrompts("...:", null));
+            Assert.AreEqual("", ReplPromptHelpers.RemovePrompts("    ...:", null));
+            Assert.AreEqual("", ReplPromptHelpers.RemovePrompts("  ...: ", null));
+            Assert.AreEqual("    ", ReplPromptHelpers.RemovePrompts("  ...:     ", null));
+            Assert.AreEqual("pass", ReplPromptHelpers.RemovePrompts("  ...: pass", null));
+            Assert.AreEqual(" pass", ReplPromptHelpers.RemovePrompts("  ...:  pass", null));
+
+            Assert.AreEqual(@"x = 1
+print(x)
+if True:
+    pass
+
+
+print(x)
+1
+
+if True:
+    print(x)
+
+1".Replace("\r\n", "\n"), ReplPromptHelpers.RemovePrompts(@">>> x = 1
+>>> print(x)
+>>> if True:
+...     pass
+...
+
+In [2]: print(x)
+1
+
+In [3]: if True:
+   ...:     print(x)
+   ...: 
+1", "\n"));
+        }
+
+        #endregion
 
         private static StringLiteralCompletionList.EntryInfo MakeEntryInfo(string rootpath, string filename, string insertionText = null, string fullpath = null, bool? isFile = null) {
             var realIsFile = isFile ?? !string.IsNullOrEmpty(Path.GetExtension(filename));


### PR DESCRIPTION
Fixes #2398 Paste adds extra whitespaces at the end
Replaces prompt removal with a two-step process so that Paste works properly.
Expands prompts to include IPython-style prompts