### PR TITLE
Improve debugger tests reliability.

### DIFF
--- a/Python/Tests/DebuggerTests/BaseDebuggerTests.cs
+++ b/Python/Tests/DebuggerTests/BaseDebuggerTests.cs
@@ -267,8 +267,10 @@ namespace DebuggerTests {
                                     }
                                 }
 
-                                await breakpoint.AddAsync(TimeoutToken());
+                                // Bind failed and succeeded events expect to find the breakpoint
+                                // in the dictionary, so update it before sending the add request.
                                 bps.Add(breakpoint, bp);
+                                await breakpoint.AddAsync(TimeoutToken());
                             }
 
                             OnProcessLoaded?.Invoke(newproc);


### PR DESCRIPTION
I ran all the debugger tests twice and did not see a single failure (compared to 3-5% failure before).

Changes the callback passed to CreateProcess to be `Func<Task>` instead of `Action`, and ensure that it is awaited on. This ensures proper order of execution during process load event handling.

The callers that were already passing an async delegate didn't have to change, just the ones that were passing non-async delegate.