### PR TITLE
Disable logging of ObjectDisposedException in debugger tests

### DIFF
--- a/Common/Tests/Utilities/AssertListener.cs
+++ b/Common/Tests/Utilities/AssertListener.cs
@@ -38,6 +38,8 @@ namespace TestUtilities {
             set { }
         }
 
+        public static bool LogObjectDisposedExceptions { get; set; } = true;
+
         public static void Initialize() {
             var listener = new AssertListener();
             if (null == Debug.Listeners[listener.Name]) {
@@ -68,7 +70,7 @@ namespace TestUtilities {
         }
 
         static void CurrentDomain_FirstChanceException(object sender, FirstChanceExceptionEventArgs e) {
-            if (e.Exception is NullReferenceException || e.Exception is ObjectDisposedException) {
+            if (e.Exception is NullReferenceException || (e.Exception is ObjectDisposedException && LogObjectDisposedExceptions)) {
                 // Exclude safe handle messages because they are noisy
                 if (!e.Exception.Message.Contains("Safe handle has been closed")) {
                     var log = new EventLog("Application");

--- a/Python/Tests/DebuggerTests/BaseDebuggerTests.cs
+++ b/Python/Tests/DebuggerTests/BaseDebuggerTests.cs
@@ -672,11 +672,17 @@ namespace DebuggerTests {
         }
 
         internal void TerminateProcess(PythonProcess p) {
+            // Killing the process will cause multiple ObjectDisposedException
+            // which are normal, since the communication stream is forcibly closed.
+            // Disable their logging to reduce the noise.
+            AssertListener.LogObjectDisposedExceptions = false;
             try {
                 p.Terminate();
             } catch (Exception ex) {
                 Console.WriteLine("Failed to detach process");
                 Console.WriteLine(ex);
+            } finally {
+                AssertListener.LogObjectDisposedExceptions = true;
             }
         }
 


### PR DESCRIPTION
Fix #2628 DebuggerTests that log warnings to event viewer