### PR TITLE
Fixes #1434 Try to launch PyLint crashes my PTVS

### DIFF
--- a/Python/Product/Cookiecutter/Shared/Infrastructure/OutputWindowRedirector.cs
+++ b/Python/Product/Cookiecutter/Shared/Infrastructure/OutputWindowRedirector.cs
@@ -104,7 +104,7 @@ namespace Microsoft.CookiecutterTools.Infrastructure {
             try {
                 GetUIThread(_serviceProvider).Invoke(() => ErrorHandler.ThrowOnFailure(_pane.Activate()));
             } catch (Exception ex) when (!ex.IsCriticalException()) {
-                ex.ReportUnhandledException(_serviceProvider, GetType());
+                Debug.Fail(ex.ToUnhandledExceptionMessage(GetType()));
             }
         }
 
@@ -117,7 +117,7 @@ namespace Microsoft.CookiecutterTools.Infrastructure {
                     }
                 });
             } catch (Exception ex) when (!ex.IsCriticalException()) {
-                ex.ReportUnhandledException(_serviceProvider, GetType());
+                Debug.Fail(ex.ToUnhandledExceptionMessage(GetType()));
             }
         }
 

--- a/Python/Product/PythonTools/PythonTools/Project/CustomCommand.cs
+++ b/Python/Product/PythonTools/PythonTools/Project/CustomCommand.cs
@@ -353,12 +353,20 @@ namespace Microsoft.PythonTools.Project {
             }
 
             public override void Show() {
-                _errorListProvider.Show();
+                try {
+                    _errorListProvider.Show();
+                } catch (Exception ex) when (!ex.IsCriticalException()) {
+                    Debug.Fail(ex.ToUnhandledExceptionMessage(GetType()));
+                }
             }
 
             public override void ShowAndActivate() {
-                _errorListProvider.Show();
-                _errorListProvider.BringToFront();
+                try {
+                    _errorListProvider.Show();
+                    _errorListProvider.BringToFront();
+                } catch (Exception ex) when (!ex.IsCriticalException()) {
+                    Debug.Fail(ex.ToUnhandledExceptionMessage(GetType()));
+                }
             }
 
             private void OnNavigate(object sender, EventArgs e) {

--- a/Python/Product/VSCommon/Infrastructure/OutputWindowRedirector.cs
+++ b/Python/Product/VSCommon/Infrastructure/OutputWindowRedirector.cs
@@ -103,7 +103,7 @@ namespace Microsoft.PythonTools.Infrastructure {
             try {
                 GetUIThread(_serviceProvider).Invoke(() => ErrorHandler.ThrowOnFailure(_pane.Activate()));
             } catch (Exception ex) when (!ex.IsCriticalException()) {
-                ex.ReportUnhandledException(_serviceProvider, GetType());
+                Debug.Fail(ex.ToUnhandledExceptionMessage(GetType()));
             }
         }
 
@@ -116,7 +116,7 @@ namespace Microsoft.PythonTools.Infrastructure {
                     }
                 });
             } catch (Exception ex) when (!ex.IsCriticalException()) {
-                ex.ReportUnhandledException(_serviceProvider, GetType());
+                Debug.Fail(ex.ToUnhandledExceptionMessage(GetType()));
             }
         }
 


### PR DESCRIPTION
Fixes #1434 Try to launch PyLint crashes my PTVS
Makes failure to open output/error windows a silent failure, as there is nothing we can do at that stage to fix it.