### PR TITLE
fixes #2473 - Tooltip is shown for indentation

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Intellisense/ReverseExpressionParser.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/ReverseExpressionParser.cs
@@ -389,8 +389,7 @@ namespace Microsoft.PythonTools.Intellisense {
                 } while (enumerator.MoveNext());
             }
 
-            if (start.HasValue && lastToken != null && (lastToken.Span.End.Position - start.Value.Start.Position) >= 0)
-            {
+            if (start.HasValue && lastToken != null && (lastToken.Span.End.Position - start.Value.Start.Position) >= 0) {
                 var spanToReturn = new SnapshotSpan(
                     Snapshot,
                     new Span(
@@ -399,8 +398,7 @@ namespace Microsoft.PythonTools.Intellisense {
                     )
                 );
                 // To handle a case where a space is returned for displaying the type signature.
-                if (string.IsNullOrWhiteSpace(spanToReturn.GetText()))
-                {
+                if (string.IsNullOrWhiteSpace(spanToReturn.GetText())) {
                     return null;
                 }
                 return spanToReturn;

--- a/Python/Product/PythonTools/PythonTools/Intellisense/ReverseExpressionParser.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/ReverseExpressionParser.cs
@@ -389,14 +389,21 @@ namespace Microsoft.PythonTools.Intellisense {
                 } while (enumerator.MoveNext());
             }
 
-            if (start.HasValue && lastToken != null && (lastToken.Span.End.Position - start.Value.Start.Position) >= 0) {
-                return new SnapshotSpan(
+            if (start.HasValue && lastToken != null && (lastToken.Span.End.Position - start.Value.Start.Position) >= 0)
+            {
+                var spanToReturn = new SnapshotSpan(
                     Snapshot,
                     new Span(
                         start.Value.Start.Position,
                         lastToken.Span.End.Position - start.Value.Start.Position
                     )
                 );
+                // To handle a case where a space is returned for displaying the type signature.
+                if (string.IsNullOrWhiteSpace(spanToReturn.GetText()))
+                {
+                    return null;
+                }
+                return spanToReturn;
             }
 
             return _span.GetSpan(_snapshot);


### PR DESCRIPTION
fixes #2473 - Tooltip is shown for indentation

Reverse expression parser "fix" (in quotes due to my own uncertainty) to attempt and catch whitespace-strings identified for type hover over.