### PR TITLE
Debug interactive window protocol changes

### DIFF
--- a/Python/Product/Common/Strings.Designer.cs
+++ b/Python/Product/Common/Strings.Designer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.PythonTools {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Strings {
@@ -1275,6 +1275,24 @@ namespace Microsoft.PythonTools {
         public static string DebugReplCannotChangeCurrentThreadNoFrame {
             get {
                 return ResourceManager.GetString("DebugReplCannotChangeCurrentThreadNoFrame", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Could not retrieve the current frame..
+        /// </summary>
+        public static string DebugReplCannotRetrieveFrameError {
+            get {
+                return ResourceManager.GetString("DebugReplCannotRetrieveFrameError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &lt;Current Frame&gt;.
+        /// </summary>
+        public static string DebugReplCurrentFrameScope {
+            get {
+                return ResourceManager.GetString("DebugReplCurrentFrameScope", resourceCulture);
             }
         }
         

--- a/Python/Product/Common/Strings.resx
+++ b/Python/Product/Common/Strings.resx
@@ -1627,6 +1627,13 @@ Connect anyway?</value>
     <comment>{0} is function name
 {1} is filename</comment>
   </data>
+  <data name="DebugReplCannotRetrieveFrameError" xml:space="preserve">
+    <value>Could not retrieve the current frame.</value>
+  </data>
+  <data name="DebugReplCurrentFrameScope" xml:space="preserve">
+    <value>&lt;Current Frame&gt;</value>
+    <comment>&lt; and &gt; are significant, to differentiate from the other regular module names in the list.</comment>
+  </data>
   <data name="DebugReplModuleName" xml:space="preserve">
     <value>&lt;REPL&gt;</value>
   </data>

--- a/Python/Product/Debugger/Debugger/DebugConnection.cs
+++ b/Python/Product/Debugger/Debugger/DebugConnection.cs
@@ -66,13 +66,13 @@ namespace Microsoft.PythonTools.Debugger {
         public event EventHandler<LDP.EnumChildrenEvent> LegacyEnumChildren;
         public event EventHandler<LDP.ThreadFrameListEvent> LegacyThreadFrameList;
         public event EventHandler<LDP.RemoteConnectedEvent> LegacyRemoteConnected;
+        public event EventHandler<LDP.ModulesChangedEvent> LegacyModulesChanged;
 
         public DebugConnection(Stream stream) {
             _stream = stream;
             _connection = new Connection(stream, false, stream, false, null, LDP.RegisteredTypes, "DebugConnection");
             _connection.EventReceived += _connection_EventReceived;
         }
-
 
         private void _connection_EventReceived(object sender, EventReceivedEventArgs e) {
             // Process events in a separate thread from the one that is processing messages
@@ -260,6 +260,9 @@ namespace Microsoft.PythonTools.Debugger {
                         break;
                     case LDP.RemoteConnectedEvent.Name:
                         LegacyRemoteConnected?.Invoke(this, (LDP.RemoteConnectedEvent)e.Event);
+                        break;
+                    case LDP.ModulesChangedEvent.Name:
+                        LegacyModulesChanged?.Invoke(this, (LDP.ModulesChangedEvent)e.Event);
                         break;
                     case LDP.RequestHandlersEvent.Name:
                         LegacyRequestHandlers?.Invoke(this, (LDP.RequestHandlersEvent)e.Event);

--- a/Python/Product/Debugger/Debugger/DebugEngine/AD7Engine.cs
+++ b/Python/Product/Debugger/Debugger/DebugEngine/AD7Engine.cs
@@ -1436,9 +1436,13 @@ namespace Microsoft.PythonTools.Debugger.DebugEngine {
         }
 
         private void OnDebuggerOutput(object sender, OutputEventArgs e) {
-            AD7Thread thread;
-            if (!_threads.TryGetValue(e.Thread, out thread)) {
-                _threads[e.Thread] = thread = new AD7Thread(this, e.Thread);
+            // Output from debug REPL code execution may be run on debugger
+            // event handling thread, and e.Thread will be null.
+            AD7Thread thread = null;
+            if (e.Thread != null) {
+                if (!_threads.TryGetValue(e.Thread, out thread)) {
+                    _threads[e.Thread] = thread = new AD7Thread(this, e.Thread);
+                }
             }
 
             Send(new AD7DebugOutputStringEvent2(e.Output), AD7DebugOutputStringEvent2.IID, thread);

--- a/Python/Product/Debugger/Debugger/DebugEngine/Remote/PythonRemoteProcess.cs
+++ b/Python/Product/Debugger/Debugger/DebugEngine/Remote/PythonRemoteProcess.cs
@@ -30,7 +30,7 @@ using LDP = Microsoft.PythonTools.Debugger.LegacyDebuggerProtocol;
 
 namespace Microsoft.PythonTools.Debugger.Remote {
     internal class PythonRemoteProcess : PythonProcess {
-        public const byte DebuggerProtocolVersion = 7; // must be kept in sync with PTVSDBG_VER in attach_server.py
+        public const byte DebuggerProtocolVersion = 8; // must be kept in sync with PTVSDBG_VER in attach_server.py
         public const string DebuggerSignature = "PTVSDBG";
         private const int ConnectTimeoutMs = 5000;
 

--- a/Python/Product/Debugger/Debugger/LegacyDebuggerProtocol.cs
+++ b/Python/Product/Debugger/Debugger/LegacyDebuggerProtocol.cs
@@ -187,6 +187,8 @@ namespace Microsoft.PythonTools.Debugger {
             public int frameId;
             public FrameKind frameKind;
             public ReprKind reprKind;
+            public string moduleName;
+            public bool printResult;
         }
 
         public sealed class DetachRequest : GenericRequest {
@@ -202,20 +204,6 @@ namespace Microsoft.PythonTools.Debugger {
 
             public int defaultBreakOnMode;
             public ExceptionInfo[] breakOn;
-        }
-
-        public sealed class ConnectReplRequest : GenericRequest {
-            public const string Command = "legacyConnectRepl";
-
-            public override string command => Command;
-
-            public int portNum;
-        }
-
-        public sealed class DisconnectReplRequest : GenericRequest {
-            public const string Command = "legacyDisconnectRepl";
-
-            public override string command => Command;
         }
 
         public sealed class LastAckRequest : GenericRequest {
@@ -314,14 +302,14 @@ namespace Microsoft.PythonTools.Debugger {
             public int pythonMicro;
         }
 
-        public sealed class RemoteReplAttachRequest : Request<RemoteReplAttachResponse> {
-            public const string Command = "legacyRemoteReplAttach";
+        public sealed class ListReplModulesRequest : Request<ListReplModulesResponse> {
+            public const string Command = "legacyListReplModules";
 
             public override string command => Command;
         }
 
-        public sealed class RemoteReplAttachResponse : Response {
-            public bool accepted;
+        public sealed class ListReplModulesResponse : Response {
+            public ModuleItem[] modules;
         }
 
         //////////////////////////////////////////////////////////////////////
@@ -456,6 +444,7 @@ namespace Microsoft.PythonTools.Debugger {
 
             public long threadId;
             public string output;
+            public bool isStdOut;
         }
 
         public sealed class ExecutionResultEvent : Event {
@@ -493,6 +482,12 @@ namespace Microsoft.PythonTools.Debugger {
             public long threadId;
             public string threadName;
             public ThreadFrameItem[] threadFrames;
+        }
+
+        public sealed class ModulesChangedEvent : Event {
+            public const string Name = "legacyModulesChanged";
+
+            public override string name => Name;
         }
 
         //////////////////////////////////////////////////////////////////////
@@ -576,6 +571,11 @@ namespace Microsoft.PythonTools.Debugger {
             public int lineStart;
             public int lineEnd;
             public string[] expressions;
+        }
+
+        public sealed class ModuleItem {
+            public string name;
+            public string fileName;
         }
     }
 }

--- a/Python/Product/Debugger/Debugger/OutputEventArgs.cs
+++ b/Python/Product/Debugger/Debugger/OutputEventArgs.cs
@@ -20,10 +20,12 @@ namespace Microsoft.PythonTools.Debugger {
     sealed class OutputEventArgs : EventArgs {
         private readonly string _output;
         private readonly PythonThread _thread;
+        private readonly bool _isStdOut;
 
-        public OutputEventArgs(PythonThread thread, string output) {
+        public OutputEventArgs(PythonThread thread, string output, bool isStdOut) {
             _thread = thread;
             _output = output;
+            _isStdOut = isStdOut;
         }
 
         public PythonThread Thread {
@@ -35,6 +37,12 @@ namespace Microsoft.PythonTools.Debugger {
         public string Output {
             get {
                 return _output;
+            }
+        }
+
+        public bool IsStdOut {
+            get {
+                return _isStdOut;
             }
         }
     }

--- a/Python/Product/Debugger/Debugger/PythonStackFrame.cs
+++ b/Python/Product/Debugger/Debugger/PythonStackFrame.cs
@@ -161,7 +161,7 @@ namespace Microsoft.PythonTools.Debugger {
         }
 
         public Task ExecuteTextAsync(string text, PythonEvaluationResultReprKind reprKind, Action<PythonEvaluationResult> completion, CancellationToken ct) {
-            return _thread.Process.ExecuteTextAsync(text, reprKind, this, completion, ct);
+            return _thread.Process.ExecuteTextAsync(text, reprKind, this, false, completion, ct);
         }
 
         public async Task<PythonEvaluationResult> ExecuteTextAsync(string text, PythonEvaluationResultReprKind reprKind = PythonEvaluationResultReprKind.Normal, CancellationToken ct = default(CancellationToken)) {

--- a/Python/Product/PythonTools/PythonTools.csproj
+++ b/Python/Product/PythonTools/PythonTools.csproj
@@ -722,6 +722,7 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
+    <None Include="ptvsd\setup.py" />
     <Content Include="Snippets\Python\for.snippet">
       <IncludeInVSIX>true</IncludeInVSIX>
       <SubType>Designer</SubType>

--- a/Python/Product/PythonTools/PythonTools.csproj
+++ b/Python/Product/PythonTools/PythonTools.csproj
@@ -293,6 +293,8 @@
       <SubType>Component</SubType>
     </Compile>
     <Compile Include="PythonTools\Project\DeprecatedReferenceNode.cs" />
+    <Compile Include="PythonTools\Repl\PythonCommonInteractiveEvaluator.cs" />
+    <Compile Include="PythonTools\Repl\PythonDebugProcessReplEvaluator.cs" />
     <Compile Include="PythonTools\SearchPathManager.cs" />
     <Compile Include="PythonTools\Project\VsPackageManagerUI.cs" />
     <Compile Include="PythonTools\ProvideBraceCompletionAttribute.cs" />

--- a/Python/Product/PythonTools/PythonTools/Repl/PythonCommonInteractiveEvaluator.cs
+++ b/Python/Product/PythonTools/PythonTools/Repl/PythonCommonInteractiveEvaluator.cs
@@ -1,0 +1,742 @@
+﻿// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABLITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+using Microsoft.PythonTools.Editor;
+using Microsoft.PythonTools.Infrastructure;
+using Microsoft.PythonTools.Intellisense;
+using Microsoft.PythonTools.Interpreter;
+using Microsoft.PythonTools.Options;
+using Microsoft.PythonTools.Parsing;
+using Microsoft.PythonTools.Project;
+using Microsoft.VisualStudio.InteractiveWindow;
+using Microsoft.VisualStudio.InteractiveWindow.Commands;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Editor.OptionsExtensionMethods;
+using Microsoft.VisualStudio.Utilities;
+using Microsoft.VisualStudioTools;
+using Task = System.Threading.Tasks.Task;
+
+namespace Microsoft.PythonTools.Repl {
+    [InteractiveWindowRole("Execution")]
+    [InteractiveWindowRole("Reset")]
+    [ContentType(PythonCoreConstants.ContentType)]
+    [ContentType(PredefinedInteractiveCommandsContentTypes.InteractiveCommandContentTypeName)]
+    internal abstract class PythonCommonInteractiveEvaluator :
+        IInteractiveEvaluator,
+        IPythonInteractiveEvaluator,
+        IMultipleScopeEvaluator,
+        IPythonInteractiveIntellisense,
+        IDisposable {
+        protected readonly IServiceProvider _serviceProvider;
+        private readonly StringBuilder _deferredOutput;
+
+        private PythonProjectNode _projectWithHookedEvents;
+
+        protected IInteractiveWindowCommands _commands;
+        private IInteractiveWindow _window;
+        private PythonInteractiveOptions _options;
+
+        private VsProjectAnalyzer _analyzer;
+        private readonly string _analysisFilename;
+
+        private bool _enableMultipleScopes;
+        private IReadOnlyList<string> _availableScopes;
+
+        private bool _isDisposed;
+
+        internal const string DoNotResetConfigurationLaunchOption = "DoNotResetConfiguration";
+
+        public PythonCommonInteractiveEvaluator(IServiceProvider serviceProvider) {
+            _serviceProvider = serviceProvider;
+            _deferredOutput = new StringBuilder();
+            _analysisFilename = Guid.NewGuid().ToString() + ".py";
+        }
+
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2213:DisposableFieldsShouldBeDisposed", MessageId = "_analyzer")]
+        protected virtual void Dispose(bool disposing) {
+            if (_isDisposed) {
+                return;
+            }
+            _isDisposed = true;
+
+            if (_projectWithHookedEvents != null) {
+                _projectWithHookedEvents.ActiveInterpreterChanged -= Project_ConfigurationChanged;
+                _projectWithHookedEvents._searchPaths.Changed -= Project_ConfigurationChanged;
+                _projectWithHookedEvents = null;
+            }
+
+            if (disposing) {
+                _analyzer?.Dispose();
+            }
+        }
+
+        public void Dispose() {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        ~PythonCommonInteractiveEvaluator() {
+            Dispose(false);
+        }
+
+        public string DisplayName { get; set; }
+        public string ProjectMoniker { get; set; }
+        public LaunchConfiguration Configuration { get; set; }
+        public string ScriptsPath { get; set; }
+
+        public PythonLanguageVersion LanguageVersion {
+            get {
+                return Configuration?.Interpreter?.Version.ToLanguageVersion() ?? PythonLanguageVersion.None;
+            }
+        }
+
+        public bool UseSmartHistoryKeys { get; set; }
+        public bool LiveCompletionsOnly { get; set; }
+        public string BackendName { get; set; }
+
+        internal bool AssociatedProjectHasChanged { get; set; }
+
+        private PythonProjectNode GetAssociatedPythonProject(InterpreterConfiguration interpreter = null) {
+            _serviceProvider.GetUIThread().MustBeCalledFromUIThread();
+
+            var moniker = ProjectMoniker;
+            if (interpreter == null) {
+                interpreter = Configuration?.Interpreter;
+            }
+
+            if (string.IsNullOrEmpty(moniker) && interpreter != null) {
+                var interpreterService = _serviceProvider.GetComponentModel().GetService<IInterpreterRegistryService>();
+                moniker = interpreterService.GetProperty(interpreter.Id, "ProjectMoniker") as string;
+            }
+
+            if (string.IsNullOrEmpty(moniker)) {
+                return null;
+            }
+
+            return _serviceProvider.GetProjectFromFile(moniker);
+        }
+
+
+        public VsProjectAnalyzer Analyzer {
+            get {
+                if (_analyzer != null) {
+                    return _analyzer;
+                }
+
+                var config = Configuration;
+                IPythonInterpreterFactory factory = null;
+                if (config?.Interpreter != null) {
+                    var interpreterService = _serviceProvider.GetComponentModel().GetService<IInterpreterRegistryService>();
+                    factory = interpreterService.FindInterpreter(config.Interpreter.Id);
+                }
+
+                if (factory == null) {
+                    _analyzer = _serviceProvider.GetPythonToolsService().DefaultAnalyzer;
+                } else {
+                    var projectFile = GetAssociatedPythonProject(config.Interpreter)?.BuildProject;
+                    _analyzer = new VsProjectAnalyzer(
+                        _serviceProvider,
+                        factory,
+                        projectFile: projectFile,
+                        comment: "{0} Interactive".FormatInvariant(DisplayName.IfNullOrEmpty("Unnamed"))
+                    );
+                }
+                return _analyzer;
+            }
+        }
+
+        public string AnalysisFilename => _analysisFilename;
+
+        internal void WriteOutput(string text, bool addNewline = true) {
+            var wnd = CurrentWindow;
+            if (wnd == null) {
+                lock (_deferredOutput) {
+                    _deferredOutput.Append(text);
+                }
+            } else {
+                AppendTextWithEscapes(wnd, text, addNewline, isError: false);
+            }
+        }
+
+        internal void WriteError(string text, bool addNewline = true) {
+            var wnd = CurrentWindow;
+            if (wnd == null) {
+                lock (_deferredOutput) {
+                    _deferredOutput.Append(text);
+                }
+            } else {
+                AppendTextWithEscapes(wnd, text, addNewline, isError: true);
+            }
+        }
+
+        public abstract bool IsDisconnected { get; }
+
+        public abstract bool IsExecuting { get; }
+
+        public abstract string CurrentScopeName { get; }
+
+        public abstract string CurrentScopePath { get; }
+
+        public abstract string CurrentWorkingDirectory { get; }
+
+        public IInteractiveWindow CurrentWindow {
+            get {
+                return _window;
+            }
+            set {
+                if (_window != null) {
+                }
+                _commands = null;
+
+                if (value != null) {
+                    lock (_deferredOutput) {
+                        AppendTextWithEscapes(value, _deferredOutput.ToString(), false, false);
+                        _deferredOutput.Clear();
+                    }
+
+                    _options = _serviceProvider.GetPythonToolsService().InteractiveOptions;
+                    _options.Changed += InteractiveOptions_Changed;
+                    UseSmartHistoryKeys = _options.UseSmartHistory;
+                    LiveCompletionsOnly = _options.LiveCompletionsOnly;
+                } else {
+                    if (_options != null) {
+                        _options.Changed -= InteractiveOptions_Changed;
+                        _options = null;
+                    }
+                }
+                _window = value;
+            }
+        }
+
+        private async void InteractiveOptions_Changed(object sender, EventArgs e) {
+            if (!ReferenceEquals(sender, _options)) {
+                return;
+            }
+
+            UseSmartHistoryKeys = _options.UseSmartHistory;
+            LiveCompletionsOnly = _options.LiveCompletionsOnly;
+
+            var window = CurrentWindow;
+            if (window == null) {
+                return;
+            }
+
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+            window.TextView.Options.SetOptionValue(InteractiveWindowOptions.SmartUpDown, UseSmartHistoryKeys);
+        }
+
+        public bool EnableMultipleScopes {
+            get { return _enableMultipleScopes; }
+            set {
+                if (_enableMultipleScopes != value) {
+                    _enableMultipleScopes = value;
+                    MultipleScopeSupportChanged?.Invoke(this, EventArgs.Empty);
+                }
+            }
+        }
+
+        public event EventHandler<EventArgs> AvailableScopesChanged;
+        public event EventHandler<EventArgs> MultipleScopeSupportChanged;
+
+        public abstract Task<bool> GetSupportsMultipleStatementsAsync();
+
+        protected void SetAvailableScopes(string[] scopes) {
+            _availableScopes = scopes;
+            AvailableScopesChanged?.Invoke(this, EventArgs.Empty);
+        }
+
+        public abstract IEnumerable<KeyValuePair<string, string>> GetAvailableScopesAndPaths();
+
+        public abstract CompletionResult[] GetMemberNames(string text);
+
+        public abstract OverloadDoc[] GetSignatureDocumentation(string text);
+
+        public abstract void AbortExecution();
+
+        public bool CanExecuteCode(string text) {
+            if (string.IsNullOrEmpty(text)) {
+                return true;
+            }
+            if (string.IsNullOrWhiteSpace(text) && text.EndsWith("\n")) {
+                return true;
+            }
+
+            var config = Configuration;
+            using (var parser = Parser.CreateParser(new StringReader(text), LanguageVersion)) {
+                ParseResult pr;
+                parser.ParseInteractiveCode(out pr);
+                if (pr == ParseResult.IncompleteStatement) {
+                    return text.EndsWith("\n");
+                }
+                if (pr == ParseResult.Empty || pr == ParseResult.IncompleteToken) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        protected abstract Task ExecuteStartupScripts(string scriptsPath);
+
+        internal void UpdatePropertiesFromProjectMoniker() {
+            if (_projectWithHookedEvents != null) {
+                _projectWithHookedEvents.ActiveInterpreterChanged -= Project_ConfigurationChanged;
+                _projectWithHookedEvents._searchPaths.Changed -= Project_ConfigurationChanged;
+                _projectWithHookedEvents = null;
+            }
+
+            AssociatedProjectHasChanged = false;
+            var pyProj = GetAssociatedPythonProject();
+            if (pyProj == null) {
+                return;
+            }
+
+            if (Configuration?.GetLaunchOption(DoNotResetConfigurationLaunchOption) == null) {
+                Configuration = pyProj.GetLaunchConfigurationOrThrow();
+                if (Configuration?.Interpreter != null) {
+                    ScriptsPath = GetScriptsPath(_serviceProvider, Configuration.Interpreter.Description, Configuration.Interpreter);
+                }
+            }
+
+            _projectWithHookedEvents = pyProj;
+            pyProj.ActiveInterpreterChanged += Project_ConfigurationChanged;
+            pyProj._searchPaths.Changed += Project_ConfigurationChanged;
+        }
+
+        private void Project_ConfigurationChanged(object sender, EventArgs e) {
+            var pyProj = _projectWithHookedEvents;
+            _projectWithHookedEvents = null;
+
+            if (pyProj != null) {
+                Debug.Assert(pyProj == sender || pyProj._searchPaths == sender, "Unexpected project raised the event");
+                // Only warn once
+                pyProj.ActiveInterpreterChanged -= Project_ConfigurationChanged;
+                pyProj._searchPaths.Changed -= Project_ConfigurationChanged;
+                WriteError(Strings.ReplProjectConfigurationChanged.FormatUI(pyProj.Caption));
+                AssociatedProjectHasChanged = true;
+            }
+        }
+
+        internal static string GetScriptsPath(
+            IServiceProvider provider,
+            string displayName,
+            InterpreterConfiguration config,
+            bool onlyIfExists = true
+        ) {
+            // TODO: Allow customizing the scripts path
+            //var root = _serviceProvider.GetPythonToolsService().InteractiveOptions.ScriptsPath;
+            string root;
+            try {
+                if (!provider.TryGetShellProperty((__VSSPROPID)__VSSPROPID2.VSSPROPID_VisualStudioDir, out root)) {
+                    root = PathUtils.GetAbsoluteDirectoryPath(
+                        Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments),
+                        "Visual Studio {0}".FormatInvariant(AssemblyVersionInfo.VSName)
+                    );
+                }
+
+                root = PathUtils.GetAbsoluteDirectoryPath(root, "Python Scripts");
+            } catch (ArgumentException ex) {
+                ex.ReportUnhandledException(provider, typeof(PythonInteractiveEvaluator));
+                return null;
+            }
+
+            string candidate;
+            if (!string.IsNullOrEmpty(displayName)) {
+                candidate = PathUtils.GetAbsoluteDirectoryPath(root, displayName);
+                if (!onlyIfExists || Directory.Exists(candidate)) {
+                    return candidate;
+                }
+            }
+
+            var version = config?.Version?.ToString();
+            if (!string.IsNullOrEmpty(version)) {
+                candidate = PathUtils.GetAbsoluteDirectoryPath(root, version);
+                if (!onlyIfExists || Directory.Exists(candidate)) {
+                    return candidate;
+                }
+            }
+
+            return null;
+        }
+
+        public abstract Task<ExecutionResult> ExecuteCodeAsync(string text);
+
+        public abstract Task<bool> ExecuteFileAsync(string filename, string extraArgs);
+
+        public abstract Task<bool> ExecuteModuleAsync(string name, string extraArgs);
+
+        public abstract Task<bool> ExecuteProcessAsync(string filename, string extraArgs);
+
+        const string _splitRegexPattern = @"(?x)\s*,\s*(?=(?:[^""]*""[^""]*"")*[^""]*$)"; // http://regexhero.net/library/52/
+        private static Regex _splitLineRegex = new Regex(_splitRegexPattern);
+
+        public string FormatClipboard() {
+            if (Clipboard.ContainsData(DataFormats.CommaSeparatedValue)) {
+                string data = Clipboard.GetData(DataFormats.CommaSeparatedValue) as string;
+                if (data != null) {
+                    string[] lines = data.Split(new[] { "\n", "\r\n" }, StringSplitOptions.RemoveEmptyEntries);
+                    StringBuilder res = new StringBuilder();
+                    res.AppendLine("[");
+                    foreach (var line in lines) {
+                        string[] items = _splitLineRegex.Split(line);
+
+                        res.Append("  [");
+                        for (int i = 0; i < items.Length; i++) {
+                            res.Append(FormatItem(items[i]));
+
+                            if (i != items.Length - 1) {
+                                res.Append(", ");
+                            }
+                        }
+                        res.AppendLine("],");
+                    }
+                    res.AppendLine("]");
+                    return res.ToString();
+                }
+            }
+
+            var txt = Clipboard.GetText();
+            if (!_serviceProvider.GetPythonToolsService().AdvancedOptions.PasteRemovesReplPrompts) {
+                return txt;
+            }
+
+
+            return ReplPromptHelpers.RemovePrompts(
+                txt,
+                _window.TextView.Options.GetNewLineCharacter()
+            );
+        }
+
+        private static string FormatItem(string item) {
+            if (String.IsNullOrWhiteSpace(item)) {
+                return "None";
+            }
+            double doubleVal;
+            int intVal;
+            if (Double.TryParse(item, out doubleVal) ||
+                Int32.TryParse(item, out intVal)) {
+                return item;
+            }
+
+            if (item[0] == '"' && item[item.Length - 1] == '"' && item.IndexOf(',') != -1) {
+                // remove outer quotes, remove "" escaping
+                item = item.Substring(1, item.Length - 2).Replace("\"\"", "\"");
+            }
+
+            // put in single quotes and escape single quotes and backslashes
+            return "'" + item.Replace("\\", "\\\\").Replace("'", "\\'") + "'";
+        }
+
+        public IEnumerable<string> GetAvailableScopes() {
+            return _availableScopes ?? Enumerable.Empty<string>();
+        }
+
+        public abstract void SetScope(string scopeName);
+
+        public string GetPrompt() {
+            if ((_window?.CurrentLanguageBuffer.CurrentSnapshot.LineCount ?? 1) > 1) {
+                return SecondaryPrompt;
+            } else {
+                return PrimaryPrompt;
+            }
+        }
+
+        internal abstract string PrimaryPrompt { get; }
+        internal abstract string SecondaryPrompt { get; }
+
+        public virtual async Task<ExecutionResult> InitializeAsync() {
+            if (_commands != null) {
+                // Already initialized
+                return ExecutionResult.Success;
+            }
+
+            var msg = Strings.ReplInitializationMessage.FormatUI(
+                DisplayName,
+                AssemblyVersionInfo.Version,
+                AssemblyVersionInfo.VSVersion
+            ).Replace("&#x1b;", "\x1b");
+
+            WriteOutput(msg, addNewline: true);
+
+            _window.TextView.Options.SetOptionValue(InteractiveWindowOptions.SmartUpDown, UseSmartHistoryKeys);
+            _commands = GetInteractiveCommands(_serviceProvider, _window, this);
+
+            return ExecutionResult.Success;
+        }
+
+        public Task<ExecutionResult> ResetAsync(bool initialize = true) {
+            return ResetWorkerAsync(initialize, false);
+        }
+
+        public Task<ExecutionResult> ResetAsync(bool initialize, bool quiet) {
+            return ResetWorkerAsync(initialize, quiet);
+        }
+
+        protected abstract Task<ExecutionResult> ResetWorkerAsync(bool initialize, bool quiet);
+
+        internal Task InvokeAsync(Action action) {
+            return _window.TextView.VisualElement.Dispatcher.InvokeAsync(action).Task;
+        }
+
+        internal void WriteFrameworkElement(System.Windows.UIElement control, System.Windows.Size desiredSize) {
+            if (_window == null) {
+                return;
+            }
+
+            _window.Write("");
+            _window.FlushOutput();
+
+            var caretPos = _window.TextView.Caret.Position.BufferPosition;
+            var manager = InlineReplAdornmentProvider.GetManager(_window.TextView);
+            manager.AddAdornment(new ZoomableInlineAdornment(control, _window.TextView, desiredSize), caretPos);
+        }
+
+
+        internal static IInteractiveWindowCommands GetInteractiveCommands(
+            IServiceProvider serviceProvider,
+            IInteractiveWindow window,
+            IInteractiveEvaluator eval
+        ) {
+            var model = serviceProvider.GetComponentModel();
+            var cmdFactory = model.GetService<IInteractiveWindowCommandsFactory>();
+            var cmds = model.GetExtensions<IInteractiveWindowCommand>();
+            var roles = eval.GetType()
+                .GetCustomAttributes(typeof(InteractiveWindowRoleAttribute), true)
+                .Select(r => ((InteractiveWindowRoleAttribute)r).Name)
+                .ToArray();
+
+            var contentTypeRegistry = model.GetService<IContentTypeRegistryService>();
+            var contentTypes = eval.GetType()
+                .GetCustomAttributes(typeof(ContentTypeAttribute), true)
+                .Select(r => contentTypeRegistry.GetContentType(((ContentTypeAttribute)r).ContentTypes))
+                .ToArray();
+
+            return cmdFactory.CreateInteractiveCommands(
+                window,
+                "$",
+                cmds.Where(x => IsCommandApplicable(x, roles, contentTypes))
+            );
+        }
+
+        private static bool IsCommandApplicable(
+            IInteractiveWindowCommand command,
+            string[] supportedRoles,
+            IContentType[] supportedContentTypes
+        ) {
+            var commandRoles = command.GetType().GetCustomAttributes(typeof(InteractiveWindowRoleAttribute), true).Select(r => ((InteractiveWindowRoleAttribute)r).Name).ToArray();
+
+            // Commands with no roles are always applicable.
+            // If a command specifies roles and none apply, exclude it
+            if (commandRoles.Any() && !commandRoles.Intersect(supportedRoles).Any()) {
+                return false;
+            }
+
+            var commandContentTypes = command.GetType()
+                .GetCustomAttributes(typeof(ContentTypeAttribute), true)
+                .Select(a => ((ContentTypeAttribute)a).ContentTypes)
+                .ToArray();
+
+            // Commands with no content type are always applicable
+            // If a commands specifies content types and none apply, exclude it
+            if (commandContentTypes.Any() && !commandContentTypes.Any(cct => supportedContentTypes.Any(sct => sct.IsOfType(cct)))) {
+                return false;
+            }
+
+            return true;
+        }
+
+        #region Append Text helpers
+
+        private static void AppendTextWithEscapes(
+            IInteractiveWindow window,
+            string text,
+            bool addNewLine,
+            bool isError
+        ) {
+            int start = 0, escape = text.IndexOf("\x1b[");
+            var colors = window.OutputBuffer.Properties.GetOrCreateSingletonProperty(
+                ReplOutputClassifier.ColorKey,
+                () => new List<ColoredSpan>()
+            );
+            ConsoleColor? color = null;
+
+            Span span;
+            var write = isError ? (Func<string, Span>)window.WriteError : window.Write;
+
+            while (escape >= 0) {
+                span = write(text.Substring(start, escape - start));
+                if (span.Length > 0) {
+                    colors.Add(new ColoredSpan(span, color));
+                }
+
+                start = escape + 2;
+                color = GetColorFromEscape(text, ref start);
+                escape = text.IndexOf("\x1b[", start);
+            }
+
+            var rest = text.Substring(start);
+            if (addNewLine) {
+                rest += Environment.NewLine;
+            }
+
+            span = write(rest);
+            if (span.Length > 0) {
+                colors.Add(new ColoredSpan(span, color));
+            }
+        }
+
+        private static ConsoleColor Change(ConsoleColor? from, ConsoleColor to) {
+            return ((from ?? ConsoleColor.Black) & ConsoleColor.DarkGray) | to;
+        }
+
+        private static ConsoleColor? GetColorFromEscape(string text, ref int start) {
+            // http://en.wikipedia.org/wiki/ANSI_escape_code
+            // process any ansi color sequences...
+            ConsoleColor? color = null;
+            List<int> codes = new List<int>();
+            int? value = 0;
+
+            while (start < text.Length) {
+                if (text[start] >= '0' && text[start] <= '9') {
+                    // continue parsing the integer...
+                    if (value == null) {
+                        value = 0;
+                    }
+                    value = 10 * value.Value + (text[start] - '0');
+                } else if (text[start] == ';') {
+                    if (value != null) {
+                        codes.Add(value.Value);
+                        value = null;
+                    } else {
+                        // CSI ; - invalid or CSI ### ;;, both invalid
+                        break;
+                    }
+                } else if (text[start] == 'm') {
+                    start += 1;
+                    if (value != null) {
+                        codes.Add(value.Value);
+                    }
+
+                    // parsed a valid code
+                    if (codes.Count == 0) {
+                        // reset
+                        color = null;
+                    } else {
+                        for (int j = 0; j < codes.Count; j++) {
+                            switch (codes[j]) {
+                                case 0: color = ConsoleColor.White; break;
+                                case 1: // bright/bold
+                                    color |= ConsoleColor.DarkGray;
+                                    break;
+                                case 2: // faint
+
+                                case 3: // italic
+                                case 4: // single underline
+                                    break;
+                                case 5: // blink slow
+                                case 6: // blink fast
+                                    break;
+                                case 7: // negative
+                                case 8: // conceal
+                                case 9: // crossed out
+                                case 10: // primary font
+                                case 11: // 11-19, n-th alternate font
+                                    break;
+                                case 21: // bright/bold off 
+                                    color &= ~ConsoleColor.DarkGray;
+                                    break;
+                                case 22: // normal intensity
+                                case 24: // underline off
+                                    break;
+                                case 25: // blink off
+                                    break;
+                                case 27: // image - postive
+                                case 28: // reveal
+                                case 29: // not crossed out
+                                case 30: color = Change(color, ConsoleColor.Black); break;
+                                case 31: color = Change(color, ConsoleColor.DarkRed); break;
+                                case 32: color = Change(color, ConsoleColor.DarkGreen); break;
+                                case 33: color = Change(color, ConsoleColor.DarkYellow); break;
+                                case 34: color = Change(color, ConsoleColor.DarkBlue); break;
+                                case 35: color = Change(color, ConsoleColor.DarkMagenta); break;
+                                case 36: color = Change(color, ConsoleColor.DarkCyan); break;
+                                case 37: color = Change(color, ConsoleColor.Gray); break;
+                                case 38: // xterm 286 background color
+                                case 39: // default text color
+                                    color = null;
+                                    break;
+                                case 40: // background colors
+                                case 41:
+                                case 42:
+                                case 43:
+                                case 44:
+                                case 45:
+                                case 46:
+                                case 47: break;
+                                case 90: color = ConsoleColor.DarkGray; break;
+                                case 91: color = ConsoleColor.Red; break;
+                                case 92: color = ConsoleColor.Green; break;
+                                case 93: color = ConsoleColor.Yellow; break;
+                                case 94: color = ConsoleColor.Blue; break;
+                                case 95: color = ConsoleColor.Magenta; break;
+                                case 96: color = ConsoleColor.Cyan; break;
+                                case 97: color = ConsoleColor.White; break;
+                            }
+                        }
+                    }
+                    break;
+                } else {
+                    // unknown char, invalid escape
+                    break;
+                }
+                start += 1;
+            }
+            return color;
+        }
+
+        #endregion
+    }
+
+    internal static class PythonCommonInteractiveEvaluatorExtensions {
+        public static PythonCommonInteractiveEvaluator GetPythonEvaluator(this IInteractiveWindow window) {
+            var pie = window?.Evaluator as PythonCommonInteractiveEvaluator;
+            if (pie != null) {
+                return pie;
+            }
+
+            pie = (window?.Evaluator as SelectableReplEvaluator)?.Evaluator as PythonCommonInteractiveEvaluator;
+            return pie;
+        }
+
+        public static async Task<bool> GetSupportsMultipleStatements(this IInteractiveWindow window) {
+            var pie = window.GetPythonEvaluator();
+            if (pie == null) {
+                return false;
+            }
+            return await pie.GetSupportsMultipleStatementsAsync();
+        }
+    }
+}

--- a/Python/Product/PythonTools/PythonTools/Repl/PythonDebugProcessReplEvaluator.cs
+++ b/Python/Product/PythonTools/PythonTools/Repl/PythonDebugProcessReplEvaluator.cs
@@ -1,0 +1,379 @@
+// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABLITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Runtime.ExceptionServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.PythonTools.Debugger;
+using Microsoft.PythonTools.Debugger.Remote;
+using Microsoft.PythonTools.Infrastructure;
+using Microsoft.PythonTools.Intellisense;
+using Microsoft.PythonTools.Parsing;
+using Microsoft.VisualStudio.InteractiveWindow;
+using Microsoft.VisualStudio.InteractiveWindow.Commands;
+using Microsoft.VisualStudio.Utilities;
+using Microsoft.VisualStudioTools;
+
+namespace Microsoft.PythonTools.Repl {
+    [InteractiveWindowRole("Debug")]
+    [ContentType(PythonCoreConstants.ContentType)]
+    [ContentType(PredefinedInteractiveCommandsContentTypes.InteractiveCommandContentTypeName)]
+    internal class PythonDebugProcessReplEvaluator : PythonInteractiveEvaluator {
+        private readonly PythonProcess _process;
+        private readonly IThreadIdMapper _threadIdMapper;
+        private long _threadId;
+        private int _frameId;
+        private PythonLanguageVersion _languageVersion;
+        private Dictionary<string, string> _moduleToFileName;
+        private string _currentScopeName;
+        private string _currentScopeFileName;
+
+        /// <summary>
+        /// Backwards compatible and non-localized name for the scope
+        /// that represents execution on the current frame.
+        /// </summary>
+        private const string CurrentFrameScopeFixedName = "<CurrentFrame>";
+
+        public PythonDebugProcessReplEvaluator(IServiceProvider serviceProvider, PythonProcess process, IThreadIdMapper threadIdMapper)
+            : base(serviceProvider) {
+            _process = process;
+            _threadIdMapper = threadIdMapper;
+            _threadId = process.GetThreads()[0].Id;
+            _languageVersion = process.LanguageVersion;
+            _currentScopeName = CurrentFrameScopeFixedName;
+            DisplayName = Strings.DebugReplDisplayName;
+        }
+
+        public override async Task<ExecutionResult> InitializeAsync() {
+            var result = await base.InitializeAsync();
+            if (!result.IsSuccessful) {
+                return result;
+            }
+
+            result = await _serviceProvider.GetUIThread().InvokeTask(async () => {
+                try {
+                    UpdatePropertiesFromProjectMoniker();
+                } catch (NoInterpretersException ex) {
+                    WriteError(ex.ToString());
+                } catch (MissingInterpreterException ex) {
+                    WriteError(ex.ToString());
+                } catch (DirectoryNotFoundException ex) {
+                    WriteError(ex.ToString());
+                } catch (Exception ex) when (!ex.IsCriticalException()) {
+                    WriteError(ex.ToUnhandledExceptionMessage(GetType()));
+                }
+
+                var remoteProcess = _process as PythonRemoteProcess;
+
+                try {
+                    _serviceProvider.GetPythonToolsService().Logger.LogEvent(Logging.PythonLogEvent.DebugRepl, new Logging.DebugReplInfo {
+                        RemoteProcess = remoteProcess != null,
+                        Version = _process.LanguageVersion.ToVersion().ToString()
+                    });
+                } catch (Exception ex) {
+                    Debug.Fail(ex.ToUnhandledExceptionMessage(GetType()));
+                }
+
+                _process.ModulesChanged += OnModulesChanged;
+
+                var threads = _process.GetThreads();
+                PythonThread activeThread = null;
+
+                var dte = _serviceProvider.GetDTE();
+                if (dte != null) {
+                    // If we are broken into the debugger, let's set the debug REPL active thread
+                    // to be the one that is active in the debugger
+                    var dteDebugger = dte.Debugger;
+                    if (dteDebugger.CurrentMode == EnvDTE.dbgDebugMode.dbgBreakMode &&
+                        dteDebugger.CurrentProcess != null &&
+                        dteDebugger.CurrentThread != null) {
+                        if (_process.Id == dteDebugger.CurrentProcess.ProcessID) {
+                            var activeThreadId = _threadIdMapper.GetPythonThreadId((uint)dteDebugger.CurrentThread.ID);
+                            activeThread = threads.SingleOrDefault(t => t.Id == activeThreadId);
+                        }
+                    }
+                }
+
+                if (activeThread == null) {
+                    activeThread = threads.Count > 0 ? threads[0] : null;
+                }
+
+                if (activeThread != null) {
+                    SwitchThread(activeThread, false);
+                }
+
+                return ExecutionResult.Success;
+            });
+
+            return result;
+        }
+
+        private async void OnModulesChanged(object sender, EventArgs e) {
+            await RefreshAvailableScopes();
+        }
+
+        internal async Task<KeyValuePair<string, string>[]> RefreshAvailableScopes() {
+            var modules = await _process.GetModuleNamesAndPaths();
+
+            var moduleToFile = new Dictionary<string, string>();
+            foreach (var item in modules) {
+                if (!string.IsNullOrEmpty(item.Value)) {
+                    moduleToFile[item.Key] = item.Value;
+                }
+            }
+            _moduleToFileName = moduleToFile;
+
+            SetAvailableScopes(modules.Select(m => m.Key).ToArray());
+            EnableMultipleScopes = true;
+
+            return modules;
+        }
+
+        protected override Task ExecuteStartupScripts(string scriptsPath) {
+            // Do not execute scripts for debug evaluator
+            return Task.FromResult<object>(null);
+        }
+
+        public override async Task<ExecutionResult> ExecuteCodeAsync(string text) {
+            var tcs = new TaskCompletionSource<ExecutionResult>();
+            var ct = new CancellationToken();
+            var cancellationRegistration = ct.Register(() => tcs.TrySetCanceled());
+
+            EventHandler<ProcessExitedEventArgs> processExited = delegate {
+                tcs.TrySetCanceled();
+            };
+
+            EventHandler<OutputEventArgs> debuggerOutput = (object sender, OutputEventArgs e) => {
+                if (e.IsStdOut) {
+                    WriteOutput(e.Output, addNewline: false);
+                } else {
+                    WriteError(e.Output, addNewline: false);
+                }
+            };
+
+            Action<PythonEvaluationResult> resultReceived = (PythonEvaluationResult result) => {
+                if (!string.IsNullOrEmpty(result.ExceptionText)) {
+                    tcs.TrySetResult(ExecutionResult.Failure);
+                } else {
+                    tcs.TrySetResult(ExecutionResult.Success);
+                }
+            };
+
+            _process.ProcessExited += processExited;
+            _process.DebuggerOutput += debuggerOutput;
+            try {
+                if (_currentScopeName == CurrentFrameScopeFixedName) {
+                    var frame = GetFrames().SingleOrDefault(f => f.FrameId == _frameId);
+                    if (frame != null) {
+                        await _process.ExecuteTextAsync(text, PythonEvaluationResultReprKind.Normal, frame, true, resultReceived, ct);
+                    } else {
+                        WriteError(Strings.DebugReplCannotRetrieveFrameError);
+                        tcs.TrySetResult(ExecutionResult.Failure);
+                    }
+                } else {
+                    await _process.ExecuteTextAsync(text, PythonEvaluationResultReprKind.Normal, _currentScopeName, true, resultReceived, ct);
+                }
+
+                return await tcs.Task;
+            } finally {
+                _process.ProcessExited -= processExited;
+                _process.DebuggerOutput -= debuggerOutput;
+                cancellationRegistration.Dispose();
+            }
+        }
+
+        public PythonProcess Process {
+            get { return _process; }
+
+        }
+
+        public int ProcessId {
+            get { return _process.Id; }
+        }
+
+        public long ThreadId {
+            get { return _threadId; }
+        }
+
+        public int FrameId {
+            get { return _frameId; }
+        }
+
+        public override string CurrentScopeName {
+            get {
+                // Callers expect the localized name
+                return _currentScopeName == CurrentFrameScopeFixedName
+                    ? Strings.DebugReplCurrentFrameScope : _currentScopeName;
+            }
+        }
+
+        public override string CurrentScopePath {
+            get {
+                return _currentScopeFileName;
+            }
+        }
+
+        public override string CurrentWorkingDirectory {
+            get {
+                // This is never called
+                return null;
+            }
+        }
+
+        public override IEnumerable<KeyValuePair<string, string>> GetAvailableScopesAndPaths() {
+            var t = RefreshAvailableScopes();
+            if (t != null && t.Wait(1000) && t.Result != null) {
+                return t.Result;
+            }
+
+            return Enumerable.Empty<KeyValuePair<string, string>>();
+        }
+
+        public override CompletionResult[] GetMemberNames(string text) {
+            // TODO: implement this
+            return new CompletionResult[0];
+        }
+
+        public override OverloadDoc[] GetSignatureDocumentation(string text) {
+            // TODO: implement this
+            return new OverloadDoc[0];
+        }
+
+        public override void SetScope(string scopeName) {
+            if (!string.IsNullOrWhiteSpace(scopeName)) {
+                if (scopeName == Strings.DebugReplCurrentFrameScope) {
+                    // Most callers will pass in the localized name, but the $mod command may have either.
+                    // Always store the unlocalized name.
+                    scopeName = CurrentFrameScopeFixedName;
+                }
+                _currentScopeName = scopeName;
+
+                if (!(_moduleToFileName?.TryGetValue(scopeName, out _currentScopeFileName) ?? false)) {
+                    _currentScopeFileName = null;
+                }
+
+                WriteOutput(Strings.ReplModuleChanged.FormatUI(CurrentScopeName));
+            } else {
+                WriteOutput(CurrentScopeName);
+            }
+        }
+
+        internal IList<PythonThread> GetThreads() {
+            return _process.GetThreads();
+        }
+
+        internal IList<PythonStackFrame> GetFrames() {
+            var activeThread = _process.GetThreads().SingleOrDefault(t => t.Id == _threadId);
+            return activeThread != null ? activeThread.Frames : new List<PythonStackFrame>();
+        }
+
+        internal void SwitchThread(PythonThread thread, bool verbose) {
+            var frame = thread.Frames.FirstOrDefault();
+            if (frame == null) {
+                WriteError(Strings.DebugReplCannotChangeCurrentThreadNoFrame.FormatUI(thread.Id));
+                return;
+            }
+
+            _threadId = thread.Id;
+            _frameId = frame.FrameId;
+            _currentScopeName = CurrentFrameScopeFixedName;
+            _currentScopeFileName = null;
+            if (verbose) {
+                WriteOutput(Strings.DebugReplThreadChanged.FormatUI(_threadId, _frameId));
+            }
+        }
+
+        internal void SwitchFrame(PythonStackFrame frame) {
+            _frameId = frame.FrameId;
+            _currentScopeName = CurrentFrameScopeFixedName;
+            _currentScopeFileName = null;
+            WriteOutput(Strings.DebugReplFrameChanged.FormatUI(frame.FrameId));
+        }
+
+        internal void FrameUp() {
+            var frames = GetFrames();
+            var currentFrame = frames.SingleOrDefault(f => f.FrameId == _frameId);
+            if (currentFrame != null) {
+                int index = frames.IndexOf(currentFrame);
+                if (index < (frames.Count - 1)) {
+                    SwitchFrame(frames[index + 1]);
+                }
+            }
+        }
+
+        internal void FrameDown() {
+            var frames = GetFrames();
+            var currentFrame = frames.SingleOrDefault(f => f.FrameId == _frameId);
+            if (currentFrame != null) {
+                int index = frames.IndexOf(currentFrame);
+                if (index > 0) {
+                    SwitchFrame(frames[index - 1]);
+                }
+            }
+        }
+
+        internal void StepOut() {
+            UpdateDTEDebuggerProcessAndThread();
+            _serviceProvider.GetDTE().Debugger.CurrentThread.Parent.StepOut();
+        }
+
+        internal void StepInto() {
+            UpdateDTEDebuggerProcessAndThread();
+            _serviceProvider.GetDTE().Debugger.CurrentThread.Parent.StepInto();
+        }
+
+        internal void StepOver() {
+            UpdateDTEDebuggerProcessAndThread();
+            _serviceProvider.GetDTE().Debugger.CurrentThread.Parent.StepOver();
+        }
+
+        internal void Resume() {
+            UpdateDTEDebuggerProcessAndThread();
+            _serviceProvider.GetDTE().Debugger.CurrentThread.Parent.Go();
+        }
+
+        private void UpdateDTEDebuggerProcessAndThread() {
+            EnvDTE.Process dteActiveProcess = null;
+            foreach (EnvDTE.Process dteProcess in _serviceProvider.GetDTE().Debugger.DebuggedProcesses) {
+                if (dteProcess.ProcessID == _process.Id) {
+                    dteActiveProcess = dteProcess;
+                    break;
+                }
+            }
+
+            if (dteActiveProcess != _serviceProvider.GetDTE().Debugger.CurrentProcess) {
+                _serviceProvider.GetDTE().Debugger.CurrentProcess = dteActiveProcess;
+            }
+
+            EnvDTE.Thread dteActiveThread = null;
+            foreach (EnvDTE.Thread dteThread in _serviceProvider.GetDTE().Debugger.CurrentProgram.Threads) {
+                if (_threadIdMapper.GetPythonThreadId((uint)dteThread.ID) == _threadId) {
+                    dteActiveThread = dteThread;
+                    break;
+                }
+            }
+
+            if (dteActiveThread != _serviceProvider.GetDTE().Debugger.CurrentThread) {
+                _serviceProvider.GetDTE().Debugger.CurrentThread = dteActiveThread;
+            }
+        }
+    }
+}

--- a/Python/Product/PythonTools/PythonTools/Repl/PythonInteractiveEvaluator.cs
+++ b/Python/Product/PythonTools/PythonTools/Repl/PythonInteractiveEvaluator.cs
@@ -19,25 +19,12 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Text;
-using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Windows.Forms;
-using Microsoft.PythonTools.Editor;
 using Microsoft.PythonTools.Infrastructure;
 using Microsoft.PythonTools.Intellisense;
-using Microsoft.PythonTools.Interpreter;
-using Microsoft.PythonTools.Language;
-using Microsoft.PythonTools.Options;
-using Microsoft.PythonTools.Parsing;
-using Microsoft.PythonTools.Project;
 using Microsoft.VisualStudio.InteractiveWindow;
 using Microsoft.VisualStudio.InteractiveWindow.Commands;
-using Microsoft.VisualStudio.Shell;
-using Microsoft.VisualStudio.Shell.Interop;
-using Microsoft.VisualStudio.Text;
-using Microsoft.VisualStudio.Text.Editor.OptionsExtensionMethods;
 using Microsoft.VisualStudio.Utilities;
 using Microsoft.VisualStudioTools;
 using Task = System.Threading.Tasks.Task;
@@ -48,50 +35,23 @@ namespace Microsoft.PythonTools.Repl {
     [ContentType(PythonCoreConstants.ContentType)]
     [ContentType(PredefinedInteractiveCommandsContentTypes.InteractiveCommandContentTypeName)]
     partial class PythonInteractiveEvaluator :
-        IInteractiveEvaluator,
-        IPythonInteractiveEvaluator,
-        IMultipleScopeEvaluator,
-        IPythonInteractiveIntellisense, 
-        IDisposable
+        PythonCommonInteractiveEvaluator
     {
-        protected readonly IServiceProvider _serviceProvider;
-        private readonly StringBuilder _deferredOutput;
-
-        private PythonProjectNode _projectWithHookedEvents;
-
         protected CommandProcessorThread _thread;
-        private IInteractiveWindowCommands _commands;
-        private IInteractiveWindow _window;
-        private PythonInteractiveOptions _options;
-
-        private VsProjectAnalyzer _analyzer;
-        private readonly string _analysisFilename;
-
-        private bool _enableMultipleScopes;
-        private IReadOnlyList<string> _availableScopes;
-
         private bool _isDisposed;
 
-        internal const string DoNotResetConfigurationLaunchOption = "DoNotResetConfiguration";
-
-        public PythonInteractiveEvaluator(IServiceProvider serviceProvider) {
-            _serviceProvider = serviceProvider;
-            _deferredOutput = new StringBuilder();
-            _analysisFilename = Guid.NewGuid().ToString() + ".py";
+        public PythonInteractiveEvaluator(IServiceProvider serviceProvider) :
+            base(serviceProvider) {
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2213:DisposableFieldsShouldBeDisposed", MessageId = "_analyzer")]
-        protected void Dispose(bool disposing) {
+        protected override void Dispose(bool disposing) {
+            base.Dispose(disposing);
+
             if (_isDisposed) {
                 return;
             }
             _isDisposed = true;
-
-            if (_projectWithHookedEvents != null) {
-                _projectWithHookedEvents.ActiveInterpreterChanged -= Project_ConfigurationChanged;
-                _projectWithHookedEvents._searchPaths.Changed -= Project_ConfigurationChanged;
-                _projectWithHookedEvents = null;
-            }
 
             if (disposing) {
                 var thread = Interlocked.Exchange(ref _thread, null);
@@ -99,195 +59,35 @@ namespace Microsoft.PythonTools.Repl {
                     thread.Dispose();
                     WriteError(Strings.ReplExited);
                 }
-                _analyzer?.Dispose();
             }
         }
 
-        public void Dispose() {
-            Dispose(true);
-            GC.SuppressFinalize(this);
-        }
+        public override bool IsDisconnected => !(_thread?.IsConnected ?? false);
 
-        ~PythonInteractiveEvaluator() {
-            Dispose(false);
-        }
+        public override bool IsExecuting => (_thread?.IsExecuting ?? false);
 
-        public string DisplayName { get; set; }
-        public string ProjectMoniker { get; set; }
-        public LaunchConfiguration Configuration { get; set; }
-        public string ScriptsPath { get; set; }
-
-        public PythonLanguageVersion LanguageVersion {
-            get {
-                return Configuration?.Interpreter?.Version.ToLanguageVersion() ?? PythonLanguageVersion.None;
-            }
-        }
-
-        public bool UseSmartHistoryKeys { get; set; }
-        public bool LiveCompletionsOnly { get; set; }
-        public string BackendName { get; set; }
-
-        internal virtual void OnConnected() { }
-        internal virtual void OnAttach() { }
-        internal virtual void OnDetach() { }
-
-        internal bool AssociatedProjectHasChanged { get; set; }
-
-        private PythonProjectNode GetAssociatedPythonProject(InterpreterConfiguration interpreter = null) {
-            _serviceProvider.GetUIThread().MustBeCalledFromUIThread();
-
-            var moniker = ProjectMoniker;
-            if (interpreter == null) {
-                interpreter = Configuration?.Interpreter;
-            }
-
-            if (string.IsNullOrEmpty(moniker) && interpreter != null) {
-                var interpreterService = _serviceProvider.GetComponentModel().GetService<IInterpreterRegistryService>();
-                moniker = interpreterService.GetProperty(interpreter.Id, "ProjectMoniker") as string;
-            }
-
-            if (string.IsNullOrEmpty(moniker)) {
-                return null;
-            }
-
-            return _serviceProvider.GetProjectFromFile(moniker);
-        }
-
-
-        public VsProjectAnalyzer Analyzer {
-            get {
-                if (_analyzer != null) {
-                    return _analyzer;
-                }
-
-                var config = Configuration;
-                IPythonInterpreterFactory factory = null;
-                if (config?.Interpreter != null) {
-                    var interpreterService = _serviceProvider.GetComponentModel().GetService<IInterpreterRegistryService>();
-                    factory = interpreterService.FindInterpreter(config.Interpreter.Id);
-                }
-
-                if (factory == null) {
-                    _analyzer = _serviceProvider.GetPythonToolsService().DefaultAnalyzer;
-                } else {
-                    var projectFile = GetAssociatedPythonProject(config.Interpreter)?.BuildProject;
-                    _analyzer = new VsProjectAnalyzer(
-                        _serviceProvider,
-                        factory,
-                        projectFile: projectFile,
-                        comment: "{0} Interactive".FormatInvariant(DisplayName.IfNullOrEmpty("Unnamed"))
-                    );
-                }
-                return _analyzer;
-            }
-        }
-
-        public string AnalysisFilename => _analysisFilename;
-
-        internal void WriteOutput(string text, bool addNewline = true) {
-            var wnd = CurrentWindow;
-            if (wnd == null) {
-                lock (_deferredOutput) {
-                    _deferredOutput.Append(text);
-                }
-            } else {
-                AppendTextWithEscapes(wnd, text, addNewline, isError: false);
-            }
-        }
-
-        internal void WriteError(string text, bool addNewline = true) {
-            var wnd = CurrentWindow;
-            if (wnd == null) {
-                lock (_deferredOutput) {
-                    _deferredOutput.Append(text);
-                }
-            } else {
-                AppendTextWithEscapes(wnd, text, addNewline, isError: true);
-            }
-        }
-
-        public bool IsDisconnected => !(_thread?.IsConnected ?? false);
-
-        public bool IsExecuting => (_thread?.IsExecuting ?? false);
-
-        public string CurrentScopeName {
+        public override string CurrentScopeName {
             get {
                 return (_thread?.IsConnected ?? false) ? _thread.CurrentScope : "<disconnected>";
             }
         }
 
-        public string CurrentScopePath {
+        public override string CurrentScopePath {
             get {
                 return (_thread?.IsConnected ?? false) ? _thread.CurrentScopeFileName : null;
             }
         }
 
-        public string CurrentWorkingDirectory {
+        public override string CurrentWorkingDirectory {
             get {
                 return (_thread?.IsConnected ?? false) ? _thread.CurrentWorkingDirectory : null;
             }
         }
 
-        public IInteractiveWindow CurrentWindow {
-            get {
-                return _window;
-            }
-            set {
-                if (_window != null) {
-                }
-                _commands = null;
+        internal override string PrimaryPrompt => _thread?.PrimaryPrompt ?? ">>> ";
+        internal override string SecondaryPrompt => _thread?.SecondaryPrompt ?? "... ";
 
-                if (value != null) {
-                    lock (_deferredOutput) {
-                        AppendTextWithEscapes(value, _deferredOutput.ToString(), false, false);
-                        _deferredOutput.Clear();
-                    }
-
-                    _options = _serviceProvider.GetPythonToolsService().InteractiveOptions;
-                    _options.Changed += InteractiveOptions_Changed;
-                    UseSmartHistoryKeys = _options.UseSmartHistory;
-                    LiveCompletionsOnly = _options.LiveCompletionsOnly;
-                } else {
-                    if (_options != null) {
-                        _options.Changed -= InteractiveOptions_Changed;
-                        _options = null;
-                    }
-                }
-                _window = value;
-            }
-        }
-
-        private async void InteractiveOptions_Changed(object sender, EventArgs e) {
-            if (!ReferenceEquals(sender, _options)) {
-                return;
-            }
-
-            UseSmartHistoryKeys = _options.UseSmartHistory;
-            LiveCompletionsOnly = _options.LiveCompletionsOnly;
-
-            var window = CurrentWindow;
-            if (window == null) {
-                return;
-            }
-
-            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-            window.TextView.Options.SetOptionValue(InteractiveWindowOptions.SmartUpDown, UseSmartHistoryKeys);
-        }
-
-        public bool EnableMultipleScopes {
-            get { return _enableMultipleScopes; }
-            set {
-                if (_enableMultipleScopes != value) {
-                    _enableMultipleScopes = value;
-                    MultipleScopeSupportChanged?.Invoke(this, EventArgs.Empty);
-                }
-            }
-        }
-
-        public event EventHandler<EventArgs> AvailableScopesChanged;
-        public event EventHandler<EventArgs> MultipleScopeSupportChanged;
-
-        public async Task<bool> GetSupportsMultipleStatementsAsync() {
+        public override async Task<bool> GetSupportsMultipleStatementsAsync() {
             var thread = await EnsureConnectedAsync();
             if (thread == null) {
                 return false;
@@ -297,11 +97,11 @@ namespace Microsoft.PythonTools.Repl {
         }
 
         private async void Thread_AvailableScopesChanged(object sender, EventArgs e) {
-            _availableScopes = (await ((CommandProcessorThread)sender).GetAvailableUserScopesAsync(10000))?.ToArray();
-            AvailableScopesChanged?.Invoke(this, EventArgs.Empty);
+            var availableScopes = (await ((CommandProcessorThread)sender).GetAvailableUserScopesAsync(10000))?.ToArray();
+            SetAvailableScopes(availableScopes);
         }
 
-        public IEnumerable<KeyValuePair<string, string>> GetAvailableScopesAndPaths() {
+        public override IEnumerable<KeyValuePair<string, string>> GetAvailableScopesAndPaths() {
             var t = _thread?.GetAvailableScopesAndPathsAsync(1000);
             if (t != null && t.Wait(1000) && t.Result != null) {
                 return t.Result;
@@ -309,41 +109,19 @@ namespace Microsoft.PythonTools.Repl {
             return Enumerable.Empty<KeyValuePair<string, string>>();
         }
 
-        public CompletionResult[] GetMemberNames(string text) {
+        public override CompletionResult[] GetMemberNames(string text) {
             return _thread?.GetMemberNames(text) ?? new CompletionResult[0];
         }
 
-        public OverloadDoc[] GetSignatureDocumentation(string text) {
+        public override OverloadDoc[] GetSignatureDocumentation(string text) {
             return _thread?.GetSignatureDocumentation(text) ?? new OverloadDoc[0];
         }
 
-        public void AbortExecution() {
+        public override void AbortExecution() {
             _thread?.AbortCommand();
         }
 
-        public bool CanExecuteCode(string text) {
-            if (string.IsNullOrEmpty(text)) {
-                return true;
-            }
-            if (string.IsNullOrWhiteSpace(text) && text.EndsWith("\n")) {
-                return true;
-            }
-
-            var config = Configuration;
-            using (var parser = Parser.CreateParser(new StringReader(text), LanguageVersion)) {
-                ParseResult pr;
-                parser.ParseInteractiveCode(out pr);
-                if (pr == ParseResult.IncompleteStatement) {
-                    return text.EndsWith("\n");
-                }
-                if (pr == ParseResult.Empty || pr == ParseResult.IncompleteToken) {
-                    return false;
-                }
-            }
-            return true;
-        }
-
-        protected async Task<CommandProcessorThread> EnsureConnectedAsync() {
+        private async Task<CommandProcessorThread> EnsureConnectedAsync() {
             var thread = Volatile.Read(ref _thread);
             if (thread != null) {
                 return thread;
@@ -408,7 +186,7 @@ namespace Microsoft.PythonTools.Repl {
             });
         }
 
-        protected virtual async Task ExecuteStartupScripts(string scriptsPath) {
+        protected override async Task ExecuteStartupScripts(string scriptsPath) {
             if (File.Exists(scriptsPath)) {
                 if (!(await ExecuteFileAsync(scriptsPath, null))) {
                     WriteError("Error executing " + scriptsPath);
@@ -422,88 +200,7 @@ namespace Microsoft.PythonTools.Repl {
             }
         }
 
-        internal void UpdatePropertiesFromProjectMoniker() {
-            if (_projectWithHookedEvents != null) {
-                _projectWithHookedEvents.ActiveInterpreterChanged -= Project_ConfigurationChanged;
-                _projectWithHookedEvents._searchPaths.Changed -= Project_ConfigurationChanged;
-                _projectWithHookedEvents = null;
-            }
-
-            AssociatedProjectHasChanged = false;
-            var pyProj = GetAssociatedPythonProject();
-            if (pyProj == null) {
-                return;
-            }
-
-            if (Configuration?.GetLaunchOption(DoNotResetConfigurationLaunchOption) == null) {
-                Configuration = pyProj.GetLaunchConfigurationOrThrow();
-                if (Configuration?.Interpreter != null) {
-                    ScriptsPath = GetScriptsPath(_serviceProvider, Configuration.Interpreter.Description, Configuration.Interpreter);
-                }
-            }
-
-            _projectWithHookedEvents = pyProj;
-            pyProj.ActiveInterpreterChanged += Project_ConfigurationChanged;
-            pyProj._searchPaths.Changed += Project_ConfigurationChanged;
-        }
-
-        private void Project_ConfigurationChanged(object sender, EventArgs e) {
-            var pyProj = _projectWithHookedEvents;
-            _projectWithHookedEvents = null;
-
-            if (pyProj != null) {
-                Debug.Assert(pyProj == sender || pyProj._searchPaths == sender, "Unexpected project raised the event");
-                // Only warn once
-                pyProj.ActiveInterpreterChanged -= Project_ConfigurationChanged;
-                pyProj._searchPaths.Changed -= Project_ConfigurationChanged;
-                WriteError(Strings.ReplProjectConfigurationChanged.FormatUI(pyProj.Caption));
-                AssociatedProjectHasChanged = true;
-            }
-        }
-
-        internal static string GetScriptsPath(
-            IServiceProvider provider,
-            string displayName,
-            InterpreterConfiguration config,
-            bool onlyIfExists = true
-        ) {
-            // TODO: Allow customizing the scripts path
-            //var root = _serviceProvider.GetPythonToolsService().InteractiveOptions.ScriptsPath;
-            string root;
-            try {
-                if (!provider.TryGetShellProperty((__VSSPROPID)__VSSPROPID2.VSSPROPID_VisualStudioDir, out root)) {
-                    root = PathUtils.GetAbsoluteDirectoryPath(
-                        Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments),
-                        "Visual Studio {0}".FormatInvariant(AssemblyVersionInfo.VSName)
-                    );
-                }
-
-                root = PathUtils.GetAbsoluteDirectoryPath(root, "Python Scripts");
-            } catch (ArgumentException ex) {
-                ex.ReportUnhandledException(provider, typeof(PythonInteractiveEvaluator));
-                return null;
-            }
-
-            string candidate;
-            if (!string.IsNullOrEmpty(displayName)) {
-                candidate = PathUtils.GetAbsoluteDirectoryPath(root, displayName);
-                if (!onlyIfExists || Directory.Exists(candidate)) {
-                    return candidate;
-                }
-            }
-
-            var version = config?.Version?.ToString();
-            if (!string.IsNullOrEmpty(version)) {
-                candidate = PathUtils.GetAbsoluteDirectoryPath(root, version);
-                if (!onlyIfExists || Directory.Exists(candidate)) {
-                    return candidate;
-                }
-            }
-
-            return null;
-        }
-
-        public async Task<ExecutionResult> ExecuteCodeAsync(string text) {
+        public override async Task<ExecutionResult> ExecuteCodeAsync(string text) {
             var cmdRes = _commands.TryExecuteCommand();
             if (cmdRes != null) {
                 return await cmdRes;
@@ -526,7 +223,7 @@ namespace Microsoft.PythonTools.Repl {
             return ExecutionResult.Failure;
         }
 
-        public async Task<bool> ExecuteFileAsync(string filename, string extraArgs) {
+        public override async Task<bool> ExecuteFileAsync(string filename, string extraArgs) {
             var thread = await EnsureConnectedAsync();
             if (thread != null) {
                 return await thread.ExecuteFile(filename, extraArgs, "script");
@@ -536,7 +233,7 @@ namespace Microsoft.PythonTools.Repl {
             return false;
         }
 
-        public async Task<bool> ExecuteModuleAsync(string name, string extraArgs) {
+        public override async Task<bool> ExecuteModuleAsync(string name, string extraArgs) {
             var thread = await EnsureConnectedAsync();
             if (thread != null) {
                 return await thread.ExecuteFile(name, extraArgs, "module");
@@ -546,7 +243,7 @@ namespace Microsoft.PythonTools.Repl {
             return false;
         }
 
-        public async Task<bool> ExecuteProcessAsync(string filename, string extraArgs) {
+        public override async Task<bool> ExecuteProcessAsync(string filename, string extraArgs) {
             var thread = await EnsureConnectedAsync();
             if (thread != null) {
                 return await thread.ExecuteFile(filename, extraArgs, "process");
@@ -556,114 +253,11 @@ namespace Microsoft.PythonTools.Repl {
             return false;
         }
 
-        const string _splitRegexPattern = @"(?x)\s*,\s*(?=(?:[^""]*""[^""]*"")*[^""]*$)"; // http://regexhero.net/library/52/
-        private static Regex _splitLineRegex = new Regex(_splitRegexPattern);
-
-        public string FormatClipboard() {
-            if (Clipboard.ContainsData(DataFormats.CommaSeparatedValue)) {
-                string data = Clipboard.GetData(DataFormats.CommaSeparatedValue) as string;
-                if (data != null) {
-                    string[] lines = data.Split(new[] { "\n", "\r\n" }, StringSplitOptions.RemoveEmptyEntries);
-                    StringBuilder res = new StringBuilder();
-                    res.AppendLine("[");
-                    foreach (var line in lines) {
-                        string[] items = _splitLineRegex.Split(line);
-
-                        res.Append("  [");
-                        for (int i = 0; i < items.Length; i++) {
-                            res.Append(FormatItem(items[i]));
-
-                            if (i != items.Length - 1) {
-                                res.Append(", ");
-                            }
-                        }
-                        res.AppendLine("],");
-                    }
-                    res.AppendLine("]");
-                    return res.ToString();
-                }
-            }
-
-            var txt = Clipboard.GetText();
-            if (!_serviceProvider.GetPythonToolsService().AdvancedOptions.PasteRemovesReplPrompts) {
-                return txt;
-            }
-
-
-            return ReplPromptHelpers.RemovePrompts(
-                txt,
-                _window.TextView.Options.GetNewLineCharacter()
-            );
-        }
-
-        private static string FormatItem(string item) {
-            if (String.IsNullOrWhiteSpace(item)) {
-                return "None";
-            }
-            double doubleVal;
-            int intVal;
-            if (Double.TryParse(item, out doubleVal) ||
-                Int32.TryParse(item, out intVal)) {
-                return item;
-            }
-
-            if (item[0] == '"' && item[item.Length - 1] == '"' && item.IndexOf(',') != -1) {
-                // remove outer quotes, remove "" escaping
-                item = item.Substring(1, item.Length - 2).Replace("\"\"", "\"");
-            }
-
-            // put in single quotes and escape single quotes and backslashes
-            return "'" + item.Replace("\\", "\\\\").Replace("'", "\\'") + "'";
-        }
-
-        public IEnumerable<string> GetAvailableScopes() {
-            return _availableScopes ?? Enumerable.Empty<string>();
-        }
-
-        public void SetScope(string scopeName) {
+        public override void SetScope(string scopeName) {
             _thread?.SetScope(scopeName);
         }
 
-        public string GetPrompt() {
-            if ((_window?.CurrentLanguageBuffer.CurrentSnapshot.LineCount ?? 1) > 1) {
-                return SecondaryPrompt;
-            } else {
-                return PrimaryPrompt;
-            }
-        }
-
-        internal string PrimaryPrompt => _thread?.PrimaryPrompt ?? ">>> ";
-        internal string SecondaryPrompt => _thread?.SecondaryPrompt ?? "... ";
-
-        public async Task<ExecutionResult> InitializeAsync() {
-            if (_commands != null) {
-                // Already initialized
-                return ExecutionResult.Success;
-            }
-
-            var msg = Strings.ReplInitializationMessage.FormatUI(
-                DisplayName,
-                AssemblyVersionInfo.Version,
-                AssemblyVersionInfo.VSVersion
-            ).Replace("&#x1b;", "\x1b");
-
-            WriteOutput(msg, addNewline: true);
-
-            _window.TextView.Options.SetOptionValue(InteractiveWindowOptions.SmartUpDown, UseSmartHistoryKeys);
-            _commands = GetInteractiveCommands(_serviceProvider, _window, this);
-
-            return ExecutionResult.Success;
-        }
-
-        public Task<ExecutionResult> ResetAsync(bool initialize = true) {
-            return ResetWorkerAsync(initialize, false);
-        }
-
-        public Task<ExecutionResult> ResetAsync(bool initialize, bool quiet) {
-            return ResetWorkerAsync(initialize, quiet);
-        }
-
-        private async Task<ExecutionResult> ResetWorkerAsync(bool initialize, bool quiet) {
+        protected override async Task<ExecutionResult> ResetWorkerAsync(bool initialize, bool quiet) {
             // suppress reporting "failed to launch repl" process
             var thread = Interlocked.Exchange(ref _thread, null);
             if (thread == null) {
@@ -691,248 +285,6 @@ namespace Microsoft.PythonTools.Repl {
             EnableMultipleScopes = false;
 
             return ExecutionResult.Success;
-        }
-
-        internal Task InvokeAsync(Action action) {
-            return _window.TextView.VisualElement.Dispatcher.InvokeAsync(action).Task;
-        }
-
-        internal void WriteFrameworkElement(System.Windows.UIElement control, System.Windows.Size desiredSize) {
-            if (_window == null) {
-                return;
-            }
-
-            _window.Write("");
-            _window.FlushOutput();
-
-            var caretPos = _window.TextView.Caret.Position.BufferPosition;
-            var manager = InlineReplAdornmentProvider.GetManager(_window.TextView);
-            manager.AddAdornment(new ZoomableInlineAdornment(control, _window.TextView, desiredSize), caretPos);
-        }
-
-
-        internal static IInteractiveWindowCommands GetInteractiveCommands(
-            IServiceProvider serviceProvider,
-            IInteractiveWindow window,
-            IInteractiveEvaluator eval
-        ) {
-            var model = serviceProvider.GetComponentModel();
-            var cmdFactory = model.GetService<IInteractiveWindowCommandsFactory>();
-            var cmds = model.GetExtensions<IInteractiveWindowCommand>();
-            var roles = eval.GetType()
-                .GetCustomAttributes(typeof(InteractiveWindowRoleAttribute), true)
-                .Select(r => ((InteractiveWindowRoleAttribute)r).Name)
-                .ToArray();
-
-            var contentTypeRegistry = model.GetService<IContentTypeRegistryService>();
-            var contentTypes = eval.GetType()
-                .GetCustomAttributes(typeof(ContentTypeAttribute), true)
-                .Select(r => contentTypeRegistry.GetContentType(((ContentTypeAttribute)r).ContentTypes))
-                .ToArray();
-
-            return cmdFactory.CreateInteractiveCommands(
-                window,
-                "$",
-                cmds.Where(x => IsCommandApplicable(x, roles, contentTypes))
-            );
-        }
-
-        private static bool IsCommandApplicable(
-            IInteractiveWindowCommand command,
-            string[] supportedRoles,
-            IContentType[] supportedContentTypes
-        ) {
-            var commandRoles = command.GetType().GetCustomAttributes(typeof(InteractiveWindowRoleAttribute), true).Select(r => ((InteractiveWindowRoleAttribute)r).Name).ToArray();
-
-            // Commands with no roles are always applicable.
-            // If a command specifies roles and none apply, exclude it
-            if (commandRoles.Any() && !commandRoles.Intersect(supportedRoles).Any()) {
-                return false;
-            }
-
-            var commandContentTypes = command.GetType()
-                .GetCustomAttributes(typeof(ContentTypeAttribute), true)
-                .Select(a => ((ContentTypeAttribute)a).ContentTypes)
-                .ToArray();
-
-            // Commands with no content type are always applicable
-            // If a commands specifies content types and none apply, exclude it
-            if (commandContentTypes.Any() && !commandContentTypes.Any(cct => supportedContentTypes.Any(sct => sct.IsOfType(cct)))) {
-                return false;
-            }
-
-            return true;
-        }
-
-        #region Append Text helpers
-
-        private static void AppendTextWithEscapes(
-            IInteractiveWindow window,
-            string text,
-            bool addNewLine,
-            bool isError
-        ) {
-            int start = 0, escape = text.IndexOf("\x1b[");
-            var colors = window.OutputBuffer.Properties.GetOrCreateSingletonProperty(
-                ReplOutputClassifier.ColorKey,
-                () => new List<ColoredSpan>()
-            );
-            ConsoleColor? color = null;
-
-            Span span;
-            var write = isError ? (Func<string, Span>)window.WriteError : window.Write;
-
-            while (escape >= 0) {
-                span = write(text.Substring(start, escape - start));
-                if (span.Length > 0) {
-                    colors.Add(new ColoredSpan(span, color));
-                }
-
-                start = escape + 2;
-                color = GetColorFromEscape(text, ref start);
-                escape = text.IndexOf("\x1b[", start);
-            }
-
-            var rest = text.Substring(start);
-            if (addNewLine) {
-                rest += Environment.NewLine;
-            }
-
-            span = write(rest);
-            if (span.Length > 0) {
-                colors.Add(new ColoredSpan(span, color));
-            }
-        }
-
-        private static ConsoleColor Change(ConsoleColor? from, ConsoleColor to) {
-            return ((from ?? ConsoleColor.Black) & ConsoleColor.DarkGray) | to;
-        }
-
-        private static ConsoleColor? GetColorFromEscape(string text, ref int start) {
-            // http://en.wikipedia.org/wiki/ANSI_escape_code
-            // process any ansi color sequences...
-            ConsoleColor? color = null;
-            List<int> codes = new List<int>();
-            int? value = 0;
-
-            while (start < text.Length) {
-                if (text[start] >= '0' && text[start] <= '9') {
-                    // continue parsing the integer...
-                    if (value == null) {
-                        value = 0;
-                    }
-                    value = 10 * value.Value + (text[start] - '0');
-                } else if (text[start] == ';') {
-                    if (value != null) {
-                        codes.Add(value.Value);
-                        value = null;
-                    } else {
-                        // CSI ; - invalid or CSI ### ;;, both invalid
-                        break;
-                    }
-                } else if (text[start] == 'm') {
-                    start += 1;
-                    if (value != null) {
-                        codes.Add(value.Value);
-                    }
-
-                    // parsed a valid code
-                    if (codes.Count == 0) {
-                        // reset
-                        color = null;
-                    } else {
-                        for (int j = 0; j < codes.Count; j++) {
-                            switch (codes[j]) {
-                                case 0: color = ConsoleColor.White; break;
-                                case 1: // bright/bold
-                                    color |= ConsoleColor.DarkGray;
-                                    break;
-                                case 2: // faint
-
-                                case 3: // italic
-                                case 4: // single underline
-                                    break;
-                                case 5: // blink slow
-                                case 6: // blink fast
-                                    break;
-                                case 7: // negative
-                                case 8: // conceal
-                                case 9: // crossed out
-                                case 10: // primary font
-                                case 11: // 11-19, n-th alternate font
-                                    break;
-                                case 21: // bright/bold off 
-                                    color &= ~ConsoleColor.DarkGray;
-                                    break;
-                                case 22: // normal intensity
-                                case 24: // underline off
-                                    break;
-                                case 25: // blink off
-                                    break;
-                                case 27: // image - postive
-                                case 28: // reveal
-                                case 29: // not crossed out
-                                case 30: color = Change(color, ConsoleColor.Black); break;
-                                case 31: color = Change(color, ConsoleColor.DarkRed); break;
-                                case 32: color = Change(color, ConsoleColor.DarkGreen); break;
-                                case 33: color = Change(color, ConsoleColor.DarkYellow); break;
-                                case 34: color = Change(color, ConsoleColor.DarkBlue); break;
-                                case 35: color = Change(color, ConsoleColor.DarkMagenta); break;
-                                case 36: color = Change(color, ConsoleColor.DarkCyan); break;
-                                case 37: color = Change(color, ConsoleColor.Gray); break;
-                                case 38: // xterm 286 background color
-                                case 39: // default text color
-                                    color = null;
-                                    break;
-                                case 40: // background colors
-                                case 41:
-                                case 42:
-                                case 43:
-                                case 44:
-                                case 45:
-                                case 46:
-                                case 47: break;
-                                case 90: color = ConsoleColor.DarkGray; break;
-                                case 91: color = ConsoleColor.Red; break;
-                                case 92: color = ConsoleColor.Green; break;
-                                case 93: color = ConsoleColor.Yellow; break;
-                                case 94: color = ConsoleColor.Blue; break;
-                                case 95: color = ConsoleColor.Magenta; break;
-                                case 96: color = ConsoleColor.Cyan; break;
-                                case 97: color = ConsoleColor.White; break;
-                            }
-                        }
-                    }
-                    break;
-                } else {
-                    // unknown char, invalid escape
-                    break;
-                }
-                start += 1;
-            }
-            return color;
-        }
-
-        #endregion
-    }
-
-    internal static class PythonInteractiveEvaluatorExtensions {
-        public static PythonInteractiveEvaluator GetPythonEvaluator(this IInteractiveWindow window) {
-            var pie = window?.Evaluator as PythonInteractiveEvaluator;
-            if (pie != null) {
-                return pie;
-            }
-
-            pie = (window?.Evaluator as SelectableReplEvaluator)?.Evaluator as PythonInteractiveEvaluator;
-            return pie;
-        }
-
-        public static async Task<bool> GetSupportsMultipleStatements(this IInteractiveWindow window) {
-            var pie = window.GetPythonEvaluator();
-            if (pie == null) {
-                return false;
-            }
-            return await pie.GetSupportsMultipleStatementsAsync();
         }
     }
 }

--- a/Python/Product/PythonTools/ptvsd/__init__.py
+++ b/Python/Product/PythonTools/ptvsd/__init__.py
@@ -15,7 +15,7 @@
 # permissions and limitations under the License.
 
 __author__ = "Microsoft Corporation <ptvshelp@microsoft.com>"
-__version__ = "3.1.0.0"
+__version__ = "3.2.0.0"
 
 __all__ = ['enable_attach', 'wait_for_attach', 'break_into_debugger', 'settrace', 'is_attached', 'AttachAlreadyEnabledError']
 

--- a/Python/Product/PythonTools/ptvsd/__main__.py
+++ b/Python/Product/PythonTools/ptvsd/__main__.py
@@ -15,7 +15,7 @@
 # permissions and limitations under the License.
 
 __author__ = "Microsoft Corporation <ptvshelp@microsoft.com>"
-__version__ = "3.1.0.0"
+__version__ = "3.2.0.0"
 
 import os
 import sys

--- a/Python/Product/PythonTools/ptvsd/attach_server.py
+++ b/Python/Product/PythonTools/ptvsd/attach_server.py
@@ -15,7 +15,7 @@
 # permissions and limitations under the License.
 
 __author__ = "Microsoft Corporation <ptvshelp@microsoft.com>"
-__version__ = "3.1.0.0"
+__version__ = "3.2.0.0"
 
 __all__ = ['enable_attach', 'wait_for_attach', 'break_into_debugger', 'settrace', 'is_attached', 'AttachAlreadyEnabledError']
 
@@ -79,7 +79,7 @@ import ptvsd.visualstudio_py_ipcjson as vsipc
 #   already attached), the server responds with accepted=False and closes the connection. 
 
 DEFAULT_PORT = 5678
-PTVSDBG_VER = 7 # must be kept in sync with DebuggerProtocolVersion in PythonRemoteProcess.cs
+PTVSDBG_VER = 8 # must be kept in sync with DebuggerProtocolVersion in PythonRemoteProcess.cs
 PTVSDBG = 'PTVSDBG'
 
 _attach_enabled = False

--- a/Python/Product/PythonTools/ptvsd/setup.py
+++ b/Python/Product/PythonTools/ptvsd/setup.py
@@ -18,7 +18,7 @@
 from distutils.core import setup
 
 setup(name='ptvsd',
-      version='3.1.0',
+      version='3.2.0',
       description='Visual Studio remote debugging server for Python',
       license='Apache License 2.0',
       author='Microsoft Corporation',

--- a/Python/Product/PythonTools/visualstudio_py_debugger.py
+++ b/Python/Product/PythonTools/visualstudio_py_debugger.py
@@ -94,6 +94,25 @@ if sys.platform == 'cli':
     from System.Runtime.CompilerServices import ConditionalWeakTable
     IPY_SEEN_MODULES = ConditionalWeakTable[object, object]()
 
+    clr.AddReference('Microsoft.Dynamic')
+    clr.AddReference('Microsoft.Scripting')
+    clr.AddReference('IronPython')
+    from Microsoft.Scripting import KeyboardInterruptException
+    from Microsoft.Scripting import ParamDictionaryAttribute
+    from IronPython.Runtime.Operations import PythonOps
+    from IronPython.Runtime import PythonContext
+    from Microsoft.Scripting import SourceUnit, SourceCodeKind
+    from Microsoft.Scripting.Runtime import Scope
+
+    python_context = clr.GetCurrentRuntime().GetLanguage(PythonContext)
+
+    from System import DBNull, ParamArrayAttribute
+    builtin_method_descriptor_type = type(list.append)
+
+    import System
+    NamespaceType = type(System)
+
+
 # Import encodings early to avoid import on the debugger thread, which may cause deadlock
 from encodings import utf_8
 
@@ -1242,28 +1261,28 @@ class Thread(object):
         self.unblock_work = work
         self.unblock()
 
-    def run_on_thread(self, text, cur_frame, execution_id, frame_kind, repr_kind = PYTHON_EVALUATION_RESULT_REPR_KIND_NORMAL):
+    def run_on_thread(self, text, cur_frame, execution_id, frame_kind, print_result, repr_kind = PYTHON_EVALUATION_RESULT_REPR_KIND_NORMAL):
         self._block_starting_lock.acquire()
         
         if not self._is_blocked:
             report_execution_error('<expression cannot be evaluated at this time>', execution_id)
         elif not self._is_working:
-            self.schedule_work(lambda : self.run_locally(text, cur_frame, execution_id, frame_kind, repr_kind))
+            self.schedule_work(lambda : self.run_locally(text, cur_frame, execution_id, frame_kind, print_result, repr_kind))
         else:
             report_execution_error('<error: previous evaluation has not completed>', execution_id)
-        
+
         self._block_starting_lock.release()
 
     def run_on_thread_no_report(self, text, cur_frame, frame_kind):
         self._block_starting_lock.acquire()
-        
+
         if not self._is_blocked:
             pass
         elif not self._is_working:
             self.schedule_work(lambda : self.run_locally_no_report(text, cur_frame, frame_kind))
         else:
             pass
-        
+
         self._block_starting_lock.release()
 
     def enum_child_on_thread(self, text, cur_frame, execution_id, frame_kind):
@@ -1297,28 +1316,26 @@ class Thread(object):
         except:
             pass
 
-    def compile(self, text, cur_frame):
+    def run_locally(self, text, cur_frame, execution_id, frame_kind, print_result, repr_kind = PYTHON_EVALUATION_RESULT_REPR_KIND_NORMAL):
         try:
-            code = compile(text, '<debug input>', 'eval')
-        except:
-            code = compile(text, '<debug input>', 'exec')
-        return code
-
-    def run_locally(self, text, cur_frame, execution_id, frame_kind, repr_kind = PYTHON_EVALUATION_RESULT_REPR_KIND_NORMAL):
-        try:
-            code = self.compile(text, cur_frame)
+            code = compile_eval_or_exec(text)
             res = eval(code, cur_frame.f_globals, self.get_locals(cur_frame, frame_kind))
             self.locals_to_fast(cur_frame)
             # Report any updated variable values first
             self.enum_thread_frames_locally()
+            if print_result:
+                sys.displayhook(res)
             report_execution_result(execution_id, res, repr_kind)
         except:
             # Report any updated variable values first
             self.enum_thread_frames_locally()
+            if print_result:
+                exc_type, exc_value, exc_tb = sys.exc_info()
+                _vspr.print_exception_frames(exc_type, exc_value, exc_tb)
             report_execution_exception(execution_id, sys.exc_info())
 
     def run_locally_no_report(self, text, cur_frame, frame_kind):
-        code = self.compile(text, cur_frame)
+        code = compile_eval_or_exec(text)
         res = eval(code, cur_frame.f_globals, self.get_locals(cur_frame, frame_kind))
         self.locals_to_fast(cur_frame)
         sys.displayhook(res)
@@ -1627,7 +1644,7 @@ class DebuggerLoop(_vsipc.SocketIO, _vsipc.IpcChannel):
         super(DebuggerLoop, self).__init__(socket=socket)
         
         DebuggerLoop.instance = self
-        self.repl_backend = None
+        self._cur_repl_modules = set()
 
     def loop(self):
         try:
@@ -1790,32 +1807,6 @@ class DebuggerLoop(_vsipc.SocketIO, _vsipc.IpcChannel):
             if bp_info is not None:
                 bp_info.remove_breakpoint(lineno)
 
-    def on_legacyConnectRepl(self, request, args):
-        port_num = args['portNum']
-
-        self.send_debug_response(request)
-
-        _start_new_thread(self.connect_to_repl_backend, (port_num,))
-
-    def connect_to_repl_backend(self, port_num):
-        DONT_DEBUG.append(path.normcase(_vspr.__file__))
-        self.repl_backend = _vspr.DebugReplBackend(self)
-        self.repl_backend.connect_from_debugger(port_num)
-        self.repl_backend.execution_loop()
-
-    def connect_to_repl_backend_using_socket(self, sock):
-        DONT_DEBUG.append(path.normcase(_vspr.__file__))
-        self.repl_backend = _vspr.DebugReplBackend(self)
-        self.repl_backend.connect_from_debugger_using_socket(sock)
-        self.repl_backend.execution_loop()
-
-    def on_legacyDisconnectRepl(self, request, args):
-        self.send_debug_response(request)
-
-        if self.repl_backend is not None:
-            self.repl_backend.disconnect_from_debugger()
-            self.repl_backend = None
-
     def on_legacyBreakAll(self, request, args):
         self.send_debug_response(request)
 
@@ -1954,12 +1945,43 @@ class DebuggerLoop(_vsipc.SocketIO, _vsipc.IpcChannel):
         eid = args['executionId']
         frame_kind = args['frameKind']
         repr_kind = args['reprKind']
+        module_name = args['moduleName']
+        print_result = args['printResult']
 
         self.send_debug_response(request)
 
-        thread, cur_frame = self.get_thread_and_frame(tid, fid, frame_kind)
-        if thread is not None and cur_frame is not None:
-            thread.run_on_thread(text, cur_frame, eid, frame_kind, repr_kind)
+        if module_name:
+            self.execute_code_in_module(text, module_name, eid, print_result, repr_kind)
+        else:
+            thread, cur_frame = self.get_thread_and_frame(tid, fid, frame_kind)
+            if thread is not None and cur_frame is not None:
+                thread.run_on_thread(text, cur_frame, eid, frame_kind, print_result, repr_kind)
+
+        # keep track of the module set so the debug REPL can update its available scopes
+        new_modules = _vspr.get_cur_module_set()
+        try:
+            if new_modules != self._cur_repl_modules:
+                self.send_debug_event(name='legacyModulesChanged')
+        except:
+            pass
+        self._cur_repl_modules = new_modules
+
+    def execute_code_in_module(self, text, module_name, execution_id, print_result, repr_kind):
+        try:
+            mod = sys.modules.get(module_name)
+            if mod is not None:
+                code = compile_eval_or_exec(text)
+                res = eval(code, mod.__dict__, mod.__dict__)
+                if print_result:
+                    sys.displayhook(res)
+                report_execution_result(execution_id, res, repr_kind)
+            else:
+                stderr.write("Unknown module '{0}'\n".format(module_name))
+                report_execution_exception(execution_id, sys.exc_info())
+        except:
+            exc_type, exc_value, exc_tb = sys.exc_info()
+            _vspr.print_exception_frames(exc_type, exc_value, exc_tb)
+            report_execution_exception(execution_id, sys.exc_info())
 
     def execute_code_no_report(self, text, tid, fid, frame_kind):
         # execute given text in specified frame, without sending back the results
@@ -2018,6 +2040,18 @@ class DebuggerLoop(_vsipc.SocketIO, _vsipc.IpcChannel):
     def on_legacyLastAck(self, request, args):
         self.send_debug_response(request)
         last_ack_event.set()
+
+    def on_legacyListReplModules(self, request, args):
+        try:
+            res = _vspr.get_module_names()
+            res.sort()
+        except:
+            res = []
+
+        self.send_debug_response(
+            request,
+            modules=[dict(name=m[0], fileName=m[1]) for m in res]
+        )
 
     def send_debug_event(self, name, **args):
         with _SendLockCtx:
@@ -2221,6 +2255,13 @@ def report_children(execution_id, children):
 def get_code_filename(code):
     return path.abspath(code.co_filename)
 
+def compile_eval_or_exec(text):
+    try:
+        code = compile(text, '<debug input>', 'eval')
+    except:
+        code = compile(text, '<debug input>', 'exec')
+    return code
+
 NONEXPANDABLE_TYPES = [int, str, bool, float, object, type(None), unicode]
 try:
     NONEXPANDABLE_TYPES.append(long)
@@ -2369,6 +2410,8 @@ def attach_connected_process(debug_options, report = False, block = False):
     if 'RedirectOutput' in debug_options:
         enable_output_redirection()
 
+    send_debug_event(name='legacyModulesChanged')
+
 # Try to detach cooperatively, notifying the debugger as we do so.
 def detach_process_and_notify_debugger():
     if DebuggerLoop.instance:
@@ -2464,9 +2507,6 @@ def enable_output_redirection():
     sys.stdout = _DebuggerOutput(sys.stdout, is_stdout = True)
     sys.stderr = _DebuggerOutput(sys.stderr, is_stdout = False)
 
-def connect_repl_using_socket(sock):
-    _start_new_thread(DebuggerLoop.instance.connect_to_repl_backend_using_socket, (sock,))
-
 class _DebuggerOutput(object):
     """file like object which redirects output to the repl window."""
     errors = 'strict'
@@ -2496,6 +2536,7 @@ class _DebuggerOutput(object):
                 name='legacyDebuggerOutput',
                 threadId=thread.get_ident(),
                 output=value,
+                isStdOut=self.is_stdout,
             )
         if self.old_out:
             self.old_out.write(value)

--- a/Python/Product/PythonTools/visualstudio_py_debugger.py
+++ b/Python/Product/PythonTools/visualstudio_py_debugger.py
@@ -17,7 +17,7 @@
 from __future__ import with_statement
 
 __author__ = "Microsoft Corporation <ptvshelp@microsoft.com>"
-__version__ = "3.1.0.0"
+__version__ = "3.2.0.0"
 
 # This module MUST NOT import threading in global scope. This is because in a direct (non-ptvsd)
 # attach scenario, it is loaded on the injected debugger attach thread, and if threading module

--- a/Python/Product/PythonTools/visualstudio_py_ipcjson.py
+++ b/Python/Product/PythonTools/visualstudio_py_ipcjson.py
@@ -17,7 +17,7 @@
 from __future__ import with_statement, absolute_import
 
 __author__ = "Microsoft Corporation <ptvshelp@microsoft.com>"
-__version__ = "3.1.0.0"
+__version__ = "3.2.0.0"
 
 import json
 import os.path

--- a/Python/Product/PythonTools/visualstudio_py_launcher.py
+++ b/Python/Product/PythonTools/visualstudio_py_launcher.py
@@ -21,7 +21,7 @@ the second argument.
 """
 
 __author__ = "Microsoft Corporation <ptvshelp@microsoft.com>"
-__version__ = "3.1.0.0"
+__version__ = "3.2.0.0"
 
 import os
 import os.path

--- a/Python/Product/PythonTools/visualstudio_py_repl.py
+++ b/Python/Product/PythonTools/visualstudio_py_repl.py
@@ -350,13 +350,6 @@ actual inspection and introspection."""
         args = read_string(self.conn)
         self.execute_file_ex(filetype, filename, args)
 
-    def _cmd_debug_attach(self):
-        import visualstudio_py_debugger
-        port = read_int(self.conn)
-        id = read_string(self.conn)
-        debug_options = visualstudio_py_debugger.parse_debug_options(read_string(self.conn))
-        self.attach_process(port, id, debug_options)
-
     _COMMANDS = {
         to_bytes('run '): _cmd_run,
         to_bytes('abrt'): _cmd_abrt,
@@ -369,7 +362,6 @@ actual inspection and introspection."""
         to_bytes('inpl'): _cmd_inpl,
         to_bytes('excf'): _cmd_excf,
         to_bytes('excx'): _cmd_excx,
-        to_bytes('dbga'): _cmd_debug_attach,
     }
 
     def _write_member_dict(self, mem_dict):
@@ -377,10 +369,6 @@ actual inspection and introspection."""
         for name, type_name in mem_dict.items():
             write_string(self.conn, name)
             write_string(self.conn, type_name)
-
-    def on_debugger_detach(self):
-        with self.send_lock:
-            write_bytes(self.conn, ReplBackend._DETC)
 
     def init_debugger(self):
         from os import path
@@ -508,10 +496,6 @@ actual inspection and introspection."""
 
     def flush(self):
         """flushes the stdout/stderr buffers"""
-        raise NotImplementedError
-
-    def attach_process(self, port, debugger_id, debug_options):
-        """starts processing execution requests"""
         raise NotImplementedError
 
 def exit_work_item():
@@ -646,7 +630,7 @@ due to the exec, so we do it here"""
         # Otherwise we have a nested exception hanging around and the 2nd abort doesn't
         # work (that's probably an IronPython bug)
         try:    
-            new_modules = self._get_cur_module_set()
+            new_modules = get_cur_module_set()
             try:
                 if new_modules != cur_modules:
                     self.send_modules_changed()
@@ -707,11 +691,9 @@ due to the exec, so we do it here"""
                     sys.stderr.write('KeyboardInterrupt')
                 else:
                     # let IronPython format the exception so users can do -X:ExceptionDetail or -X:ShowClrExceptions
-                    exc_next = self.skip_internal_frames(exc_tb)
-                    sys.stderr.write(''.join(traceback.format_exception(exc_type, exc_value, exc_next)))
+                    print_exception_frames(exc_type, exc_value, exc_tb)
             else:
-                exc_next = self.skip_internal_frames(exc_tb)
-                sys.stderr.write(''.join(traceback.format_exception(exc_type, exc_value, exc_next)))
+                print_exception_frames(exc_type, exc_value, exc_tb)
 
             try:
                 self.send_error()
@@ -720,19 +702,6 @@ due to the exec, so we do it here"""
                 return True, None, None, None
 
         return False, cur_modules, cur_ps1, cur_ps2
-
-    def skip_internal_frames(self, tb):
-        """return the first frame outside of the repl/debugger code"""
-        while tb is not None and self.is_internal_frame(tb):
-            tb = tb.tb_next
-        return tb
-
-    def is_internal_frame(self, tb):
-        """return true if the frame is from internal code (repl or debugger)"""
-        f = tb.tb_frame
-        co = f.f_code
-        filename = co.co_filename
-        return filename.endswith('visualstudio_py_repl.py') or filename.endswith('visualstudio_py_debugger.py')
 
     def execution_loop(self):
         """loop on the main thread which is responsible for executing code"""
@@ -794,23 +763,6 @@ due to the exec, so we do it here"""
                 print(out_codec.decode(line, 'replace')[0].rstrip('\r\n'))
         except Exception:
             traceback.print_exc()
-
-    @staticmethod
-    def _get_cur_module_set():
-        """gets the set of modules avoiding exceptions if someone puts something
-        weird in there"""
-
-        try:
-            return set(sys.modules)
-        except:
-            res = set()
-            for name in sys.modules:
-                try:
-                    res.add(name)
-                except:
-                    pass
-            return res
-
 
     def run_command(self, command):
         self.current_code = command
@@ -972,51 +924,10 @@ due to the exec, so we do it here"""
             _debug_write('Unknown module ' + module)
 
     def get_module_names(self):
-        res = []
-        for name, module in sys.modules.items():
-            try:
-                if name != 'visualstudio_py_repl' and name != '$visualstudio_py_debugger':
-                    if sys.platform == 'cli' and type(module) is NamespaceType:
-                        self.get_namespaces(name, module, res)
-                    else:
-                        try:
-                            filename = os.path.abspath(module.__file__)
-                        except Exception:
-                            filename = None
-                        res.append((name, filename))
-
-            except:
-                pass
-        return res
-
-    def get_namespaces(self, basename, namespace, names):
-        names.append((basename, ''))
-        try:
-            for name in dir(namespace):
-                new_name = basename + '.' + name
-                new_namespace = getattr(namespace, name)
-
-                if type(new_namespace) is NamespaceType:
-                    self.get_namespaces(new_name, new_namespace, names)
-        except:
-            pass
+        return get_module_names()
 
     def flush(self):
         sys.stdout.flush()
-
-    def do_detach(self):
-        import visualstudio_py_debugger
-        visualstudio_py_debugger.DETACH_CALLBACKS.remove(self.do_detach)
-        self.on_debugger_detach()
-
-    def attach_process(self, port, debugger_id, debug_options):
-        def execute_attach_process_work_item():
-            import visualstudio_py_debugger
-            visualstudio_py_debugger.DETACH_CALLBACKS.append(self.do_detach)
-            visualstudio_py_debugger.attach_process(port, debugger_id, debug_options, report=True, block=True)
-
-        self.execute_item = execute_attach_process_work_item
-        self.execute_item_lock.release()
 
     @staticmethod
     def get_type_name(val):
@@ -1045,6 +956,73 @@ due to the exec, so we do it here"""
                 except:
                     pass
             return
+
+def get_cur_module_set():
+    """gets the set of modules avoiding exceptions if someone puts something
+    weird in there"""
+
+    try:
+        return set(sys.modules)
+    except:
+        res = set()
+        for name in sys.modules:
+            try:
+                res.add(name)
+            except:
+                pass
+        return res
+
+def get_module_names():
+    res = []
+    for name, module in sys.modules.items():
+        try:
+            if name != 'visualstudio_py_repl' and name != '$visualstudio_py_debugger':
+                if sys.platform == 'cli' and type(module) is NamespaceType:
+                    get_namespaces(name, module, res)
+                else:
+                    try:
+                        filename = os.path.abspath(module.__file__)
+                    except Exception:
+                        filename = None
+                    res.append((name, filename))
+
+        except:
+            pass
+    return res
+
+def get_namespaces(basename, namespace, names):
+    names.append((basename, ''))
+    try:
+        for name in dir(namespace):
+            new_name = basename + '.' + name
+            new_namespace = getattr(namespace, name)
+
+            if type(new_namespace) is NamespaceType:
+                get_namespaces(new_name, new_namespace, names)
+    except:
+        pass
+
+def print_exception_frames(exc_type, exc_value, exc_tb):
+    exc_next = skip_internal_frames(exc_tb)
+    sys.stderr.write(''.join(traceback.format_exception(exc_type, exc_value, exc_next)))
+
+def skip_internal_frames(tb):
+    """return the first frame outside of the repl/debugger code"""
+    while tb is not None and is_internal_frame(tb):
+        tb = tb.tb_next
+    return tb
+
+def is_internal_frame(tb):
+    """return true if the frame is from internal code (repl or debugger)"""
+    f = tb.tb_frame
+    co = f.f_code
+    filename = co.co_filename
+    return filename.endswith('visualstudio_py_repl.py') or filename.endswith('visualstudio_py_debugger.py')
+
+'''
+This code is no longer used.
+Kept as a reference for now until the members and signatures functionality is
+ported over to the debugger.
 
 class DebugReplBackend(BasicReplBackend):
     def __init__(self, debugger):
@@ -1177,6 +1155,7 @@ class DebugReplBackend(BasicReplBackend):
 
     def check_for_exit_execution_loop(self):
         return self.disconnect_requested
+'''
 
 class _ReplOutput(object):
     """file like object which redirects output to the repl window."""

--- a/Python/Product/PythonTools/visualstudio_py_repl.py
+++ b/Python/Product/PythonTools/visualstudio_py_repl.py
@@ -17,7 +17,7 @@
 from __future__ import with_statement
 
 __author__ = "Microsoft Corporation <ptvshelp@microsoft.com>"
-__version__ = "3.1.0.0"
+__version__ = "3.2.0.0"
 
 # This module MUST NOT import threading in global scope. This is because in a direct (non-ptvsd)
 # attach scenario, it is loaded on the injected debugger attach thread, and if threading module

--- a/Python/Product/PythonTools/visualstudio_py_util.py
+++ b/Python/Product/PythonTools/visualstudio_py_util.py
@@ -15,7 +15,7 @@
 # permissions and limitations under the License.
 
 __author__ = "Microsoft Corporation <ptvshelp@microsoft.com>"
-__version__ = "3.1.0.0"
+__version__ = "3.2.0.0"
 
 # This module MUST NOT import threading in global scope. This is because in a direct (non-ptvsd)
 # attach scenario, it is loaded on the injected debugger attach thread, and if threading module

--- a/Python/Tests/Core/DebugReplEvaluatorTests.cs
+++ b/Python/Tests/Core/DebugReplEvaluatorTests.cs
@@ -37,7 +37,6 @@ namespace PythonToolsTests {
         private PythonDebugReplEvaluator _evaluator;
         private MockReplWindow _window;
         private List<PythonProcess> _processes;
-        private string _moduleFileExtension;
 
         [ClassInitialize]
         public static void DoDeployment(TestContext context) {
@@ -65,7 +64,6 @@ namespace PythonToolsTests {
             _window = new MockReplWindow(_evaluator);
             _evaluator._Initialize(_window);
             _processes = new List<PythonProcess>();
-            _moduleFileExtension = Version.Version < Microsoft.PythonTools.Parsing.PythonLanguageVersion.V30 && Version.IsCPython ? ".pyc" : ".py";
         }
 
         [TestCleanup]
@@ -182,7 +180,7 @@ NameError: name 'does_not_exist' is not defined
                 var actualItem = scopesAndPaths.SingleOrDefault(d => d.Key == expectedItem.Key);
                 Assert.IsNotNull(actualItem);
                 if (!string.IsNullOrEmpty(expectedItem.Value)) {
-                    Assert.IsTrue(PathUtils.IsSamePath(Path.Combine(Version.PrefixPath, "lib", expectedItem.Value + _moduleFileExtension), actualItem.Value));
+                    Assert.IsTrue(PathUtils.IsSamePath(Path.Combine(Version.PrefixPath, "lib", expectedItem.Value), Path.ChangeExtension(actualItem.Value, null)));
                 } else {
                     Assert.IsNull(actualItem.Value);
                 }
@@ -198,7 +196,7 @@ NameError: name 'does_not_exist' is not defined
             // Change to the dis module
             Assert.AreEqual("Current module changed to dis", ExecuteCommand(new SwitchModuleCommand(), "dis"));
             Assert.AreEqual("dis", _evaluator.CurrentScopeName);
-            Assert.IsTrue(PathUtils.IsSamePath(_evaluator.CurrentScopePath, Path.Combine(Version.PrefixPath, "lib", "dis" + _moduleFileExtension)));
+            Assert.IsTrue(PathUtils.IsSamePath(Path.ChangeExtension(_evaluator.CurrentScopePath, null), Path.Combine(Version.PrefixPath, "lib", "dis")));
             Assert.AreEqual("", ExecuteText("test = 'world'"));
             Assert.AreEqual("'world'", ExecuteText("test"));
 

--- a/Python/Tests/DebuggerTests/BaseDebuggerTests.cs
+++ b/Python/Tests/DebuggerTests/BaseDebuggerTests.cs
@@ -181,7 +181,7 @@ namespace DebuggerTests {
             }
         }
 
-        internal PythonProcess DebugProcess(PythonDebugger debugger, string filename, Action<PythonProcess, PythonThread> onLoaded = null, bool resumeOnProcessLoaded = true, string interpreterOptions = null, PythonDebugOptions debugOptions = PythonDebugOptions.RedirectOutput, string cwd = null, string arguments = "") {
+        internal PythonProcess DebugProcess(PythonDebugger debugger, string filename, Func<PythonProcess, PythonThread, Task> onLoaded = null, bool resumeOnProcessLoaded = true, string interpreterOptions = null, PythonDebugOptions debugOptions = PythonDebugOptions.RedirectOutput, string cwd = null, string arguments = "") {
             return debugger.DebugProcess(Version, filename, onLoaded, resumeOnProcessLoaded, interpreterOptions, debugOptions, cwd, arguments);
         }
 

--- a/Python/Tests/DebuggerTests/DebugExtensions.cs
+++ b/Python/Tests/DebuggerTests/DebugExtensions.cs
@@ -17,12 +17,13 @@
 using System;
 using System.IO;
 using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.PythonTools.Debugger;
 using TestUtilities;
 
 namespace DebuggerTests {
     static class DebugExtensions {
-        internal static PythonProcess DebugProcess(this PythonDebugger debugger, PythonVersion version, string filename, Action<PythonProcess, PythonThread> onLoaded = null, bool resumeOnProcessLoaded = true, string interpreterOptions = null, PythonDebugOptions debugOptions = PythonDebugOptions.RedirectOutput, string cwd = null, string arguments = "") {
+        internal static PythonProcess DebugProcess(this PythonDebugger debugger, PythonVersion version, string filename, Func<PythonProcess, PythonThread, Task> onLoaded = null, bool resumeOnProcessLoaded = true, string interpreterOptions = null, PythonDebugOptions debugOptions = PythonDebugOptions.RedirectOutput, string cwd = null, string arguments = "") {
             string fullPath = Path.GetFullPath(filename);
             string dir = cwd ?? Path.GetFullPath(Path.GetDirectoryName(filename));
             if (!String.IsNullOrEmpty(arguments)) {
@@ -35,7 +36,9 @@ namespace DebuggerTests {
                 Console.WriteLine("{0}: {1}", args.Thread.Id, args.Output);
             };
             process.ProcessLoaded += async (sender, args) => {
-                onLoaded?.Invoke(process, args.Thread);
+                if (onLoaded != null) {
+                    await onLoaded(process, args.Thread);
+                }
                 if (resumeOnProcessLoaded) {
                     await process.ResumeAsync(default(CancellationToken));
                 }

--- a/Python/Tests/DebuggerTests/DebugExtensions.cs
+++ b/Python/Tests/DebuggerTests/DebugExtensions.cs
@@ -33,7 +33,7 @@ namespace DebuggerTests {
             }
             var process = debugger.CreateProcess(version.Version, version.InterpreterPath, arguments, dir, "", interpreterOptions, debugOptions);
             process.DebuggerOutput += (sender, args) => {
-                Console.WriteLine("{0}: {1}", args.Thread.Id, args.Output);
+                Console.WriteLine("{0}: {1}", args.Thread?.Id, args.Output);
             };
             process.ProcessLoaded += async (sender, args) => {
                 if (onLoaded != null) {


### PR DESCRIPTION
Makes the DebugReplEvaluatorTests* pass more reliably, and add some more coverage.
Change the protocol to be the debugger's, which is JSON, instead of the REPL's, which is binary.

Note that IntelliSense is broken in debug repl prior to these changes (the 2 IntelliSense related methods that are marked TODO are never called).

Need to decide how to increment the ptvsd version (this is breaking change, so 4.0?)

I've added an intermediate base class `PythonCommonInteractiveEvaluator` that the regular repl and debug repl now derive from, so that debug repl doesn't inherit any of the binary repl protocol specific code. A lot of that code is the same, but it's now split between the new base class and the original `PythonInteractiveEvaluator`.
