### PR TITLE
Fixes #2622 VS cannot handle when ConfigProvider returns no configurations

### DIFF
--- a/Python/Tests/Core.UI/BasicProjectTests.cs
+++ b/Python/Tests/Core.UI/BasicProjectTests.cs
@@ -163,6 +163,28 @@ namespace PythonToolsUITests {
 
         [TestMethod, Priority(1)]
         [HostType("VSTestHost"), TestCategory("Installed")]
+        public void LoadPythonProjectWithNoConfigurations() {
+            using (var app = new VisualStudioApp()) {
+                string fullPath = Path.GetFullPath(@"TestData\NoConfigurations\HelloWorld.pyproj");
+                Assert.IsTrue(File.Exists(fullPath), "Can't find project file");
+                app.OpenProject(fullPath);
+
+                Assert.IsTrue(app.Dte.Solution.IsOpen, "The solution is not open");
+                Assert.IsTrue(app.Dte.Solution.Projects.Count == 1, String.Format("Loading project resulted in wrong number of loaded projects, expected 1, received {0}", app.Dte.Solution.Projects.Count));
+
+                var iter = app.Dte.Solution.Projects.GetEnumerator();
+                Assert.IsTrue(iter.MoveNext());
+                Project project = (Project)iter.Current;
+                Assert.AreEqual("HelloWorld.pyproj", Path.GetFileName(project.FileName), "Wrong project file name");
+
+                // Expect an exception here causing the test to fail
+                var value = (string)project.Properties.Item("CommandLineArguments").Value;
+                Assert.AreEqual("expected", value);
+            }
+        }
+
+        [TestMethod, Priority(1)]
+        [HostType("VSTestHost"), TestCategory("Installed")]
         public void LoadFlavoredProject() {
             using (var app = new VisualStudioApp()) {
                 var project = app.OpenProject(@"TestData\FlavoredProject.sln");

--- a/Python/Tests/Core.UI/PythonToolsUITests.csproj
+++ b/Python/Tests/Core.UI/PythonToolsUITests.csproj
@@ -178,18 +178,6 @@
       <Project>{b20e082b-4d3c-457d-b2bd-60420b434573}</Project>
       <Name>EnvironmentsList</Name>
     </ProjectReference>
-    <ProjectReference Include="..\..\Product\IronPythonResolver\IronPythonResolver.csproj">
-      <Project>{31f224b1-68da-4524-9a1c-95f22492775b}</Project>
-      <Name>IronPythonResolver</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\..\Product\IronPython\IronPython.csproj">
-      <Project>{5ae43c93-8ef6-4d57-bc10-511035ef56c5}</Project>
-      <Name>IronPython</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\..\Product\IronPython\IronPython.Interpreter.csproj">
-      <Project>{012293b1-168a-4c48-a678-db8361b50ba7}</Project>
-      <Name>IronPython.Interpreter</Name>
-    </ProjectReference>
     <ProjectReference Include="..\..\Product\VSCommon\VSCommon.csproj">
       <Project>{A52AC77F-6DF9-4387-BB08-8DED3FD95A0F}</Project>
       <Name>VSCommon</Name>

--- a/Python/Tests/TestData/NoConfigurations/HelloWorld.pyproj
+++ b/Python/Tests/TestData/NoConfigurations/HelloWorld.pyproj
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{12535e18-06da-4f15-b99e-8f492fe721e2}</ProjectGuid>
+    <ProjectHome>.</ProjectHome>
+    <StartupFile>Program.py</StartupFile>
+    <SearchPath>
+    </SearchPath>
+    <WorkingDirectory>.</WorkingDirectory>
+    <AssemblyName>HelloWorld</AssemblyName>
+    <Name>HelloWorld</Name>
+    <RootNamespace>HelloWorld</RootNamespace>
+    <OutputPath>.</OutputPath>
+    <CommandLineArguments>expected</CommandLineArguments>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Program.py" />
+  </ItemGroup>
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\Python Tools\Microsoft.PythonTools.targets" />
+</Project>

--- a/Python/Tests/TestData/NoConfigurations/Program.py
+++ b/Python/Tests/TestData/NoConfigurations/Program.py
@@ -1,0 +1,1 @@
+print('hello world')


### PR DESCRIPTION
Fixes #2622 VS cannot handle when ConfigProvider returns no configurations
Adds default configurations for when projects do not have any conditions.
Allows VisualStudioApp.OpenProject() to also open projects
Adds test
Removes unnecessary references from PythonToolsUITests