### PR TITLE
Fixes #2389 Cannot go to definition of variables

### DIFF
--- a/Python/Product/Analysis/Analysis.csproj
+++ b/Python/Product/Analysis/Analysis.csproj
@@ -179,6 +179,7 @@
     <Compile Include="Values\DictBuiltinClassInfo.cs" />
     <Compile Include="Values\PartialFunctionInfo.cs" />
     <Compile Include="Values\SpecializedInstanceInfo.cs" />
+    <Compile Include="Values\SyntheticDefinitionInfo.cs" />
     <Compile Include="Values\SysModuleInfo.cs" />
     <Compile Include="VariableDef.cs" />
     <Compile Include="Interpreter\Default\CPythonFunctionOverload.cs" />

--- a/Python/Product/Analysis/ModuleAnalysis.cs
+++ b/Python/Product/Analysis/ModuleAnalysis.cs
@@ -584,7 +584,9 @@ namespace Microsoft.PythonTools.Analysis {
             foreach (var s in scope.EnumerateTowardsGlobal) {
                 foreach (var kvp in s.GetAllMergedVariables()) {
                     // deliberately overwrite variables from outer scopes
-                    result[kvp.Key] = new List<AnalysisValue>(kvp.Value.TypesNoCopy);
+                    var values = new List<AnalysisValue>(kvp.Value.TypesNoCopy);
+                    values.Add(new SyntheticDefinitionInfo(kvp.Value.Definitions));
+                    result[kvp.Key] = values;
                 }
             }
 

--- a/Python/Product/Analysis/Values/SyntheticDefinitionInfo.cs
+++ b/Python/Product/Analysis/Values/SyntheticDefinitionInfo.cs
@@ -1,0 +1,32 @@
+﻿// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABLITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.PythonTools.Analysis.Values {
+    class SyntheticDefinitionInfo : AnalysisValue {
+        public SyntheticDefinitionInfo(IEnumerable<LocationInfo> locations) {
+            Locations = locations.ToArray();
+        }
+
+        public SyntheticDefinitionInfo(IEnumerable<EncodedLocation> locations) {
+            Locations = locations.Select(e => e.GetLocationInfo()).ToArray();
+        }
+
+        public override IEnumerable<LocationInfo> Locations { get; }
+    }
+}


### PR DESCRIPTION
Fixes #2389 Cannot go to definition of variables
Ensures all definition locations are made available for variables.
Improves MemberResult implementation using Lazy.
Fixes MemberResult not ignoring Unknown type information properly.