### PR TITLE
Fixes #1694 Intellisense packages are not sorted

### DIFF
--- a/Python/Product/EnvironmentsList/DBExtension.xaml
+++ b/Python/Product/EnvironmentsList/DBExtension.xaml
@@ -27,7 +27,7 @@
 
                             <TextBlock Grid.Column="1"
                                        VerticalAlignment="Center"
-                                       Text="{Binding Name}"/>
+                                       Text="{Binding FullName}"/>
 
                             <TextBlock Grid.Column="2"
                                        VerticalAlignment="Center"


### PR DESCRIPTION
Fixes #1694 Intellisense packages are not sorted
Displays full package name in list so it is obvious that they are sorted.