### PR TITLE
Django test fixes

### DIFF
--- a/Common/Tests/Utilities.UI/TestUtilities.UI.csproj
+++ b/Common/Tests/Utilities.UI/TestUtilities.UI.csproj
@@ -121,8 +121,8 @@
     <Compile Include="UI\MenuItem.cs" />
     <Compile Include="UI\Mouse.cs" />
     <Compile Include="UI\NavigateToDialog.cs" />
-    <Compile Include="UI\NewItemDialog.cs" />
     <Compile Include="UI\NewProjectDialog.cs" />
+    <Compile Include="UI\NewItemDialog.cs" />
     <Compile Include="UI\ObjectBrowser.cs" />
     <Compile Include="UI\OverwriteFileDialog.cs" />
     <Compile Include="UI\ProjectPropertiesWindow.cs" />

--- a/Common/Tests/Utilities.UI/UI/NewItemDialog.cs
+++ b/Common/Tests/Utilities.UI/UI/NewItemDialog.cs
@@ -19,64 +19,33 @@ using System.Windows.Automation;
 
 namespace TestUtilities.UI {
     /// <summary>
-    /// Wrapps VS's File->New Project dialog.
+    /// Wrapps VS's Project->Add Item dialog.
     /// </summary>
-    public class NewProjectDialog  : AutomationDialog {
-        private TreeView _installedTemplates;
+    public class NewItemDialog : AutomationDialog, IAddNewItem {
+        private readonly VisualStudioApp _app;
         private ListView _projectTypesTable;
 
-        public NewProjectDialog(VisualStudioApp app, AutomationElement element)
+        public NewItemDialog(VisualStudioApp app, AutomationElement element)
             : base(app, element) {
+            _app = app;
         }
 
-        public static NewProjectDialog FromDte(VisualStudioApp app) {
-            return app.FileNewProject();
+        public static NewItemDialog FromDte(VisualStudioApp app) {
+            return new NewItemDialog(
+                app,
+                AutomationElement.FromHandle(app.OpenDialogWithDteExecuteCommand("Project.AddNewItem"))
+            );
         }
 
+        /// <summary>
+        /// Clicks the OK button on the dialog.
+        /// </summary>
         public override void OK() {
             ClickButtonAndClose("btn_OK", nameIsAutomationId: true);
         }
 
         /// <summary>
-        /// Gets the installed templates tree view which enables access to all of the project types.
-        /// </summary>
-        public TreeView InstalledTemplates {
-            get {
-                if (_installedTemplates == null) {
-                    var templates = Element.FindAll(
-                        TreeScope.Descendants,
-                        new PropertyCondition(
-                            AutomationElement.AutomationIdProperty,
-#if DEV11_OR_LATER
-                            "Installed"
-#else
-                            "Installed Templates"
-#endif
-                        )
-                    );
-                    
-
-                    // all the templates have the same name (Installed, Recent, etc...)
-                    // so we need to find the one that actually has our templates.
-                    foreach (AutomationElement template in templates) {
-                        var temp = new TreeView(template);
-#if DEV11_OR_LATER
-                        var item = temp.FindItem("Templates");
-#else
-                        var item = temp.FindItem("Visual C#");
-#endif
-                        if (item != null) {
-                            _installedTemplates = temp;
-                            break;
-                        }
-                    }
-                }
-                return _installedTemplates;
-            }
-        }
-
-        /// <summary>
-        /// Gets the project types table which enables selecting an individual project type.
+        /// Gets the project types list view which enables selecting an individual project type.
         /// </summary>
         public ListView ProjectTypes {
             get {
@@ -99,68 +68,26 @@ namespace TestUtilities.UI {
             }
         }
 
-        public string ProjectName {
+        public string FileName {
             get {
-                return ProjectNameBox.GetValuePattern().Current.Value;
+                var patterns = GetFileNameBox().GetSupportedPatterns();
+                var filename = (ValuePattern)GetFileNameBox().GetCurrentPattern(ValuePattern.Pattern);
+                return filename.Current.Value;
             }
             set {
-                ProjectNameBox.GetValuePattern().SetValue(value);
+                var patterns = GetFileNameBox().GetSupportedPatterns();
+                var filename = (ValuePattern)GetFileNameBox().GetCurrentPattern(ValuePattern.Pattern);
+                filename.SetValue(value);
             }
         }
 
-        public string Location {
-            get {
-                return LocationBox.GetValuePattern().Current.Value;
-            }
-            set {
-                LocationBox.GetValuePattern().SetValue(value);
-            }
-        }
-
-        public void FocusLanguageNode(string name = "Python") {
-            if (InstalledTemplates == null) {
-                Console.WriteLine("Failed to find InstalledTemplates:");
-                AutomationWrapper.DumpElement(Element);
-            }
-#if DEV11_OR_LATER
-            var item = InstalledTemplates.FindItem("Templates", name);
-            if (item == null) {
-                item = InstalledTemplates.FindItem("Templates", "Other Languages", name);
-            }
-#else
-            var item = InstalledTemplates.FindItem("Other Languages", name);
-            if (item == null) {
-                // VS can be configured so that there is no Other Languages category
-                item = InstalledTemplates.FindItem(name);
-            }
-#endif
-            if (item == null) {
-                Console.WriteLine("Failed to find templates for " + name);
-                AutomationWrapper.DumpElement(InstalledTemplates.Element);
-            }
-            item.SetFocus();
-        }
-
-        private AutomationElement ProjectNameBox {
-            get {
-                return Element.FindFirst(TreeScope.Descendants,
-                    new AndCondition(
-                        new PropertyCondition(AutomationElement.AutomationIdProperty, "txt_Name"),
-                        new PropertyCondition(AutomationElement.ControlTypeProperty, ControlType.Edit)
-                    )
-                );
-            }
-        }
-
-        private AutomationElement LocationBox {
-            get {
-                return Element.FindFirst(TreeScope.Descendants,
-                    new AndCondition(
-                        new PropertyCondition(AutomationElement.AutomationIdProperty, "PART_EditableTextBox"),
-                        new PropertyCondition(AutomationElement.ControlTypeProperty, ControlType.Edit)
-                    )
-                );
-            }
+        private AutomationElement GetFileNameBox() {
+            return Element.FindFirst(TreeScope.Descendants,
+                new AndCondition(
+                    new PropertyCondition(AutomationElement.AutomationIdProperty, "txt_Name"),
+                    new PropertyCondition(AutomationElement.ControlTypeProperty, ControlType.Edit)
+                )
+            );
         }
     }
 }

--- a/Common/Tests/Utilities.UI/UI/NewProjectDialog.cs
+++ b/Common/Tests/Utilities.UI/UI/NewProjectDialog.cs
@@ -19,35 +19,66 @@ using System.Windows.Automation;
 
 namespace TestUtilities.UI {
     /// <summary>
-    /// Wrapps VS's Project->Add Item dialog.
+    /// Wrapps VS's File->New Project dialog.
     /// </summary>
-    public class NewItemDialog : AutomationDialog, IAddNewItem {
-        private readonly VisualStudioApp _app;
-        private Table _projectTypesTable;
+    public class NewProjectDialog  : AutomationDialog {
+        private TreeView _installedTemplates;
+        private ListView _projectTypesTable;
 
-        public NewItemDialog(VisualStudioApp app, AutomationElement element)
+        public NewProjectDialog(VisualStudioApp app, AutomationElement element)
             : base(app, element) {
-            _app = app;
         }
 
-        public static NewItemDialog FromDte(VisualStudioApp app) {
-            return new NewItemDialog(
-                app,
-                AutomationElement.FromHandle(app.OpenDialogWithDteExecuteCommand("Project.AddNewItem"))
-            );
+        public static NewProjectDialog FromDte(VisualStudioApp app) {
+            return app.FileNewProject();
         }
 
-        /// <summary>
-        /// Clicks the OK button on the dialog.
-        /// </summary>
         public override void OK() {
             ClickButtonAndClose("btn_OK", nameIsAutomationId: true);
         }
 
         /// <summary>
+        /// Gets the installed templates tree view which enables access to all of the project types.
+        /// </summary>
+        public TreeView InstalledTemplates {
+            get {
+                if (_installedTemplates == null) {
+                    var templates = Element.FindAll(
+                        TreeScope.Descendants,
+                        new PropertyCondition(
+                            AutomationElement.AutomationIdProperty,
+#if DEV11_OR_LATER
+                            "Installed"
+#else
+                            "Installed Templates"
+#endif
+                        )
+                    );
+                    
+
+                    // all the templates have the same name (Installed, Recent, etc...)
+                    // so we need to find the one that actually has our templates.
+                    foreach (AutomationElement template in templates) {
+                        var temp = new TreeView(template);
+#if DEV11_OR_LATER
+                        var item = temp.FindItem("Templates");
+#else
+                        var item = temp.FindItem("Visual C#");
+#endif
+                        if (item != null) {
+                            _installedTemplates = temp;
+                            break;
+                        }
+                    }
+                }
+                return _installedTemplates;
+            }
+        }
+
+        /// <summary>
         /// Gets the project types table which enables selecting an individual project type.
         /// </summary>
-        public Table ProjectTypes {
+        public ListView ProjectTypes {
             get {
                 if (_projectTypesTable == null) {
                     var extensions = Element.FindAll(
@@ -61,33 +92,75 @@ namespace TestUtilities.UI {
                     if (extensions.Count != 1) {
                         throw new Exception("multiple controls match");
                     }
-                    _projectTypesTable = new Table(extensions[0]);
+                    _projectTypesTable = new ListView(extensions[0]);
 
                 }
                 return _projectTypesTable;
             }
         }
 
-        public string FileName {
+        public string ProjectName {
             get {
-                var patterns = GetFileNameBox().GetSupportedPatterns();
-                var filename = (ValuePattern)GetFileNameBox().GetCurrentPattern(ValuePattern.Pattern);
-                return filename.Current.Value;
+                return ProjectNameBox.GetValuePattern().Current.Value;
             }
             set {
-                var patterns = GetFileNameBox().GetSupportedPatterns();
-                var filename = (ValuePattern)GetFileNameBox().GetCurrentPattern(ValuePattern.Pattern);
-                filename.SetValue(value);
+                ProjectNameBox.GetValuePattern().SetValue(value);
             }
         }
 
-        private AutomationElement GetFileNameBox() {
-            return Element.FindFirst(TreeScope.Descendants,
-                new AndCondition(
-                    new PropertyCondition(AutomationElement.AutomationIdProperty, "txt_Name"),
-                    new PropertyCondition(AutomationElement.ControlTypeProperty, ControlType.Edit)
-                )
-            );
+        public string Location {
+            get {
+                return LocationBox.GetValuePattern().Current.Value;
+            }
+            set {
+                LocationBox.GetValuePattern().SetValue(value);
+            }
+        }
+
+        public void FocusLanguageNode(string name = "Python") {
+            if (InstalledTemplates == null) {
+                Console.WriteLine("Failed to find InstalledTemplates:");
+                AutomationWrapper.DumpElement(Element);
+            }
+#if DEV11_OR_LATER
+            var item = InstalledTemplates.FindItem("Templates", name);
+            if (item == null) {
+                item = InstalledTemplates.FindItem("Templates", "Other Languages", name);
+            }
+#else
+            var item = InstalledTemplates.FindItem("Other Languages", name);
+            if (item == null) {
+                // VS can be configured so that there is no Other Languages category
+                item = InstalledTemplates.FindItem(name);
+            }
+#endif
+            if (item == null) {
+                Console.WriteLine("Failed to find templates for " + name);
+                AutomationWrapper.DumpElement(InstalledTemplates.Element);
+            }
+            item.SetFocus();
+        }
+
+        private AutomationElement ProjectNameBox {
+            get {
+                return Element.FindFirst(TreeScope.Descendants,
+                    new AndCondition(
+                        new PropertyCondition(AutomationElement.AutomationIdProperty, "txt_Name"),
+                        new PropertyCondition(AutomationElement.ControlTypeProperty, ControlType.Edit)
+                    )
+                );
+            }
+        }
+
+        private AutomationElement LocationBox {
+            get {
+                return Element.FindFirst(TreeScope.Descendants,
+                    new AndCondition(
+                        new PropertyCondition(AutomationElement.AutomationIdProperty, "PART_EditableTextBox"),
+                        new PropertyCondition(AutomationElement.ControlTypeProperty, ControlType.Edit)
+                    )
+                );
+            }
         }
     }
 }

--- a/Python/Tests/Core.UI/UITests.cs
+++ b/Python/Tests/Core.UI/UITests.cs
@@ -688,7 +688,8 @@ namespace PythonToolsUITests {
                 selectedHierarchy.AdviseHierarchyEvents(events, out cookie);
 
                 using (var newItem = NewItemDialog.FromDte(app)) {
-                    AutomationWrapper.Select(newItem.ProjectTypes.FindItem("Empty Python File"));
+                    var pythonFile = newItem.ProjectTypes.FindItem("Empty Python File");
+                    pythonFile.Select();
                     newItem.FileName = "zmodule1.py";
                     newItem.OK();
                 }
@@ -744,14 +745,15 @@ namespace PythonToolsUITests {
                 const string filename = "Program2.py";
 
                 using (var addItemDlg = NewItemDialog.FromDte(app)) {
-                    AutomationWrapper.Select(addItemDlg.ProjectTypes.FindItem("Empty Python File"));
+                    var pythonFile = addItemDlg.ProjectTypes.FindItem("Empty Python File");
+                    pythonFile.Select();
                     addItemDlg.FileName = filename;
                     addItemDlg.OK();
                 }
 
                 VisualStudioApp.CheckMessageBox(
                     MessageBoxButton.Yes,
-                    "A file with the same name", filename, "already exists. Do you want to overwrite it?"
+                    "A file named", filename, "already exists. Do you want to overwrite it?"
                 );
 
                 app.OpenSolutionExplorer().WaitForChildOfProject(project, "Program2.py");

--- a/Python/Tests/Django.UI/DjangoEditingTests.cs
+++ b/Python/Tests/Django.UI/DjangoEditingTests.cs
@@ -432,6 +432,7 @@ namespace DjangoUITests {
             );
         }
 
+        [Ignore] // https://github.com/Microsoft/PTVS/issues/2720
         [TestMethod, Priority(1)]
         [HostType("VSTestHost"), TestCategory("Installed")]
         public void Insertion2() {
@@ -1437,6 +1438,7 @@ namespace DjangoUITests {
             );
         }
 
+        [Ignore] // https://github.com/Microsoft/PTVS/issues/2719
         [TestMethod, Priority(1)]
         [HostType("VSTestHost"), TestCategory("Installed")]
         public void IntellisenseCompletions2() {
@@ -1519,6 +1521,7 @@ namespace DjangoUITests {
             );
         }
 
+        [Ignore] // https://github.com/Microsoft/PTVS/issues/2719
         [TestMethod, Priority(1)]
         [HostType("VSTestHost"), TestCategory("Installed")]
         public void IntellisenseCompletions5() {
@@ -1947,6 +1950,7 @@ namespace DjangoUITests {
             );
         }
 
+        [Ignore] // https://github.com/Microsoft/PTVS/issues/2719
         [TestMethod, Priority(1)]
         [HostType("VSTestHost"), TestCategory("Installed")]
         public void IntellisenseCompletionsJS() {

--- a/Python/Tests/Django.UI/DjangoProjectTests.cs
+++ b/Python/Tests/Django.UI/DjangoProjectTests.cs
@@ -188,7 +188,8 @@ namespace DjangoUITests {
                 app.SolutionExplorerTreeView.SelectProject(project);
 
                 using (var newItem = NewItemDialog.FromDte(app)) {
-                    AutomationWrapper.Select(newItem.ProjectTypes.FindItem("HTML Page"));
+                    var htmlPage = newItem.ProjectTypes.FindItem("HTML Page");
+                    htmlPage.Select();
                     newItem.FileName = "NewPage.html";
                     newItem.OK();
                 }
@@ -259,6 +260,7 @@ namespace DjangoUITests {
             }
         }
 
+        [Ignore] // https://devdiv.visualstudio.com/DevDiv/_workitems?id=433488
         [TestMethod, Priority(1)]
         [HostType("VSTestHost"), TestCategory("Installed")]
         public void DebugProjectProperties() {

--- a/Python/Tests/Django/DjangoDebuggerTests.cs
+++ b/Python/Tests/Django/DjangoDebuggerTests.cs
@@ -188,12 +188,8 @@ namespace DjangoTests {
         public async Task TemplateLocals() {
             Init(DbState.OarApp);
 
-            // TODO: investigate why latest_poll_list is no longer a local, can't be evaluated
-            await DjangoLocalsTestAsync("polls\\index.html", 3, new string[0]);
-            await DjangoLocalsTestAsync("polls\\index.html", 4, new[] { "forloop", "poll" });
-
-            //await DjangoLocalsTestAsync("polls\\index.html", 3, new[] { "latest_poll_list" });
-            //await DjangoLocalsTestAsync("polls\\index.html", 4, new[] { "forloop", "latest_poll_list", "poll" });
+            await DjangoLocalsTestAsync("polls\\index.html", 3, new[] { "latest_poll_list" });
+            await DjangoLocalsTestAsync("polls\\index.html", 4, new[] { "forloop", "latest_poll_list", "poll" });
         }
 
         private async Task DjangoLocalsTestAsync(string filename, int breakLine, string[] expectedLocals) {

--- a/Python/Tests/TestData/DjangoProject/Oar/views.py
+++ b/Python/Tests/TestData/DjangoProject/Oar/views.py
@@ -11,29 +11,29 @@ def main(request):
 def index(request):
     latest_poll_list = Poll.objects.all().order_by('-pub_date')[:5]
     t = loader.get_template('polls/index.html')
-    c = Context({
+    c = {
         'latest_poll_list': latest_poll_list,
-    })
+    }
     return HttpResponse(t.render(c))
 
 def loop(request):
     t = loader.get_template('polls/loop.html')
-    c = Context({
+    c = {
         'colors': ['red', 'blue', 'green']
-    })
+    }
     return HttpResponse(t.render(c))
 
 def loop_nobom(request):
     t = loader.get_template('polls/loop_nobom.html')
-    c = Context({
+    c = {
         'colors': ['red', 'blue', 'green']
-    })
+    }
     return HttpResponse(t.render(c))
 
 def loop2(request):
     t = loader.get_template('polls/loop2.html')
-    c = Context({
+    c = {
         'colors': ['red', 'blue', 'green']
-    })
+    }
     return HttpResponse(t.render(c))
 


### PR DESCRIPTION
Fixes #2716 TestUtilities.UI.NewItemDialog.get_ProjectTypes throws InvalidOperationException

NewItemDialog was implemented in NewProjectDialog.cs and vice-versa, so I renamed the files, making the changes look larger than they really are.

I just changed the control type for ProjectItems to be ListView instead of DataTable. That was already correct for NewProjectDialog, but hadn't been updated for NewItemDialog yet.

Fix debugger test data for latest django (use dict instead of Context).

Skip some failing django editing tests that have been filed.

With this, there is just one failing Django test left (the one that creates an Azure Cloud Service project - I'm installing Azure workload to see if it passes with it).

Edit: DjangoUITests.DjangoAzureProjectTests.AddCloudProject passes with Azure workload.