### PR TITLE
Fixes #2648 REPL code analysis does not include variables

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Repl/PythonInteractiveEvaluator.CommandProcessorThread.cs
+++ b/Python/Product/PythonTools/PythonTools/Repl/PythonInteractiveEvaluator.CommandProcessorThread.cs
@@ -75,17 +75,16 @@ namespace Microsoft.PythonTools.Repl {
             }
 
             var processInfo = new ProcessStartInfo(interpreterPath);
+            processInfo.UseShellExecute = false;
 
 #if DEBUG
             bool debugMode = Environment.GetEnvironmentVariable("_PTVS_DEBUG_REPL") != null;
             processInfo.CreateNoWindow = !debugMode;
-            processInfo.UseShellExecute = debugMode;
             processInfo.RedirectStandardOutput = !debugMode;
             processInfo.RedirectStandardError = !debugMode;
             processInfo.RedirectStandardInput = !debugMode;
 #else
             processInfo.CreateNoWindow = true;
-            processInfo.UseShellExecute = false;
             processInfo.RedirectStandardOutput = true;
             processInfo.RedirectStandardError = true;
             processInfo.RedirectStandardInput = true;

--- a/Python/Product/PythonTools/visualstudio_ipython_repl.py
+++ b/Python/Product/PythonTools/visualstudio_ipython_repl.py
@@ -356,7 +356,7 @@ exec(compile(%(contents)r, %(filename)r, 'exec'))
         for member in reply['matches']:
             m_name = member[text_len:]
             if not any(c in m_name for c in '%!?-.,'):
-                res[member[text_len:]] = 'object'
+                res[m_name] = 'object'
 
         return 'unknown', res, {}
 


### PR DESCRIPTION
Fixes #2648 REPL code analysis does not include variables
Fixes handling of empty expression completion for IPython mode
Fixes error in heartbeat channel
Prevents invalid names being shown in completion list (since they do not filter properly)
Fixes debug mode failing due to incorrect use of ShellExecute.