### PR TITLE
Fixes #2085 Cannot see imports from search paths

### DIFF
--- a/Python/Product/Analysis/Analyzer/DDG.cs
+++ b/Python/Product/Analysis/Analyzer/DDG.cs
@@ -117,7 +117,7 @@ namespace Microsoft.PythonTools.Analysis.Analyzer {
             if (!ProjectState.Modules.TryImport(_unit.DeclaringModule.Name, out existingRef)) {
                 // publish our module ref now so that we don't collect dependencies as we'll be fully processed
                 if (existingRef == null) {
-                    ProjectState.Modules[_unit.DeclaringModule.Name] = new ModuleReference(_unit.DeclaringModule);
+                    ProjectState.Modules[_unit.DeclaringModule.Name] = new ModuleReference(_unit.DeclaringModule, _unit.DeclaringModule.Name);
                 } else {
                     existingRef.Module = _unit.DeclaringModule;
                 }

--- a/Python/Product/Analysis/Interpreter/Default/CPythonInterpreter.cs
+++ b/Python/Product/Analysis/Interpreter/Default/CPythonInterpreter.cs
@@ -309,8 +309,6 @@ namespace Microsoft.PythonTools.Interpreter.Default {
             _zipPackageCache = null;
 
             BeginUpdateSearchPathPackages();
-
-            ModuleNamesChanged?.Invoke(this, EventArgs.Empty);
         }
 
         public event EventHandler ModuleNamesChanged;

--- a/Python/Product/Analysis/ModuleAnalysis.cs
+++ b/Python/Product/Analysis/ModuleAnalysis.cs
@@ -585,7 +585,11 @@ namespace Microsoft.PythonTools.Analysis {
                 foreach (var kvp in s.GetAllMergedVariables()) {
                     // deliberately overwrite variables from outer scopes
                     var values = new List<AnalysisValue>(kvp.Value.TypesNoCopy);
-                    values.Add(new SyntheticDefinitionInfo(kvp.Value.Definitions));
+                    values.Add(new SyntheticDefinitionInfo(
+                        kvp.Key,
+                        null,
+                        kvp.Value.Definitions.Select(e => e.GetLocationInfo())
+                    ));
                     result[kvp.Key] = values;
                 }
             }

--- a/Python/Product/Analysis/ModulePath.cs
+++ b/Python/Product/Analysis/ModulePath.cs
@@ -385,6 +385,19 @@ namespace Microsoft.PythonTools.Analysis {
         }
         
         /// <summary>
+        /// Returns true if the provided name can be imported in Python code.
+        /// </summary>
+        /// <param name="name"></param>
+        /// <returns></returns>
+        public static bool IsImportable(string name) {
+            try {
+                return PythonPackageRegex.IsMatch(name);
+            } catch (RegexMatchTimeoutException) {
+                return false;
+            }
+        }
+
+        /// <summary>
         /// Returns true if the provided path references an importable Python
         /// module. This function does not access the filesystem.
         /// Retuns false if an invalid string is provided. This function does

--- a/Python/Product/Analysis/ModuleReference.cs
+++ b/Python/Product/Analysis/ModuleReference.cs
@@ -25,9 +25,12 @@ namespace Microsoft.PythonTools.Analysis {
 
         private readonly Lazy<HashSet<ModuleInfo>> _references = new Lazy<HashSet<ModuleInfo>>();
 
-        public ModuleReference(IModule module = null) {
+        public ModuleReference(IModule module = null, string name = null) {
             Module = module;
+            name = name ?? "";
         }
+
+        public string Name { get; }
 
         public AnalysisValue AnalysisModule {
             get {

--- a/Python/Product/Analysis/ModuleTable.cs
+++ b/Python/Product/Analysis/ModuleTable.cs
@@ -82,7 +82,7 @@ namespace Microsoft.PythonTools.Analysis {
             bool firstImport = false;
             if (!_modules.TryGetValue(name, out res) || res == null) {
                 var mod = await Task.Run(() => _interpreter.ImportModule(name)).ConfigureAwait(false);
-                _modules[name] = res = new ModuleReference(GetBuiltinModule(mod));
+                _modules[name] = res = new ModuleReference(GetBuiltinModule(mod), name);
                 firstImport = true;
             }
             if (res != null && res.Module == null) {
@@ -255,6 +255,10 @@ namespace Microsoft.PythonTools.Analysis {
                 get { return true; }
             }
 
+            public override string Name {
+                get { return null; }
+            }
+
             public override PythonMemberType MemberType {
                 get { return PythonMemberType.Unknown; }
             }
@@ -270,7 +274,10 @@ namespace Microsoft.PythonTools.Analysis {
             private readonly string _name;
             private PythonMemberType? _type;
 
-            public UninitializedModuleLoadState(ModuleTable moduleTable, string name) {
+            public UninitializedModuleLoadState(
+                ModuleTable moduleTable,
+                string name
+            ) {
                 this._moduleTable = moduleTable;
                 this._name = name;
             }
@@ -279,6 +286,7 @@ namespace Microsoft.PythonTools.Analysis {
                 get {
                     ModuleReference res;
                     if (_moduleTable.TryImport(_name, out res)) {
+                        _type = res.AnalysisModule?.MemberType;
                         return res.AnalysisModule;
                     }
                     return null;
@@ -303,17 +311,25 @@ namespace Microsoft.PythonTools.Analysis {
                 }
             }
 
+            public override string Name {
+                get {
+                    return _name;
+                }
+            }
+
+            public override string MaybeSourceFile {
+                get {
+                    ModuleReference res;
+                    if (_moduleTable.TryGetImportedModule(_name, out res)) {
+                        return res.AnalysisModule?.DeclaringModule?.FilePath;
+                    }
+                    return null;
+                }
+            }
+
             public override PythonMemberType MemberType {
                 get {
-                    if (_type == null) {
-                        var mod = _moduleTable._interpreter.ImportModule(_name);
-                        if (mod != null) {
-                            _type = mod.MemberType;
-                        } else {
-                            _type = PythonMemberType.Module;
-                        }
-                    }
-                    return _type.Value;
+                    return _type ?? PythonMemberType.Module;
                 }
             }
 
@@ -331,6 +347,9 @@ namespace Microsoft.PythonTools.Analysis {
             private readonly ModuleReference _reference;
 
             public InitializedModuleLoadState(ModuleReference reference) {
+                if (reference == null) {
+                    throw new ArgumentNullException(nameof(reference));
+                }
                 _reference = reference;
             }
 
@@ -357,6 +376,9 @@ namespace Microsoft.PythonTools.Analysis {
                     return Module != null;
                 }
             }
+
+            public override string Name => _reference.Name;
+            public override string MaybeSourceFile => Module?.DeclaringModule?.FilePath;
 
             public override PythonMemberType MemberType {
                 get {
@@ -476,6 +498,14 @@ namespace Microsoft.PythonTools.Analysis {
 
         public abstract bool IsValid {
             get;
+        }
+
+        public abstract string Name {
+            get;
+        }
+
+        public virtual string MaybeSourceFile {
+            get { return null; }
         }
 
         public abstract PythonMemberType MemberType {

--- a/Python/Product/Analysis/PythonAnalyzer.cs
+++ b/Python/Product/Analysis/PythonAnalyzer.cs
@@ -184,7 +184,7 @@ namespace Microsoft.PythonTools.Analysis {
             if (moduleRef != null) {
                 _builtinModule = (BuiltinModule)moduleRef.Module;
             } else {
-                Modules[_builtinName] = new ModuleReference(_builtinModule);
+                Modules[_builtinName] = new ModuleReference(_builtinModule, _builtinName);
             }
 
             FinishLoadKnownTypes(null);
@@ -561,7 +561,13 @@ namespace Microsoft.PythonTools.Analysis {
 
             public IEnumerable<AnalysisValue> GetLazyModules() {
                 foreach (var value in _loaded) {
-                    yield return value.Module;
+                    yield return new SyntheticDefinitionInfo(
+                        value.Name,
+                        null,
+                        string.IsNullOrEmpty(value.MaybeSourceFile) ?
+                            Enumerable.Empty<LocationInfo>() :
+                            new[] { new LocationInfo(value.MaybeSourceFile, 0, 0) }
+                    );
                 }
             }
 

--- a/Python/Product/Analysis/Values/SyntheticDefinitionInfo.cs
+++ b/Python/Product/Analysis/Values/SyntheticDefinitionInfo.cs
@@ -26,7 +26,7 @@ namespace Microsoft.PythonTools.Analysis.Values {
         ) {
             Name = name;
             Documentation = doc;
-            Locations = locations.ToArray();
+            Locations = locations?.ToArray() ?? Enumerable.Empty<LocationInfo>();
         }
 
         public override string Name { get; }

--- a/Python/Product/Analysis/Values/SyntheticDefinitionInfo.cs
+++ b/Python/Product/Analysis/Values/SyntheticDefinitionInfo.cs
@@ -19,14 +19,18 @@ using System.Linq;
 
 namespace Microsoft.PythonTools.Analysis.Values {
     class SyntheticDefinitionInfo : AnalysisValue {
-        public SyntheticDefinitionInfo(IEnumerable<LocationInfo> locations) {
+        public SyntheticDefinitionInfo(
+            string name,
+            string doc,
+            IEnumerable<LocationInfo> locations
+        ) {
+            Name = name;
+            Documentation = doc;
             Locations = locations.ToArray();
         }
 
-        public SyntheticDefinitionInfo(IEnumerable<EncodedLocation> locations) {
-            Locations = locations.Select(e => e.GetLocationInfo()).ToArray();
-        }
-
+        public override string Name { get; }
+        public override string Documentation { get; }
         public override IEnumerable<LocationInfo> Locations { get; }
     }
 }

--- a/Python/Product/PythonTools/PythonTools/Navigation/NavigateTo/PythonNavigateToItemProvider.cs
+++ b/Python/Product/PythonTools/PythonTools/Navigation/NavigateTo/PythonNavigateToItemProvider.cs
@@ -122,7 +122,7 @@ namespace Microsoft.PythonTools.Navigation.NavigateTo {
             int total = _analyzers.Sum(r => r.Result?.completions?.Length ?? 0);
             foreach (var a in _analyzers) {
                 token.ThrowIfCancellationRequested();
-                if (a.Result?.completions?.Length == 0) {
+                if ((a.Result?.completions?.Length ?? 0) == 0) {
                     continue;
                 }
 


### PR DESCRIPTION
Fixes #2085 Cannot see imports from search paths
Adds background task to enumerate packages/modules in search path directories (ZIP files not yet supported)
Makes unimported modules lazier
Fixes NullReferenceException in Navigate To.