### PR TITLE
Fixes #2727 Editors opened by LSL are not associated with the project

### DIFF
--- a/Python/Product/Analyzer/Intellisense/OutOfProcProjectAnalyzer.cs
+++ b/Python/Product/Analyzer/Intellisense/OutOfProcProjectAnalyzer.cs
@@ -1592,7 +1592,9 @@ namespace Microsoft.PythonTools.Intellisense {
             };
 
             for(int i = 0; i < request.path.Length; ++i) {
-                entries[i] = AddNewFile(request.path[i], request.addingFromDir, out response.fileId[i]);
+                if (!string.IsNullOrEmpty(request.path[i])) {
+                    entries[i] = AddNewFile(request.path[i], request.addingFromDir, out response.fileId[i]);
+                }
             }
 
             await done(response);

--- a/Python/Product/PythonTools/PythonTools/Intellisense/BufferParser.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/BufferParser.cs
@@ -17,7 +17,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -29,8 +28,6 @@ using Microsoft.VisualStudioTools;
 namespace Microsoft.PythonTools.Intellisense {
     using AP = AnalysisProtocol;
 
-    [SuppressMessage("Microsoft.Design", "CA1001:TypesThatOwnDisposableFieldsShouldBeDisposable",
-        Justification = "ownership is unclear")]
     sealed class BufferParser : IDisposable {
         private readonly Timer _timer;
         internal readonly AnalysisEntry AnalysisEntry;
@@ -233,6 +230,7 @@ namespace Microsoft.PythonTools.Intellisense {
         }
 
         internal void UninitBuffer(ITextBuffer subjectBuffer) {
+            subjectBuffer.UnregisterAllHandlers();
             if (_document != null) {
                 _document.EncodingChanged -= EncodingChanged;
                 _document = null;
@@ -599,6 +597,16 @@ namespace Microsoft.PythonTools.Intellisense {
                 return actions.ToArray();
             }
             return Array.Empty<Action<AnalysisEntry>>();
+        }
+
+        public static void UnregisterAllHandlers(this ITextBuffer buffer) {
+            buffer.UnregisterAll(_newAnalysisKey);
+            buffer.UnregisterAll(_newAnalysisEntryKey);
+            buffer.UnregisterAll(_newParseTreeKey);
+        }
+
+        private static void UnregisterAll(this ITextBuffer buffer, object key) {
+            buffer.Properties.RemoveProperty(key);
         }
     }
 }

--- a/Python/Product/PythonTools/PythonTools/Intellisense/IntellisenseControllerProvider.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/IntellisenseControllerProvider.cs
@@ -123,10 +123,10 @@ namespace Microsoft.PythonTools.Intellisense {
 
         #region IVsTextViewCreationListener Members
 
-        public void VsTextViewCreated(VisualStudio.TextManager.Interop.IVsTextView textViewAdapter) {
+        public void VsTextViewCreated(IVsTextView textViewAdapter) {
             var textView = _adaptersFactory.GetWpfTextView(textViewAdapter);
             IntellisenseController controller;
-            if (textView.Properties.TryGetProperty<IntellisenseController>(typeof(IntellisenseController), out controller)) {
+            if (textView.Properties.TryGetProperty(typeof(IntellisenseController), out controller)) {
                 controller.AttachKeyboardFilter();
             }
             InitKeyBindings(textViewAdapter);

--- a/Python/Product/PythonTools/PythonTools/Intellisense/ProjectAnalyzer.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/ProjectAnalyzer.cs
@@ -85,6 +85,8 @@ namespace Microsoft.PythonTools.Intellisense {
         private readonly HashSet<ProjectReference> _references = new HashSet<ProjectReference>();
         private bool _disposing;
 
+        private readonly ConcurrentDictionary<object, object> _activeRequests = new ConcurrentDictionary<object, object>();
+
         private readonly IPythonToolsLogger _logger;
 
         internal Task ReloadTask;
@@ -140,22 +142,29 @@ namespace Microsoft.PythonTools.Intellisense {
             return result;
         }
 
-        internal async Task<VersionedResponse<AP.UnresolvedImportsResponse>> GetMissingImportsAsync(AnalysisEntry analysisEntry, ITextBuffer textBuffer) {
+        internal Task<VersionedResponse<AP.UnresolvedImportsResponse>> GetMissingImportsAsync(AnalysisEntry analysisEntry, ITextBuffer textBuffer) {
             var lastVersion = analysisEntry.GetAnalysisVersion(textBuffer);
 
-            var resp = await SendRequestAsync(
-                new AP.UnresolvedImportsRequest() {
-                    fileId = analysisEntry.FileId,
-                    bufferId = analysisEntry.GetBufferId(textBuffer)
-                },
-                null
-            ).ConfigureAwait(false);
+            return EnsureSingleRequest(
+                typeof(AP.UnresolvedImportsRequest),
+                lastVersion,
+                n => n == lastVersion,
+                async () => {
+                    var resp = await SendRequestAsync(
+                        new AP.UnresolvedImportsRequest() {
+                            fileId = analysisEntry.FileId,
+                            bufferId = analysisEntry.GetBufferId(textBuffer)
+                        },
+                        null
+                    ).ConfigureAwait(false);
 
-            if (resp != null) {
-                return VersionedResponse(resp, textBuffer, lastVersion);
-            }
+                    if (resp != null) {
+                        return VersionedResponse(resp, textBuffer, lastVersion);
+                    }
 
-            return null;
+                    return null;
+                }
+            );
         }
 
         internal VsProjectAnalyzer(
@@ -1772,25 +1781,93 @@ namespace Microsoft.PythonTools.Intellisense {
             return new VersionedResponse<T>(data, textBuffer, versionBeforeRequest);
         }
 
-        internal async Task<VersionedResponse<AP.AnalysisClassificationsResponse>> GetAnalysisClassificationsAsync(AnalysisEntry projFile, ITextBuffer textBuffer, bool colorNames) {
+        private struct RequestInfo<T, U> {
+            public T Value;
+            public TaskCompletionSource<U> Task;
+        }
+
+        private async Task<U> EnsureSingleRequest<T, U>(
+            object key,
+            T value,
+            Func<T, bool> valueMatches,
+            Func<Task<U>> performRequest,
+            U defaultValue = default(U)
+        ) {
+            object o;
+            RequestInfo<T, U> info = default(RequestInfo<T, U>);
+            // Spin on trying to get an existing request or add
+            // a new one. We should not normally get through this
+            // loop more than once, but it's possible under
+            // certain race conditions.
+            while (!_disposing) {
+                if (_activeRequests.TryGetValue(key, out o)) {
+                    var t = (RequestInfo<T, U>)o;
+                    if (valueMatches(t.Value)) {
+                        // Same request is already pending
+                        Debug.WriteLine($"Warning: request {key}({value}) is already pending");
+                        return await t.Task.Task.ConfigureAwait(false);
+                    } else {
+                        // Wait for the pending task and then
+                        // start a new one
+                        try {
+                            await t.Task.Task.ConfigureAwait(false);
+                        } catch (Exception ex) when (!ex.IsCriticalException()) {
+                        }
+                    }
+                }
+                if (info.Task == null) {
+                    info.Value = value;
+                    info.Task = new TaskCompletionSource<U>();
+                }
+                if (_activeRequests.TryAdd(key, info)) {
+                    // We are now the active task, so perform the request
+                    // and then set the result of the stored Task.
+                    try {
+                        var result = await performRequest().ConfigureAwait(false);
+                        info.Task.TrySetResult(result);
+                        return result;
+                    } catch (OperationCanceledException) {
+                        info.Task.TrySetCanceled();
+                        throw;
+                    } catch (Exception ex) {
+                        info.Task.TrySetException(ex);
+                        throw;
+                    } finally {
+                        object removed;
+                        _activeRequests.TryRemove(key, out removed);
+                    }
+                }
+            }
+            return defaultValue;
+        }
+
+        private bool EndRequest(object key) {
+            object o;
+            return _activeRequests.TryRemove(key, out o);
+        }
+
+        internal Task<VersionedResponse<AP.AnalysisClassificationsResponse>> GetAnalysisClassificationsAsync(AnalysisEntry projFile, ITextBuffer textBuffer, bool colorNames) {
             var lastVersion = projFile.GetAnalysisVersion(textBuffer);
 
-            var res = await SendRequestAsync(
-                    new AP.AnalysisClassificationsRequest() {
-                        fileId = projFile.FileId,
-                        bufferId = projFile.GetBufferId(textBuffer),
-                        colorNames = colorNames
-                    }
-                ).ConfigureAwait(false);
+            return EnsureSingleRequest(
+                typeof(AP.AnalysisClassificationsRequest),
+                lastVersion,
+                n => n == lastVersion,
+                async () => {
+                    var res = await SendRequestAsync(
+                        new AP.AnalysisClassificationsRequest() {
+                            fileId = projFile.FileId,
+                            bufferId = projFile.GetBufferId(textBuffer),
+                            colorNames = colorNames
+                        }
+                    ).ConfigureAwait(false);
 
-            if (res != null) {
-                return VersionedResponse(
-                    res,
-                    textBuffer,
-                    lastVersion
-                );
-            }
-            return null;
+                    if (res != null) {
+                        return VersionedResponse(res, textBuffer, lastVersion);
+                    }
+                    return null;
+                }
+            );
         }
 
         internal async Task<AP.LocationNameResponse> GetNameOfLocationAsync(AnalysisEntry entry, ITextBuffer textBuffer, int line, int column) {
@@ -2239,7 +2316,7 @@ namespace Microsoft.PythonTools.Intellisense {
             return new AnalysisVariable(type, location);
         }
 
-        internal static async Task<string> ExpressionForDataTipAsync(
+        internal static Task<string> ExpressionForDataTipAsync(
             IServiceProvider serviceProvider,
             ITextView view,
             SnapshotSpan span,
@@ -2264,9 +2341,19 @@ namespace Microsoft.PythonTools.Intellisense {
                 fileId = analysis.Entry.FileId,
             };
 
-            var resp = await analysis.Entry.Analyzer.SendRequestAsync(req, timeout: timeout).ConfigureAwait(false);
+            return analysis.Entry.Analyzer.EnsureSingleRequest(
+                typeof(AP.ExpressionForDataTipRequest),
+                req.expr,
+                t => t == req.expr,
+                async () => {
+                    var resp = await analysis.Entry.Analyzer.SendRequestAsync(
+                        req,
+                        timeout: timeout
+                    ).ConfigureAwait(false);
 
-            return resp?.expression;
+                    return resp?.expression;
+                }
+            );
         }
 
         class ApplicableExpression {

--- a/Python/Product/PythonTools/PythonTools/Intellisense/ProjectAnalyzer.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/ProjectAnalyzer.cs
@@ -2341,10 +2341,11 @@ namespace Microsoft.PythonTools.Intellisense {
                 fileId = analysis.Entry.FileId,
             };
 
+            var v = $"{req.expr}:{req.index}";
             return analysis.Entry.Analyzer.EnsureSingleRequest(
                 typeof(AP.ExpressionForDataTipRequest),
-                req.expr,
-                t => t == req.expr,
+                v,
+                v.Equals,
                 async () => {
                     var resp = await analysis.Entry.Analyzer.SendRequestAsync(
                         req,

--- a/Python/Product/PythonTools/PythonTools/Intellisense/TaskProvider.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/TaskProvider.cs
@@ -488,6 +488,7 @@ namespace Microsoft.PythonTools.Intellisense {
         /// for the given project entry and moniker for the error source.
         /// </summary>
         public void RemoveBufferForErrorSource(AnalysisEntry entry, string moniker, ITextBuffer buffer) {
+            Clear(entry, moniker);
             lock (_errorSources) {
                 var key = new EntryKey(entry, moniker);
                 HashSet<ITextBuffer> buffers;
@@ -502,6 +503,7 @@ namespace Microsoft.PythonTools.Intellisense {
         /// the error source.
         /// </summary>
         public void ClearErrorSource(AnalysisEntry entry, string moniker) {
+            Clear(entry, moniker);
             lock (_errorSources) {
                 _errorSources.Remove(new EntryKey(entry, moniker));
             }


### PR DESCRIPTION
Fixes #2727 Editors opened by LSL are not associated with the project
Updates open editors on project reanalysis to ensure they are associated with the correct project
Ensures squiggles are cleared.
Prevents overlapping asynchronous requests to out-of-proc analyzer.
Prevents unnecessary notifications after disconnecting a buffer parser
Some minor code cleaning.