### PR TITLE
Fixes #161 Rename directory error message

### DIFF
--- a/Common/Product/SharedProject/FolderNode.cs
+++ b/Common/Product/SharedProject/FolderNode.cs
@@ -168,7 +168,7 @@ namespace Microsoft.VisualStudioTools.Project {
                 //Refresh the properties in the properties window
                 IVsUIShell shell = this.ProjectMgr.GetService(typeof(SVsUIShell)) as IVsUIShell;
                 Utilities.CheckNotNull(shell, "Could not get the UI shell from the project");
-                ErrorHandler.ThrowOnFailure(shell.RefreshPropertyBrowser(0));
+                shell.RefreshPropertyBrowser(0);
 
                 // Notify the listeners that the name of this folder is changed. This will
                 // also force a refresh of the SolutionExplorer's node.


### PR DESCRIPTION
Fixes #161 Rename directory error message
Stops raising on non-fatal failure to refresh property browser.

As far as I can tell, this is the only place we can get an `E_FAIL` from this code path. It's certainly not a big deal, but no need to scare the user with a dialog.