### PR TITLE
Disable start debugging command for a text view that doesn't have a valid file path

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Navigation/EditFilter.cs
+++ b/Python/Product/PythonTools/PythonTools/Navigation/EditFilter.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using System.Windows;
 using Microsoft.PythonTools.Analysis;
@@ -873,7 +874,13 @@ namespace Microsoft.PythonTools.Language {
                             break;
                         case CommonConstants.StartDebuggingCmdId:
                         case CommonConstants.StartWithoutDebuggingCmdId:
-                            prgCmds[i].cmdf = (uint)(OLECMDF.OLECMDF_ENABLED | OLECMDF.OLECMDF_SUPPORTED);
+                            // Don't enable the command when the file is null or doesn't exist,
+                            // which can happen in the diff window.
+                            if (File.Exists(_textView.GetFilePath())) {
+                                prgCmds[i].cmdf = (uint)(OLECMDF.OLECMDF_ENABLED | OLECMDF.OLECMDF_SUPPORTED);
+                            } else {
+                                prgCmds[i].cmdf = CommandDisabledAndHidden;
+                            }
                             return VSConstants.S_OK;
                         default:
                             lock (PythonToolsPackage.CommandsLock) {

--- a/Python/Product/VSCommon/Infrastructure/TextExtensions.cs
+++ b/Python/Product/VSCommon/Infrastructure/TextExtensions.cs
@@ -1,8 +1,19 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿// Visual Studio Shared Project
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABLITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
 


### PR DESCRIPTION
Fix #2790 Visual Studio 2017 error

I didn't find how to repro the original bug, where the file path was null. According to `TextExtensions .GetFilePath`, this happens when the text buffer doesn't have the property of key `typeof(TextDocument)`.

While testing the source control compare window,  I noticed that the pane that was an in-memory file was returning a file path that didn't exist. If you tried to start debugging, the console would start and immediately complain that the file doesn't exist.

Adding the File.Exists check should prevent both cases.
