### PR TITLE
Prevent NullReferenceException when request returns null in GetProximityExpressions

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Navigation/PythonLanguageInfo.cs
+++ b/Python/Product/PythonTools/PythonTools/Navigation/PythonLanguageInfo.cs
@@ -124,7 +124,7 @@ namespace Microsoft.PythonTools.Navigation {
             AnalysisEntry entry;
             if (entryService != null && entryService.TryGetAnalysisEntry(buffer, out entry)) {
                 var names = entry.Analyzer.WaitForRequest(entry.Analyzer.GetProximityExpressionsAsync(entry, buffer, iLine, iCol, cLines), "PythonLanguageInfo.GetProximityExpressions");
-                ppEnum = new EnumBSTR(names);
+                ppEnum = new EnumBSTR(names ?? Enumerable.Empty<string>());
             } else {
                 ppEnum = new EnumBSTR(Enumerable.Empty<string>());
             }


### PR DESCRIPTION
Fix #2745 