### PR TITLE
Fix broken IntelliSense and high CPU

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Intellisense/ProjectAnalyzer.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/ProjectAnalyzer.cs
@@ -1817,7 +1817,7 @@ namespace Microsoft.PythonTools.Intellisense {
                 }
                 if (info.Task == null) {
                     info.Value = value;
-                    info.Task = new TaskCompletionSource<U>();
+                    info.Task = new TaskCompletionSource<U>(TaskCreationOptions.RunContinuationsAsynchronously);
                 }
                 if (_activeRequests.TryAdd(key, info)) {
                     // We are now the active task, so perform the request


### PR DESCRIPTION
Fix #2802 IntelliSense stops working and devenv.exe CPU usage goes up

I added a bunch of tracing code and found out that when this bug occurred, the code right after TrySetResult wasn't getting executed (because the thread was executing the continuation).

I tested almost all afternoon with and without the fix, and was getting consistent results (ie no repro with the fix, always repro without).

