### PR TITLE
Fix VS crash when error points to a missing file

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Project/CustomCommand.cs
+++ b/Python/Product/PythonTools/PythonTools/Project/CustomCommand.cs
@@ -383,7 +383,11 @@ namespace Microsoft.PythonTools.Project {
                     try {
                         PythonToolsPackage.NavigateTo(_serviceProvider, document, Guid.Empty, task.Line, task.Column < 0 ? 0 : task.Column);
                     } catch (FileNotFoundException ex) {
+                        // Happens when file was deleted from the project.
                         MessageBox.Show(ex.Message, Strings.ProductTitle, MessageBoxButton.OK, MessageBoxImage.Error);
+                    } catch (ArgumentException) {
+                        // Happens when file was deleted from disk but not from project.
+                        // A descriptive message was already shown to the user, so don't show another.
                     }
                 }
             }

--- a/Python/Product/PythonTools/PythonTools/Project/CustomCommand.cs
+++ b/Python/Product/PythonTools/PythonTools/Project/CustomCommand.cs
@@ -23,6 +23,7 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Windows;
 using System.Windows.Threading;
 using Microsoft.Build.Construction;
 using Microsoft.Build.Execution;
@@ -379,7 +380,11 @@ namespace Microsoft.PythonTools.Project {
                         // If it's not a valid path, then it's not a navigable error item.
                         return;
                     }
-                    PythonToolsPackage.NavigateTo(_serviceProvider, document, Guid.Empty, task.Line, task.Column < 0 ? 0 : task.Column);
+                    try {
+                        PythonToolsPackage.NavigateTo(_serviceProvider, document, Guid.Empty, task.Line, task.Column < 0 ? 0 : task.Column);
+                    } catch (FileNotFoundException ex) {
+                        MessageBox.Show(ex.Message, Strings.ProductTitle, MessageBoxButton.OK, MessageBoxImage.Error);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Fix #2816 VS crash when error points to a missing file

Here's the fix in action:
```
---------------------------
Visual Studio - Python support
---------------------------
The document cannot be opened. It has been renamed, deleted or moved.
---------------------------
OK   
---------------------------
```
