### PR TITLE
Fix failing test adapter tests.

### DIFF
--- a/Python/Tests/TestAdapterTests/TestDiscovererTests.cs
+++ b/Python/Tests/TestAdapterTests/TestDiscovererTests.cs
@@ -95,7 +95,7 @@ namespace TestAdapterTests {
 
         private static IEnumerable<TestCaseInfo> GetTestCasesFromAst(string code, PythonAnalyzer analyzer) {
             var codeStream = new MemoryStream(Encoding.UTF8.GetBytes(code));
-            var m = AstPythonModule.FromStream(analyzer.Interpreter, codeStream, "<string>", analyzer.LanguageVersion);
+            var m = AstPythonModule.FromStream(analyzer.Interpreter, codeStream, "<string>", analyzer.LanguageVersion, "__main__");
             return TestAnalyzer.GetTestCasesFromAst(m, null);
         }
 


### PR DESCRIPTION
Fixes 4 failing tests.

It was trying to determine the module name from the file name `"<string>"`, which was determined to be an invalid path and throwing an exception.