### PR TITLE
Fix #2837: Debugger breaks inside ptvsd

### DIFF
--- a/Python/Product/PythonTools/ptvsd/attach_server.py
+++ b/Python/Product/PythonTools/ptvsd/attach_server.py
@@ -137,11 +137,9 @@ def enable_attach(secret, address=('0.0.0.0', ptvsd.DEFAULT_PORT), certfile=None
 
     frames = []
     f = sys._getframe()
-    while True:
-        f = f.f_back
-        if f is None:
-            break
+    while f is not None:
         frames.append(f)
+        f = f.f_back
     frames.reverse()
     cur_thread = vspd.new_thread()
     for f in frames:

--- a/Python/Product/PythonTools/ptvsd/debugger.py
+++ b/Python/Product/PythonTools/ptvsd/debugger.py
@@ -43,6 +43,7 @@ import runpy
 import datetime
 from codecs import BOM_UTF8
 
+import ptvsd
 import ptvsd.util as _vspu
 import ptvsd.ipcjson as _vsipc
 import ptvsd.repl as _vspr
@@ -155,7 +156,13 @@ class SynthesizedValue(object):
 
 # Specifies list of files not to debug. Can be extended by other modules
 # (the REPL does this for $attach support and not stepping into the REPL).
-DONT_DEBUG = [path.normcase(__file__), path.normcase(_vspu.__file__)]
+DONT_DEBUG = [
+    path.normcase(__file__),
+    path.normcase(ptvsd.__file__),
+    path.normcase(_vspu.__file__),
+    path.normcase(_vspr.__file__),
+    path.normcase(_vsipc.__file__),
+]
 if sys.version_info >= (3, 3):
     DONT_DEBUG.append(path.normcase('<frozen importlib._bootstrap>'))
 if sys.version_info >= (3, 5):


### PR DESCRIPTION
Fix initial frame list when attaching not including enable_attach frame, causing incorrect stack traces if enable_attach is called from another function.

Add missing modules to DONT_DEBUG list.