### PR TITLE
Fix test result duration

### DIFF
--- a/Python/Product/TestAdapter.Executor/TestExecutor.cs
+++ b/Python/Product/TestAdapter.Executor/TestExecutor.cs
@@ -326,7 +326,7 @@ namespace Microsoft.PythonTools.TestAdapter {
             private Connection _connection;
             private readonly Socket _socket;
             private readonly StringBuilder _stdOut = new StringBuilder(), _stdErr = new StringBuilder();
-            private TestCase _curTest;
+            private TestResult _curTestResult;
             private readonly bool _dryRun, _showConsole;
 
             public TestRunner(
@@ -386,7 +386,7 @@ namespace Microsoft.PythonTools.TestAdapter {
                 throw new NotImplementedException();
             }
 
-            private void ConectionReceivedEvent(object sender, EventReceivedEventArgs e) {
+            private void ConnectionReceivedEvent(object sender, EventReceivedEventArgs e) {
                 switch (e.Name) {
                     case TP.ResultEvent.Name:
                         var result = (TP.ResultEvent)e.Event;
@@ -397,11 +397,9 @@ namespace Microsoft.PythonTools.TestAdapter {
                             case "skipped": outcome = TestOutcome.Skipped; break;
                         }
 
-                        var testResult = new TestResult(_curTest);
                         RecordEnd(
                             _frameworkHandle,
-                            _curTest,
-                            testResult,
+                            _curTestResult,
                             _stdOut.ToString(),
                             _stdErr.ToString(),
                             outcome,
@@ -414,16 +412,19 @@ namespace Microsoft.PythonTools.TestAdapter {
 
                     case TP.StartEvent.Name:
                         var start = (TP.StartEvent)e.Event;
-                        _curTest = null;
+
+                        // Create the TestResult object right away, so that
+                        // StartTime is initialized correctly.
+                        _curTestResult = null;
                         foreach (var test in GetTestCases()) {
                             if (test.Key == start.test) {
-                                _curTest = test.Value;
+                                _curTestResult = new TestResult(test.Value);
                                 break;
                             }
                         }
 
-                        if (_curTest != null) {
-                            _frameworkHandle.RecordStart(_curTest);
+                        if (_curTestResult != null) {
+                            _frameworkHandle.RecordStart(_curTestResult.TestCase);
                         } else {
                             Warning(Strings.Test_UnexpectedResult.FormatUI(start.classname, start.method));
                         }
@@ -490,7 +491,7 @@ namespace Microsoft.PythonTools.TestAdapter {
                     TP.RegisteredTypes,
                     "TestExecutor"
                 );
-                _connection.EventReceived += ConectionReceivedEvent;
+                _connection.EventReceived += ConnectionReceivedEvent;
                 _connection.StartProcessing();
                 _connected.Set();
             }
@@ -739,7 +740,7 @@ namespace Microsoft.PythonTools.TestAdapter {
             }
         }
 
-        private static void RecordEnd(IFrameworkHandle frameworkHandle, TestCase test, TestResult result, string stdout, string stderr, TestOutcome outcome, TP.ResultEvent resultInfo) {
+        private static void RecordEnd(IFrameworkHandle frameworkHandle, TestResult result, string stdout, string stderr, TestOutcome outcome, TP.ResultEvent resultInfo) {
             result.EndTime = DateTimeOffset.Now;
             result.Duration = result.EndTime - result.StartTime;
             result.Outcome = outcome;
@@ -760,7 +761,7 @@ namespace Microsoft.PythonTools.TestAdapter {
             }
 
             frameworkHandle.RecordResult(result);
-            frameworkHandle.RecordEnd(test, outcome);
+            frameworkHandle.RecordEnd(result.TestCase, outcome);
         }
 
         class TestReceiver : ITestCaseDiscoverySink {

--- a/Python/Product/TestAdapter.Executor/TestExecutor.cs
+++ b/Python/Product/TestAdapter.Executor/TestExecutor.cs
@@ -742,7 +742,7 @@ namespace Microsoft.PythonTools.TestAdapter {
 
         private static void RecordEnd(IFrameworkHandle frameworkHandle, TestResult result, string stdout, string stderr, TestOutcome outcome, TP.ResultEvent resultInfo) {
             result.EndTime = DateTimeOffset.Now;
-            result.Duration = result.EndTime - result.StartTime;
+            result.Duration = TimeSpan.FromSeconds(resultInfo.durationInSecs);
             result.Outcome = outcome;
             
             // Replace \n with \r\n to be more friendly when copying output...

--- a/Python/Product/TestAdapter.Executor/TestProtocol.cs
+++ b/Python/Product/TestAdapter.Executor/TestProtocol.cs
@@ -66,6 +66,7 @@ namespace Microsoft.PythonTools.TestAdapter {
         public class ResultEvent : Event {
             public const string Name = "result";
             public string test, outcome, traceback, message;
+            public double durationInSecs;
 
             public override string name => Name;
         }

--- a/Python/Product/TestAdapter/visualstudio_py_testlauncher.py
+++ b/Python/Product/TestAdapter/visualstudio_py_testlauncher.py
@@ -21,6 +21,7 @@ __version__ = "3.0.0.0"
 
 import sys
 import json
+import time
 import unittest
 import socket
 import traceback
@@ -123,8 +124,11 @@ _channel = None
 
 
 class VsTestResult(unittest.TextTestResult):
+    _start_time = None
+
     def startTest(self, test):
         super(VsTestResult, self).startTest(test)
+        self._start_time = time.time()
         if _channel is not None:
             _channel.send_event(
                 name='start', 
@@ -159,6 +163,7 @@ class VsTestResult(unittest.TextTestResult):
         if _channel is not None:
             tb = None
             message = None
+            duration = time.time() - self._start_time if self._start_time else 0
             if trace is not None:
                 traceback.print_exception(*trace)
                 formatted = traceback.format_exception(*trace)
@@ -171,6 +176,7 @@ class VsTestResult(unittest.TextTestResult):
                 outcome=outcome,
                 traceback = tb,
                 message = message,
+                durationInSecs = duration,
                 test = test.test_id
             )
 

--- a/Python/Tests/TestAdapterTests/TestExecutorTests.cs
+++ b/Python/Tests/TestAdapterTests/TestExecutorTests.cs
@@ -209,7 +209,7 @@ namespace TestAdapterTests {
                 AssertUtil.ContainsAtLeast(resultNames, expectedResult.TestCase.FullyQualifiedName);
                 var actualResult = recorder.Results.SingleOrDefault(tr => tr.TestCase.FullyQualifiedName == expectedResult.TestCase.FullyQualifiedName);
                 Assert.AreEqual(expectedResult.Outcome, actualResult.Outcome, expectedResult.TestCase.FullyQualifiedName + " had incorrect result");
-                Assert.IsTrue(actualResult.Duration >= TimeSpan.Zero);
+                Assert.IsTrue(actualResult.Duration >= expectedResult.MinDuration);
             }
         }
 
@@ -232,7 +232,7 @@ namespace TestAdapterTests {
                 AssertUtil.ContainsAtLeast(resultNames, expectedResult.TestCase.FullyQualifiedName);
                 var actualResult = recorder.Results.SingleOrDefault(tr => tr.TestCase.FullyQualifiedName == expectedResult.TestCase.FullyQualifiedName);
                 Assert.AreEqual(expectedResult.Outcome, actualResult.Outcome, expectedResult.TestCase.FullyQualifiedName + " had incorrect result");
-                Assert.IsTrue(actualResult.Duration >= TimeSpan.Zero);
+                Assert.IsTrue(actualResult.Duration >= expectedResult.MinDuration);
             }
         }
 
@@ -410,6 +410,29 @@ namespace TestAdapterTests {
                 AssertUtil.ContainsAtLeast(resultNames, expectedResult.TestCase.FullyQualifiedName);
                 var actualResult = recorder.Results.SingleOrDefault(tr => tr.TestCase.FullyQualifiedName == expectedResult.TestCase.FullyQualifiedName);
                 Assert.AreEqual(expectedResult.Outcome, actualResult.Outcome, expectedResult.TestCase.FullyQualifiedName + " had incorrect result");
+            }
+        }
+
+        [TestMethod, Priority(1)]
+        [TestCategory("10s")]
+        public void TestDuration() {
+            PythonPaths.Python27.AssertInstalled();
+
+            var executor = new TestExecutor();
+            var recorder = new MockTestExecutionRecorder();
+            var expectedTests = new[] { TestInfo.DurationSleep01TestSuccess, TestInfo.DurationSleep05TestFailure };
+            var runContext = CreateRunContext(expectedTests);
+            var testCases = expectedTests.Select(tr => tr.TestCase);
+
+            executor.RunTests(testCases, runContext, recorder);
+            PrintTestResults(recorder);
+
+            var resultNames = recorder.Results.Select(tr => tr.TestCase.FullyQualifiedName).ToSet();
+            foreach (var expectedResult in expectedTests) {
+                AssertUtil.ContainsAtLeast(resultNames, expectedResult.TestCase.FullyQualifiedName);
+                var actualResult = recorder.Results.SingleOrDefault(tr => tr.TestCase.FullyQualifiedName == expectedResult.TestCase.FullyQualifiedName);
+                Assert.AreEqual(expectedResult.Outcome, actualResult.Outcome, expectedResult.TestCase.FullyQualifiedName + " had incorrect result");
+                Assert.IsTrue(actualResult.Duration >= expectedResult.MinDuration);
             }
         }
 

--- a/Python/Tests/TestAdapterTests/TestExecutorTests.cs
+++ b/Python/Tests/TestAdapterTests/TestExecutorTests.cs
@@ -420,7 +420,13 @@ namespace TestAdapterTests {
 
             var executor = new TestExecutor();
             var recorder = new MockTestExecutionRecorder();
-            var expectedTests = new[] { TestInfo.DurationSleep01TestSuccess, TestInfo.DurationSleep05TestFailure };
+            var expectedTests = new[] {
+                TestInfo.DurationSleep01TestSuccess,
+                TestInfo.DurationSleep03TestSuccess,
+                TestInfo.DurationSleep05TestSuccess,
+                TestInfo.DurationSleep08TestSuccess,
+                TestInfo.DurationSleep15TestFailure
+            };
             var runContext = CreateRunContext(expectedTests);
             var testCases = expectedTests.Select(tr => tr.TestCase);
 
@@ -479,10 +485,11 @@ namespace TestAdapterTests {
                 Console.WriteLine(message);
             }
             foreach (var result in recorder.Results) {
-                Console.WriteLine("Test: " + result.TestCase.FullyQualifiedName);
-                Console.WriteLine("Result: " + result.Outcome);
+                Console.WriteLine("Test: {0}", result.TestCase.FullyQualifiedName);
+                Console.WriteLine("Result: {0}", result.Outcome);
+                Console.WriteLine("Duration: {0}ms", result.Duration.TotalMilliseconds);
                 foreach(var msg in result.Messages) {
-                    Console.WriteLine("Message " + msg.Category + ":");
+                    Console.WriteLine("Message {0}:", msg.Category);
                     Console.WriteLine(msg.Text);
                 }
                 Console.WriteLine("");

--- a/Python/Tests/TestAdapterTests/TestExecutorTests.cs
+++ b/Python/Tests/TestAdapterTests/TestExecutorTests.cs
@@ -209,6 +209,7 @@ namespace TestAdapterTests {
                 AssertUtil.ContainsAtLeast(resultNames, expectedResult.TestCase.FullyQualifiedName);
                 var actualResult = recorder.Results.SingleOrDefault(tr => tr.TestCase.FullyQualifiedName == expectedResult.TestCase.FullyQualifiedName);
                 Assert.AreEqual(expectedResult.Outcome, actualResult.Outcome, expectedResult.TestCase.FullyQualifiedName + " had incorrect result");
+                Assert.IsTrue(actualResult.Duration >= TimeSpan.Zero);
             }
         }
 
@@ -231,6 +232,7 @@ namespace TestAdapterTests {
                 AssertUtil.ContainsAtLeast(resultNames, expectedResult.TestCase.FullyQualifiedName);
                 var actualResult = recorder.Results.SingleOrDefault(tr => tr.TestCase.FullyQualifiedName == expectedResult.TestCase.FullyQualifiedName);
                 Assert.AreEqual(expectedResult.Outcome, actualResult.Outcome, expectedResult.TestCase.FullyQualifiedName + " had incorrect result");
+                Assert.IsTrue(actualResult.Duration >= TimeSpan.Zero);
             }
         }
 

--- a/Python/Tests/TestAdapterTests/TestInfo.cs
+++ b/Python/Tests/TestAdapterTests/TestInfo.cs
@@ -155,6 +155,9 @@ namespace TestAdapterTests {
 
         public static string TestAdapterDurationProject = TestData.GetPath(@"TestData\TestAdapterTests\DurationTest.pyproj");
         public static TestInfo DurationSleep01TestSuccess = TestInfo.FromRelativePaths("DurationTests", "test_sleep_0_1", @"TestData\TestAdapterTests\DurationTest.pyproj", @"TestData\TestAdapterTests\DurationTest.py", 5, TestOutcome.Passed, minDuration: TimeSpan.FromSeconds(0.1));
-        public static TestInfo DurationSleep05TestFailure = TestInfo.FromRelativePaths("DurationTests", "test_sleep_0_5", @"TestData\TestAdapterTests\DurationTest.pyproj", @"TestData\TestAdapterTests\DurationTest.py", 8, TestOutcome.Failed, minDuration: TimeSpan.FromSeconds(0.5));
+        public static TestInfo DurationSleep03TestSuccess = TestInfo.FromRelativePaths("DurationTests", "test_sleep_0_3", @"TestData\TestAdapterTests\DurationTest.pyproj", @"TestData\TestAdapterTests\DurationTest.py", 8, TestOutcome.Passed, minDuration: TimeSpan.FromSeconds(0.3));
+        public static TestInfo DurationSleep05TestSuccess = TestInfo.FromRelativePaths("DurationTests", "test_sleep_0_5", @"TestData\TestAdapterTests\DurationTest.pyproj", @"TestData\TestAdapterTests\DurationTest.py", 11, TestOutcome.Passed, minDuration: TimeSpan.FromSeconds(0.5));
+        public static TestInfo DurationSleep08TestSuccess = TestInfo.FromRelativePaths("DurationTests", "test_sleep_0_8", @"TestData\TestAdapterTests\DurationTest.pyproj", @"TestData\TestAdapterTests\DurationTest.py", 14, TestOutcome.Passed, minDuration: TimeSpan.FromSeconds(0.8));
+        public static TestInfo DurationSleep15TestFailure = TestInfo.FromRelativePaths("DurationTests", "test_sleep_1_5", @"TestData\TestAdapterTests\DurationTest.pyproj", @"TestData\TestAdapterTests\DurationTest.py", 17, TestOutcome.Failed, minDuration: TimeSpan.FromSeconds(1.5));
     }
 }

--- a/Python/Tests/TestAdapterTests/TestInfo.cs
+++ b/Python/Tests/TestAdapterTests/TestInfo.cs
@@ -34,21 +34,23 @@ namespace TestAdapterTests {
         public string SourceCodeFilePath { get; private set; }
         public int SourceCodeLineNumber { get; private set; }
         public TestOutcome Outcome { get; private set; }
+        public TimeSpan MinDuration { get; private set; }
 
         private TestInfo() {
         }
 
-        public static TestInfo FromRelativePaths(string className, string methodName, string projectFilePath, string sourceCodeFilePath, int sourceCodeLineNumber, TestOutcome outcome, string classFilePath = null) {
+        public static TestInfo FromRelativePaths(string className, string methodName, string projectFilePath, string sourceCodeFilePath, int sourceCodeLineNumber, TestOutcome outcome, string classFilePath = null, TimeSpan? minDuration = null) {
             return FromAbsolutePaths(className,
                 methodName,
                 TestData.GetPath(projectFilePath),
                 TestData.GetPath(sourceCodeFilePath),
                 sourceCodeLineNumber,
                 outcome,
-                classFilePath != null ? TestData.GetPath(classFilePath) : null);
+                classFilePath != null ? TestData.GetPath(classFilePath) : null,
+                minDuration);
         }
 
-        public static TestInfo FromAbsolutePaths(string className, string methodName, string projectFilePath, string sourceCodeFilePath, int sourceCodeLineNumber, TestOutcome outcome, string classFilePath = null) {
+        public static TestInfo FromAbsolutePaths(string className, string methodName, string projectFilePath, string sourceCodeFilePath, int sourceCodeLineNumber, TestOutcome outcome, string classFilePath = null, TimeSpan? minDuration = null) {
             TestInfo ti = new TestInfo();
             ti.ClassName = className;
             ti.MethodName = methodName;
@@ -58,6 +60,7 @@ namespace TestAdapterTests {
             ti.Outcome = outcome;
             ti.ClassFilePath = classFilePath ?? sourceCodeFilePath;
             ti.RelativeClassFilePath = CommonUtils.GetRelativeFilePath(Path.GetDirectoryName(ti.ProjectFilePath), ti.ClassFilePath);
+            ti.MinDuration = minDuration ?? TimeSpan.Zero;
             return ti;
         }
 
@@ -149,5 +152,9 @@ namespace TestAdapterTests {
 
         public static string TestAdapterExtensionReferenceProject = TestData.GetPath(@"TestData\TestAdapterTests\ExtensionReferenceTest.pyproj");
         public static TestInfo ExtensionReferenceTestSuccess = TestInfo.FromRelativePaths("SpamTests", "test_spam", @"TestData\TestAdapterTests\ExtensionReferenceTest.pyproj", @"TestData\TestAdapterTests\ExtensionReferenceTest.py", 5, TestOutcome.Passed);
+
+        public static string TestAdapterDurationProject = TestData.GetPath(@"TestData\TestAdapterTests\DurationTest.pyproj");
+        public static TestInfo DurationSleep01TestSuccess = TestInfo.FromRelativePaths("DurationTests", "test_sleep_0_1", @"TestData\TestAdapterTests\DurationTest.pyproj", @"TestData\TestAdapterTests\DurationTest.py", 5, TestOutcome.Passed, minDuration: TimeSpan.FromSeconds(0.1));
+        public static TestInfo DurationSleep05TestFailure = TestInfo.FromRelativePaths("DurationTests", "test_sleep_0_5", @"TestData\TestAdapterTests\DurationTest.pyproj", @"TestData\TestAdapterTests\DurationTest.py", 8, TestOutcome.Failed, minDuration: TimeSpan.FromSeconds(0.5));
     }
 }

--- a/Python/Tests/TestData/TestAdapterTests/DurationTest.py
+++ b/Python/Tests/TestData/TestAdapterTests/DurationTest.py
@@ -5,8 +5,17 @@ class DurationTests(unittest.TestCase):
     def test_sleep_0_1(self):
         time.sleep(0.1)
 
+    def test_sleep_0_3(self):
+        time.sleep(0.3)
+
     def test_sleep_0_5(self):
         time.sleep(0.5)
+
+    def test_sleep_0_8(self):
+        time.sleep(0.8)
+
+    def test_sleep_1_5(self):
+        time.sleep(1.5)
         self.assertTrue(False)
 
 if __name__ == '__main__':

--- a/Python/Tests/TestData/TestAdapterTests/DurationTest.py
+++ b/Python/Tests/TestData/TestAdapterTests/DurationTest.py
@@ -1,0 +1,13 @@
+import unittest
+import time
+
+class DurationTests(unittest.TestCase):
+    def test_sleep_0_1(self):
+        time.sleep(0.1)
+
+    def test_sleep_0_5(self):
+        time.sleep(0.5)
+        self.assertTrue(False)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/Python/Tests/TestData/TestAdapterTests/DurationTest.pyproj
+++ b/Python/Tests/TestData/TestAdapterTests/DurationTest.pyproj
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>1E2F00BC-96DA-4D81-A421-054DC473B332</ProjectGuid>
+    <ProjectHome>.</ProjectHome>
+    <StartupFile>DurationTest.py</StartupFile>
+    <WorkingDirectory>.</WorkingDirectory>
+    <OutputPath>.</OutputPath>
+    <Name>DurationTest</Name>
+    <RootNamespace>DurationTest</RootNamespace>
+    <IsWindowsApplication>False</IsWindowsApplication>
+    <InterpreterId>Global|PythonCore|2.7</InterpreterId>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
+    <DebugSymbols>true</DebugSymbols>
+    <EnableUnmanagedDebugging>false</EnableUnmanagedDebugging>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+    <DebugSymbols>true</DebugSymbols>
+    <EnableUnmanagedDebugging>false</EnableUnmanagedDebugging>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="DurationTest.py" />
+  </ItemGroup>
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\Python Tools\Microsoft.PythonTools.targets" />
+</Project>


### PR DESCRIPTION
Fix #2822 After running tests, elapsed time is incorrect

(will wait to merge - this is a 3.2 bug)