### PR TITLE
Fix #2842: Stop Debugging asserts while debugging unit tests

### DIFF
--- a/Python/Product/Debugger/Debugger/DebugConnection.cs
+++ b/Python/Product/Debugger/Debugger/DebugConnection.cs
@@ -200,6 +200,7 @@ namespace Microsoft.PythonTools.Debugger {
                 if (!paused && _eventsPending.TryDequeue(out eventReceived)) {
                     try {
                         HandleEvent(eventReceived);
+                    } catch (OperationCanceledException) {
                     } catch (Exception e) when (!e.IsCriticalException()) {
                         Debug.Fail(string.Format("Error while handling debugger event '{0}'.\n{1}", eventReceived.Name, e));
                     }

--- a/Python/Product/Debugger/Debugger/PythonProcess.cs
+++ b/Python/Product/Debugger/Debugger/PythonProcess.cs
@@ -183,7 +183,13 @@ namespace Microsoft.PythonTools.Debugger {
             DebugConnectionListener.UnregisterProcess(_processGuid);
 
             if (disposing) {
+                DebugConnection connection;
+                Process process;
+
                 lock (_connectionLock) {
+                    connection = _connection;
+                    process = _process;
+
                     if (_connection != null) {
                         _connection.ProcessingMessagesEnded -= OnProcessingMessagesEnded;
                         _connection.LegacyAsyncBreak -= OnLegacyAsyncBreak;
@@ -205,13 +211,16 @@ namespace Microsoft.PythonTools.Debugger {
                         _connection.LegacyThreadExit -= OnLegacyThreadExit;
                         _connection.LegacyThreadFrameList -= OnLegacyThreadFrameList;
                         _connection.LegacyModulesChanged -= OnLegacyModulesChanged;
-                        _connection.Dispose();
                         _connection = null;
                     }
-                    // Avoiding ?. syntax because FxCop doesn't understand it
-                    if (_process != null) {
-                        _process.Dispose();
-                    }
+                }
+
+                if (connection != null) {
+                    connection.Dispose();
+                }
+
+                if (process != null) {
+                    process.Dispose();
                 }
 
                 _connectedEvent.Dispose();

--- a/Python/Tests/TestData/DebuggerProject/AttachPtvsdUnitTest.py
+++ b/Python/Tests/TestData/DebuggerProject/AttachPtvsdUnitTest.py
@@ -1,0 +1,13 @@
+import sys
+if '.' not in sys.path: sys.path.insert(0, '.') # so that we can find ptvsd
+
+import ptvsd
+ptvsd.enable_attach('secret', redirect_output=False)
+ptvsd.wait_for_attach()
+
+import unittest
+
+class Test_test1(unittest.TestCase):
+    def test_A(self):
+        self.fail("Not implemented")
+unittest.main()


### PR DESCRIPTION
Prevent deadlock when disposing debugger connection.

Gracefully handle cancellation from debugger event handlers to prevent asserts during connection teardown.

