### PR TITLE
Fix #2797: Import tensorflow module in PTVS is very slow

### DIFF
--- a/Python/Product/Debugger/Debugger.csproj
+++ b/Python/Product/Debugger/Debugger.csproj
@@ -83,6 +83,10 @@
       <EmbedInteropTypes>True</EmbedInteropTypes>
       <HintPath>DkmDebugger\Microsoft.Dia.Interop.$(VSTarget).dll</HintPath>
     </Reference>
+    <Reference Include="Newtonsoft.Json">
+      <HintPath>$(PackagesPath)\Newtonsoft.Json\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
   </ItemGroup>
   <Choose>
     <When Condition="$(VSTarget) == '15.0'">

--- a/Python/Product/Debugger/Debugger/OutputEventArgs.cs
+++ b/Python/Product/Debugger/Debugger/OutputEventArgs.cs
@@ -17,33 +17,23 @@
 using System;
 
 namespace Microsoft.PythonTools.Debugger {
+    enum OutputChannel {
+        Debug,
+        StdOut, 
+        StdErr,
+    }
+
     sealed class OutputEventArgs : EventArgs {
-        private readonly string _output;
-        private readonly PythonThread _thread;
-        private readonly bool _isStdOut;
-
-        public OutputEventArgs(PythonThread thread, string output, bool isStdOut) {
-            _thread = thread;
-            _output = output;
-            _isStdOut = isStdOut;
+        public OutputEventArgs(PythonThread thread, string output, OutputChannel channel) {
+            Thread = thread;
+            Output = output;
+            Channel = channel;
         }
 
-        public PythonThread Thread {
-            get {
-                return _thread;
-            }
-        }
+        public PythonThread Thread { get; }
 
-        public string Output {
-            get {
-                return _output;
-            }
-        }
+        public string Output { get; }
 
-        public bool IsStdOut {
-            get {
-                return _isStdOut;
-            }
-        }
+        public OutputChannel Channel { get; }
     }
 }

--- a/Python/Product/Debugger/Debugger/PythonProcess.cs
+++ b/Python/Product/Debugger/Debugger/PythonProcess.cs
@@ -591,7 +591,22 @@ namespace Microsoft.PythonTools.Debugger {
                 thread = null;
             }
 
-            DebuggerOutput?.Invoke(this, new OutputEventArgs(thread, e.output, e.isStdOut));
+            OutputChannel channel;
+            switch (e.channel) {
+                case LDP.OutputChannel.debug:
+                    channel = OutputChannel.Debug;
+                    break;
+                case LDP.OutputChannel.stdout:
+                    channel = OutputChannel.StdOut;
+                    break;
+                case LDP.OutputChannel.stderr:
+                    channel = OutputChannel.StdErr;
+                    break;
+                default:
+                    throw new ArgumentException("Invalid channel", "e");
+            }
+
+            DebuggerOutput?.Invoke(this, new OutputEventArgs(thread, e.output, channel));
         }
 
         private void OnLegacyAsyncBreak(object sender, LDP.AsyncBreakEvent e) {

--- a/Python/Product/PythonTools/PythonTools/Repl/PythonDebugProcessReplEvaluator.cs
+++ b/Python/Product/PythonTools/PythonTools/Repl/PythonDebugProcessReplEvaluator.cs
@@ -162,10 +162,13 @@ namespace Microsoft.PythonTools.Repl {
             };
 
             EventHandler<OutputEventArgs> debuggerOutput = (object sender, OutputEventArgs e) => {
-                if (e.IsStdOut) {
-                    WriteOutput(e.Output, addNewline: false);
-                } else {
-                    WriteError(e.Output, addNewline: false);
+                switch (e.Channel) {
+                    case OutputChannel.StdOut:
+                        WriteOutput(e.Output, addNewline: false);
+                        break;
+                    case OutputChannel.StdErr:
+                        WriteError(e.Output, addNewline: false);
+                        break;
                 }
             };
 


### PR DESCRIPTION
Disable tracing while importing stdlib modules.