### PR TITLE
Fixes #2400 Publish ptvsd with next update

### DIFF
--- a/Python/Product/PythonTools/ptvsd/setup.cfg
+++ b/Python/Product/PythonTools/ptvsd/setup.cfg
@@ -1,0 +1,2 @@
+[wheel]
+universal = 1

--- a/Python/Product/PythonTools/ptvsd/setup.py
+++ b/Python/Product/PythonTools/ptvsd/setup.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 #--------------------------------------------------------------------------
 
-from distutils.core import setup
+from setuptools import setup
 
 setup(name='ptvsd',
       version='3.2.0',


### PR DESCRIPTION
Fixes #2400 Publish ptvsd with next update
Updates ptvsd to use setuptools instead of distutils.
Enables building universal wheel for ptvsd

Once this is merged, I'll roll the change forward to master and up the ptvsd version.

It's already been published to https://pypi.org/project/ptvsd/3.2.0/ - note that the ptvsd and PTVS version numbers are not required to be in sync anymore.