### PR TITLE
Fixes #2904 Mixed-mode debugger does not support 3.7

### DIFF
--- a/Python/Product/Analysis/Parsing/PythonLanguageVersion.cs
+++ b/Python/Product/Analysis/Parsing/PythonLanguageVersion.cs
@@ -34,7 +34,8 @@ namespace Microsoft.PythonTools.Parsing {
         V33 = 0x0303,
         V34 = 0x0304,
         V35 = 0x0305,
-        V36 = 0x0306
+        V36 = 0x0306,
+        V37 = 0x0307
     }
 
     public static class PythonLanguageVersionExtensions {
@@ -55,31 +56,9 @@ namespace Microsoft.PythonTools.Parsing {
         }
 
         public static PythonLanguageVersion ToLanguageVersion(this Version version) {
-            switch (version.Major) {
-                case 0:
-                    switch (version.Minor) {
-                        case 0: return PythonLanguageVersion.None;
-                    }
-                    break;
-                case 2:
-                    switch (version.Minor) {
-                        case 4: return PythonLanguageVersion.V24;
-                        case 5: return PythonLanguageVersion.V25;
-                        case 6: return PythonLanguageVersion.V26;
-                        case 7: return PythonLanguageVersion.V27;
-                    }
-                    break;
-                case 3:
-                    switch (version.Minor) {
-                        case 0: return PythonLanguageVersion.V30;
-                        case 1: return PythonLanguageVersion.V31;
-                        case 2: return PythonLanguageVersion.V32;
-                        case 3: return PythonLanguageVersion.V33;
-                        case 4: return PythonLanguageVersion.V34;
-                        case 5: return PythonLanguageVersion.V35;
-                        case 6: return PythonLanguageVersion.V36;
-                    }
-                    break;
+            int value = (version.Major << 8) + version.Minor;
+            if (Enum.IsDefined(typeof(PythonLanguageVersion), value)) {
+                return (PythonLanguageVersion)value;
             }
             throw new InvalidOperationException(String.Format("Unsupported Python version: {0}", version.ToString()));
         }

--- a/Python/Product/Debugger/DkmDebugger/PythonRuntimeInfo.cs
+++ b/Python/Product/Debugger/DkmDebugger/PythonRuntimeInfo.cs
@@ -71,6 +71,7 @@ namespace Microsoft.PythonTools.DkmDebugger {
                 case "34": return PythonLanguageVersion.V34;
                 case "35": return PythonLanguageVersion.V35;
                 case "36": return PythonLanguageVersion.V36;
+                case "37": return PythonLanguageVersion.V37;
                 default: return PythonLanguageVersion.None;
             }
         }

--- a/Python/Product/EnvironmentsList/ConfigurationExtension.xaml.cs
+++ b/Python/Product/EnvironmentsList/ConfigurationExtension.xaml.cs
@@ -329,7 +329,8 @@ namespace Microsoft.PythonTools.EnvironmentsList {
             "3.3",
             "3.4",
             "3.5",
-            "3.6"
+            "3.6",
+            "3.7"
         };
 
         private readonly EnvironmentView _view;

--- a/Python/Product/VsPyProf/PythonApi.cpp
+++ b/Python/Product/VsPyProf/PythonApi.cpp
@@ -136,6 +136,8 @@ bool VsPyProf::GetUserToken(PyFrameObject* frameObj, DWORD_PTR& func, DWORD_PTR&
             filename = ((PyCodeObject33_35*)codeObj)->co_filename;
         } else if (PyCodeObject36::IsFor(MajorVersion, MinorVersion)) {
             filename = ((PyCodeObject36*)codeObj)->co_filename;
+        } else if (PyCodeObject37::IsFor(MajorVersion, MinorVersion)) {
+            filename = ((PyCodeObject37*)codeObj)->co_filename;
         }
         module = (DWORD_PTR)filename;
 
@@ -250,6 +252,9 @@ wstring VsPyProf::GetClassNameFromFrame(PyFrameObject* frameObj, PyObject *codeO
         } else if (PyCodeObject36::IsFor(MajorVersion, MinorVersion)) {
             argCount = ((PyCodeObject36*)codeObj)->co_argcount;
             argNames = (PyTupleObject*)((PyCodeObject36*)codeObj)->co_varnames;
+        } else if (PyCodeObject37::IsFor(MajorVersion, MinorVersion)) {
+            argCount = ((PyCodeObject37*)codeObj)->co_argcount;
+            argNames = (PyTupleObject*)((PyCodeObject37*)codeObj)->co_varnames;
         }
 
         if (argCount != 0 && argNames && argNames->ob_type == PyTuple_Type) {
@@ -260,8 +265,8 @@ wstring VsPyProf::GetClassNameFromFrame(PyFrameObject* frameObj, PyObject *codeO
                 PyObject* self = nullptr;
                 if (PyFrameObject25_33::IsFor(MajorVersion, MinorVersion)) {
                     self = ((PyFrameObject25_33*)frameObj)->f_localsplus[0];
-                } else if (PyFrameObject34_36::IsFor(MajorVersion, MinorVersion)) {
-                    self = ((PyFrameObject34_36*)frameObj)->f_localsplus[0];
+                } else if (PyFrameObject34_37::IsFor(MajorVersion, MinorVersion)) {
+                    self = ((PyFrameObject34_37*)frameObj)->f_localsplus[0];
                 }
                 return GetClassNameFromSelf(self, codeObj);
             }

--- a/Python/Tests/Analysis/ParserTests.cs
+++ b/Python/Tests/Analysis/ParserTests.cs
@@ -40,7 +40,7 @@ namespace AnalysisTests {
             PythonTestData.Deploy();
         }
 
-        internal static readonly PythonLanguageVersion[] AllVersions = new[] { PythonLanguageVersion.V24, PythonLanguageVersion.V25, PythonLanguageVersion.V26, PythonLanguageVersion.V27, PythonLanguageVersion.V30, PythonLanguageVersion.V31, PythonLanguageVersion.V32, PythonLanguageVersion.V33, PythonLanguageVersion.V34, PythonLanguageVersion.V35, PythonLanguageVersion.V36 };
+        internal static readonly PythonLanguageVersion[] AllVersions = new[] { PythonLanguageVersion.V24, PythonLanguageVersion.V25, PythonLanguageVersion.V26, PythonLanguageVersion.V27, PythonLanguageVersion.V30, PythonLanguageVersion.V31, PythonLanguageVersion.V32, PythonLanguageVersion.V33, PythonLanguageVersion.V34, PythonLanguageVersion.V35, PythonLanguageVersion.V36, PythonLanguageVersion.V37 };
         internal static readonly PythonLanguageVersion[] V25AndUp = AllVersions.Where(v => v >= PythonLanguageVersion.V25).ToArray();
         internal static readonly PythonLanguageVersion[] V26AndUp = AllVersions.Where(v => v >= PythonLanguageVersion.V26).ToArray();
         internal static readonly PythonLanguageVersion[] V27AndUp = AllVersions.Where(v => v >= PythonLanguageVersion.V27).ToArray();

--- a/Python/Tests/Core/DebugReplEvaluatorTests.cs
+++ b/Python/Tests/Core/DebugReplEvaluatorTests.cs
@@ -536,6 +536,21 @@ NameError: name 'does_not_exist' is not defined
     }
 
     [TestClass]
+    public class DebugReplEvaluatorTests37 : DebugReplEvaluatorTests {
+        [ClassInitialize]
+        public static new void DoDeployment(TestContext context) {
+            AssertListener.Initialize();
+            PythonTestData.Deploy();
+        }
+
+        internal override PythonVersion Version {
+            get {
+                return PythonPaths.Python37 ?? PythonPaths.Python37_x64;
+            }
+        }
+    }
+
+    [TestClass]
     public class DebugReplEvaluatorTests27 : DebugReplEvaluatorTests {
         [ClassInitialize]
         public static new void DoDeployment(TestContext context) {

--- a/Python/Tests/DebuggerTests/AttachTests.cs
+++ b/Python/Tests/DebuggerTests/AttachTests.cs
@@ -1383,10 +1383,32 @@ int main(int argc, char* argv[]) {
     }
 
     [TestClass]
-    public class AttachTests36_x64 : AttachTests35 {
+    public class AttachTests36_x64 : AttachTests36 {
         internal override PythonVersion Version {
             get {
                 return PythonPaths.Python36_x64;
+            }
+        }
+    }
+
+    [TestClass]
+    public class AttachTests37 : AttachTests {
+        internal override PythonVersion Version {
+            get {
+                return PythonPaths.Python37;
+            }
+        }
+
+        public override async Task AttachNewThread_PyThreadState_New() {
+            // PyEval_AcquireLock deprecated in 3.2
+        }
+    }
+
+    [TestClass]
+    public class AttachTests37_x64 : AttachTests37 {
+        internal override PythonVersion Version {
+            get {
+                return PythonPaths.Python37_x64;
             }
         }
     }

--- a/Python/Tests/DebuggerTests/DebuggerTests.cs
+++ b/Python/Tests/DebuggerTests/DebuggerTests.cs
@@ -2317,6 +2317,24 @@ namespace DebuggerTests {
     }
 
     [TestClass]
+    public class DebuggerTests37 : DebuggerTests3x {
+        internal override PythonVersion Version {
+            get {
+                return PythonPaths.Python37;
+            }
+        }
+    }
+
+    [TestClass]
+    public class DebuggerTests37_x64 : DebuggerTests37 {
+        internal override PythonVersion Version {
+            get {
+                return PythonPaths.Python37_x64;
+            }
+        }
+    }
+
+    [TestClass]
     public class DebuggerTests26 : DebuggerTests {
         internal override PythonVersion Version {
             get {

--- a/Python/Tests/ProfilingUITests/ProfilingUITests.cs
+++ b/Python/Tests/ProfilingUITests/ProfilingUITests.cs
@@ -1530,6 +1530,26 @@ namespace ProfilingUITests {
 
         [TestMethod, Priority(1)]
         [HostType("VSTestHost"), TestCategory("Installed")]
+        public void BuiltinsProfilePython37() {
+            BuiltinsProfile(
+                PythonPaths.Python37,
+                new[] { "BuiltinsProfile.f", "str.startswith", "isinstance", "marshal.dumps", "array.array.tostring" },
+                new[] { "compile", "exec", "execfile", "_io.TextIOWrapper.read" }
+            );
+        }
+
+        [TestMethod, Priority(1)]
+        [HostType("VSTestHost"), TestCategory("Installed")]
+        public void BuiltinsProfilePython37x64() {
+            BuiltinsProfile(
+                PythonPaths.Python37_x64,
+                new[] { "BuiltinsProfile.f", "str.startswith", "isinstance", "marshal.dumps", "array.array.tostring" },
+                new[] { "compile", "exec", "execfile", "_io.TextIOWrapper.read" }
+            );
+        }
+
+        [TestMethod, Priority(1)]
+        [HostType("VSTestHost"), TestCategory("Installed")]
         public void LaunchExecutableUsingInterpreterGuid() {
             PythonPaths.Python27.AssertInstalled();
 

--- a/Python/Tests/Utilities.Python.Analysis/PythonPaths.cs
+++ b/Python/Tests/Utilities.Python.Analysis/PythonPaths.cs
@@ -42,6 +42,7 @@ namespace TestUtilities {
         public static readonly PythonVersion Python34 = GetCPythonVersion(PythonLanguageVersion.V34, InterpreterArchitecture.x86);
         public static readonly PythonVersion Python35 = GetCPythonVersion(PythonLanguageVersion.V35, InterpreterArchitecture.x86);
         public static readonly PythonVersion Python36 = GetCPythonVersion(PythonLanguageVersion.V36, InterpreterArchitecture.x86);
+        public static readonly PythonVersion Python37 = GetCPythonVersion(PythonLanguageVersion.V37, InterpreterArchitecture.x86);
         public static readonly PythonVersion IronPython27 = GetIronPythonVersion(false);
         public static readonly PythonVersion Python25_x64 = GetCPythonVersion(PythonLanguageVersion.V25, InterpreterArchitecture.x64);
         public static readonly PythonVersion Python26_x64 = GetCPythonVersion(PythonLanguageVersion.V26, InterpreterArchitecture.x64);
@@ -53,6 +54,7 @@ namespace TestUtilities {
         public static readonly PythonVersion Python34_x64 = GetCPythonVersion(PythonLanguageVersion.V34, InterpreterArchitecture.x64);
         public static readonly PythonVersion Python35_x64 = GetCPythonVersion(PythonLanguageVersion.V35, InterpreterArchitecture.x64);
         public static readonly PythonVersion Python36_x64 = GetCPythonVersion(PythonLanguageVersion.V36, InterpreterArchitecture.x64);
+        public static readonly PythonVersion Python37_x64 = GetCPythonVersion(PythonLanguageVersion.V37, InterpreterArchitecture.x64);
         public static readonly PythonVersion Anaconda36 = GetAnacondaVersion(PythonLanguageVersion.V36, InterpreterArchitecture.x86);
         public static readonly PythonVersion Anaconda36_x64 = GetAnacondaVersion(PythonLanguageVersion.V36, InterpreterArchitecture.x64);
         public static readonly PythonVersion IronPython27_x64 = GetIronPythonVersion(true);
@@ -208,6 +210,7 @@ namespace TestUtilities {
                 if (Python34 != null) yield return Python34;
                 if (Python35 != null) yield return Python35;
                 if (Python36 != null) yield return Python36;
+                if (Python37 != null) yield return Python37;
                 if (IronPython27 != null) yield return IronPython27;
                 if (Python25_x64 != null) yield return Python25_x64;
                 if (Python26_x64 != null) yield return Python26_x64;
@@ -219,6 +222,7 @@ namespace TestUtilities {
                 if (Python34_x64 != null) yield return Python34_x64;
                 if (Python35_x64 != null) yield return Python35_x64;
                 if (Python36_x64 != null) yield return Python36_x64;
+                if (Python37_x64 != null) yield return Python37_x64;
                 if (IronPython27_x64 != null) yield return IronPython27_x64;
                 if (Jython27 != null) yield return Jython27;
             }


### PR DESCRIPTION
Fixes #2904 Mixed-mode debugger does not support 3.7
Adds support for version 3.7 to whole system

I don't think I missed any lists of versions - in general everything should go through the `PythonLanguageVersion` enum (which is now easier to maintain).

I checked the diff between 3.6 and 3.7 as well and there don't seem to be any changes needed in the structures just yet, but there's still time :)

Biggest value of this is that when combined with the VC debug launcher we'll be able to actively use this when working on CPython.