### PR TITLE
Fixes #2900 Preparing cookiecutter message not themed

### DIFF
--- a/Python/Product/Cookiecutter/View/CookiecutterSearchPage.xaml
+++ b/Python/Product/Cookiecutter/View/CookiecutterSearchPage.xaml
@@ -168,12 +168,12 @@
                                             Margin="0 0 0 2"
                                             Moniker="{x:Static rc:ImageMonikers.CookiecutterTemplateWarning}">
                         </imaging:CrispImage>
-                        <ccv:LiveTextBlock Margin="3 3"
+                        <TextBlock Margin="3 3"
                                    Text="{Binding Path=ErrorDescription}">
-                            <ccv:LiveTextBlock.ToolTip>
+                            <TextBlock.ToolTip>
                                 <TextBlock TextWrapping="Wrap" Text="{Binding Path=ErrorDetails}"/>
-                            </ccv:LiveTextBlock.ToolTip>
-                        </ccv:LiveTextBlock>
+                            </TextBlock.ToolTip>
+                        </TextBlock>
                     </StackPanel>
                 </DataTemplate>
                 <DataTemplate DataType="{x:Type vm:LoadingViewModel}">
@@ -239,11 +239,33 @@
                     <imaging:CrispImage Width="16" Height="16"
                                         Moniker="{Binding StatusImage}"
                                         AutomationProperties.HelpText="{Binding StatusMessage}"
-                                        Visibility="{Binding StatusImageVisibility}"/>
-                    <ccv:LiveTextBlock Margin="4 0 0 0"
-                                       Text="{Binding StatusMessage}"
-                                       TextWrapping="Wrap"
-                                       ToolTip="{Binding StatusHelp}" />
+                                        Visibility="{Binding StatusImageVisibility}" />
+                    <imaging:CrispImage Width="16" Height="16"
+                                        Moniker="{Binding StatusImage}"
+                                        AutomationProperties.HelpText="{Binding StatusMessage}"
+                                        Visibility="{Binding SpinningStatusImageVisibility}"
+                                        RenderTransformOrigin="0.5, 0.5">
+                        <imaging:CrispImage.RenderTransform>
+                            <RotateTransform x:Name="Rotation" />
+                        </imaging:CrispImage.RenderTransform>
+                        <imaging:CrispImage.Triggers>
+                            <EventTrigger RoutedEvent="Image.Loaded">
+                                <BeginStoryboard>
+                                    <Storyboard>
+                                        <DoubleAnimation Storyboard.TargetName="Rotation"
+                                                         Storyboard.TargetProperty="Angle"
+                                                         By="360.0"
+                                                         Duration="0:0:2.0"
+                                                         RepeatBehavior="Forever" />
+                                    </Storyboard>
+                                </BeginStoryboard>
+                            </EventTrigger>
+                        </imaging:CrispImage.Triggers>
+                    </imaging:CrispImage>
+                    <TextBlock Margin="4 0 0 0"
+                               Text="{Binding StatusMessage}"
+                               TextWrapping="Wrap"
+                               ToolTip="{Binding StatusHelp}" />
                 </StackPanel>
                 <ProgressBar Margin="4" IsIndeterminate="True"
                              Visibility="{Binding StatusProgressVisibility}"/>

--- a/Python/Product/Cookiecutter/View/LiveTextBlock.cs
+++ b/Python/Product/Cookiecutter/View/LiveTextBlock.cs
@@ -21,77 +21,76 @@ using System.Windows.Automation.Peers;
 using System.Windows.Automation.Provider;
 using System.Windows.Controls;
 using System.Windows.Data;
-using Microsoft.Internal.VisualStudio.PlatformUI.Automation;
 
 namespace Microsoft.CookiecutterTools.View {
-    public sealed class LiveTextBlock : TextBlock {
-        public LiveTextBlock() {
-            // Bind LiveText to the Text property.
-            // They are not set independently - this just gives us the
-            // notification when it changes
-            SetBinding(
-                LiveTextProperty,
-                new Binding {
-                    Path = new PropertyPath(TextProperty),
-                    Source = this,
-                    Mode = BindingMode.OneWay
-                }
-            );
+    //public sealed class LiveTextBlock : TextBlock {
+    //    public LiveTextBlock() {
+    //        // Bind LiveText to the Text property.
+    //        // They are not set independently - this just gives us the
+    //        // notification when it changes
+    //        SetBinding(
+    //            LiveTextProperty,
+    //            new Binding {
+    //                Path = new PropertyPath(TextProperty),
+    //                Source = this,
+    //                Mode = BindingMode.OneWay
+    //            }
+    //        );
 
-            Loaded += LiveTextBlock_Loaded;
-            IsVisibleChanged += LiveTextBlock_IsVisibleChanged;
-        }
+    //        Loaded += LiveTextBlock_Loaded;
+    //        IsVisibleChanged += LiveTextBlock_IsVisibleChanged;
+    //    }
 
-        private void LiveTextBlock_IsVisibleChanged(object sender, DependencyPropertyChangedEventArgs e) {
-            if (e.NewValue is bool && (bool)e.NewValue) {
-                SetLiveProperty();
-            }
-        }
+    //    private void LiveTextBlock_IsVisibleChanged(object sender, DependencyPropertyChangedEventArgs e) {
+    //        if (e.NewValue is bool && (bool)e.NewValue) {
+    //            SetLiveProperty();
+    //        }
+    //    }
 
-        private void LiveTextBlock_Loaded(object sender, RoutedEventArgs e) {
-            SetLiveProperty();
-            Loaded -= LiveTextBlock_Loaded;
-        }
+    //    private void LiveTextBlock_Loaded(object sender, RoutedEventArgs e) {
+    //        SetLiveProperty();
+    //        Loaded -= LiveTextBlock_Loaded;
+    //    }
 
-        private static void SetLivePropertyWorker(UIElement obj) {
-            var peer = UIElementAutomationPeer.CreatePeerForElement(obj) as LiveTextBlockAutomationPeer;
-            if (peer == null) {
-                return;
-            }
+    //    private static void SetLivePropertyWorker(UIElement obj) {
+    //        var peer = UIElementAutomationPeer.CreatePeerForElement(obj) as LiveTextBlockAutomationPeer;
+    //        if (peer == null) {
+    //            return;
+    //        }
 
-            CustomAutomationProperties.SetLiveSetting(obj, AutomationLiveSetting.Polite);
-            peer.RaiseCustomAutomationEvent(CustomAutomationEvents.LiveRegionChangedEvent);
-        }
+    //        CustomAutomationProperties.SetLiveSetting(obj, AutomationLiveSetting.Polite);
+    //        peer.RaiseCustomAutomationEvent(CustomAutomationEvents.LiveRegionChangedEvent);
+    //    }
 
-        private void SetLiveProperty() {
-            // HACK: This function uses an internal API that may change.
-            // We're using it for now until the support arrives in WPF properly,
-            // and we will try to detect and warn about changes so we degrade
-            // gracefully.
-            try {
-                SetLivePropertyWorker(this);
-            } catch (Exception) {
-                Debug.Fail("Internal LiveSetting API is broken");
-            }
-        }
+    //    private void SetLiveProperty() {
+    //        // HACK: This function uses an internal API that may change.
+    //        // We're using it for now until the support arrives in WPF properly,
+    //        // and we will try to detect and warn about changes so we degrade
+    //        // gracefully.
+    //        try {
+    //            SetLivePropertyWorker(this);
+    //        } catch (Exception) {
+    //            Debug.Fail("Internal LiveSetting API is broken");
+    //        }
+    //    }
 
-        private static readonly DependencyProperty LiveTextProperty =
-            DependencyProperty.Register("LiveText", typeof(string), typeof(LiveTextBlock), new PropertyMetadata(null, OnTextChanged));
+    //    private static readonly DependencyProperty LiveTextProperty =
+    //        DependencyProperty.Register("LiveText", typeof(string), typeof(LiveTextBlock), new PropertyMetadata(null, OnTextChanged));
 
-        private static void OnTextChanged(DependencyObject d, DependencyPropertyChangedEventArgs e) {
-            (d as LiveTextBlock).SetLiveProperty();
-        }
+    //    private static void OnTextChanged(DependencyObject d, DependencyPropertyChangedEventArgs e) {
+    //        (d as LiveTextBlock).SetLiveProperty();
+    //    }
 
-        protected override AutomationPeer OnCreateAutomationPeer() {
-            return new LiveTextBlockAutomationPeer(this);
-        }
+    //    protected override AutomationPeer OnCreateAutomationPeer() {
+    //        return new LiveTextBlockAutomationPeer(this);
+    //    }
 
-        private class LiveTextBlockAutomationPeer : TextBlockAutomationPeer, ICustomAutomationEventSource {
-            public LiveTextBlockAutomationPeer(LiveTextBlock owner) : base(owner) { }
+    //    private class LiveTextBlockAutomationPeer : TextBlockAutomationPeer, ICustomAutomationEventSource {
+    //        public LiveTextBlockAutomationPeer(LiveTextBlock owner) : base(owner) { }
 
-            public IRawElementProviderSimple GetProvider() => ProviderFromPeer(this);
+    //        public IRawElementProviderSimple GetProvider() => ProviderFromPeer(this);
 
-            protected override string GetClassNameCore() => nameof(LiveTextBlock);
-        }
-    }
+    //        protected override string GetClassNameCore() => nameof(LiveTextBlock);
+    //    }
+    //}
 }

--- a/Python/Product/Cookiecutter/ViewModel/CookiecutterViewModel.cs
+++ b/Python/Product/Cookiecutter/ViewModel/CookiecutterViewModel.cs
@@ -78,6 +78,7 @@ namespace Microsoft.CookiecutterTools.ViewModel {
         private ImageMoniker _statusImage;
         private Visibility _statusVisibility = Visibility.Collapsed;
         private Visibility _statusImageVisibility = Visibility.Collapsed;
+        private Visibility _spinningStatusImageVisibility = Visibility.Collapsed;
         private Visibility _statusProgressVisibility = Visibility.Collapsed;
         private Visibility _statusUpdateProgressVisibility = Visibility.Collapsed;
 
@@ -225,6 +226,7 @@ namespace Microsoft.CookiecutterTools.ViewModel {
         public ImageMoniker StatusImage => _statusImage;
         public Visibility StatusVisibility => _statusVisibility;
         public Visibility StatusImageVisibility => _statusImageVisibility;
+        public Visibility SpinningStatusImageVisibility => _spinningStatusImageVisibility;
         public Visibility StatusProgressVisibility => _statusProgressVisibility;
         public Visibility StatusUpdateProgressVisibility => _statusUpdateProgressVisibility;
 
@@ -239,7 +241,8 @@ namespace Microsoft.CookiecutterTools.ViewModel {
             _statusMessage = message ?? string.Empty;
             _statusHelp = help ?? string.Empty;
             _statusImage = image ?? default(ImageMoniker);
-            _statusImageVisibility = image.HasValue ? Visibility.Visible : Visibility.Collapsed;
+            _statusImageVisibility = image.HasValue && !progressVisible ? Visibility.Visible : Visibility.Collapsed;
+            _spinningStatusImageVisibility = image.HasValue && progressVisible ? Visibility.Visible : Visibility.Collapsed;
             bool v = (visible ?? !string.IsNullOrEmpty(message));
             _statusVisibility = v ? Visibility.Visible : Visibility.Collapsed;
             _statusProgressVisibility = progressVisible ? Visibility.Visible : Visibility.Collapsed;
@@ -252,6 +255,7 @@ namespace Microsoft.CookiecutterTools.ViewModel {
             OnPropertyChange(nameof(StatusHelp));
             OnPropertyChange(nameof(StatusImage));
             OnPropertyChange(nameof(StatusImageVisibility));
+            OnPropertyChange(nameof(SpinningStatusImageVisibility));
             OnPropertyChange(nameof(StatusProgressVisibility));
             OnPropertyChange(nameof(StatusUpdateProgressVisibility));
             if (v) {

--- a/Python/Product/EnvironmentsList/DBExtension.xaml
+++ b/Python/Product/EnvironmentsList/DBExtension.xaml
@@ -105,14 +105,14 @@
                          Focusable="False"
                          ToolTipService.ShowDuration="{x:Static s:Int32.MaxValue}" />
 
-            <inf:LiveTextBlock HorizontalAlignment="Center"
-                               VerticalAlignment="Center"
-                               Visibility="{Binding RefreshProgressVisibility}"
-                               Margin="5 4"
-                               TextTrimming="CharacterEllipsis"
-                               IsHitTestVisible="False"
-                               Text="{Binding RefreshDBMessage,Mode=OneWay}"
-                               ToolTip="{Binding RefreshDBMessage,Mode=OneWay}"/>
+            <TextBlock HorizontalAlignment="Center"
+                       VerticalAlignment="Center"
+                       Visibility="{Binding RefreshProgressVisibility}"
+                       Margin="5 4"
+                       TextTrimming="CharacterEllipsis"
+                       IsHitTestVisible="False"
+                       Text="{Binding RefreshDBMessage,Mode=OneWay}"
+                       ToolTip="{Binding RefreshDBMessage,Mode=OneWay}"/>
         </Grid>
 
         <ListBox Grid.Row="2"

--- a/Python/Product/VSCommon/Infrastructure/LiveTextBlock.cs
+++ b/Python/Product/VSCommon/Infrastructure/LiveTextBlock.cs
@@ -21,77 +21,76 @@ using System.Windows.Automation.Peers;
 using System.Windows.Automation.Provider;
 using System.Windows.Controls;
 using System.Windows.Data;
-using Microsoft.Internal.VisualStudio.PlatformUI.Automation;
 
 namespace Microsoft.PythonTools.Infrastructure {
-    public sealed class LiveTextBlock : TextBlock {
-        public LiveTextBlock() {
-            // Bind LiveText to the Text property.
-            // They are not set independently - this just gives us the
-            // notification when it changes
-            SetBinding(
-                LiveTextProperty,
-                new Binding {
-                    Path = new PropertyPath(TextProperty),
-                    Source = this,
-                    Mode = BindingMode.OneWay
-                }
-            );
+    //public sealed class LiveTextBlock : TextBlock {
+    //    public LiveTextBlock() {
+    //        // Bind LiveText to the Text property.
+    //        // They are not set independently - this just gives us the
+    //        // notification when it changes
+    //        SetBinding(
+    //            LiveTextProperty,
+    //            new Binding {
+    //                Path = new PropertyPath(TextProperty),
+    //                Source = this,
+    //                Mode = BindingMode.OneWay
+    //            }
+    //        );
 
-            Loaded += LiveTextBlock_Loaded;
-            IsVisibleChanged += LiveTextBlock_IsVisibleChanged;
-        }
+    //        Loaded += LiveTextBlock_Loaded;
+    //        IsVisibleChanged += LiveTextBlock_IsVisibleChanged;
+    //    }
 
-        private void LiveTextBlock_IsVisibleChanged(object sender, DependencyPropertyChangedEventArgs e) {
-            if (e.NewValue is bool && (bool)e.NewValue) {
-                SetLiveProperty();
-            }
-        }
+    //    private void LiveTextBlock_IsVisibleChanged(object sender, DependencyPropertyChangedEventArgs e) {
+    //        if (e.NewValue is bool && (bool)e.NewValue) {
+    //            SetLiveProperty();
+    //        }
+    //    }
 
-        private void LiveTextBlock_Loaded(object sender, RoutedEventArgs e) {
-            SetLiveProperty();
-            Loaded -= LiveTextBlock_Loaded;
-        }
+    //    private void LiveTextBlock_Loaded(object sender, RoutedEventArgs e) {
+    //        SetLiveProperty();
+    //        Loaded -= LiveTextBlock_Loaded;
+    //    }
 
-        private static void SetLivePropertyWorker(UIElement obj) {
-            var peer = UIElementAutomationPeer.CreatePeerForElement(obj) as LiveTextBlockAutomationPeer;
-            if (peer == null) {
-                return;
-            }
+    //    private static void SetLivePropertyWorker(UIElement obj) {
+    //        var peer = UIElementAutomationPeer.CreatePeerForElement(obj) as LiveTextBlockAutomationPeer;
+    //        if (peer == null) {
+    //            return;
+    //        }
 
-            CustomAutomationProperties.SetLiveSetting(obj, AutomationLiveSetting.Polite);
-            peer.RaiseCustomAutomationEvent(CustomAutomationEvents.LiveRegionChangedEvent);
-        }
+    //        CustomAutomationProperties.SetLiveSetting(obj, AutomationLiveSetting.Polite);
+    //        peer.RaiseCustomAutomationEvent(CustomAutomationEvents.LiveRegionChangedEvent);
+    //    }
 
-        private void SetLiveProperty() {
-            // HACK: This function uses an internal API that may change.
-            // We're using it for now until the support arrives in WPF properly,
-            // and we will try to detect and warn about changes so we degrade
-            // gracefully.
-            try {
-                SetLivePropertyWorker(this);
-            } catch (Exception) {
-                Debug.Fail("Internal LiveSetting API is broken");
-            }
-        }
+    //    private void SetLiveProperty() {
+    //        // HACK: This function uses an internal API that may change.
+    //        // We're using it for now until the support arrives in WPF properly,
+    //        // and we will try to detect and warn about changes so we degrade
+    //        // gracefully.
+    //        try {
+    //            SetLivePropertyWorker(this);
+    //        } catch (Exception) {
+    //            Debug.Fail("Internal LiveSetting API is broken");
+    //        }
+    //    }
 
-        private static readonly DependencyProperty LiveTextProperty =
-            DependencyProperty.Register("LiveText", typeof(string), typeof(LiveTextBlock), new PropertyMetadata(null, OnTextChanged));
+    //    private static readonly DependencyProperty LiveTextProperty =
+    //        DependencyProperty.Register("LiveText", typeof(string), typeof(LiveTextBlock), new PropertyMetadata(null, OnTextChanged));
 
-        private static void OnTextChanged(DependencyObject d, DependencyPropertyChangedEventArgs e) {
-            (d as LiveTextBlock).SetLiveProperty();
-        }
+    //    private static void OnTextChanged(DependencyObject d, DependencyPropertyChangedEventArgs e) {
+    //        (d as LiveTextBlock).SetLiveProperty();
+    //    }
 
-        protected override AutomationPeer OnCreateAutomationPeer() {
-            return new LiveTextBlockAutomationPeer(this);
-        }
+    //    protected override AutomationPeer OnCreateAutomationPeer() {
+    //        return new LiveTextBlockAutomationPeer(this);
+    //    }
 
-        private class LiveTextBlockAutomationPeer : TextBlockAutomationPeer, ICustomAutomationEventSource {
-            public LiveTextBlockAutomationPeer(LiveTextBlock owner) : base(owner) { }
+    //    private class LiveTextBlockAutomationPeer : TextBlockAutomationPeer, ICustomAutomationEventSource {
+    //        public LiveTextBlockAutomationPeer(LiveTextBlock owner) : base(owner) { }
 
-            public IRawElementProviderSimple GetProvider() => ProviderFromPeer(this);
+    //        public IRawElementProviderSimple GetProvider() => ProviderFromPeer(this);
 
-            protected override string GetClassNameCore() => nameof(LiveTextBlock);
-        }
-    }
+    //        protected override string GetClassNameCore() => nameof(LiveTextBlock);
+    //    }
+    //}
 }


### PR DESCRIPTION
Fixes #2900 Preparing cookiecutter message not themed
Removes (broken) live text blocks
Makes status image spinnable.