### PR TITLE
Fixes #2908 Ast interpreter needs to scrape its own builtin types

### DIFF
--- a/Python/Product/Analysis/Analysis.csproj
+++ b/Python/Product/Analysis/Analysis.csproj
@@ -61,6 +61,7 @@
     <Compile Include="Interpreter\Ast\AstAnalysisFunctionWalker.cs" />
     <Compile Include="Interpreter\Ast\AstAnalysisWalker.cs" />
     <Compile Include="IHasRichDescription.cs" />
+    <Compile Include="Interpreter\Ast\AstBuiltinsPythonModule.cs" />
     <Compile Include="Interpreter\Ast\AstPythonBuiltinType.cs" />
     <Compile Include="Interpreter\Ast\AstPythonInterpreter.cs" />
     <Compile Include="Interpreter\Ast\AstNestedPythonModule.cs" />

--- a/Python/Product/Analysis/Analysis.csproj
+++ b/Python/Product/Analysis/Analysis.csproj
@@ -395,6 +395,7 @@
       <IncludeInVSIX>true</IncludeInVSIX>
       <VSIXSubPath>.</VSIXSubPath>
     </Content>
+    <Content Include="scrape_builtins.py" />
     <Content Include="scrape_module.py">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <IncludeInVSIX>true</IncludeInVSIX>

--- a/Python/Product/Analysis/Analysis.csproj
+++ b/Python/Product/Analysis/Analysis.csproj
@@ -61,6 +61,7 @@
     <Compile Include="Interpreter\Ast\AstAnalysisFunctionWalker.cs" />
     <Compile Include="Interpreter\Ast\AstAnalysisWalker.cs" />
     <Compile Include="IHasRichDescription.cs" />
+    <Compile Include="Interpreter\Ast\AstPythonBuiltinType.cs" />
     <Compile Include="Interpreter\Ast\AstPythonInterpreter.cs" />
     <Compile Include="Interpreter\Ast\AstNestedPythonModule.cs" />
     <Compile Include="Interpreter\Ast\AstPythonType.cs" />

--- a/Python/Product/Analysis/Analysis.csproj
+++ b/Python/Product/Analysis/Analysis.csproj
@@ -58,6 +58,7 @@
   <ItemGroup>
     <Compile Include="AggregateProjectEntry.cs" />
     <Compile Include="AnalysisDictionary.cs" />
+    <Compile Include="Interpreter\Ast\AstAnalysisFunctionWalker.cs" />
     <Compile Include="Interpreter\Ast\AstAnalysisWalker.cs" />
     <Compile Include="IHasRichDescription.cs" />
     <Compile Include="Interpreter\Ast\AstPythonInterpreter.cs" />
@@ -70,6 +71,7 @@
     <Compile Include="Interpreter\Ast\AstPythonParameterInfo.cs" />
     <Compile Include="Interpreter\Ast\AstPythonInterpreterFactory.cs" />
     <Compile Include="Interpreter\Ast\AstScrapedPythonModule.cs" />
+    <Compile Include="Interpreter\Ast\NameLookupContext.cs" />
     <Compile Include="Interpreter\EmptyModule.cs" />
     <Compile Include="Interpreter\GlobalInterpreterOptions.cs" />
     <Compile Include="Interpreter\InterpreterArchitecture.cs" />
@@ -395,7 +397,10 @@
       <IncludeInVSIX>true</IncludeInVSIX>
       <VSIXSubPath>.</VSIXSubPath>
     </Content>
-    <Content Include="scrape_builtins.py" />
+    <Content Include="scrape_builtins.py">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <IncludeInVSIX>true</IncludeInVSIX>
+    </Content>
     <Content Include="scrape_module.py">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <IncludeInVSIX>true</IncludeInVSIX>

--- a/Python/Product/Analysis/EncodedLocation.cs
+++ b/Python/Product/Analysis/EncodedLocation.cs
@@ -39,16 +39,16 @@ namespace Microsoft.PythonTools.Analysis {
         public readonly object Location;
 
         public EncodedLocation(ILocationResolver resolver, object location) {
+            if (resolver == null && !(location is LocationInfo)) {
+                throw new ArgumentNullException(nameof(resolver));
+            }
+
             Resolver = resolver;
             Location = location;
         }
 
         public override int GetHashCode() {
-            if (Location != null) {
-                return Resolver.GetHashCode() ^ Location.GetHashCode();
-            }
-
-            return Resolver.GetHashCode();
+            return (Resolver?.GetHashCode() ?? 0) ^ (Location?.GetHashCode() ?? 0);
         }
 
         public override bool Equals(object obj) {
@@ -68,6 +68,12 @@ namespace Microsoft.PythonTools.Analysis {
         #endregion
 
         public LocationInfo GetLocationInfo() {
+            if (Location == null) {
+                return null;
+            }
+            if (Resolver == null) {
+                return Location as LocationInfo;
+            }
             return Resolver.ResolveLocation(Location);
         }
     }

--- a/Python/Product/Analysis/Interpreter/Ast/AstAnalysisFunctionWalker.cs
+++ b/Python/Product/Analysis/Interpreter/Ast/AstAnalysisFunctionWalker.cs
@@ -14,11 +14,10 @@
 // See the Apache Version 2.0 License for specific language governing
 // permissions and limitations under the License.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.PythonTools.Analysis;
 using Microsoft.PythonTools.Infrastructure;
-using Microsoft.PythonTools.Parsing;
 using Microsoft.PythonTools.Parsing.Ast;
 
 namespace Microsoft.PythonTools.Interpreter.Ast {
@@ -32,8 +31,8 @@ namespace Microsoft.PythonTools.Interpreter.Ast {
             NameLookupContext scope,
             FunctionDefinition targetFunction
         ) {
-            _scope = scope;
-            _target = targetFunction;
+            _scope = scope ?? throw new ArgumentNullException(nameof(scope));
+            _target = targetFunction ?? throw new ArgumentNullException(nameof(targetFunction));
             _returnTypes = new List<IPythonType>();
             _overload = new AstPythonFunctionOverload(
                 AstPythonFunction.MakeParameters(_scope.Ast, _target),

--- a/Python/Product/Analysis/Interpreter/Ast/AstAnalysisFunctionWalker.cs
+++ b/Python/Product/Analysis/Interpreter/Ast/AstAnalysisFunctionWalker.cs
@@ -1,0 +1,116 @@
+﻿// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABLITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.PythonTools.Infrastructure;
+using Microsoft.PythonTools.Parsing.Ast;
+
+namespace Microsoft.PythonTools.Interpreter.Ast {
+    class AstAnalysisFunctionWalker : PythonWalker {
+        private readonly FunctionDefinition _target;
+        private readonly NameLookupContext _scope;
+        private readonly List<IPythonType> _returnTypes;
+
+        public AstAnalysisFunctionWalker(
+            NameLookupContext scope,
+            FunctionDefinition targetFunction
+        ) {
+            _scope = scope;
+            _target = targetFunction;
+            _returnTypes = new List<IPythonType>();
+        }
+
+        public string Documentation { get; private set; }
+        public IList<IPythonType> ReturnTypes => _returnTypes;
+
+        private void GetMethodType(FunctionDefinition node, out bool classmethod, out bool staticmethod) {
+            classmethod = false;
+            staticmethod = false;
+
+            if (node.IsLambda) {
+                staticmethod = true;
+                return;
+            }
+
+            var classmethodObj = _scope.Interpreter.GetBuiltinType(BuiltinTypeId.ClassMethod);
+            var staticmethodObj = _scope.Interpreter.GetBuiltinType(BuiltinTypeId.StaticMethod);
+            foreach (var d in (_target.Decorators?.Decorators).MaybeEnumerate()) {
+                var m = _scope.GetValueFromExpression(d, NameLookupContext.LookupOptions.Global);
+                if (m == classmethodObj) {
+                    classmethod = true;
+                } else if (m == staticmethodObj) {
+                    staticmethod = true;
+                }
+            }
+        }
+
+        public void Walk() {
+            IMember self = null;
+            bool classmethod, staticmethod;
+            GetMethodType(_target, out classmethod, out staticmethod);
+            if (!staticmethod) {
+                self = _scope.LookupNameInScopes("__class__", NameLookupContext.LookupOptions.LocalOnly);
+                if (!classmethod) {
+                    var cls = self as IPythonType;
+                    if (cls == null) {
+                        self = null;
+                    } else {
+                        self = new AstPythonConstant(cls, ((cls as ILocatedMember)?.Locations).MaybeEnumerate().ToArray());
+                    }
+                }
+            }
+
+            _scope.PushScope();
+            if (self != null) {
+                var p0 = _target.Parameters?.FirstOrDefault();
+                if (p0 != null && !string.IsNullOrEmpty(p0.Name)) {
+                    _scope.SetInScope(p0.Name, self);
+                }
+            }
+            _target.Walk(this);
+            _scope.PopScope();
+        }
+
+        public override bool Walk(FunctionDefinition node) {
+            if (node != _target) {
+                // Do not walk nested functions (yet)
+                return false;
+            }
+
+            if (Documentation == null) {
+                var docNode = (node.Body as SuiteStatement)?.Statements.FirstOrDefault();
+                var ce = (docNode as ExpressionStatement)?.Expression as ConstantExpression;
+                Documentation = ce?.Value as string;
+            }
+
+            return true;
+        }
+
+        public override bool Walk(ExpressionStatement node) {
+            return base.Walk(node);
+        }
+
+        public override bool Walk(ReturnStatement node) {
+            var type = _scope.GetTypeFromValue(_scope.GetValueFromExpression(node.Expression));
+            if (type != null) {
+                _returnTypes.Add(type);
+            }
+
+            return false;
+        }
+    }
+}

--- a/Python/Product/Analysis/Interpreter/Ast/AstAnalysisWalker.cs
+++ b/Python/Product/Analysis/Interpreter/Ast/AstAnalysisWalker.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Numerics;
 using System.Text;
@@ -27,15 +28,12 @@ using Microsoft.PythonTools.Parsing.Ast;
 
 namespace Microsoft.PythonTools.Interpreter.Ast {
     class AstAnalysisWalker : PythonWalker {
-        private readonly IPythonInterpreter _interpreter;
-        private readonly IModuleContext _context;
-        private readonly PythonAst _ast;
         private readonly IPythonModule _module;
-        private readonly string _filePath;
         private readonly Dictionary<string, IMember> _members;
-        private readonly bool _includeLocationInfo;
 
-        private readonly Stack<Dictionary<string, IMember>> _scope;
+        private readonly NameLookupContext _scope;
+
+        private readonly List<AstAnalysisFunctionWalker> _postWalkers;
 
         private IMember _noneInst;
 
@@ -47,32 +45,40 @@ namespace Microsoft.PythonTools.Interpreter.Ast {
             Dictionary<string, IMember> members,
             bool includeLocationInfo
         ) {
-            _interpreter = interpreter;
-            _context = _interpreter.CreateModuleContext();
-            _ast = ast;
+            _scope = new NameLookupContext(interpreter, interpreter.CreateModuleContext(), ast, filePath, includeLocationInfo);
             _module = module;
-            _filePath = filePath;
             _members = members;
-            _scope = new Stack<Dictionary<string, IMember>>();
             _noneInst = new AstPythonConstant(_interpreter.GetBuiltinType(BuiltinTypeId.NoneType));
-            _includeLocationInfo = includeLocationInfo;
+            _postWalkers = new List<AstAnalysisFunctionWalker>();
         }
+
+        private IPythonInterpreter _interpreter => _scope.Interpreter;
+        private PythonAst _ast => _scope.Ast;
+        private string _filePath => _scope.FilePath;
 
         public override bool Walk(PythonAst node) {
             if (_ast != node) {
                 throw new InvalidOperationException("walking wrong AST");
             }
-            _scope.Push(_members);
+            _scope.PushScope(_members);
+
+            CollectAllClasses(_members, (node.Body as SuiteStatement)?.Statements.OfType<ClassDefinition>());
+
             return base.Walk(node);
         }
 
         public override void PostWalk(PythonAst node) {
-            _scope.Pop();
+            _scope.PopScope();
+
+            foreach (var walker in _postWalkers) {
+                walker.Walk();
+            }
+
             base.PostWalk(node);
         }
 
         internal LocationInfo GetLoc(ClassDefinition node) {
-            if (!_includeLocationInfo) {
+            if (!_scope.IncludeLocationInfo) {
                 return null;
             }
             if (node == null || node.StartIndex >= node.EndIndex) {
@@ -85,7 +91,7 @@ namespace Microsoft.PythonTools.Interpreter.Ast {
         }
 
         internal LocationInfo GetLoc(FunctionDefinition node) {
-            if (!_includeLocationInfo) {
+            if (!_scope.IncludeLocationInfo) {
                 return null;
             }
             if (node == null || node.StartIndex >= node.EndIndex) {
@@ -97,234 +103,88 @@ namespace Microsoft.PythonTools.Interpreter.Ast {
             return new LocationInfo(_filePath, start.Line, start.Column, end.Line, end.Column);
         }
 
-        internal LocationInfo GetLoc(Node node) {
-            if (!_includeLocationInfo) {
-                return null;
-            }
-            if (node == null || node.StartIndex >= node.EndIndex) {
-                return null;
-            }
+        internal LocationInfo GetLoc(Node node) => _scope.GetLoc(node);
 
-            var start = node.GetStart(_ast);
-            var end = node.GetEnd(_ast);
-            return new LocationInfo(_filePath, start.Line, start.Column, end.Line, end.Column);
-        }
-
-        private string GetNameFromExpressionWorker(Expression expr) {
-            var ne = expr as NameExpression;
-            if (ne != null) {
-                return ne.Name;
-            }
-
-            var me = expr as MemberExpression;
-            if (me != null) {
-                return "{0}.{1}".FormatInvariant(GetNameFromExpressionWorker(me.Target), me.Name);
-            }
-
-            throw new FormatException();
-        }
-
-        private string GetNameFromExpression(Expression expr) {
-            try {
-                return GetNameFromExpressionWorker(expr);
-            } catch (FormatException) {
-                return null;
-            }
-        }
-
-        private IMember GetValueFromExpression(Expression expr, Dictionary<string, IMember> scope) {
-            var ne = expr as NameExpression;
-            if (ne != null) {
-                IMember existing = null;
-                if (scope != null && scope.TryGetValue(ne.Name, out existing) && existing != null) {
-                    return existing;
-                }
-                if (_members != null && _members.TryGetValue(ne.Name, out existing) && existing != null) {
-                    return existing;
-                }
-            }
-
-            IPythonType type;
-
-            var me = expr as MemberExpression;
-            if (me != null && me.Target != null && !string.IsNullOrEmpty(me.Name)) {
-                var mc = GetValueFromExpression(me.Target, scope) as IMemberContainer;
-                if (mc != null) {
-                    return mc.GetMember(_context, me.Name);
-                }
-                return null;
-            }
-
-            if (expr is CallExpression) {
-                var cae = (CallExpression)expr;
-                var m = GetValueFromExpression(cae.Target, scope);
-                type = m as IPythonType;
-                if (type != null) {
-                    return new AstPythonConstant(type, GetLoc(expr));
-                }
-                var fn = m as IPythonFunction;
-                if (fn != null) {
-                    return new AstPythonConstant(_interpreter.GetBuiltinType(BuiltinTypeId.NoneType), GetLoc(expr));
-                }
-            }
-
-            type = GetTypeFromExpression(expr);
-            if (type != null) {
-                return new AstPythonConstant(type, GetLoc(expr));
-            }
-
-            return null;
-        }
-
-        private IPythonType GetTypeFromExpression(Expression expr) {
-            var ce = expr as ConstantExpression;
-            if (ce != null) {
-                if (ce.Value == null) {
-                    return _interpreter.GetBuiltinType(BuiltinTypeId.NoneType);
-                }
-                switch (Type.GetTypeCode(ce.Value.GetType())) {
-                    case TypeCode.Boolean: return _interpreter.GetBuiltinType(BuiltinTypeId.Bool);
-                    case TypeCode.Double: return _interpreter.GetBuiltinType(BuiltinTypeId.Float);
-                    case TypeCode.Int32: return _interpreter.GetBuiltinType(BuiltinTypeId.Int);
-                    case TypeCode.String: return _interpreter.GetBuiltinType(BuiltinTypeId.Unicode);
-                    case TypeCode.Object:
-                        if (ce.Value.GetType() == typeof(Complex)) {
-                            return _interpreter.GetBuiltinType(BuiltinTypeId.Complex);
-                        } else if (ce.Value.GetType() == typeof(AsciiString)) {
-                            return _interpreter.GetBuiltinType(BuiltinTypeId.Bytes);
-                        } else if (ce.Value.GetType() == typeof(BigInteger)) {
-                            return _interpreter.GetBuiltinType(BuiltinTypeId.Long);
-                        } else if (ce.Value.GetType() == typeof(Ellipsis)) {
-                            return _interpreter.GetBuiltinType(BuiltinTypeId.Ellipsis);
-                        }
-                        break;
-                }
-                return null;
-            }
-
-            if (expr is ListExpression || expr is ListComprehension) {
-                return _interpreter.GetBuiltinType(BuiltinTypeId.List);
-            }
-            if (expr is DictionaryExpression || expr is DictionaryComprehension) {
-                return _interpreter.GetBuiltinType(BuiltinTypeId.Dict);
-            }
-            if (expr is TupleExpression) {
-                return _interpreter.GetBuiltinType(BuiltinTypeId.Tuple);
-            }
-            if (expr is SetExpression || expr is SetComprehension) {
-                return _interpreter.GetBuiltinType(BuiltinTypeId.Set);
-            }
-            if (expr is LambdaExpression) {
-                return _interpreter.GetBuiltinType(BuiltinTypeId.Function);
-            }
-
-            return null;
-        }
-
-        private IMember GetInScope(string name) {
-            foreach (var m in _scope) {
-                if (m == null) {
-                    continue;
-                }
-                IMember obj;
-                if (m.TryGetValue("__class__", out obj)) {
-                    return obj;
-                }
-            }
-            return null;
-        }
-
-        private IPythonType CurrentClass {
-            get {
-                var m = _scope.Peek();
-                if (m != null) {
-                    IMember cls;
-                    m.TryGetValue("__class__", out cls);
-                    return cls as IPythonType;
-                }
-                return null;
-            }
-        }
+        private IPythonType CurrentClass => _scope.GetInScope("__class__") as IPythonType;
 
         public override bool Walk(AssignmentStatement node) {
-            var m = _scope.Peek();
-            if (m != null) {
-                var value = GetValueFromExpression(node.Right, m);
-                foreach (var ne in node.Left.OfType<NameExpression>()) {
-                    m[ne.Name] = value;
-                }
+            var value = _scope.GetValueFromExpression(node.Right, NameLookupContext.LookupOptions.LocalOnly);
+            foreach (var ne in node.Left.OfType<NameExpression>()) {
+                _scope.SetInScope(ne.Name, value);
             }
+
             return base.Walk(node);
         }
 
         public override bool Walk(ImportStatement node) {
-            var m = _scope.Peek();
-            if (m != null && node.Names != null) {
-                try {
-                    for (int i = 0; i < node.Names.Count; ++i) {
-                        var n = node.AsNames?[i] ?? node.Names[i].Names[0];
-                        if (n != null) {
-                            
-                            m[n.Name] = new AstNestedPythonModule(
-                                _interpreter,
-                                n.Name,
-                                PythonAnalyzer.ResolvePotentialModuleNames(_module.Name, _filePath, n.Name, true).ToArray()
-                            );
-                        }
+            if (node.Names == null) {
+                return false;
+            }
+
+            try {
+                for (int i = 0; i < node.Names.Count; ++i) {
+                    var n = node.AsNames?[i] ?? node.Names[i].Names[0];
+                    if (n != null) {
+                        _scope.SetInScope(n.Name, new AstNestedPythonModule(
+                            _interpreter,
+                            n.Name,
+                            PythonAnalyzer.ResolvePotentialModuleNames(_module.Name, _filePath, n.Name, true).ToArray()
+                        ));
                     }
-                } catch (IndexOutOfRangeException) {
                 }
+            } catch (IndexOutOfRangeException) {
             }
             return false;
         }
 
         public override bool Walk(FromImportStatement node) {
-            var m = _scope.Peek();
             var modName = node.Root.MakeString();
             if (modName == "__future__") {
                 return false;
             }
 
-            if (m != null && node.Names != null) {
-                bool onlyImportModules = modName.EndsWith(".");
+            if (node.Names == null) {
+                return false;
+            }
 
-                var mod = new AstNestedPythonModule(
-                    _interpreter,
-                    modName,
-                    PythonAnalyzer.ResolvePotentialModuleNames(_module.Name, _filePath, modName, true).ToArray()
-                );
-                var ctxt = _interpreter.CreateModuleContext();
-                mod.Imported(ctxt);
-                // Ensure child modules have been loaded
-                mod.GetChildrenModules();
+            bool onlyImportModules = modName.EndsWith(".");
 
-                try {
-                    for (int i = 0; i < node.Names.Count; ++i) {
-                        if (!onlyImportModules) {
-                            if (node.Names[i].Name == "*") {
-                                foreach (var member in mod.GetMemberNames(ctxt)) {
-                                    IMember mem;
-                                    m[member] = mem = mod.GetMember(ctxt, member) ?? new AstPythonConstant(
-                                        _interpreter.GetBuiltinType(BuiltinTypeId.Unknown),
-                                        mod.Locations.ToArray()
-                                    );
-                                    (mem as IPythonModule)?.Imported(ctxt);
-                                }
-                                continue;
-                            }
-                            var n = node.AsNames?[i] ?? node.Names[i];
-                            if (n != null) {
-                                IMember mem;
-                                m[n.Name] = mem = mod.GetMember(ctxt, node.Names[i].Name) ?? new AstPythonConstant(
+            var mod = new AstNestedPythonModule(
+                _interpreter,
+                modName,
+                PythonAnalyzer.ResolvePotentialModuleNames(_module.Name, _filePath, modName, true).ToArray()
+            );
+            var ctxt = _interpreter.CreateModuleContext();
+            mod.Imported(ctxt);
+            // Ensure child modules have been loaded
+            mod.GetChildrenModules();
+
+            try {
+                for (int i = 0; i < node.Names.Count; ++i) {
+                    if (!onlyImportModules) {
+                        if (node.Names[i].Name == "*") {
+                            foreach (var member in mod.GetMemberNames(ctxt)) {
+                                var mem = mod.GetMember(ctxt, member) ?? new AstPythonConstant(
                                     _interpreter.GetBuiltinType(BuiltinTypeId.Unknown),
-                                    GetLoc(n)
+                                    mod.Locations.ToArray()
                                 );
+                                _scope.SetInScope(member, mem);
                                 (mem as IPythonModule)?.Imported(ctxt);
                             }
+                            continue;
+                        }
+                        var n = node.AsNames?[i] ?? node.Names[i];
+                        if (n != null) {
+                            var mem = mod.GetMember(ctxt, node.Names[i].Name) ?? new AstPythonConstant(
+                                _interpreter.GetBuiltinType(BuiltinTypeId.Unknown),
+                                GetLoc(n)
+                            );
+                            _scope.SetInScope(n.Name, mem);
+                            (mem as IPythonModule)?.Imported(ctxt);
                         }
                     }
-                } catch (IndexOutOfRangeException) {
                 }
+            } catch (IndexOutOfRangeException) {
             }
             return false;
         }
@@ -334,15 +194,19 @@ namespace Microsoft.PythonTools.Interpreter.Ast {
                 return false;
             }
 
-            var existing = GetInScope(node.Name) as AstPythonFunction;
+            var existing = _scope.LookupNameInScopes(node.Name, NameLookupContext.LookupOptions.LocalOnly) as AstPythonFunction;
+
             if (existing == null) {
-                var m = _scope.Peek();
-                if (m != null) {
-                    m[node.Name] = new AstPythonFunction(_ast, _module, CurrentClass, node, GetLoc(node), GetDoc(node.Body as SuiteStatement));
-                }
-            } else {
-                existing.AddOverload(_ast, node);
+                existing = new AstPythonFunction(_ast, _module, CurrentClass, node, GetLoc(node));
+                _scope.SetInScope(node.Name, existing);
             }
+
+            var funcWalk = new AstAnalysisFunctionWalker(_scope.Clone(), node);
+            _postWalkers.Add(funcWalk);
+
+            var overload = new AstPythonFunctionOverload(AstPythonFunction.MakeParameters(_ast, node), GetLoc(node), funcWalk.ReturnTypes);
+            existing.AddOverload(overload);
+
             // Do not recurse into functions
             return false;
         }
@@ -353,27 +217,38 @@ namespace Microsoft.PythonTools.Interpreter.Ast {
             return ce?.Value as string;
         }
 
-        public override bool Walk(ClassDefinition node) {
-            var m = _scope.Peek();
-            if (m != null) {
-                var n = new Dictionary<string, IMember>();
-                var mro = node.Bases.Where(a => string.IsNullOrEmpty(a.Name))
-                    .Select(a => GetNameFromExpression(a.Expression))
-                    .Where(a => !string.IsNullOrEmpty(a))
-                    .Select(a => new AstPythonType(a));
-
-                var t = new AstPythonType(_ast, _module, node, GetDoc(node.Body as SuiteStatement), GetLoc(node), mro);
-                m[node.Name] = n["__class__"] = t;
-                _scope.Push(n);
-
-                return true;
+        private void CollectAllClasses(Dictionary<string, IMember> members, IEnumerable<ClassDefinition> classes) {
+            foreach (var node in classes.MaybeEnumerate()) {
+                var t = new AstPythonType(_ast, _module, node, GetDoc(node.Body as SuiteStatement), GetLoc(node));
+                _scope.SetInScope(node.Name, t);
             }
-            return false;
+        }
+
+        public override bool Walk(ClassDefinition node) {
+            var t = _scope.GetInScope(node.Name) as AstPythonType;
+            if (t == null) {
+                t = new AstPythonType(_ast, _module, node, GetDoc(node.Body as SuiteStatement), GetLoc(node));
+                _scope.SetInScope(node.Name, t);
+            }
+
+            var mro = node.Bases.Where(a => string.IsNullOrEmpty(a.Name))
+                .Select(a => _scope.GetNameFromExpression(a.Expression))
+                .Where(a => !string.IsNullOrEmpty(a))
+                .Select(a => new AstPythonType(a));
+
+            if (t.Mro == null) {
+                t.SetMro(mro);
+            }
+
+            _scope.PushScope();
+            _scope.SetInScope("__class__", t);
+
+            return true;
         }
 
         public override void PostWalk(ClassDefinition node) {
             var cls = CurrentClass as AstPythonType;
-            var m = _scope.Pop();
+            var m = _scope.PopScope();
             if (cls != null && m != null) {
                 cls.AddMembers(m, true);
             }

--- a/Python/Product/Analysis/Interpreter/Ast/AstAnalysisWalker.cs
+++ b/Python/Product/Analysis/Interpreter/Ast/AstAnalysisWalker.cs
@@ -16,14 +16,9 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
-using System.Numerics;
-using System.Text;
-using System.Threading.Tasks;
 using Microsoft.PythonTools.Analysis;
 using Microsoft.PythonTools.Infrastructure;
-using Microsoft.PythonTools.Parsing;
 using Microsoft.PythonTools.Parsing.Ast;
 
 namespace Microsoft.PythonTools.Interpreter.Ast {
@@ -45,9 +40,15 @@ namespace Microsoft.PythonTools.Interpreter.Ast {
             Dictionary<string, IMember> members,
             bool includeLocationInfo
         ) {
-            _scope = new NameLookupContext(interpreter, interpreter.CreateModuleContext(), ast, filePath, includeLocationInfo);
-            _module = module;
-            _members = members;
+            _scope = new NameLookupContext(
+                interpreter ?? throw new ArgumentNullException(nameof(interpreter)),
+                interpreter.CreateModuleContext(),
+                ast ?? throw new ArgumentNullException(nameof(ast)),
+                filePath,
+                includeLocationInfo
+            );
+            _module = module ?? throw new ArgumentNullException(nameof(module));
+            _members = members ?? throw new ArgumentNullException(nameof(members));
             _noneInst = new AstPythonConstant(_interpreter.GetBuiltinType(BuiltinTypeId.NoneType));
             _postWalkers = new List<AstAnalysisFunctionWalker>();
         }

--- a/Python/Product/Analysis/Interpreter/Ast/AstBuiltinsPythonModule.cs
+++ b/Python/Product/Analysis/Interpreter/Ast/AstBuiltinsPythonModule.cs
@@ -1,0 +1,98 @@
+﻿// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABLITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.PythonTools.Infrastructure;
+using Microsoft.PythonTools.Parsing;
+using Microsoft.PythonTools.Parsing.Ast;
+
+namespace Microsoft.PythonTools.Interpreter.Ast {
+    class AstBuiltinsPythonModule : AstScrapedPythonModule, IBuiltinPythonModule {
+        // protected by lock(_members)
+        private readonly HashSet<string> _hiddenNames;
+
+        public AstBuiltinsPythonModule(PythonLanguageVersion version)
+            : base(version.Is3x() ? SharedDatabaseState.BuiltinName3x : SharedDatabaseState.BuiltinName2x, null) {
+            _hiddenNames = new HashSet<string>();
+        }
+
+        public override IMember GetMember(IModuleContext context, string name) {
+            lock (_members) {
+                if (_hiddenNames.Contains(name)) {
+                    return null;
+                }
+            }
+            return base.GetMember(context, name);
+        }
+
+        public IMember GetAnyMember(string name) {
+            lock (_members) {
+                IMember m;
+                _members.TryGetValue(name, out m);
+                return m;
+            }
+        }
+
+        public override IEnumerable<string> GetMemberNames(IModuleContext moduleContext) {
+            lock (_members) {
+                return base.GetMemberNames(moduleContext).Except(_hiddenNames).ToArray();
+            }
+        }
+
+        protected override List<string> GetScrapeArguments(IPythonInterpreterFactory factory) {
+            var args = new List<string> { "-B", "-E", "-S" };
+
+            var sb = PythonToolsInstallPath.TryGetFile("scrape_builtins.py", GetType().Assembly);
+            if (!File.Exists(sb)) {
+                return null;
+            }
+            args.Add(sb);
+
+            return args;
+        }
+
+        protected override PythonWalker PrepareWalker(IPythonInterpreter interpreter, PythonAst ast) {
+            var walker = new AstAnalysisWalker(interpreter, ast, this, null, _members, false);
+            walker.CreateBuiltinTypes = true;
+            walker.Scope.SuppressBuiltinLookup = true;
+            return walker;
+        }
+
+        protected override void PostWalk(PythonWalker walker) {
+            foreach (BuiltinTypeId typeId in Enum.GetValues(typeof(BuiltinTypeId))) {
+                IMember m;
+                AstPythonBuiltinType biType;
+                if (_members.TryGetValue($"__{typeId}", out m) && (biType = m as AstPythonBuiltinType) != null) {
+                    if (typeId != BuiltinTypeId.Str &&
+                        typeId != BuiltinTypeId.StrIterator) {
+                        biType.TrySetTypeId(typeId);
+                    }
+
+                    if (biType.IsHidden) {
+                        _hiddenNames.Add(biType.Name);
+                    }
+                    _hiddenNames.Add($"__{typeId}");
+                }
+            }
+        }
+
+    }
+}

--- a/Python/Product/Analysis/Interpreter/Ast/AstNestedPythonModule.cs
+++ b/Python/Product/Analysis/Interpreter/Ast/AstNestedPythonModule.cs
@@ -36,9 +36,9 @@ namespace Microsoft.PythonTools.Interpreter.Ast {
             string name,
             IReadOnlyList<string> importNames
         ) {
-            _interpreter = interpreter;
-            _name = name;
-            _importNames = importNames;
+            _interpreter = interpreter ?? throw new ArgumentNullException(nameof(interpreter));
+            _name = name ?? throw new ArgumentNullException(nameof(name));
+            _importNames = importNames ?? throw new ArgumentNullException(nameof(importNames));
         }
 
         public string Name => MaybeModule?.Name ?? _name;

--- a/Python/Product/Analysis/Interpreter/Ast/AstPythonBuiltinType.cs
+++ b/Python/Product/Analysis/Interpreter/Ast/AstPythonBuiltinType.cs
@@ -45,5 +45,13 @@ namespace Microsoft.PythonTools.Interpreter.Ast {
 
         public override bool IsBuiltin => true;
         public override BuiltinTypeId TypeId => _typeId;
+
+        public bool IsHidden {
+            get {
+                lock (_members) {
+                    return _members.ContainsKey("__hidden");
+                }
+            }
+        }
     }
 }

--- a/Python/Product/Analysis/Interpreter/Ast/AstPythonBuiltinType.cs
+++ b/Python/Product/Analysis/Interpreter/Ast/AstPythonBuiltinType.cs
@@ -1,0 +1,49 @@
+﻿// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABLITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System;
+using Microsoft.PythonTools.Parsing.Ast;
+
+namespace Microsoft.PythonTools.Interpreter.Ast {
+    class AstPythonBuiltinType : AstPythonType {
+        private BuiltinTypeId _typeId;
+
+        public AstPythonBuiltinType(string name, BuiltinTypeId typeId)
+            : base(name) {
+            _typeId = typeId;
+        }
+
+        public AstPythonBuiltinType(
+            PythonAst ast,
+            IPythonModule declModule,
+            ClassDefinition def,
+            string doc
+        ) : base(ast, declModule, def, doc, null) {
+            _typeId = BuiltinTypeId.Unknown;
+        }
+
+        public bool TrySetTypeId(BuiltinTypeId typeId) {
+            if (_typeId != BuiltinTypeId.Unknown) {
+                return false;
+            }
+            _typeId = typeId;
+            return true;
+        }
+
+        public override bool IsBuiltin => true;
+        public override BuiltinTypeId TypeId => _typeId;
+    }
+}

--- a/Python/Product/Analysis/Interpreter/Ast/AstPythonConstant.cs
+++ b/Python/Product/Analysis/Interpreter/Ast/AstPythonConstant.cs
@@ -14,6 +14,7 @@
 // See the Apache Version 2.0 License for specific language governing
 // permissions and limitations under the License.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.PythonTools.Analysis;
@@ -21,7 +22,7 @@ using Microsoft.PythonTools.Analysis;
 namespace Microsoft.PythonTools.Interpreter.Ast {
     class AstPythonConstant : IPythonConstant, ILocatedMember {
         public AstPythonConstant(IPythonType type, params LocationInfo[] locations) {
-            Type = type;
+            Type = type ?? throw new ArgumentNullException(nameof(type));
             Locations = locations.ToArray();
         }
 

--- a/Python/Product/Analysis/Interpreter/Ast/AstPythonFunction.cs
+++ b/Python/Product/Analysis/Interpreter/Ast/AstPythonFunction.cs
@@ -32,7 +32,7 @@ namespace Microsoft.PythonTools.Interpreter.Ast {
             FunctionDefinition def,
             LocationInfo loc
         ) {
-            DeclaringModule = declModule;
+            DeclaringModule = declModule ?? throw new ArgumentNullException(nameof(declModule));
             DeclaringType = declType;
 
             Name = def.Name;
@@ -47,7 +47,7 @@ namespace Microsoft.PythonTools.Interpreter.Ast {
 
             _overloads = new List<IPythonFunctionOverload>();
 
-            Locations = new[] { loc };
+            Locations = loc != null ? new[] { loc } : Array.Empty<LocationInfo>();
         }
 
         internal void AddOverload(IPythonFunctionOverload overload) {

--- a/Python/Product/Analysis/Interpreter/Ast/AstPythonFunction.cs
+++ b/Python/Product/Analysis/Interpreter/Ast/AstPythonFunction.cs
@@ -23,14 +23,19 @@ using Microsoft.PythonTools.Parsing.Ast;
 
 namespace Microsoft.PythonTools.Interpreter.Ast {
     class AstPythonFunction : IPythonFunction, ILocatedMember {
-        private readonly List<AstPythonFunctionOverload> _overloads;
+        private readonly List<IPythonFunctionOverload> _overloads;
 
-        public AstPythonFunction(PythonAst ast, IPythonModule declModule, IPythonType declType, FunctionDefinition def, LocationInfo loc, string doc) {
+        public AstPythonFunction(
+            PythonAst ast,
+            IPythonModule declModule,
+            IPythonType declType,
+            FunctionDefinition def,
+            LocationInfo loc
+        ) {
             DeclaringModule = declModule;
             DeclaringType = declType;
 
             Name = def.Name;
-            Documentation = doc;
 
             foreach (var dec in (def.Decorators?.Decorators).MaybeEnumerate().OfType<NameExpression>()) {
                 if (dec.Name == "classmethod") {
@@ -40,31 +45,25 @@ namespace Microsoft.PythonTools.Interpreter.Ast {
                 }
             }
 
-            _overloads = new List<AstPythonFunctionOverload> {
-                new AstPythonFunctionOverload(Documentation, "", MakeParameters(ast, def), MakeReturns(def))
-            };
+            _overloads = new List<IPythonFunctionOverload>();
 
             Locations = new[] { loc };
         }
 
-        internal void AddOverload(PythonAst ast, FunctionDefinition def) {
-            _overloads.Add(new AstPythonFunctionOverload(def.Documentation, "", MakeParameters(ast, def), MakeReturns(def)));
+        internal void AddOverload(IPythonFunctionOverload overload) {
+            _overloads.Add(overload);
         }
 
-        private static IEnumerable<IParameterInfo> MakeParameters(PythonAst ast, FunctionDefinition def) {
+        internal static IEnumerable<IParameterInfo> MakeParameters(PythonAst ast, FunctionDefinition def) {
             foreach (var p in def.Parameters) {
                 yield return new AstPythonParameterInfo(ast, p);
             }
         }
 
-        private static IEnumerable<IPythonType> MakeReturns(FunctionDefinition def) {
-            yield break;
-        }
-
         public IPythonModule DeclaringModule {get;}
         public IPythonType DeclaringType {get;}
         public string Name { get; }
-        public string Documentation {get;}
+        public string Documentation => _overloads.FirstOrDefault()?.Documentation;
         public bool IsBuiltin => true;
 
         public bool IsClassMethod { get; }

--- a/Python/Product/Analysis/Interpreter/Ast/AstPythonFunctionOverload.cs
+++ b/Python/Product/Analysis/Interpreter/Ast/AstPythonFunctionOverload.cs
@@ -29,9 +29,9 @@ namespace Microsoft.PythonTools.Interpreter.Ast {
             LocationInfo loc, 
             IList<IPythonType> returnType
         ) {
-            _parameters = parameters.ToArray();
-            Locations = new[] { loc };
-            ReturnType = returnType;
+            _parameters = parameters?.ToArray() ?? throw new ArgumentNullException(nameof(parameters));
+            Locations = loc != null ? new[] { loc } : Array.Empty<LocationInfo>();
+            ReturnType = returnType ?? throw new ArgumentNullException(nameof(returnType));
         }
 
         internal void SetDocumentation(string doc) {

--- a/Python/Product/Analysis/Interpreter/Ast/AstPythonFunctionOverload.cs
+++ b/Python/Product/Analysis/Interpreter/Ast/AstPythonFunctionOverload.cs
@@ -14,28 +14,37 @@
 // See the Apache Version 2.0 License for specific language governing
 // permissions and limitations under the License.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.PythonTools.Analysis;
+using Microsoft.PythonTools.Infrastructure;
 
 namespace Microsoft.PythonTools.Interpreter.Ast {
-    class AstPythonFunctionOverload : IPythonFunctionOverload {
+    class AstPythonFunctionOverload : IPythonFunctionOverload, ILocatedMember {
         private readonly IReadOnlyList<IParameterInfo> _parameters;
 
         public AstPythonFunctionOverload(
-            string doc,
-            string returnDoc,
             IEnumerable<IParameterInfo> parameters,
-            IEnumerable<IPythonType> returns
+            LocationInfo loc, 
+            IList<IPythonType> returnType
         ) {
-            Documentation = doc;
-            ReturnDocumentation = returnDoc;
             _parameters = parameters.ToArray();
-            ReturnType = returns.ToList();
+            Locations = new[] { loc };
+            ReturnType = returnType;
         }
 
-        public string Documentation { get; }
+        internal void SetDocumentation(string doc) {
+            if (Documentation != null) {
+                throw new InvalidOperationException("cannot set Documentation twice");
+            }
+            Documentation = doc;
+        }
+
+        public string Documentation { get; private set; }
         public string ReturnDocumentation { get; }
         public IParameterInfo[] GetParameters() => _parameters.ToArray();
         public IList<IPythonType> ReturnType { get; }
+        public IEnumerable<LocationInfo> Locations { get; }
     }
 }

--- a/Python/Product/Analysis/Interpreter/Ast/AstPythonInterpreter.cs
+++ b/Python/Product/Analysis/Interpreter/Ast/AstPythonInterpreter.cs
@@ -18,7 +18,6 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO;
 using System.Linq;
 using Microsoft.PythonTools.Analysis;
 using Microsoft.PythonTools.Infrastructure;
@@ -39,10 +38,7 @@ namespace Microsoft.PythonTools.Interpreter.Ast {
         private HashSet<string> _userSearchPathImported;
 
         public AstPythonInterpreter(AstPythonInterpreterFactory factory) {
-            if (factory == null) {
-                throw new ArgumentNullException(nameof(factory));
-            }
-            _factory = factory;
+            _factory = factory ?? throw new ArgumentNullException(nameof(factory));
             _factory.ImportableModulesChanged += Factory_ImportableModulesChanged;
             _modules = new ConcurrentDictionary<string, IPythonModule>();
             _builtinTypes = new Dictionary<BuiltinTypeId, IPythonType>();

--- a/Python/Product/Analysis/Interpreter/Ast/AstPythonInterpreterFactory.cs
+++ b/Python/Product/Analysis/Interpreter/Ast/AstPythonInterpreterFactory.cs
@@ -35,15 +35,10 @@ namespace Microsoft.PythonTools.Interpreter.Ast {
             InterpreterConfiguration config,
             InterpreterFactoryCreationOptions options
         ) {
-            if (config == null) {
-                throw new ArgumentNullException(nameof(config));
-            }
-            if (options == null) {
-                options = new InterpreterFactoryCreationOptions();
-            }
-            Configuration = config;
+            Configuration = config ?? throw new ArgumentNullException(nameof(config));
             LanguageVersion = Configuration.Version.ToLanguageVersion();
 
+            options = options ?? new InterpreterFactoryCreationOptions();
             _databasePath = options.DatabasePath;
 
             if (!GlobalInterpreterOptions.SuppressPackageManagers) {

--- a/Python/Product/Analysis/Interpreter/Ast/AstPythonParameterInfo.cs
+++ b/Python/Product/Analysis/Interpreter/Ast/AstPythonParameterInfo.cs
@@ -14,13 +14,14 @@
 // See the Apache Version 2.0 License for specific language governing
 // permissions and limitations under the License.
 
+using System;
 using System.Collections.Generic;
 using Microsoft.PythonTools.Parsing.Ast;
 
 namespace Microsoft.PythonTools.Interpreter.Ast {
     class AstPythonParameterInfo : IParameterInfo {
         public AstPythonParameterInfo(PythonAst ast, Parameter p) {
-            Name = p.Name;
+            Name = p?.Name ?? throw new ArgumentNullException(nameof(p));
             Documentation = "";
             DefaultValue = p.DefaultValue?.ToCodeString(ast);
             IsParamArray = p.Kind == ParameterKind.List;

--- a/Python/Product/Analysis/Interpreter/Ast/AstPythonParameterInfo.cs
+++ b/Python/Product/Analysis/Interpreter/Ast/AstPythonParameterInfo.cs
@@ -22,7 +22,7 @@ namespace Microsoft.PythonTools.Interpreter.Ast {
         public AstPythonParameterInfo(PythonAst ast, Parameter p) {
             Name = p.Name;
             Documentation = "";
-            DefaultValue = p.DefaultValue?.ToCodeString(ast) ?? "";
+            DefaultValue = p.DefaultValue?.ToCodeString(ast);
             IsParamArray = p.Kind == ParameterKind.List;
             IsKeywordDict = p.Kind == ParameterKind.Dictionary;
             ParameterTypes = new IPythonType[0];

--- a/Python/Product/Analysis/Interpreter/Ast/AstPythonType.cs
+++ b/Python/Product/Analysis/Interpreter/Ast/AstPythonType.cs
@@ -40,15 +40,13 @@ namespace Microsoft.PythonTools.Interpreter.Ast {
             IPythonModule declModule,
             ClassDefinition def,
             string doc,
-            LocationInfo loc,
-            IEnumerable<IPythonType> mro
+            LocationInfo loc
         ) {
             _members = new Dictionary<string, IMember>();
 
             Name = def.Name;
             Documentation = doc;
             DeclaringModule = declModule;
-            Mro = mro.MaybeEnumerate().ToArray();
             Locations = new[] { loc };
         }
 
@@ -66,10 +64,17 @@ namespace Microsoft.PythonTools.Interpreter.Ast {
             }
         }
 
+        internal void SetMro(IEnumerable<IPythonType> mro) {
+            if (Mro != null) {
+                throw new InvalidOperationException("cannot set Mro multiple times");
+            }
+            Mro = mro.MaybeEnumerate().ToArray();
+        }
+
         public string Name { get; }
         public string Documentation { get; }
         public IPythonModule DeclaringModule {get;}
-        public IList<IPythonType> Mro { get; }
+        public IList<IPythonType> Mro { get; private set; }
         public bool IsBuiltin => true;
         public PythonMemberType MemberType => PythonMemberType.Class;
         public BuiltinTypeId TypeId => BuiltinTypeId.Type;

--- a/Python/Product/Analysis/Interpreter/Ast/AstPythonType.cs
+++ b/Python/Product/Analysis/Interpreter/Ast/AstPythonType.cs
@@ -23,7 +23,7 @@ using Microsoft.PythonTools.Parsing.Ast;
 
 namespace Microsoft.PythonTools.Interpreter.Ast {
     class AstPythonType : IPythonType, IMemberContainer, ILocatedMember {
-        private readonly Dictionary<string, IMember> _members;
+        protected readonly Dictionary<string, IMember> _members;
 
         private static readonly IPythonModule NoDeclModule = new AstPythonModule();
 

--- a/Python/Product/Analysis/Interpreter/Ast/AstPythonType.cs
+++ b/Python/Product/Analysis/Interpreter/Ast/AstPythonType.cs
@@ -75,9 +75,9 @@ namespace Microsoft.PythonTools.Interpreter.Ast {
         public string Documentation { get; }
         public IPythonModule DeclaringModule {get;}
         public IList<IPythonType> Mro { get; private set; }
-        public bool IsBuiltin => true;
+        public virtual bool IsBuiltin => false;
         public PythonMemberType MemberType => PythonMemberType.Class;
-        public BuiltinTypeId TypeId => BuiltinTypeId.Type;
+        public virtual BuiltinTypeId TypeId => BuiltinTypeId.Type;
 
         public IEnumerable<LocationInfo> Locations { get; }
 

--- a/Python/Product/Analysis/Interpreter/Ast/AstPythonType.cs
+++ b/Python/Product/Analysis/Interpreter/Ast/AstPythonType.cs
@@ -29,7 +29,7 @@ namespace Microsoft.PythonTools.Interpreter.Ast {
 
         public AstPythonType(string name) {
             _members = new Dictionary<string, IMember>();
-            Name = name;
+            Name = name ?? throw new ArgumentNullException(nameof(name));
             DeclaringModule = NoDeclModule;
             Mro = Array.Empty<IPythonType>();
             Locations = Array.Empty<LocationInfo>();
@@ -44,10 +44,10 @@ namespace Microsoft.PythonTools.Interpreter.Ast {
         ) {
             _members = new Dictionary<string, IMember>();
 
-            Name = def.Name;
+            Name = def?.Name ?? throw new ArgumentNullException(nameof(def));
             Documentation = doc;
-            DeclaringModule = declModule;
-            Locations = new[] { loc };
+            DeclaringModule = declModule ?? throw new ArgumentNullException(nameof(declModule));
+            Locations = loc != null ? new[] { loc } : Array.Empty<LocationInfo>();
         }
 
         internal void AddMembers(IEnumerable<KeyValuePair<string, IMember>> members, bool overwrite) {

--- a/Python/Product/Analysis/Interpreter/Ast/AstScrapedPythonModule.cs
+++ b/Python/Product/Analysis/Interpreter/Ast/AstScrapedPythonModule.cs
@@ -16,7 +16,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -33,7 +32,7 @@ namespace Microsoft.PythonTools.Interpreter.Ast {
         private bool _scraped;
 
         public AstScrapedPythonModule(string name, string filePath) {
-            Name = name;
+            Name = name ?? throw new ArgumentNullException(nameof(name));
             _documentation = string.Empty;
             _filePath = filePath;
             _members = new Dictionary<string, IMember>();

--- a/Python/Product/Analysis/Interpreter/Ast/NameLookupContext.cs
+++ b/Python/Product/Analysis/Interpreter/Ast/NameLookupContext.cs
@@ -1,0 +1,272 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Numerics;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.PythonTools.Analysis;
+using Microsoft.PythonTools.Infrastructure;
+using Microsoft.PythonTools.Parsing;
+using Microsoft.PythonTools.Parsing.Ast;
+
+namespace Microsoft.PythonTools.Interpreter.Ast {
+    class NameLookupContext {
+        private readonly Stack<Dictionary<string, IMember>> _scopes;
+
+        public NameLookupContext(
+            IPythonInterpreter interpreter,
+            IModuleContext context,
+            PythonAst ast,
+            string filePath,
+            bool includeLocationInfo
+        ) {
+            Interpreter = interpreter;
+            Context = context;
+            Ast = ast;
+            FilePath = filePath;
+            IncludeLocationInfo = includeLocationInfo;
+
+            _scopes = new Stack<Dictionary<string, IMember>>();
+        }
+
+        public IPythonInterpreter Interpreter { get; }
+        public IModuleContext Context { get; }
+        public PythonAst Ast { get; }
+        public string FilePath { get; }
+        public bool IncludeLocationInfo { get; }
+
+        public NameLookupContext Clone(bool copyScopeContents = false) {
+            var ctxt = new NameLookupContext(
+                Interpreter,
+                Context,
+                Ast,
+                FilePath,
+                IncludeLocationInfo
+            );
+
+            foreach (var scope in _scopes.Reverse()) {
+                if (copyScopeContents) {
+                    ctxt._scopes.Push(new Dictionary<string, IMember>(scope));
+                } else {
+                    ctxt._scopes.Push(scope);
+                }
+            }
+
+            return ctxt;
+        }
+
+        public Dictionary<string, IMember> PushScope(Dictionary<string, IMember> scope = null) {
+            scope = scope ?? new Dictionary<string, IMember>();
+            _scopes.Push(scope);
+            return scope;
+        }
+
+        public Dictionary<string, IMember> PopScope() {
+            return _scopes.Pop();
+        }
+
+        internal LocationInfo GetLoc(Node node) {
+            if (!IncludeLocationInfo) {
+                return null;
+            }
+            if (node == null || node.StartIndex >= node.EndIndex) {
+                return null;
+            }
+
+            var start = node.GetStart(Ast);
+            var end = node.GetEnd(Ast);
+            return new LocationInfo(FilePath, start.Line, start.Column, end.Line, end.Column);
+        }
+
+        private string GetNameFromExpressionWorker(Expression expr) {
+            var ne = expr as NameExpression;
+            if (ne != null) {
+                return ne.Name;
+            }
+
+            var me = expr as MemberExpression;
+            if (me != null) {
+                return "{0}.{1}".FormatInvariant(GetNameFromExpressionWorker(me.Target), me.Name);
+            }
+
+            throw new FormatException();
+        }
+
+        public string GetNameFromExpression(Expression expr) {
+            try {
+                return GetNameFromExpressionWorker(expr);
+            } catch (FormatException) {
+                return null;
+            }
+        }
+
+        public IMember GetValueFromExpression(Expression expr, LookupOptions options = LookupOptions.Normal) {
+            var ne = expr as NameExpression;
+            if (ne != null) {
+                IMember existing = LookupNameInScopes(ne.Name, options);
+                if (existing != null) {
+                    return existing;
+                }
+            }
+
+            IPythonType type;
+
+            var me = expr as MemberExpression;
+            if (me != null && me.Target != null && !string.IsNullOrEmpty(me.Name)) {
+                var mc = GetValueFromExpression(me.Target) as IMemberContainer;
+                if (mc != null) {
+                    return mc.GetMember(Context, me.Name);
+                }
+                return null;
+            }
+
+            if (expr is CallExpression) {
+                var cae = (CallExpression)expr;
+                var m = GetValueFromExpression(cae.Target);
+                type = m as IPythonType;
+                if (type != null) {
+                    if (type == Interpreter.GetBuiltinType(BuiltinTypeId.Type) && cae.Args.Count >= 1) {
+                        var aType = GetTypeFromValue(GetValueFromExpression(cae.Args[0].Expression));
+                        if (aType != null) {
+                            return aType;
+                        }
+                    }
+                    return type;
+                }
+
+                var fn = m as IPythonFunction;
+                if (fn != null) {
+                    // TODO: Select correct overload and handle multiple return types
+                    if (fn.Overloads.Count > 0 && fn.Overloads[0].ReturnType.Count > 0) {
+                        return new AstPythonConstant(fn.Overloads[0].ReturnType[0]);
+                    }
+                    return new AstPythonConstant(Interpreter.GetBuiltinType(BuiltinTypeId.NoneType), GetLoc(expr));
+                }
+            }
+
+            type = GetTypeFromLiteral(expr);
+            if (type != null) {
+                return new AstPythonConstant(type, GetLoc(expr));
+            }
+
+            return null;
+        }
+
+        public IPythonType GetTypeFromValue(IMember value) {
+            if (value == null) {
+                return null;
+            }
+
+            var type = (value as IPythonConstant)?.Type;
+            if (type != null) {
+                return type;
+            }
+
+            if (value is IPythonType) {
+                return Interpreter.GetBuiltinType(BuiltinTypeId.Type);
+            }
+
+            if (value is IPythonFunction) {
+                return Interpreter.GetBuiltinType(BuiltinTypeId.Function);
+            }
+
+            Debug.Fail("Unhandled type() value: " + value.GetType().FullName);
+            return null;
+        }
+
+        public IPythonType GetTypeFromLiteral(Expression expr) {
+            var ce = expr as ConstantExpression;
+            if (ce != null) {
+                if (ce.Value == null) {
+                    return Interpreter.GetBuiltinType(BuiltinTypeId.NoneType);
+                }
+                switch (Type.GetTypeCode(ce.Value.GetType())) {
+                    case TypeCode.Boolean: return Interpreter.GetBuiltinType(BuiltinTypeId.Bool);
+                    case TypeCode.Double: return Interpreter.GetBuiltinType(BuiltinTypeId.Float);
+                    case TypeCode.Int32: return Interpreter.GetBuiltinType(BuiltinTypeId.Int);
+                    case TypeCode.String: return Interpreter.GetBuiltinType(BuiltinTypeId.Unicode);
+                    case TypeCode.Object:
+                        if (ce.Value.GetType() == typeof(Complex)) {
+                            return Interpreter.GetBuiltinType(BuiltinTypeId.Complex);
+                        } else if (ce.Value.GetType() == typeof(AsciiString)) {
+                            return Interpreter.GetBuiltinType(BuiltinTypeId.Bytes);
+                        } else if (ce.Value.GetType() == typeof(BigInteger)) {
+                            return Interpreter.GetBuiltinType(BuiltinTypeId.Long);
+                        } else if (ce.Value.GetType() == typeof(Ellipsis)) {
+                            return Interpreter.GetBuiltinType(BuiltinTypeId.Ellipsis);
+                        }
+                        break;
+                }
+                return null;
+            }
+
+            if (expr is ListExpression || expr is ListComprehension) {
+                return Interpreter.GetBuiltinType(BuiltinTypeId.List);
+            }
+            if (expr is DictionaryExpression || expr is DictionaryComprehension) {
+                return Interpreter.GetBuiltinType(BuiltinTypeId.Dict);
+            }
+            if (expr is TupleExpression) {
+                return Interpreter.GetBuiltinType(BuiltinTypeId.Tuple);
+            }
+            if (expr is SetExpression || expr is SetComprehension) {
+                return Interpreter.GetBuiltinType(BuiltinTypeId.Set);
+            }
+            if (expr is LambdaExpression) {
+                return Interpreter.GetBuiltinType(BuiltinTypeId.Function);
+            }
+
+            return null;
+        }
+
+        public IMember GetInScope(string name) {
+            if (_scopes.Count == 0) {
+                return null;
+            }
+
+            IMember obj;
+            if (_scopes.Peek().TryGetValue(name, out obj)) {
+                return obj;
+            }
+            return null;
+        }
+
+        public void SetInScope(string name, IMember value) {
+            _scopes.Peek()[name] = value;
+        }
+
+        public enum LookupOptions {
+            Normal = 0,
+            LocalOnly = 1,
+            Nonlocal = 2,
+            Global = 3
+        }
+
+        public IMember LookupNameInScopes(string name, LookupOptions options) {
+            IMember value;
+            if (options == LookupOptions.Global) {
+                if (_scopes.Last().TryGetValue(name, out value) && value != null) {
+                    return value;
+                }
+                return null;
+            }
+
+            foreach (var scope in _scopes) {
+                if (options == LookupOptions.Nonlocal) {
+                    options = LookupOptions.Normal;
+                    continue;
+                }
+
+                if (scope.TryGetValue(name, out value) && value != null) {
+                    return value;
+                }
+
+                if (options == LookupOptions.LocalOnly) {
+                    return null;
+                }
+            }
+            return null;
+        }
+    }
+}

--- a/Python/Product/Analysis/ModulePath.cs
+++ b/Python/Product/Analysis/ModulePath.cs
@@ -659,6 +659,14 @@ namespace Microsoft.PythonTools.Analysis {
         internal static bool FromBasePathAndName_NoThrow(
             string basePath,
             string moduleName,
+            out ModulePath modulePath
+        ) {
+            return FromBasePathAndName_NoThrow(basePath, moduleName, null, null, out modulePath, out _, out _, out _);
+        }
+
+        internal static bool FromBasePathAndName_NoThrow(
+            string basePath,
+            string moduleName,
             Func<string, bool> isPackage,
             Func<string, string, string> getModule,
             out ModulePath modulePath,

--- a/Python/Product/Analysis/ModulePath.cs
+++ b/Python/Product/Analysis/ModulePath.cs
@@ -631,6 +631,46 @@ namespace Microsoft.PythonTools.Analysis {
             Func<string, bool> isPackage = null,
             Func<string, string, string> getModule = null
         ) {
+            ModulePath module;
+            string errorParameter;
+            bool isInvalid, isMissing;
+            if (FromBasePathAndName_NoThrow(
+                basePath,
+                moduleName,
+                isPackage,
+                getModule,
+                out module,
+                out isInvalid,
+                out isMissing,
+                out errorParameter
+            )) {
+                return module;
+            }
+
+            if (isInvalid) {
+                throw new ArgumentException("Not a valid Python package: " + errorParameter);
+            }
+            if (isMissing) {
+                throw new ArgumentException("Python package not found: " + errorParameter);
+            }
+            throw new ArgumentException("Unknown error finding module");
+        }
+
+        internal static bool FromBasePathAndName_NoThrow(
+            string basePath,
+            string moduleName,
+            Func<string, bool> isPackage,
+            Func<string, string, string> getModule,
+            out ModulePath modulePath,
+            out bool isInvalid,
+            out bool isMissing,
+            out string errorParameter
+        ) {
+            modulePath = default(ModulePath);
+            isInvalid = false;
+            isMissing = false;
+            errorParameter = null;
+
             var bits = moduleName.Split('.');
             var lastBit = bits.Last();
 
@@ -653,7 +693,9 @@ namespace Microsoft.PythonTools.Analysis {
 
             foreach (var bit in bits.Take(bits.Length - 1)) {
                 if (!PythonPackageRegex.IsMatch(bit)) {
-                    throw new ArgumentException("Not a valid Python package: " + bit);
+                    isInvalid = true;
+                    errorParameter = bit;
+                    return false;
                 }
                 if (string.IsNullOrEmpty(path)) {
                     path = bit;
@@ -661,18 +703,26 @@ namespace Microsoft.PythonTools.Analysis {
                     path = PathUtils.GetAbsoluteFilePath(path, bit);
                 }
                 if (!isPackage(path)) {
-                    throw new ArgumentException("Python package not found: " + path);
+                    isMissing = true;
+                    errorParameter = path;
+                    return false;
                 }
             }
 
             if (!PythonPackageRegex.IsMatch(lastBit)) {
-                throw new ArgumentException("Not a valid Python module: " + moduleName);
+                isInvalid = true;
+                errorParameter = moduleName;
+                return false;
             }
             path = getModule(path, lastBit);
             if (string.IsNullOrEmpty(path)) {
-                throw new ArgumentException("Python module not found: " + moduleName);
+                isMissing = true;
+                errorParameter = moduleName;
+                return false;
             }
-            return new ModulePath(moduleName, path, basePath);
+
+            modulePath = new ModulePath(moduleName, path, basePath);
+            return true;
         }
 
         internal static IEnumerable<string> GetParents(string name, bool includeFullName = true) {

--- a/Python/Product/Analysis/scrape_builtins.py
+++ b/Python/Product/Analysis/scrape_builtins.py
@@ -30,97 +30,97 @@ INCLUDE_DOCS = 1
 # actual names within AstPythonInterpreter.
 
 DIRECT_MAP = {
-    object: "Object",
-    type: "Type",
-    tuple: "Tuple",
-    int: "Int",
-    str: "Str",
+    object: "__Object",
+    type: "__Type",
+    tuple: "__Tuple",
+    int: "__Int",
+    str: "__Str",
     None: "None",
-    type(int.real): "Property",
-    type(complex.real): "Property",
+    type(int.real): "__Property",
+    type(complex.real): "__Property",
 }
 
 # These two dictionaries start with Python 3 values.
 # There is an update below for Python 2 differences.
 
-T = "Type(self)()"
+T = "__Type(self)()"
 N = "None"
 KNOWN_RESTYPES = {
     "__abs__": T,
     "__add__": T,
     "__and__": T,
     "__annotations__": "{}",
-    "__base__": "Type()",
-    "__bases__": "(Type(),)",
-    "__bool__": "Bool()",
-    "__call__": "Unknown()",
-    "Type.__call__": "cls()",
+    "__base__": "__Type()",
+    "__bases__": "(__Type(),)",
+    "__bool__": "__Bool()",
+    "__call__": "__Unknown()",
+    "__Type.__call__": "cls()",
     "__ceil__": T,
-    "__code__": "Object()",
-    "__contains__": "Bool()",
+    "__code__": "__Object()",
+    "__contains__": "__Bool()",
     "__del__": N,
     "__delattr__": N,
-    "Property.__delete__": N,
+    "__Property.__delete__": N,
     "__delitem__": N,
-    "__dict__": "{'': Unknown()}",
+    "__dict__": "{'': __Unknown()}",
     "__dir__": "['']",
-    "__divmod__": "(Int(), Int())",
-    "__eq__": "Bool()",
+    "__divmod__": "(0, 0)",
+    "__eq__": "__Bool()",
     "__format__": "''",
-    "__float__": "Float()",
+    "__float__": "__Float()",
     "__floor__": T,
-    "__floordiv__": "Int()",
-    "__ge__": "Bool()",
+    "__floordiv__": "0",
+    "__ge__": "__Bool()",
     "__get__": T,
-    "__getattribute__": "Unknown()",
-    "Float.__getformat__": "''",
-    "__getitem__": "Unknown()",
+    "__getattribute__": "__Unknown()",
+    "__Float.__getformat__": "''",
+    "__getitem__": "__Unknown()",
     "__getnewargs__": "()",
     "__getnewargs_ex__": "((), {})",
     "__globals__": "{}",
-    "__gt__": "Bool()",
-    "__hash__": "Int()",
+    "__gt__": "__Bool()",
+    "__hash__": "0",
     "__iadd__": N,
     "__iand__": N,
     "__imul__": N,
-    "__index__": "Int()",
+    "__index__": "0",
     "__init__": T,
     "__init_subclass__": N,
-    "__int__": "Int()",
-    "Type.__instancecheck__": "Bool()",
+    "__int__": "0",
+    "__Type.__instancecheck__": "__Bool()",
     "__invert__": T,
     "__ior__": N,
     "__isub__": N,
     "__iter__": T,
-    "Tuple.__iter__": "TupleIterator()",
-    "List.__iter__": "ListIterator()",
-    "Dict.__iter__": "DictKeys()",
-    "Set.__iter__": "SetIterator()",
-    "FrozenSet.__iter__": "SetIterator()",
-    "Bytes.__iter__": "BytesIterator()",
-    "Unicode.__iter__": "UnicodeIterator()",
+    "__Tuple.__iter__": "__TupleIterator()",
+    "__List.__iter__": "__ListIterator()",
+    "__Dict.__iter__": "__DictKeys()",
+    "__Set.__iter__": "__SetIterator()",
+    "__FrozenSet.__iter__": "__SetIterator()",
+    "__Bytes.__iter__": "__BytesIterator()",
+    "__Unicode.__iter__": "__UnicodeIterator()",
     "__ixor__": N,
-    "__le__": "Bool()",
-    "__len__": "Int()",
-    "__length_hint__": "Int()",
+    "__le__": "__Bool()",
+    "__len__": "0",
+    "__length_hint__": "0",
     "__lshift__": T,
-    "__lt__": "Bool()",
+    "__lt__": "__Bool()",
     "__mod__": T,
     "__mul__": T,
-    "__ne__": "Bool()",
+    "__ne__": "__Bool()",
     "__neg__": T,
     "__new__": "cls()",
-    "__next__": "Unknown()",
-    "BytesIterator.__next__": "Int()",
-    "UnicodeIterator.__next__": "Unicode()",
-    "Type.__prepare__": N,
+    "__next__": "__Unknown()",
+    "__BytesIterator.__next__": "0",
+    "__UnicodeIterator.__next__": "__Unicode()",
+    "__Type.__prepare__": N,
     "__pos__": T,
     "__pow__": T,
     "__or__": T,
     "__radd__": T,
     "__rand__": T,
-    "__rdivmod__": "(Int(), Int())",
-    "List.__reversed__": "ListIterator()",
+    "__rdivmod__": "(0, 0)",
+    "__List.__reversed__": "__ListIterator()",
     "__rfloordiv__": T,
     "__rlshift__": T,
     "__rmod__": T,
@@ -138,205 +138,205 @@ KNOWN_RESTYPES = {
     "__repr__": "''",
     "__set__": N,
     "__setattr__": N,
-    "Float.__setformat__": N,
+    "__Float.__setformat__": N,
     "__setitem__": N,
     "__setstate__": N,
-    "__sizeof__": "Int()",
+    "__sizeof__": "0",
     "__str__": "''",
-    "Type.__subclasses__": "(cls,)",
+    "__Type.__subclasses__": "(cls,)",
     "__sub__": T,
     "__truediv__": "Float()",
     "__trunc__": T,
     "__xor__": T,
-    "Type.__subclasscheck__": "Bool()",
-    "__subclasshook__": "Bool()",
+    "__Type.__subclasscheck__": "__Bool()",
+    "__subclasshook__": "__Bool()",
     "__text_signature__": "''",
-    "Set.add": N,
-    "List.append": N,
-    "Float.as_integer_ratio": "(Int(), Int())",
-    "Int.bit_length": "Int()",
+    "__Set.add": N,
+    "__List.append": N,
+    "__Float.as_integer_ratio": "(0, 0)",
+    "__Int.bit_length": "0",
     "capitalize": T,
     "casefold": T,
     "center": T,
     "clear": N,
-    "Generator.close": N,
-    "conjugate": "Complex()",
+    "__Generator.close": N,
+    "conjugate": "__Complex()",
     "copy": T,
-    "count": "Int()",
-    "Bytes.decode": "''",
-    "Property.deleter": "func",
-    "Set.difference": T,
-    "FrozenSet.difference": T,
-    "Set.difference_update": N,
-    "Set.discard": N,
-    "Bytes.encode": "b''",
-    "Unicode.encode": "b''",
-    "endswith": "Bool()",
+    "count": "0",
+    "__Bytes.decode": "''",
+    "__Property.deleter": "func",
+    "__Set.difference": T,
+    "__FrozenSet.difference": T,
+    "__Set.difference_update": N,
+    "__Set.discard": N,
+    "__Bytes.encode": "b''",
+    "__Unicode.encode": "b''",
+    "endswith": "__Bool()",
     "expandtabs": T,
-    "List.extend": N,
-    "find": "Int()",
-    "Unicode.format": T,
-    "Unicode.format_map": T,
-    "Bool.from_bytes": "Bool()",
-    "Int.from_bytes": "Int()",
-    "Long.from_bytes": "Long()",
-    "Float.fromhex": "Float()",
-    "Bytes.fromhex": "b''",
-    "Dict.fromkeys": "{}",
-    "Dict.get": "self.__getitem__()",
-    "Property.getter": "func",
+    "__List.extend": N,
+    "find": "0",
+    "__Unicode.format": T,
+    "__Unicode.format_map": T,
+    "__Bool.from_bytes": "__Bool()",
+    "__Int.from_bytes": "0",
+    "__Long.from_bytes": "__Long()",
+    "__Float.fromhex": "__Float()",
+    "__Bytes.fromhex": "b''",
+    "__Dict.fromkeys": "{}",
+    "__Dict.get": "self[0]",
+    "__Property.getter": "func",
     "hex": "''",
-    "index": "Int()",
-    "List.insert": N,
-    "Set.intersection": T,
-    "FrozenSet.intersection": T,
-    "Set.intersection_update": N,
-    "isalnum": "Bool()",
-    "isalpha": "Bool()",
-    "isdecimal": "Bool()",
-    "isdigit": "Bool()",
-    "islower": "Bool()",
-    "isidentifier": "Bool()",
-    "isnumeric": "Bool()",
-    "isprintable": "Bool()",
-    "isspace": "Bool()",
-    "istitle": "Bool()",
-    "isupper": "Bool()",
-    "Float.is_integer": "Bool()",
-    "Set.isdisjoint": "Bool()",
-    "FrozenSet.isdisjoint": "Bool()",
-    "DictKeys.isdisjoint": "Bool()",
-    "DictItems.isdisjoint": "Bool()",
-    "Set.issubset": "Bool()",
-    "FrozenSet.issubset": "Bool()",
-    "Set.issuperset": "Bool()",
-    "FrozenSet.issuperset": "Bool()",
-    "Dict.items": "DictItems()",
-    "Bytes.join": "b''",
-    "Unicode.join": "''",
-    "Dict.keys": "DictKeys()",
+    "index": "0",
+    "__List.insert": N,
+    "__Set.intersection": T,
+    "__FrozenSet.intersection": T,
+    "__Set.intersection_update": N,
+    "isalnum": "__Bool()",
+    "isalpha": "__Bool()",
+    "isdecimal": "__Bool()",
+    "isdigit": "__Bool()",
+    "islower": "__Bool()",
+    "isidentifier": "__Bool()",
+    "isnumeric": "__Bool()",
+    "isprintable": "__Bool()",
+    "isspace": "__Bool()",
+    "istitle": "__Bool()",
+    "isupper": "__Bool()",
+    "__Float.is_integer": "__Bool()",
+    "__Set.isdisjoint": "__Bool()",
+    "__FrozenSet.isdisjoint": "__Bool()",
+    "__DictKeys.isdisjoint": "__Bool()",
+    "__DictItems.isdisjoint": "__Bool()",
+    "__Set.issubset": "__Bool()",
+    "__FrozenSet.issubset": "__Bool()",
+    "__Set.issuperset": "__Bool()",
+    "__FrozenSet.issuperset": "__Bool()",
+    "__Dict.items": "__DictItems()",
+    "__Bytes.join": "b''",
+    "__Unicode.join": "''",
+    "__Dict.keys": "__DictKeys()",
     "lower": T,
     "ljust": T,
     "lstrip": T,
-    "Bytes.maketrans": "b''",
-    "Unicode.maketrans": "{}",
-    "Type.mro": "[Type()]",
-    "partition": "(Type(self)(), Type(self)(), Type(self)())",
-    "List.pop": "self.__getitem__()",
-    "Dict.pop": "self.keys().__getitem__()",
-    "Set.pop": "Unknown()",
-    "Dict.popitem": "self.items().__getitem__()",
+    "__Bytes.maketrans": "b''",
+    "__Unicode.maketrans": "{}",
+    "__Type.mro": "[__Type()]",
+    "partition": "(__Type(self)(), __Type(self)(), __Type(self)())",
+    "__List.pop": "self[0]",
+    "__Dict.pop": "self.keys()[0]",
+    "__Set.pop": "__Unknown()",
+    "__Dict.popitem": "self.items()[0]",
     "remove": N,
     "replace": T,
-    "rfind": "Int()",
-    "List.reverse": N,
-    "rindex": "Int()",
+    "rfind": "0",
+    "__List.reverse": N,
+    "rindex": "0",
     "rjust": T,
-    "rpartition": "(Type(self)(), Type(self)(), Type(self)())",
-    "rsplit": "[Type(self)()]",
+    "rpartition": "(__Type(self)(), __Type(self)(), __Type(self)())",
+    "rsplit": "[__Type(self)()]",
     "rstrip": T,
-    "Generator.send": "self.__next__()",
-    "Dict.setdefault": "self.__getitem__()",
-    "Property.setter": "func",
-    "List.sort": N,
-    "split": "[Type(self)()]",
+    "__Generator.send": "self.__next__()",
+    "__Dict.setdefault": "self[0]",
+    "__Property.setter": "func",
+    "__List.sort": N,
+    "split": "[__Type(self)()]",
     "splitlines": "[self()]",
-    "startswith": "Bool()",
+    "startswith": "__Bool()",
     "strip": T,
     "swapcase": T,
-    "Set.symmetric_difference": T,
-    "FrozenSet.symmetric_difference": T,
-    "Set.symmetric_difference_update": N,
-    "Bytes.translate": T,
-    "Unicode.translate": T,
-    "Generator.throw": N,
+    "__Set.symmetric_difference": T,
+    "__FrozenSet.symmetric_difference": T,
+    "__Set.symmetric_difference_update": N,
+    "__Bytes.translate": T,
+    "__Unicode.translate": T,
+    "__Generator.throw": N,
     "title": T,
     "to_bytes": "b''",
-    "Set.union": T,
-    "FrozenSet.union": T,
-    "Dict.update": N,
-    "Set.update": N,
+    "__Set.union": T,
+    "__FrozenSet.union": T,
+    "__Dict.update": N,
+    "__Set.update": N,
     "upper": T,
-    "Dict.values": "DictValues()",
+    "__Dict.values": "__DictValues()",
     "zfill": T,
 }
 
 SELF = "(self)"
 KNOWN_ARGSPECS = {
-    "Type.__call__": "(cls, *args, **kwargs)",
-    "Int.__ceil__": SELF,
+    "__Type.__call__": "(cls, *args, **kwargs)",
+    "__Int.__ceil__": SELF,
     "__contains__": "(self, value)",
     "__del__": SELF,
     "__dir__": SELF,
-    "Int.__floor__": SELF,
+    "__Int.__floor__": SELF,
     "__format__": "(self, format_spec)",
-    "Float.__getformat__": "(typestr)",
+    "__Float.__getformat__": "(typestr)",
     "__getitem__": "(self, index)",
-    "Dict.__getitem__": "(self, key)",
+    "__Dict.__getitem__": "(self, key)",
     "__getnewargs__": SELF,
     "__getnewargs_ex__": SELF,
     "__init_subclass__": "(cls)",
-    "Type.__instancecheck__": "(self, instance)",
-    "Bool.__init__": "(self, x)",
-    "Int.__init__": "(self, x=0)",
+    "__Type.__instancecheck__": "(self, instance)",
+    "__Bool.__init__": "(self, x)",
+    "__Int.__init__": "(self, x=0)",
     "__length_hint__": SELF,
     "__new__": "(cls, *args, **kwargs)",
-    "Type.__prepare__": "(cls, name, bases, **kwds)",
-    "Int.__round__": "(self, ndigits=0)",
-    "Float.__round__": "(self, ndigits=0)",
+    "__Type.__prepare__": "(cls, name, bases, **kwds)",
+    "__Int.__round__": "(self, ndigits=0)",
+    "__Float.__round__": "(self, ndigits=0)",
     "__reduce__": SELF,
     "__reduce_ex__": "(self, protocol)",
-    "List.__reversed__": SELF,
-    "Float.__setformat__": "(typestr, fmt)",
-    "List.__setitem__": "(self, index, value)",
-    "Dict.__setitem__": "(self, key, value)",
+    "__List.__reversed__": SELF,
+    "__Float.__setformat__": "(typestr, fmt)",
+    "__List.__setitem__": "(self, index, value)",
+    "__Dict.__setitem__": "(self, key, value)",
     "__setstate__": "(self, state)",
     "__sizeof__": SELF,
-    "Type.__subclasses__": "(cls)",
-    "Type.__subclasscheck__": "(cls, subclass)",
+    "__Type.__subclasses__": "(cls)",
+    "__Type.__subclasscheck__": "(cls, subclass)",
     "__subclasshook__": "(cls, subclass)",
     "__trunc__": SELF,
-    "Set.add": "(self, value)",
-    "List.append": "(self, value)",
-    "Float.as_integer_ratio": SELF,
-    "Int.bit_length": SELF,
+    "__Set.add": "(self, value)",
+    "__List.append": "(self, value)",
+    "__Float.as_integer_ratio": SELF,
+    "__Int.bit_length": SELF,
     "capitalize": SELF,
     "casefold": SELF,
-    "Bytes.center": ["(self, width)", "(self, width, fillbyte)"],
-    "Unicode.center": ["(self, width)", "(self, width, fillchar)"],
+    "__Bytes.center": ["(self, width)", "(self, width, fillbyte)"],
+    "__Unicode.center": ["(self, width)", "(self, width, fillchar)"],
     "clear": SELF,
-    "Generator.close": SELF,
+    "__Generator.close": SELF,
     "conjugate": SELF,
     "copy": SELF,
     "count": "(self, x)",
-    "Bytes.count": ["(self, sub)", "(self, sub, start)", "(self, sub, start, end)"],
-    "Unicode.count": ["(self, sub)", "(self, sub, start)", "(self, sub, start, end)"],
-    "Bytes.decode": "(self, encoding='utf-8', errors='strict')",
-    "Property.deleter": "(self, func)",
-    "Set.difference": "(self, other)",
-    "FrozenSet.difference": "(self, other)",
-    "Set.difference_update": "(self, *others)",
-    "Set.discard": "(self, elem)",
-    "Unicode.encode": "(self, encoding='utf-8', errors='strict')",
+    "__Bytes.count": ["(self, sub)", "(self, sub, start)", "(self, sub, start, end)"],
+    "__Unicode.count": ["(self, sub)", "(self, sub, start)", "(self, sub, start, end)"],
+    "__Bytes.decode": "(self, encoding='utf-8', errors='strict')",
+    "__Property.deleter": "(self, func)",
+    "__Set.difference": "(self, other)",
+    "__FrozenSet.difference": "(self, other)",
+    "__Set.difference_update": "(self, *others)",
+    "__Set.discard": "(self, elem)",
+    "__Unicode.encode": "(self, encoding='utf-8', errors='strict')",
     "endswith": ["(self, suffix)", "(self, suffix, start)", "(self, suffix, start, end)"],
     "expandtabs": "(self, tabsize=8)",
-    "List.extend": "(self, iterable)",
+    "__List.extend": "(self, iterable)",
     "find": ["(self, sub)", "(self, sub, start)", "(self, sub, start, end)"],
-    "Unicode.format": "(self, *args, **kwargs)",
-    "Unicode.format_map": "(self, mapping)",
-    "Bool.from_bytes": "(bytes, byteorder, *, signed=False)",
-    "Int.from_bytes": "(bytes, byteorder, *, signed=False)",
-    "Float.fromhex": "(string)",
-    "Dict.get": "(self, key, d=Unknown())",
-    "Property.getter": "(self, func)",
+    "__Unicode.format": "(self, *args, **kwargs)",
+    "__Unicode.format_map": "(self, mapping)",
+    "__Bool.from_bytes": "(bytes, byteorder, *, signed=False)",
+    "__Int.from_bytes": "(bytes, byteorder, *, signed=False)",
+    "__Float.fromhex": "(string)",
+    "__Dict.get": "(self, key, d=Unknown())",
+    "__Property.getter": "(self, func)",
     "hex": SELF,
-    "List.insert": "(self, index, value)",
+    "__List.insert": "(self, index, value)",
     "index": "(self, v)",
-    "Bytes.index": ["(self, sub)", "(self, sub, start)", "(self, sub, start, end)"],
-    "Unicode.index": ["(self, sub)", "(self, sub, start)", "(self, sub, start, end)"],
-    "Set.intersection": "(self, other)",
-    "FrozenSet.intersection": "(self, other)",
-    "Set.intersection_update": "(self, *others)",
+    "__Bytes.index": ["(self, sub)", "(self, sub, start)", "(self, sub, start, end)"],
+    "__Unicode.index": ["(self, sub)", "(self, sub, start)", "(self, sub, start, end)"],
+    "__Set.intersection": "(self, other)",
+    "__FrozenSet.intersection": "(self, other)",
+    "__Set.intersection_update": "(self, *others)",
     "isalnum": SELF,
     "isalpha": SELF,
     "isdecimal": SELF,
@@ -348,80 +348,82 @@ KNOWN_ARGSPECS = {
     "isspace": SELF,
     "istitle": SELF,
     "isupper": SELF,
-    "Float.is_integer": SELF,
-    "Set.isdisjoint": "(self, other)",
-    "FrozenSet.isdisjoint": "(self, other)",
-    "DictKeys.isdisjoint": "(self, other)",
-    "DictItems.isdisjoint": "(self, other)",
-    "Set.issubset": "(self, other)",
-    "FrozenSet.issubset": "(self, other)",
-    "Set.issuperset": "(self, other)",
-    "FrozenSet.issuperset": "(self, other)",
-    "Dict.items": SELF,
-    "Bytes.join": "(self, iterable)",
-    "Unicode.join": "(self, iterable)",
-    "Dict.keys": SELF,
+    "__Float.is_integer": SELF,
+    "__Set.isdisjoint": "(self, other)",
+    "__FrozenSet.isdisjoint": "(self, other)",
+    "__DictKeys.isdisjoint": "(self, other)",
+    "__DictItems.isdisjoint": "(self, other)",
+    "__Set.issubset": "(self, other)",
+    "__FrozenSet.issubset": "(self, other)",
+    "__Set.issuperset": "(self, other)",
+    "__FrozenSet.issuperset": "(self, other)",
+    "__Dict.items": SELF,
+    "__Bytes.join": "(self, iterable)",
+    "__Unicode.join": "(self, iterable)",
+    "__Dict.keys": SELF,
     "lower": SELF,
-    "Bytes.ljust": ["(self, width)", "(self, width, fillbyte)"],
-    "Unicode.ljust": ["(self, width)", "(self, width, fillchar)"],
+    "__Bytes.ljust": ["(self, width)", "(self, width, fillbyte)"],
+    "__Unicode.ljust": ["(self, width)", "(self, width, fillchar)"],
     "lstrip": ["(self)", "(self, chars)"],
-    "Bytes.maketrans": "(from_, to)",
-    "Unicode.maketrans": ["(x)", "(x, y)", "(x, y, z)"],
-    "Type.mro": "(cls)",
-    "Bytes.partition": "(self, sep)",
-    "Unicode.partition": "(self, sep)",
-    "List.pop": "(self, index=-1)",
-    "Dict.pop": "(self, k, d=Unknown())",
-    "Set.pop": SELF,
-    "Dict.popitem": "(self, k, d=Unknown())",
-    "List.remove": "(self, value)",
-    "Set.remove": "(self, elem)",
+    "__Bytes.maketrans": "(from_, to)",
+    "__Unicode.maketrans": ["(x)", "(x, y)", "(x, y, z)"],
+    "__Type.mro": "(cls)",
+    "__Bytes.partition": "(self, sep)",
+    "__Unicode.partition": "(self, sep)",
+    "__List.pop": "(self, index=-1)",
+    "__Dict.pop": "(self, k, d=Unknown())",
+    "__Set.pop": SELF,
+    "__Dict.popitem": "(self, k, d=Unknown())",
+    "__List.remove": "(self, value)",
+    "__Set.remove": "(self, elem)",
     "replace": ["(self, old, new)", "(self, old, new, count)"],
-    "List.reverse": SELF,
+    "__List.reverse": SELF,
     "rfind": ["(self, sub)", "(self, sub, start)", "(self, sub, start, end)"],
     "rindex": ["(self, sub)", "(self, sub, start)", "(self, sub, start, end)"],
-    "Bytes.rjust": ["(self, width)", "(self, width, fillbyte)"],
-    "Unicode.rjust": ["(self, width)", "(self, width, fillchar)"],
-    "Bytes.rpartition": "(self, sep)",
-    "Unicode.rpartition": "(self, sep)",
+    "__Bytes.rjust": ["(self, width)", "(self, width, fillbyte)"],
+    "__Unicode.rjust": ["(self, width)", "(self, width, fillchar)"],
+    "__Bytes.rpartition": "(self, sep)",
+    "__Unicode.rpartition": "(self, sep)",
     "rsplit": "(self, sep=None, maxsplit=-1)",
     "rstrip": ["(self)", "(self, chars)"],
-    "Generator.send": "(self, value)",
-    "Dict.setdefault": "(self, k, d)",
-    "Property.setter": "(self, func)",
-    "List.sort": SELF,
+    "__Generator.send": "(self, value)",
+    "__Dict.setdefault": "(self, k, d)",
+    "__Property.setter": "(self, func)",
+    "__List.sort": SELF,
     "split": "(self, sep=None, maxsplit=-1)",
     "splitlines": "(self, keepends=False)",
     "strip": ["(self)", "(self, chars)"],
     "startswith": ["(self, prefix)", "(self, prefix, start)", "(self, prefix, start, end)"],
     "swapcase": SELF,
-    "Set.symmetric_difference": "(self, other)",
-    "FrozenSet.symmetric_difference": "(self, other)",
-    "Set.symmetric_difference_update": "(self, *others)",
-    "Generator.throw": ["(self, type)", "(self, type, value)", "(self, type, value, traceback)"],
+    "__Set.symmetric_difference": "(self, other)",
+    "__FrozenSet.symmetric_difference": "(self, other)",
+    "__Set.symmetric_difference_update": "(self, *others)",
+    "__Generator.throw": ["(self, type)", "(self, type, value)", "(self, type, value, traceback)"],
     "title": SELF,
-    "Int.to_bytes": "(bytes, byteorder, *, signed=False)",
-    "Bytes.translate": "(self, table, delete=b'')",
-    "Unicode.translate": "(self, table)",
-    "Set.union": "(self, *others)",
-    "FrozenSet.union": "(self, *others)",
-    "Dict.update": "(self, d)",
-    "Set.update": "(self, *others)",
+    "__Int.to_bytes": "(bytes, byteorder, *, signed=False)",
+    "__Bytes.translate": "(self, table, delete=b'')",
+    "__Unicode.translate": "(self, table)",
+    "__Set.union": "(self, *others)",
+    "__FrozenSet.union": "(self, *others)",
+    "__Dict.update": "(self, d)",
+    "__Set.update": "(self, *others)",
     "upper": SELF,
-    "Dict.values": SELF,
+    "__Dict.values": SELF,
     "zfill": "(self, width)",
 }
 
 if sys.version[0] == '2':
     KNOWN_RESTYPES.update({
-        "BytesIterator.__next__": None,
-        "BytesIterator.next": "Bytes()",
-        "UnicodeIterator.__next__": None,
-        "UnicodeIterator.next": "Unicode()",
-        "Generator.send": "self.next()",
+        "__BytesIterator.__next__": None,
+        "__BytesIterator.next": "b''",
+        "__UnicodeIterator.__next__": None,
+        "__UnicodeIterator.next": "u''",
+        "__Generator.send": "self.next()",
     })
 
     KNOWN_ARGSPECS.update({
+        "__BytesIterator.next": SELF,
+        "__UnicodeIterator.next": SELF,
     })
 
 
@@ -590,63 +592,63 @@ def _print_type(alias, objtype, basename=None, base=None):
     print("")
 
 # Unknown
-print("class Unknown:")
+print("class __Unknown:")
 print("    '''<unknown type>'''")
 print("")
 
 # NoneType
-print("class NoneType:")
+print("class __NoneType:")
 print("    '''Type of the None object'''")
 print("")
 
-print("None = NoneType()")
+print("None = __NoneType()")
 print("")
 
 # Object
-_print_type("Object", object)
+_print_type("__Object", object)
 
 # Type
-_print_type("Type", type)
+_print_type("__Type", type)
 
 # Bool
 if type(bool()) is int:
-    print("Bool = Int")
+    print("__Bool = __Int")
     print("")
 else:
-    _print_type("Bool", bool, "Int", int)
+    _print_type("__Bool", bool, "__Int", int)
 
 # Int
-_print_type("Int", int)
+_print_type("__Int", int)
 
 # Long
 try:
     long
 except NameError:
-    print("Long = Int")
+    print("__Long = __Int")
     print("")
 else:
-    _print_type("Long", long)
+    _print_type("__Long", long)
 
 # Float
-_print_type("Float", float)
+_print_type("__Float", float)
 
 # Complex
-_print_type("Complex", complex)
+_print_type("__Complex", complex)
 
 # Tuple
-_print_type("Tuple", tuple)
+_print_type("__Tuple", tuple)
 
 # List
-_print_type("List", list)
+_print_type("__List", list)
 
 # Dict
-_print_type("Dict", dict)
+_print_type("__Dict", dict)
 
 # Set
-_print_type("Set", set)
+_print_type("__Set", set)
 
 # FrozenSet
-_print_type("FrozenSet", frozenset)
+_print_type("__FrozenSet", frozenset)
 
 try:
     bytes
@@ -655,48 +657,48 @@ except NameError:
 
 if bytes is not str:
     # Bytes
-    _print_type("Bytes", bytes)
+    _print_type("__Bytes", bytes)
 
     # BytesIterator
-    _print_type("BytesIterator", type(iter(bytes())))
+    _print_type("__BytesIterator", type(iter(bytes())))
 
     # Unicode
-    _print_type("Unicode", str)
+    _print_type("__Unicode", str)
 
     # UnicodeIterator
-    _print_type("UnicodeIterator", type(iter(str())))
+    _print_type("__UnicodeIterator", type(iter(str())))
 
     # Str
-    print("Str = Unicode")
+    print("__Str = __Unicode")
     print("")
 
     # StrIterator
-    print("StrIterator = UnicodeIterator")
+    print("__StrIterator = __UnicodeIterator")
     print("")
 
 else:
     # Bytes
-    _print_type("Bytes", str)
+    _print_type("__Bytes", str)
 
     # BytesIterator
-    _print_type("BytesIterator", type(iter(str())))
+    _print_type("__BytesIterator", type(iter(str())))
 
     # Unicode
-    _print_type("Unicode", unicode)
+    _print_type("__Unicode", unicode)
 
     # UnicodeIterator
-    _print_type("UnicodeIterator", type(iter(unicode())))
+    _print_type("__UnicodeIterator", type(iter(unicode())))
 
     # Str
-    print("Str = Bytes")
+    print("__Str = __Bytes")
     print("")
 
     # StrIterator
-    print("StrIterator = BytesIterator")
+    print("__StrIterator = __BytesIterator")
     print("")
 
 # Module
-_print_type("Module", type(inspect))
+_print_type("__Module", type(inspect))
 
 # Function
 
@@ -724,47 +726,47 @@ for f in _FUNCTIONS:
 else:
     raise RuntimeError("no valid function could be defined")
 
-_print_type("Function", Function)
+_print_type("__Function", Function)
 
 # BuiltinMethodDescriptor
-_print_type("BuiltinMethodDescriptor", type(object.__hash__))
+_print_type("__BuiltinMethodDescriptor", type(object.__hash__))
 
 # BuiltinFunction
-_print_type("BuiltinFunction", type(abs))
+_print_type("__BuiltinFunction", type(abs))
 
 # Generator
-_print_type("Generator", type((_ for _ in [])))
+_print_type("__Generator", type((_ for _ in [])))
 
 # Property
-_print_type("Property", property)
+_print_type("__Property", property)
 
 # ClassMethod
-_print_type("ClassMethod", classmethod)
+_print_type("__ClassMethod", classmethod)
 
 # StaticMethod
-_print_type("StaticMethod", staticmethod)
+_print_type("__StaticMethod", staticmethod)
 
 # Ellipsis
-_print_type("Ellipsis", type(...))
+_print_type("__Ellipsis", type(Ellipsis))
 
 # TupleIterator
-_print_type("TupleIterator", type(iter(())))
+_print_type("__TupleIterator", type(iter(())))
 
 # ListIterator
-_print_type("ListIterator", type(iter([])))
+_print_type("__ListIterator", type(iter([])))
 
 # DictKeys
-_print_type("DictKeys", type({}.keys()))
+_print_type("__DictKeys", type({}.keys()))
 
 # DictValues
-_print_type("DictValues", type({}.values()))
+_print_type("__DictValues", type({}.values()))
 
 # DictItems
-_print_type("DictItems", type({}.items()))
+_print_type("__DictItems", type({}.items()))
 
 # SetIterator
-_print_type("SetIterator", type(iter(set())))
+_print_type("__SetIterator", type(iter(set())))
 
 # CallableIterator
-_print_type("CallableIterator", type(iter((lambda: None), None)))
+_print_type("__CallableIterator", type(iter((lambda: None), None)))
 

--- a/Python/Product/Analysis/scrape_builtins.py
+++ b/Python/Product/Analysis/scrape_builtins.py
@@ -23,6 +23,11 @@ import inspect
 import sys
 import warnings
 
+try:
+    import builtins
+except ImportError:
+    import __builtin__ as builtins
+
 INCLUDE_DOCS = 1
 
 # For scraping builtins, we use standardized names that come from
@@ -479,7 +484,7 @@ _ALREADY_WRITTEN = set()
 
 def _print_type(alias, objtype, basename=None, base=None):
     name = objtype.__name__
-    
+
     if name in _ALREADY_WRITTEN:
         if alias != name:
             print(alias + " = " + name)
@@ -514,6 +519,9 @@ def _print_type(alias, objtype, basename=None, base=None):
         if isinstance(docstring, str):
             print("    " + _triple_quote(docstring))
             members = [m for m in members if m != '__doc__']
+
+    if not hasattr(builtins, name):
+        print("    __hidden = 1")
 
     last_member = None
     while members:

--- a/Python/Product/Analysis/scrape_builtins.py
+++ b/Python/Product/Analysis/scrape_builtins.py
@@ -1,0 +1,628 @@
+﻿# Python Tools for Visual Studio
+# Copyright(c) Microsoft Corporation
+# All rights reserved.
+# 
+# Licensed under the Apache License, Version 2.0 (the License); you may not use
+# this file except in compliance with the License. You may obtain a copy of the
+# License at http://www.apache.org/licenses/LICENSE-2.0
+# 
+# THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+# OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+# IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+# MERCHANTABLITY OR NON-INFRINGEMENT.
+# 
+# See the Apache Version 2.0 License for specific language governing
+# permissions and limitations under the License.
+
+from __future__ import print_function
+
+__author__ = "Microsoft Corporation <ptvshelp@microsoft.com>"
+__version__ = "3.2"
+
+import inspect
+import sys
+import warnings
+
+INCLUDE_DOCS = 1
+
+# For scraping builtins, we use standardized names that come from
+# the BuiltinTypeId enumeration. These are parsed and mapped to
+# actual names within AstPythonInterpreter.
+
+DIRECT_MAP = {
+    object: "Object",
+    type: "Type",
+    tuple: "Tuple",
+    int: "Int",
+    str: "Str",
+    None: "None",
+    type(int.real): "Property",
+    type(complex.real): "Property",
+}
+
+T = "type(self)()"
+N = "None"
+KNOWN_RESTYPES = {
+    "__abs__": T,
+    "__add__": T,
+    "__and__": T,
+    "__base__": "Type()",
+    "__bases__": "(Type(),)",
+    "__bool__": "Bool()",
+    "Type.__call__": "cls()",
+    "__ceil__": T,
+    "__contains__": "Bool()",
+    "__delattr__": N,
+    "__delitem__": N,
+    "__dict__": "{Str(): Unknown()}",
+    "__dir__": "[Str()]",
+    "__divmod__": "(Int(), Int())",
+    "__eq__": "Bool()",
+    "__format__": "Str()",
+    "__float__": "Float()",
+    "__floor__": T,
+    "__floordiv__": "Int()",
+    "__ge__": "Bool()",
+    "__getattribute__": "Unknown()",
+    "Float.__getformat__": "Str()",
+    "__getitem__": "Unknown()",
+    "__getnewargs__": "()",
+    "__getnewargs_ex__": "((), Dict())",
+    "__gt__": "Bool()",
+    "__hash__": "Int()",
+    "__iadd__": N,
+    "__iand__": N,
+    "__imul__": N,
+    "__index__": "Int()",
+    "__init__": T,
+    "__init_subclass__": N,
+    "__int__": "Int()",
+    "Type.__instancecheck__": "Bool()",
+    "__invert__": T,
+    "__ior__": N,
+    "__isub__": N,
+    "Tuple.__iter__": "TupleIterator()",
+    "List.__iter__": "ListIterator()",
+    "Dict.__iter__": "DictKeys()",
+    "Set.__iter__": "SetIterator()",
+    "FrozenSet.__iter__": "SetIterator()",
+    "Bytes.__iter__": "BytesIterator()",
+    "Unicode.__iter__": "UnicodeIterator()",
+    "__ixor__": N,
+    "__le__": "Bool()",
+    "__len__": "Int()",
+    "__lshift__": T,
+    "__lt__": "Bool()",
+    "__mod__": T,
+    "__mul__": T,
+    "__ne__": "Bool()",
+    "__neg__": T,
+    "__new__": "cls()",
+    "Type.__prepare__": N,
+    "__pos__": T,
+    "__pow__": T,
+    "__or__": T,
+    "__radd__": T,
+    "__rand__": T,
+    "__rdivmod__": "(Int(), Int())",
+    "List.__reversed__": "ListIterator()",
+    "__rfloordiv__": T,
+    "__rlshift__": T,
+    "__rmod__": T,
+    "__rmul__": T,
+    "__ror__": T,
+    "__round__": T,
+    "__rpow__": T,
+    "__rrshift__": T,
+    "__rshift__": T,
+    "__rsub__": T,
+    "__rtruediv__": T,
+    "__rxor__": T,
+    "__reduce__": ["''", "()"],
+    "__reduce_ex__": ["''", "()"],
+    "__repr__": "''",
+    "__setattr__": N,
+    "Float.__setformat__": N,
+    "__setitem__": N,
+    "__sizeof__": "Int()",
+    "__str__": "''",
+    "Type.__subclasses__": "(cls,)",
+    "__sub__": T,
+    "__truediv__": "Float()",
+    "__trunc__": T,
+    "__xor__": T,
+    "Type.__subclasscheck__": "Bool()",
+    "__subclasshook__": "Bool()",
+    "Set.add": N,
+    "List.append": N,
+    "Float.as_integer_ratio": "(Int(), Int())",
+    "Int.bit_length": "Int()",
+    "capitalize": T,
+    "casefold": T,
+    "center": T,
+    "clear": N,
+    "conjugate": "Complex()",
+    "copy": T,
+    "count": "Int()",
+    "Bytes.decode": "''",
+    "Bytes.encode": "b''",
+    "Unicode.encode": "b''",
+    "Set.difference": T,
+    "FrozenSet.difference": T,
+    "Set.difference_update": N,
+    "Set.discard": N,
+    "endswith": "Bool()",
+    "expandtabs": T,
+    "List.extend": N,
+    "find": "Int()",
+    "Unicode.format": T,
+    "Unicode.format_map": T,
+    "Bool.from_bytes": "Bool()",
+    "Int.from_bytes": "Int()",
+    "Long.from_bytes": "Long()",
+    "Float.fromhex": "Float()",
+    "Bytes.fromhex": "b''",
+    "Dict.fromkeys": "{}",
+    "Dict.get": "self.__getitem__()",
+    "hex": "''",
+    "index": "Int()",
+    "List.insert": N,
+    "Set.intersection": T,
+    "FrozenSet.intersection": T,
+    "Set.intersection_update": N,
+    "isalnum": "Bool()",
+    "isalpha": "Bool()",
+    "isdecimal": "Bool()",
+    "isdigit": "Bool()",
+    "islower": "Bool()",
+    "isidentifier": "Bool()",
+    "isnumeric": "Bool()",
+    "isprintable": "Bool()",
+    "isspace": "Bool()",
+    "istitle": "Bool()",
+    "isupper": "Bool()",
+    "Float.is_integer": "Bool()",
+    "Set.isdisjoint": "Bool()",
+    "FrozenSet.isdisjoint": "Bool()",
+    "Set.issubset": "Bool()",
+    "FrozenSet.issubset": "Bool()",
+    "Set.issuperset": "Bool()",
+    "FrozenSet.issuperset": "Bool()",
+    "Dict.items": "DictItems()",
+    "Bytes.join": "b''",
+    "Unicode.join": "''",
+    "Dict.keys": "DictKeys()",
+    "lower": T,
+    "ljust": T,
+    "lstrip": T,
+    "Bytes.maketrans": "b''",
+    "Unicode.maketrans": "{}",
+    "Type.mro": "[Type()]",
+    "partition": "(type(self)(), type(self)(), type(self)())",
+    "List.pop": "self.__getitem__()",
+    "Dict.pop": "self.keys().__getitem__()",
+    "Set.pop": "Unknown()",
+    "Dict.popitem": "self.items().__getitem__()",
+    "remove": N,
+    "replace": T,
+    "rfind": "Int()",
+    "List.reverse": N,
+    "rindex": "Int()",
+    "rjust": T,
+    "rpartition": "(type(self)(), type(self)(), type(self)())",
+    "rsplit": "[type(self)()]",
+    "rstrip": T,
+    "Dict.setdefault": "self.__getitem__()",
+    "List.sort": N,
+    "split": "[type(self)()]",
+    "splitlines": "[self()]",
+    "startswith": "Bool()",
+    "strip": T,
+    "swapcase": T,
+    "Set.symmetric_difference": T,
+    "FrozenSet.symmetric_difference": T,
+    "Set.symmetric_difference_update": N,
+    "Bytes.translate": T,
+    "Unicode.translate": T,
+    "title": T,
+    "to_bytes": "b''",
+    "Set.union": T,
+    "FrozenSet.union": T,
+    "Dict.update": N,
+    "Set.update": N,
+    "upper": T,
+    "Dict.values": "DictValues()",
+    "zfill": T,
+}
+
+SELF = "(self)"
+KNOWN_ARGSPECS = {
+    "Type.__call__": "(cls, *args, **kwargs)",
+    "Int.__ceil__": SELF,
+    "__contains__": "(self, value)",
+    "__dir__": SELF,
+    "Int.__floor__": SELF,
+    "__format__": "(self, format_spec)",
+    "Float.__getformat__": "(typestr)",
+    "__getitem__": "(self, index)",
+    "Dict.__getitem__": "(self, key)",
+    "__getnewargs__": SELF,
+    "__getnewargs_ex__": SELF,
+    "__init_subclass__": "(cls)",
+    "Type.__instancecheck__": "(self, instance)",
+    "Bool.__init__": "(self, x)",
+    "Int.__init__": "(self, x=0)",
+    "__new__": "(cls, *args, **kwargs)",
+    "Type.__prepare__": "(cls, name, bases, **kwds)",
+    "Int.__round__": "(self, ndigits=0)",
+    "Float.__round__": "(self, ndigits=0)",
+    "__reduce__": SELF,
+    "__reduce_ex__": "(self, protocol)",
+    "List.__reversed__": SELF,
+    "Float.__setformat__": "(typestr, fmt)",
+    "List.__setitem__": "(self, index, value)",
+    "Dict.__setitem__": "(self, key, value)",
+    "__sizeof__": SELF,
+    "Type.__subclasses__": "(cls)",
+    "Type.__subclasscheck__": "(cls, subclass)",
+    "__subclasshook__": "(cls, subclass)",
+    "__trunc__": SELF,
+    "Set.add": "(self, value)",
+    "List.append": "(self, value)",
+    "Float.as_integer_ratio": SELF,
+    "Int.bit_length": SELF,
+    "capitalize": SELF,
+    "casefold": SELF,
+    "Bytes.center": ["(self, width)", "(self, width, fillbyte)"],
+    "Unicode.center": ["(self, width)", "(self, width, fillchar)"],
+    "clear": SELF,
+    "conjugate": SELF,
+    "copy": SELF,
+    "count": "(self, x)",
+    "Bytes.count": ["(self, sub)", "(self, sub, start)", "(self, sub, start, end)"],
+    "Unicode.count": ["(self, sub)", "(self, sub, start)", "(self, sub, start, end)"],
+    "Bytes.decode": "(self, encoding='utf-8', errors='strict')",
+    "Unicode.encode": "(self, encoding='utf-8', errors='strict')",
+    "Set.difference": "(self, other)",
+    "FrozenSet.difference": "(self, other)",
+    "Set.difference_update": "(self, *others)",
+    "Set.discard": "(self, elem)",
+    "endswith": ["(self, suffix)", "(self, suffix, start)", "(self, suffix, start, end)"],
+    "expandtabs": "(self, tabsize=8)",
+    "List.extend": "(self, iterable)",
+    "find": ["(self, sub)", "(self, sub, start)", "(self, sub, start, end)"],
+    "Unicode.format": "(self, *args, **kwargs)",
+    "Unicode.format_map": "(self, mapping)",
+    "Bool.from_bytes": "(bytes, byteorder, *, signed=False)",
+    "Int.from_bytes": "(bytes, byteorder, *, signed=False)",
+    "Float.fromhex": "(string)",
+    "Dict.get": "(self, key, d=Unknown())",
+    "hex": SELF,
+    "List.insert": "(self, index, value)",
+    "index": "(self, v)",
+    "Bytes.index": ["(self, sub)", "(self, sub, start)", "(self, sub, start, end)"],
+    "Unicode.index": ["(self, sub)", "(self, sub, start)", "(self, sub, start, end)"],
+    "Set.intersection": "(self, other)",
+    "FrozenSet.intersection": "(self, other)",
+    "Set.intersection_update": "(self, *others)",
+    "isalnum": SELF,
+    "isalpha": SELF,
+    "isdecimal": SELF,
+    "isdigit": SELF,
+    "isidentifier": SELF,
+    "islower": SELF,
+    "isnumeric": SELF,
+    "isprintable": SELF,
+    "isspace": SELF,
+    "istitle": SELF,
+    "isupper": SELF,
+    "Float.is_integer": SELF,
+    "Set.isdisjoint": "(self, other)",
+    "FrozenSet.isdisjoint": "(self, other)",
+    "Set.issubset": "(self, other)",
+    "FrozenSet.issubset": "(self, other)",
+    "Set.issuperset": "(self, other)",
+    "FrozenSet.issuperset": "(self, other)",
+    "Dict.items": SELF,
+    "Bytes.join": "(self, iterable)",
+    "Unicode.join": "(self, iterable)",
+    "Dict.keys": SELF,
+    "lower": SELF,
+    "Bytes.ljust": ["(self, width)", "(self, width, fillbyte)"],
+    "Unicode.ljust": ["(self, width)", "(self, width, fillchar)"],
+    "lstrip": ["(self)", "(self, chars)"],
+    "Bytes.maketrans": "(from_, to)",
+    "Unicode.maketrans": ["(x)", "(x, y)", "(x, y, z)"],
+    "Type.mro": "(cls)",
+    "Bytes.partition": "(self, sep)",
+    "Unicode.partition": "(self, sep)",
+    "List.pop": "(self, index=-1)",
+    "Dict.pop": "(self, k, d=Unknown())",
+    "Set.pop": SELF,
+    "Dict.popitem": "(self, k, d=Unknown())",
+    "List.remove": "(self, value)",
+    "Set.remove": "(self, elem)",
+    "replace": ["(self, old, new)", "(self, old, new, count)"],
+    "List.reverse": SELF,
+    "rfind": ["(self, sub)", "(self, sub, start)", "(self, sub, start, end)"],
+    "rindex": ["(self, sub)", "(self, sub, start)", "(self, sub, start, end)"],
+    "Bytes.rjust": ["(self, width)", "(self, width, fillbyte)"],
+    "Unicode.rjust": ["(self, width)", "(self, width, fillchar)"],
+    "Bytes.rpartition": "(self, sep)",
+    "Unicode.rpartition": "(self, sep)",
+    "rsplit": "(self, sep=None, maxsplit=-1)",
+    "rstrip": ["(self)", "(self, chars)"],
+    "Dict.setdefault": "(self, k, d)",
+    "List.sort": SELF,
+    "split": "(self, sep=None, maxsplit=-1)",
+    "splitlines": "(self, keepends=False)",
+    "strip": ["(self)", "(self, chars)"],
+    "startswith": ["(self, prefix)", "(self, prefix, start)", "(self, prefix, start, end)"],
+    "swapcase": SELF,
+    "Set.symmetric_difference": "(self, other)",
+    "FrozenSet.symmetric_difference": "(self, other)",
+    "Set.symmetric_difference_update": "(self, *others)",
+    "title": SELF,
+    "Int.to_bytes": "(bytes, byteorder, *, signed=False)",
+    "Bytes.translate": "(self, table, delete=b'')",
+    "Unicode.translate": "(self, table)",
+    "Set.union": "(self, *others)",
+    "FrozenSet.union": "(self, *others)",
+    "Dict.update": "(self, d)",
+    "Set.update": "(self, *others)",
+    "upper": SELF,
+    "Dict.values": SELF,
+    "zfill": "(self, width)",
+}
+
+class InspectWarning(UserWarning): pass
+
+def _get_restype(typename, membername):
+    return (KNOWN_RESTYPES.get(typename + '.' + membername) or
+            KNOWN_RESTYPES.get(membername) or
+            None)
+
+def _render_args(member, typename, membername):
+    try:
+        return KNOWN_ARGSPECS[typename + "." + membername]
+    except LookupError:
+        try:
+            return KNOWN_ARGSPECS[membername]
+        except LookupError:
+            pass
+    try:
+        return inspect.formatargspec(*inspect.getargspec(member))
+    except:
+        warnings.warn("failed to getargspec for " + repr(member), InspectWarning)
+        return "(self)"
+
+def _triple_quote(s):
+    if "'" not in s:
+        return "'''" + s + "'''"
+    if '"' not in s:
+        return '"""' + s + '"""'
+    if not s.startswith("'"):
+        return "'''" + s.replace("'''", "\\'\\'\\'") + " '''"
+    if not s.startswith('"'):
+        return '"""' + s.replace('"""', '\\"\\"\\"') + ' """'
+    return "''' " + s.replace("'''", "\\'\\'\\'") + " '''"
+
+_SKIP_MEMBERS = ["__doc__"]
+
+def _each(s, name):
+    if s == "T":
+        return [name]
+    if s == "T()":
+        return [name + "()"]
+    if isinstance(s, str):
+        return [s]
+    if hasattr(s, '__iter__'):
+        res = []
+        for i in s:
+            res.extend(_each(i, name))
+        return res
+    return [s]
+
+def _print_type(name, obj, basename=None, base=None):
+    if base:
+        base_members = list(dir(base))
+        base_members.extend(getattr(base, "__dict__", {}).keys())
+        base_members.sort()
+
+        print("class " + name + "(" + basename + "):")
+    else:
+        base_members = []
+
+        print("class " + name + ":")
+
+    members = list(dir(obj))
+    members.extend(getattr(obj, "__dict__", {}).keys())
+    members.sort()
+
+    if INCLUDE_DOCS:
+        docstring = getattr(obj, "__doc__", None)
+        if docstring:
+            print("    " + _triple_quote(docstring))
+
+    last_member = None
+    while members:
+        member = str(members.pop(0))
+        if member == last_member or member in _SKIP_MEMBERS:
+            continue
+        last_member = member
+
+        if member == "__class__":
+            print("    __class__ = " + name)
+            continue
+
+        try:
+            value = getattr(obj, member)
+        except AttributeError:
+            continue
+        except:
+            print("    " + member + " = Unknown")
+            continue
+
+        if member in base_members:
+            try:
+                base_value = getattr(base, member)
+            except:
+                pass
+            else:
+                if value is base_value:
+                    continue
+
+        try:
+            value_type = DIRECT_MAP[value]
+        except (TypeError, LookupError):
+            pass
+        else:
+            print("    " + member + " = " + value_type)
+            continue
+
+        if not type(value) is type:
+            try:
+                value_type = DIRECT_MAP[type(value)]
+            except (TypeError, LookupError):
+                pass
+            else:
+                print("    " + member + " = " + value_type + "()")
+                continue
+
+        # Builtins do not have nested types
+        if hasattr(value, "__call__") and not isinstance(value, type):
+            args = _render_args(value, name, member)
+            restype = _get_restype(name, member) or ""
+            if restype == "T":
+                restype = name
+            if not restype:
+                warnings.warn("unknown return value for " + name + "." + member + " = " + repr(value), InspectWarning)
+                restype = "Unknown()"
+
+            for a in _each(args, name):
+                print("    def " + member + a + ":")
+                if INCLUDE_DOCS:
+                    try:
+                        doc = str(getattr(value, "__doc__"))
+                    except:
+                        pass
+                    else:
+                        print("        " + _triple_quote(doc))
+                for r in _each(restype, name):
+                    print("        return " + r)
+            continue
+
+        value_type = _get_restype(name, member)
+        if not value_type:
+            warnings.warn("unknown value for " + name + "." + member + " = " +type(value).__name__, InspectWarning)
+            value_type = "Unknown()"
+
+        for r in _each(value_type, name):
+            print("    " + member + " = " + r)
+
+    print("")
+
+# Unknown
+print("class Unknown:")
+print("    '''<unknown type>'''")
+print("")
+
+# NoneType
+print("class NoneType:")
+print("    '''Type of the None object'''")
+print("")
+
+print("None = NoneType()")
+print("")
+
+# Object
+_print_type("Object", object)
+
+# Type
+_print_type("Type", type)
+
+# Bool
+if type(bool()) is int:
+    print("Bool = Int")
+    print("")
+else:
+    _print_type("Bool", bool, "Int", int)
+
+# Int
+_print_type("Int", int)
+
+# Long
+try:
+    long
+except NameError:
+    print("Long = Int")
+    print("")
+else:
+    _print_type("Long", long)
+
+# Float
+_print_type("Float", float)
+
+# Complex
+_print_type("Complex", complex)
+
+# Tuple
+_print_type("Tuple", tuple)
+
+# List
+_print_type("List", list)
+
+# Dict
+_print_type("Dict", dict)
+
+# Set
+_print_type("Set", set)
+
+# FrozenSet
+_print_type("FrozenSet", frozenset)
+
+try:
+    bytes
+except NameError:
+    bytes = str
+
+if bytes is not str:
+    # Bytes
+    _print_type("Bytes", bytes)
+
+    # Unicode
+    _print_type("Unicode", str)
+
+    # Str
+    print("Str = Unicode")
+    print("")
+else:
+    # Bytes
+    _print_type("Bytes", str)
+
+    # Unicode
+    _print_type("Unicode", unicode)
+
+    # Str
+    print("Str = Bytes")
+    print("")
+
+# StrIterator
+# BytesIterator
+# UnicodeIterator
+# Module
+# Function
+# BuiltinMethodDescriptor
+# BuiltinFunction
+# Generator
+# Property
+# ClassMethod
+# StaticMethod
+# Ellipsis
+# TupleIterator
+# ListIterator
+# DictKeys
+# DictValues
+# DictItems
+# SetIterator
+# CallableIterator

--- a/Python/Product/Analysis/scrape_builtins.py
+++ b/Python/Product/Analysis/scrape_builtins.py
@@ -40,34 +40,44 @@ DIRECT_MAP = {
     type(complex.real): "Property",
 }
 
-T = "type(self)()"
+# These two dictionaries start with Python 3 values.
+# There is an update below for Python 2 differences.
+
+T = "Type(self)()"
 N = "None"
 KNOWN_RESTYPES = {
     "__abs__": T,
     "__add__": T,
     "__and__": T,
+    "__annotations__": "{}",
     "__base__": "Type()",
     "__bases__": "(Type(),)",
     "__bool__": "Bool()",
+    "__call__": "Unknown()",
     "Type.__call__": "cls()",
     "__ceil__": T,
+    "__code__": "Object()",
     "__contains__": "Bool()",
+    "__del__": N,
     "__delattr__": N,
+    "Property.__delete__": N,
     "__delitem__": N,
-    "__dict__": "{Str(): Unknown()}",
-    "__dir__": "[Str()]",
+    "__dict__": "{'': Unknown()}",
+    "__dir__": "['']",
     "__divmod__": "(Int(), Int())",
     "__eq__": "Bool()",
-    "__format__": "Str()",
+    "__format__": "''",
     "__float__": "Float()",
     "__floor__": T,
     "__floordiv__": "Int()",
     "__ge__": "Bool()",
+    "__get__": T,
     "__getattribute__": "Unknown()",
-    "Float.__getformat__": "Str()",
+    "Float.__getformat__": "''",
     "__getitem__": "Unknown()",
     "__getnewargs__": "()",
-    "__getnewargs_ex__": "((), Dict())",
+    "__getnewargs_ex__": "((), {})",
+    "__globals__": "{}",
     "__gt__": "Bool()",
     "__hash__": "Int()",
     "__iadd__": N,
@@ -81,6 +91,7 @@ KNOWN_RESTYPES = {
     "__invert__": T,
     "__ior__": N,
     "__isub__": N,
+    "__iter__": T,
     "Tuple.__iter__": "TupleIterator()",
     "List.__iter__": "ListIterator()",
     "Dict.__iter__": "DictKeys()",
@@ -91,6 +102,7 @@ KNOWN_RESTYPES = {
     "__ixor__": N,
     "__le__": "Bool()",
     "__len__": "Int()",
+    "__length_hint__": "Int()",
     "__lshift__": T,
     "__lt__": "Bool()",
     "__mod__": T,
@@ -98,6 +110,9 @@ KNOWN_RESTYPES = {
     "__ne__": "Bool()",
     "__neg__": T,
     "__new__": "cls()",
+    "__next__": "Unknown()",
+    "BytesIterator.__next__": "Int()",
+    "UnicodeIterator.__next__": "Unicode()",
     "Type.__prepare__": N,
     "__pos__": T,
     "__pow__": T,
@@ -121,9 +136,11 @@ KNOWN_RESTYPES = {
     "__reduce__": ["''", "()"],
     "__reduce_ex__": ["''", "()"],
     "__repr__": "''",
+    "__set__": N,
     "__setattr__": N,
     "Float.__setformat__": N,
     "__setitem__": N,
+    "__setstate__": N,
     "__sizeof__": "Int()",
     "__str__": "''",
     "Type.__subclasses__": "(cls,)",
@@ -133,6 +150,7 @@ KNOWN_RESTYPES = {
     "__xor__": T,
     "Type.__subclasscheck__": "Bool()",
     "__subclasshook__": "Bool()",
+    "__text_signature__": "''",
     "Set.add": N,
     "List.append": N,
     "Float.as_integer_ratio": "(Int(), Int())",
@@ -141,16 +159,18 @@ KNOWN_RESTYPES = {
     "casefold": T,
     "center": T,
     "clear": N,
+    "Generator.close": N,
     "conjugate": "Complex()",
     "copy": T,
     "count": "Int()",
     "Bytes.decode": "''",
-    "Bytes.encode": "b''",
-    "Unicode.encode": "b''",
+    "Property.deleter": "func",
     "Set.difference": T,
     "FrozenSet.difference": T,
     "Set.difference_update": N,
     "Set.discard": N,
+    "Bytes.encode": "b''",
+    "Unicode.encode": "b''",
     "endswith": "Bool()",
     "expandtabs": T,
     "List.extend": N,
@@ -164,6 +184,7 @@ KNOWN_RESTYPES = {
     "Bytes.fromhex": "b''",
     "Dict.fromkeys": "{}",
     "Dict.get": "self.__getitem__()",
+    "Property.getter": "func",
     "hex": "''",
     "index": "Int()",
     "List.insert": N,
@@ -184,6 +205,8 @@ KNOWN_RESTYPES = {
     "Float.is_integer": "Bool()",
     "Set.isdisjoint": "Bool()",
     "FrozenSet.isdisjoint": "Bool()",
+    "DictKeys.isdisjoint": "Bool()",
+    "DictItems.isdisjoint": "Bool()",
     "Set.issubset": "Bool()",
     "FrozenSet.issubset": "Bool()",
     "Set.issuperset": "Bool()",
@@ -198,7 +221,7 @@ KNOWN_RESTYPES = {
     "Bytes.maketrans": "b''",
     "Unicode.maketrans": "{}",
     "Type.mro": "[Type()]",
-    "partition": "(type(self)(), type(self)(), type(self)())",
+    "partition": "(Type(self)(), Type(self)(), Type(self)())",
     "List.pop": "self.__getitem__()",
     "Dict.pop": "self.keys().__getitem__()",
     "Set.pop": "Unknown()",
@@ -209,12 +232,14 @@ KNOWN_RESTYPES = {
     "List.reverse": N,
     "rindex": "Int()",
     "rjust": T,
-    "rpartition": "(type(self)(), type(self)(), type(self)())",
-    "rsplit": "[type(self)()]",
+    "rpartition": "(Type(self)(), Type(self)(), Type(self)())",
+    "rsplit": "[Type(self)()]",
     "rstrip": T,
+    "Generator.send": "self.__next__()",
     "Dict.setdefault": "self.__getitem__()",
+    "Property.setter": "func",
     "List.sort": N,
-    "split": "[type(self)()]",
+    "split": "[Type(self)()]",
     "splitlines": "[self()]",
     "startswith": "Bool()",
     "strip": T,
@@ -224,6 +249,7 @@ KNOWN_RESTYPES = {
     "Set.symmetric_difference_update": N,
     "Bytes.translate": T,
     "Unicode.translate": T,
+    "Generator.throw": N,
     "title": T,
     "to_bytes": "b''",
     "Set.union": T,
@@ -240,6 +266,7 @@ KNOWN_ARGSPECS = {
     "Type.__call__": "(cls, *args, **kwargs)",
     "Int.__ceil__": SELF,
     "__contains__": "(self, value)",
+    "__del__": SELF,
     "__dir__": SELF,
     "Int.__floor__": SELF,
     "__format__": "(self, format_spec)",
@@ -252,6 +279,7 @@ KNOWN_ARGSPECS = {
     "Type.__instancecheck__": "(self, instance)",
     "Bool.__init__": "(self, x)",
     "Int.__init__": "(self, x=0)",
+    "__length_hint__": SELF,
     "__new__": "(cls, *args, **kwargs)",
     "Type.__prepare__": "(cls, name, bases, **kwds)",
     "Int.__round__": "(self, ndigits=0)",
@@ -262,6 +290,7 @@ KNOWN_ARGSPECS = {
     "Float.__setformat__": "(typestr, fmt)",
     "List.__setitem__": "(self, index, value)",
     "Dict.__setitem__": "(self, key, value)",
+    "__setstate__": "(self, state)",
     "__sizeof__": SELF,
     "Type.__subclasses__": "(cls)",
     "Type.__subclasscheck__": "(cls, subclass)",
@@ -276,17 +305,19 @@ KNOWN_ARGSPECS = {
     "Bytes.center": ["(self, width)", "(self, width, fillbyte)"],
     "Unicode.center": ["(self, width)", "(self, width, fillchar)"],
     "clear": SELF,
+    "Generator.close": SELF,
     "conjugate": SELF,
     "copy": SELF,
     "count": "(self, x)",
     "Bytes.count": ["(self, sub)", "(self, sub, start)", "(self, sub, start, end)"],
     "Unicode.count": ["(self, sub)", "(self, sub, start)", "(self, sub, start, end)"],
     "Bytes.decode": "(self, encoding='utf-8', errors='strict')",
-    "Unicode.encode": "(self, encoding='utf-8', errors='strict')",
+    "Property.deleter": "(self, func)",
     "Set.difference": "(self, other)",
     "FrozenSet.difference": "(self, other)",
     "Set.difference_update": "(self, *others)",
     "Set.discard": "(self, elem)",
+    "Unicode.encode": "(self, encoding='utf-8', errors='strict')",
     "endswith": ["(self, suffix)", "(self, suffix, start)", "(self, suffix, start, end)"],
     "expandtabs": "(self, tabsize=8)",
     "List.extend": "(self, iterable)",
@@ -297,6 +328,7 @@ KNOWN_ARGSPECS = {
     "Int.from_bytes": "(bytes, byteorder, *, signed=False)",
     "Float.fromhex": "(string)",
     "Dict.get": "(self, key, d=Unknown())",
+    "Property.getter": "(self, func)",
     "hex": SELF,
     "List.insert": "(self, index, value)",
     "index": "(self, v)",
@@ -319,6 +351,8 @@ KNOWN_ARGSPECS = {
     "Float.is_integer": SELF,
     "Set.isdisjoint": "(self, other)",
     "FrozenSet.isdisjoint": "(self, other)",
+    "DictKeys.isdisjoint": "(self, other)",
+    "DictItems.isdisjoint": "(self, other)",
     "Set.issubset": "(self, other)",
     "FrozenSet.issubset": "(self, other)",
     "Set.issuperset": "(self, other)",
@@ -352,7 +386,9 @@ KNOWN_ARGSPECS = {
     "Unicode.rpartition": "(self, sep)",
     "rsplit": "(self, sep=None, maxsplit=-1)",
     "rstrip": ["(self)", "(self, chars)"],
+    "Generator.send": "(self, value)",
     "Dict.setdefault": "(self, k, d)",
+    "Property.setter": "(self, func)",
     "List.sort": SELF,
     "split": "(self, sep=None, maxsplit=-1)",
     "splitlines": "(self, keepends=False)",
@@ -362,6 +398,7 @@ KNOWN_ARGSPECS = {
     "Set.symmetric_difference": "(self, other)",
     "FrozenSet.symmetric_difference": "(self, other)",
     "Set.symmetric_difference_update": "(self, *others)",
+    "Generator.throw": ["(self, type)", "(self, type, value)", "(self, type, value, traceback)"],
     "title": SELF,
     "Int.to_bytes": "(bytes, byteorder, *, signed=False)",
     "Bytes.translate": "(self, table, delete=b'')",
@@ -374,6 +411,19 @@ KNOWN_ARGSPECS = {
     "Dict.values": SELF,
     "zfill": "(self, width)",
 }
+
+if sys.version[0] == '2':
+    KNOWN_RESTYPES.update({
+        "BytesIterator.__next__": None,
+        "BytesIterator.next": "Bytes()",
+        "UnicodeIterator.__next__": None,
+        "UnicodeIterator.next": "Unicode()",
+        "Generator.send": "self.next()",
+    })
+
+    KNOWN_ARGSPECS.update({
+    })
+
 
 class InspectWarning(UserWarning): pass
 
@@ -407,8 +457,6 @@ def _triple_quote(s):
         return '"""' + s.replace('"""', '\\"\\"\\"') + ' """'
     return "''' " + s.replace("'''", "\\'\\'\\'") + " '''"
 
-_SKIP_MEMBERS = ["__doc__"]
-
 def _each(s, name):
     if s == "T":
         return [name]
@@ -423,8 +471,28 @@ def _each(s, name):
         return res
     return [s]
 
-def _print_type(name, obj, basename=None, base=None):
+_SKIP_MEMBERS = frozenset(["__class__"])
+
+_ALREADY_WRITTEN = set()
+
+def _print_type(alias, objtype, basename=None, base=None):
+    name = objtype.__name__
+    
+    if name in _ALREADY_WRITTEN:
+        if alias != name:
+            print(alias + " = " + name)
+            print("")
+        return
+    _ALREADY_WRITTEN.add(name)
+
+    if getattr(objtype, '__bases__', None) == (object,):
+        basename = "Object"
+        base = object
+
     if base:
+        if base not in objtype.__bases__:
+            warnings.warn(basename + " not in " + name + ".__bases__ = " + repr(objtype.__bases__), InspectWarning)
+
         base_members = list(dir(base))
         base_members.extend(getattr(base, "__dict__", {}).keys())
         base_members.sort()
@@ -435,14 +503,15 @@ def _print_type(name, obj, basename=None, base=None):
 
         print("class " + name + ":")
 
-    members = list(dir(obj))
-    members.extend(getattr(obj, "__dict__", {}).keys())
+    members = list(dir(objtype))
+    members.extend(getattr(objtype, "__dict__", {}).keys())
     members.sort()
 
     if INCLUDE_DOCS:
-        docstring = getattr(obj, "__doc__", None)
-        if docstring:
+        docstring = getattr(objtype, "__doc__", None)
+        if isinstance(docstring, str):
             print("    " + _triple_quote(docstring))
+            members = [m for m in members if m != '__doc__']
 
     last_member = None
     while members:
@@ -451,12 +520,8 @@ def _print_type(name, obj, basename=None, base=None):
             continue
         last_member = member
 
-        if member == "__class__":
-            print("    __class__ = " + name)
-            continue
-
         try:
-            value = getattr(obj, member)
+            value = getattr(objtype, member)
         except AttributeError:
             continue
         except:
@@ -491,8 +556,8 @@ def _print_type(name, obj, basename=None, base=None):
 
         # Builtins do not have nested types
         if hasattr(value, "__call__") and not isinstance(value, type):
-            args = _render_args(value, name, member)
-            restype = _get_restype(name, member) or ""
+            args = _render_args(value, alias, member)
+            restype = _get_restype(alias, member) or ""
             if restype == "T":
                 restype = name
             if not restype:
@@ -512,7 +577,7 @@ def _print_type(name, obj, basename=None, base=None):
                     print("        return " + r)
             continue
 
-        value_type = _get_restype(name, member)
+        value_type = _get_restype(alias, member)
         if not value_type:
             warnings.warn("unknown value for " + name + "." + member + " = " +type(value).__name__, InspectWarning)
             value_type = "Unknown()"
@@ -520,6 +585,8 @@ def _print_type(name, obj, basename=None, base=None):
         for r in _each(value_type, name):
             print("    " + member + " = " + r)
 
+    if alias != name:
+        print(alias + " = " + name)
     print("")
 
 # Unknown
@@ -590,39 +657,114 @@ if bytes is not str:
     # Bytes
     _print_type("Bytes", bytes)
 
+    # BytesIterator
+    _print_type("BytesIterator", type(iter(bytes())))
+
     # Unicode
     _print_type("Unicode", str)
+
+    # UnicodeIterator
+    _print_type("UnicodeIterator", type(iter(str())))
 
     # Str
     print("Str = Unicode")
     print("")
+
+    # StrIterator
+    print("StrIterator = UnicodeIterator")
+    print("")
+
 else:
     # Bytes
     _print_type("Bytes", str)
 
+    # BytesIterator
+    _print_type("BytesIterator", type(iter(str())))
+
     # Unicode
     _print_type("Unicode", unicode)
+
+    # UnicodeIterator
+    _print_type("UnicodeIterator", type(iter(unicode())))
 
     # Str
     print("Str = Bytes")
     print("")
 
-# StrIterator
-# BytesIterator
-# UnicodeIterator
+    # StrIterator
+    print("StrIterator = BytesIterator")
+    print("")
+
 # Module
+_print_type("Module", type(inspect))
+
 # Function
+
+# These functions will be exec'd in order until one succeeds.
+# This ensures the maximum number of attributes will be initialized.
+
+_FUNCTIONS = [
+"""
+def _in_closure():
+    x = 1
+    def Function(a:'a', b=None, *args, **kwds) -> 'rv': x
+    return Function
+Function = _in_closure()
+del _in_closure""",
+"def Function(a, b=None, *args, **kwds): pass",
+"def Function(): pass"
+]
+
+for f in _FUNCTIONS:
+    try:
+        exec(f)
+        break
+    except SyntaxError:
+        pass
+else:
+    raise RuntimeError("no valid function could be defined")
+
+_print_type("Function", Function)
+
 # BuiltinMethodDescriptor
+_print_type("BuiltinMethodDescriptor", type(object.__hash__))
+
 # BuiltinFunction
+_print_type("BuiltinFunction", type(abs))
+
 # Generator
+_print_type("Generator", type((_ for _ in [])))
+
 # Property
+_print_type("Property", property)
+
 # ClassMethod
+_print_type("ClassMethod", classmethod)
+
 # StaticMethod
+_print_type("StaticMethod", staticmethod)
+
 # Ellipsis
+_print_type("Ellipsis", type(...))
+
 # TupleIterator
+_print_type("TupleIterator", type(iter(())))
+
 # ListIterator
+_print_type("ListIterator", type(iter([])))
+
 # DictKeys
+_print_type("DictKeys", type({}.keys()))
+
 # DictValues
+_print_type("DictValues", type({}.values()))
+
 # DictItems
+_print_type("DictItems", type({}.items()))
+
 # SetIterator
+_print_type("SetIterator", type(iter(set())))
+
 # CallableIterator
+_print_type("CallableIterator", type(iter((lambda: None), None)))
+

--- a/Python/Product/PythonTools/PythonTools/Navigation/Navigable/NavigableSymbolSource.cs
+++ b/Python/Product/PythonTools/PythonTools/Navigation/Navigable/NavigableSymbolSource.cs
@@ -104,7 +104,7 @@ namespace Microsoft.PythonTools.Navigation.Navigable {
 
         internal static async Task<AnalysisLocation> GetDefinitionLocationAsync(AnalysisEntry entry, ITextView textView, SnapshotSpan span) {
             var result = await entry.Analyzer.AnalyzeExpressionAsync(entry, textView, span.Start).ConfigureAwait(false);
-            foreach (var variable in result?.Variables.MaybeEnumerate()) {
+            foreach (var variable in (result?.Variables).MaybeEnumerate()) {
                 if (variable.Type == Analysis.VariableType.Definition &&
                     !string.IsNullOrEmpty(variable.Location?.FilePath)) {
                     return variable.Location;

--- a/Python/Product/PythonTools/PythonTools/Project/PythonProjectNode.cs
+++ b/Python/Product/PythonTools/PythonTools/Project/PythonProjectNode.cs
@@ -1124,11 +1124,21 @@ namespace Microsoft.PythonTools.Project {
             var model = Site.GetComponentModel();
             var interpreterService = model.GetService<IInterpreterRegistryService>();
             var factory = GetInterpreterFactory();
+
+            bool inProc = false;
+            var ipp = BuildProject.GetProperty("_InProcessPythonAnalyzer");
+            if (ipp != null) {
+                if (ipp.EvaluatedValue?.IsTrue() ?? false) {
+                    inProc = true;
+                }
+            }
+
             var res = new VsProjectAnalyzer(
                 model.GetService<PythonEditorServices>(),
                 factory,
                 false,
-                BuildProject
+                BuildProject,
+                outOfProcAnalyzer: !inProc
             );
             res.AbnormalAnalysisExit += AnalysisProcessExited;
             res.AnalyzerNeedsRestart += OnActiveInterpreterChanged;

--- a/Python/Tests/Analysis/AstAnalysisTests.cs
+++ b/Python/Tests/Analysis/AstAnalysisTests.cs
@@ -202,9 +202,8 @@ R_A3 = R_A1.r_A()");
                 var fact = (AstPythonInterpreterFactory)analysis.Analyzer.InterpreterFactory;
                 var interp = (AstPythonInterpreter)analysis.Analyzer.Interpreter;
 
-                // Builtin module must be a scraped Python module
                 var mod = interp.ImportModule(interp.BuiltinModuleName);
-                Assert.IsInstanceOfType(mod, typeof(AstScrapedPythonModule));
+                Assert.IsInstanceOfType(mod, typeof(AstBuiltinsPythonModule));
 
                 // Ensure we can get all the builtin types
                 foreach (BuiltinTypeId v in Enum.GetValues(typeof(BuiltinTypeId))) {

--- a/Python/Tests/Analysis/AstAnalysisTests.cs
+++ b/Python/Tests/Analysis/AstAnalysisTests.cs
@@ -46,11 +46,8 @@ namespace AnalysisTests {
             return new PythonAnalysis(() => new AstPythonInterpreterFactory(version.Configuration, null));
         }
 
-        private static PythonAnalysis CreateAnalysis(PythonLanguageVersion version) {
-            return new PythonAnalysis(() => new AstPythonInterpreterFactory(
-                new InterpreterConfiguration("AstAnalysis|" + version, "Analysis only factory", version: version.ToVersion()),
-                null
-            ));
+        private static PythonAnalysis CreateAnalysis() {
+            return CreateAnalysis(PythonPaths.Versions.OrderByDescending(p => p.Version).FirstOrDefault());
         }
 
         #region Test cases
@@ -134,7 +131,7 @@ namespace AnalysisTests {
 
         [TestMethod, Priority(0)]
         public void AstValues() {
-            using (var entry = CreateAnalysis(PythonLanguageVersion.V35)) {
+            using (var entry = CreateAnalysis()) {
                 entry.SetSearchPaths(TestData.GetPath(@"TestData\AstAnalysis"));
                 entry.AddModule("test-module", "from Values import *");
                 entry.WaitForAnalysis();
@@ -173,34 +170,57 @@ namespace AnalysisTests {
 
         [TestMethod, Priority(0)]
         public void AstReturnTypes() {
-            using (var entry = CreateAnalysis(PythonLanguageVersion.V35)) {
+            using (var entry = CreateAnalysis()) {
                 entry.SetSearchPaths(TestData.GetPath(@"TestData\AstAnalysis"));
                 entry.AddModule("test-module", @"from ReturnValues import *
 R_str = r_str()
 R_object = r_object()
-R_A = A.r_A()");
+R_A1 = A()
+R_A2 = A.r_A()
+R_A3 = R_A1.r_A()");
                 entry.WaitForAnalysis();
 
                 entry.AssertHasAttr("",
                     "r_a", "r_b", "r_str", "r_object", "A",
-                    "R_str", "R_object", "R_A"
+                    "R_str", "R_object", "R_A1", "R_A2", "R_A3"
                 );
 
                 entry.AssertIsInstance("R_str", BuiltinTypeId.Str);
                 entry.AssertIsInstance("R_object", BuiltinTypeId.Object);
-                entry.AssertDescription("R_A", "class A");
+                entry.AssertIsInstance("R_A1", BuiltinTypeId.Type);
+                entry.AssertIsInstance("R_A2", BuiltinTypeId.Type);
+                entry.AssertIsInstance("R_A3", BuiltinTypeId.Type);
+                entry.AssertDescription("R_A1", "A");
+                entry.AssertDescription("R_A2", "A");
+                entry.AssertDescription("R_A3", "A");
             }
         }
 
         [TestMethod, Priority(0)]
         public void AstBuiltinScrape() {
-            using (var analysis = CreateAnalysis(PythonPaths.Python36_x64)) {
+            using (var analysis = CreateAnalysis()) {
                 var fact = (AstPythonInterpreterFactory)analysis.Analyzer.InterpreterFactory;
                 var interp = (AstPythonInterpreter)analysis.Analyzer.Interpreter;
 
+                // Builtin module must be a scraped Python module
+                var mod = interp.ImportModule(interp.BuiltinModuleName);
+                Assert.IsInstanceOfType(mod, typeof(AstScrapedPythonModule));
+
+                // Ensure we can get all the builtin types
                 foreach (BuiltinTypeId v in Enum.GetValues(typeof(BuiltinTypeId))) {
                     var type = interp.GetBuiltinType(v);
                     Assert.IsNotNull(type, v.ToString());
+                    Assert.IsInstanceOfType(type, typeof(AstPythonBuiltinType), v.ToString());
+                }
+
+                // Ensure we cannot see or get builtin types directly
+                AssertUtil.DoesntContain(
+                    mod.GetMemberNames(null),
+                    Enum.GetNames(typeof(BuiltinTypeId)).Select(n => $"__{n}")
+                );
+
+                foreach (var id in Enum.GetNames(typeof(BuiltinTypeId))) {
+                    Assert.IsNull(mod.GetMember(null, $"__{id}"), id);
                 }
             }
         }
@@ -208,7 +228,7 @@ R_A = A.r_A()");
         [TestMethod, Priority(0)]
         public void AstSearchPathsThroughFactory() {
             using (var evt = new ManualResetEvent(false))
-            using (var analysis = CreateAnalysis(PythonLanguageVersion.V35)) {
+            using (var analysis = CreateAnalysis()) {
                 var fact = (AstPythonInterpreterFactory)analysis.Analyzer.InterpreterFactory;
                 var interp = (AstPythonInterpreter)analysis.Analyzer.Interpreter;
 
@@ -230,7 +250,7 @@ R_A = A.r_A()");
         [TestMethod, Priority(0)]
         public void AstSearchPathsThroughAnalyzer() {
             using (var evt = new ManualResetEvent(false))
-            using (var analysis = CreateAnalysis(PythonLanguageVersion.V35)) {
+            using (var analysis = CreateAnalysis()) {
                 var fact = (AstPythonInterpreterFactory)analysis.Analyzer.InterpreterFactory;
                 var interp = (AstPythonInterpreter)analysis.Analyzer.Interpreter;
 

--- a/Python/Tests/TestData/AstAnalysis/ReturnValues.py
+++ b/Python/Tests/TestData/AstAnalysis/ReturnValues.py
@@ -1,0 +1,15 @@
+def r_a(a, b):
+    return a
+
+def r_b(a, b):
+    return b
+
+def r_str():
+    return ''
+
+def r_object():
+    return object()
+
+class A:
+    def r_A(self):
+        return type(self)()


### PR DESCRIPTION
Fixes #2908 Ast interpreter needs to scrape its own builtin types
Adds builtin type scraper to be run with current environment. (A future change will cache this output, and there is more work to make the default results better on pre-3.6 interpreters or those that cannot be executed.)
Adds initial function walker to do return value analysis