### PR TITLE
Fixes #2924 Assert, then unexpected error when using New Window

### DIFF
--- a/Common/Tests/MockVsTests/MockClassifierAggregatorService.cs
+++ b/Common/Tests/MockVsTests/MockClassifierAggregatorService.cs
@@ -42,31 +42,30 @@ namespace Microsoft.VisualStudioTools.MockVsTests {
 
         sealed class AggregatedClassifier : IClassifier, IDisposable {
             private readonly ITextBuffer _buffer;
-            private readonly List<IClassifier> _classifiers;
+            private readonly IReadOnlyList<IClassifier> _classifiers;
 
             public AggregatedClassifier(ITextBuffer textBuffer, IEnumerable<IClassifierProvider> providers) {
                 _buffer = textBuffer;
                 _classifiers = providers.Select(p => p.GetClassifier(_buffer)).ToList();
+                foreach (var c in _classifiers) {
+                    c.ClassificationChanged += Subclassification_Changed;
+                }
+            }
+
+            private void Subclassification_Changed(object sender, ClassificationChangedEventArgs e) {
+                var c = (IClassifier)sender;
+                var refreshSpans = c.GetClassificationSpans(e.ChangeSpan);
+                ClassificationChanged?.Invoke(this, e);
             }
 
             public void Dispose() {
-                foreach (var c in _classifiers.OfType<IDisposable>()) {
-                    c.Dispose();
+                foreach (var c in _classifiers) {
+                    c.ClassificationChanged -= Subclassification_Changed;
+                    (c as IDisposable)?.Dispose();
                 }
             }
 
-            public event EventHandler<ClassificationChangedEventArgs> ClassificationChanged {
-                add {
-                    foreach (var c in _classifiers) {
-                        c.ClassificationChanged += value;
-                    }
-                }
-                remove {
-                    foreach (var c in _classifiers) {
-                        c.ClassificationChanged -= value;
-                    }
-                }
-            }
+            public event EventHandler<ClassificationChangedEventArgs> ClassificationChanged;
 
             public IList<ClassificationSpan> GetClassificationSpans(SnapshotSpan span) {
                 return _classifiers.SelectMany(c => c.GetClassificationSpans(span)).ToList();

--- a/Common/Tests/Utilities/Mocks/MockComponentModel.cs
+++ b/Common/Tests/Utilities/Mocks/MockComponentModel.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel.Composition;
 using System.ComponentModel.Composition.Hosting;
 using System.ComponentModel.Composition.Primitives;
 using System.Diagnostics;
@@ -50,11 +51,21 @@ namespace TestUtilities.Mocks {
             return null;
         }
 
-        public System.ComponentModel.Composition.Primitives.ComposablePartCatalog DefaultCatalog {
+        public object GetService(Type t) {
+            List<Lazy<object>> extensions;
+            if (Extensions.TryGetValue(t, out extensions)) {
+                Debug.Assert(extensions.Count == 1, "Multiple extensions were registered");
+                return extensions[0].Value;
+            }
+            Console.WriteLine("Unregistered component model service " + t.FullName);
+            return null;
+        }
+
+        public ComposablePartCatalog DefaultCatalog {
             get { throw new NotImplementedException(); }
         }
 
-        public System.ComponentModel.Composition.ICompositionService DefaultCompositionService {
+        public ICompositionService DefaultCompositionService {
             get { throw new NotImplementedException(); }
         }
 

--- a/Python/Product/Analysis/Interpreter/Ast/AstBuiltinsPythonModule.cs
+++ b/Python/Product/Analysis/Interpreter/Ast/AstBuiltinsPythonModule.cs
@@ -18,8 +18,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Microsoft.PythonTools.Infrastructure;
 using Microsoft.PythonTools.Parsing;
 using Microsoft.PythonTools.Parsing.Ast;

--- a/Python/Product/Analysis/Interpreter/Ast/AstNestedPythonModule.cs
+++ b/Python/Product/Analysis/Interpreter/Ast/AstNestedPythonModule.cs
@@ -17,10 +17,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
-using System.Text;
 using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.PythonTools.Analysis;
 using Microsoft.PythonTools.Infrastructure;
 

--- a/Python/Product/Analysis/Interpreter/Ast/AstPythonFunctionOverload.cs
+++ b/Python/Product/Analysis/Interpreter/Ast/AstPythonFunctionOverload.cs
@@ -18,7 +18,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.PythonTools.Analysis;
-using Microsoft.PythonTools.Infrastructure;
 
 namespace Microsoft.PythonTools.Interpreter.Ast {
     class AstPythonFunctionOverload : IPythonFunctionOverload, ILocatedMember {

--- a/Python/Product/Analysis/Interpreter/Default/CPythonInterpreter.cs
+++ b/Python/Product/Analysis/Interpreter/Default/CPythonInterpreter.cs
@@ -32,6 +32,7 @@ namespace Microsoft.PythonTools.Interpreter.Default {
         readonly Version _langVersion;
         private PythonInterpreterFactoryWithDatabase _factory;
         private PythonTypeDatabase _typeDb, _searchPathDb;
+        private readonly object _searchPathDbLock = new object();
         private PythonAnalyzer _state;
         private IReadOnlyList<string> _searchPaths;
         private IReadOnlyDictionary<string, string> _searchPathPackages;
@@ -83,7 +84,11 @@ namespace Microsoft.PythonTools.Interpreter.Default {
         public IList<string> GetModuleNames() {
             var fromDb = (_typeDb?.GetModuleNames()).MaybeEnumerate().ToList();
 
-            fromDb.AddRange((_searchPathDb?.GetModuleNames()).MaybeEnumerate());
+            PythonTypeDatabase db;
+            lock (_searchPathDbLock) {
+                db = _searchPathDb;
+            }
+            fromDb.AddRange((db?.GetModuleNames()).MaybeEnumerate());
 
             fromDb.AddRange((_searchPathPackages?.Keys).MaybeEnumerate());
 
@@ -93,7 +98,11 @@ namespace Microsoft.PythonTools.Interpreter.Default {
         public IPythonModule ImportModule(string name) {
             var mod = _typeDb?.GetModule(name);
             if (mod == null) {
-                mod = _searchPathDb?.GetModule(name);
+                PythonTypeDatabase db;
+                lock (_searchPathDbLock) {
+                    db = _searchPathDb;
+                }
+                mod = db?.GetModule(name);
                 if (mod == null) {
                     foreach (var searchPath in _searchPaths.MaybeEnumerate()) {
                         try {
@@ -115,9 +124,12 @@ namespace Microsoft.PythonTools.Interpreter.Default {
             return mod;
         }
 
-        private void EnsureSearchPathDB() {
-            if (_searchPathDb == null) {
-                _searchPathDb = new PythonTypeDatabase(_factory, innerDatabase: _typeDb);
+        private PythonTypeDatabase EnsureSearchPathDB() {
+            lock (_searchPathDb) {
+                if (_searchPathDb == null) {
+                    _searchPathDb = new PythonTypeDatabase(_factory, innerDatabase: _typeDb);
+                }
+                return _searchPathDb;
             }
         }
 
@@ -191,11 +203,11 @@ namespace Microsoft.PythonTools.Interpreter.Default {
                 return null;
             }
 
-            EnsureSearchPathDB();
+            var db = EnsureSearchPathDB();
             if (package.IsNativeExtension || package.IsCompiled) {
-                _searchPathDb.LoadExtensionModule(package);
+                db.LoadExtensionModule(package);
             } else {
-                _searchPathDb.AddModule(package.FullName, AstPythonModule.FromFile(
+                db.AddModule(package.FullName, AstPythonModule.FromFile(
                     this,
                     package.SourceFile,
                     _factory.GetLanguageVersion(),
@@ -203,19 +215,33 @@ namespace Microsoft.PythonTools.Interpreter.Default {
                 ));
             }
 
-            var mod = _searchPathDb.GetModule(package.FullName);
+            if (db != _searchPathDb) {
+                // Racing with the DB being invalidated.
+                // It's okay if we miss it here, so don't worry
+                // about taking the lock.
+                return null;
+            }
+
+            var mod = db.GetModule(package.FullName);
 
             if (!package.IsSpecialName) {
                 int i = package.FullName.LastIndexOf('.');
                 if (i >= 1) {
                     var parent = package.FullName.Remove(i);
-                    var parentMod = _searchPathDb.GetModule(parent) as AstPythonModule;
+                    var parentMod = db.GetModule(parent) as AstPythonModule;
                     if (parentMod != null) {
                         parentMod.AddChildModule(package.Name, mod);
                     }
                 }
             }
-            
+
+            lock (_searchPathDbLock) {
+                if (db != _searchPathDb) {
+                    // Raced with the DB being invalidated
+                    return null;
+                }
+            }
+
             return mod;
         }
 
@@ -305,9 +331,11 @@ namespace Microsoft.PythonTools.Interpreter.Default {
         }
 
         private void PythonAnalyzer_SearchPathsChanged(object sender, EventArgs e) {
-            _searchPaths = _state.GetSearchPaths();
-            _searchPathDb = null;
-            _zipPackageCache = null;
+            lock (_searchPathDbLock) {
+                _searchPaths = _state.GetSearchPaths();
+                _searchPathDb = null;
+                _zipPackageCache = null;
+            }
 
             BeginUpdateSearchPathPackages();
         }
@@ -318,7 +346,9 @@ namespace Microsoft.PythonTools.Interpreter.Default {
 
 
         public void Dispose() {
-            _searchPathDb = null;
+            lock (_searchPathDb) {
+                _searchPathDb = null;
+            }
             _zipPackageCache = null;
             _typeDb = null;
 

--- a/Python/Product/PythonTools/PythonTools.csproj
+++ b/Python/Product/PythonTools/PythonTools.csproj
@@ -264,6 +264,7 @@
     <Compile Include="PythonTools\Commands\ImportCoverageCommand.cs" />
     <Compile Include="PythonTools\Commands\OpenWebUrlCommand.cs" />
     <Compile Include="PythonTools\Debugger\DebugLaunchHelper.cs" />
+    <Compile Include="PythonTools\Editor\IPythonTextBufferInfoEventSink.cs" />
     <Compile Include="PythonTools\Editor\PythonEditorServices.cs" />
     <Compile Include="PythonTools\Editor\PythonTextBufferInfo.cs" />
     <Compile Include="PythonTools\Editor\ReplPromptHelpers.cs" />

--- a/Python/Product/PythonTools/PythonTools/Editor/IPythonTextBufferInfoEventSink.cs
+++ b/Python/Product/PythonTools/PythonTools/Editor/IPythonTextBufferInfoEventSink.cs
@@ -1,0 +1,80 @@
+﻿// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABLITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.PythonTools.Intellisense;
+using Microsoft.VisualStudio.Text;
+
+namespace Microsoft.PythonTools.Editor {
+    /// <summary>
+    /// Interface for classes that need to receive events from text buffers.
+    /// </summary>
+    /// <remarks>
+    /// This is an interface rather than an abstract class because there are
+    /// IntelliSense features that require using another base class.
+    /// Implement no-op handlers by returning <see cref="Task.CompletedTask"/>.
+    /// </remarks>
+    interface IPythonTextBufferInfoEventSink {
+        Task PythonTextBufferEventAsync(PythonTextBufferInfo sender, PythonTextBufferInfoEventArgs e);
+    }
+
+    enum PythonTextBufferInfoEvents {
+        None = 0,
+        NewAnalysisEntry,
+        NewParseTree,
+        NewAnalysis,
+        TextContentChanged,
+        TextContentChangedLowPriority,
+        ContentTypeChanged,
+        DocumentEncodingChanged,
+        NewTextBufferInfo
+    }
+
+    class PythonTextBufferInfoEventArgs : EventArgs {
+        public PythonTextBufferInfoEventArgs(PythonTextBufferInfoEvents eventType) {
+            Event = eventType;
+        }
+
+        public PythonTextBufferInfoEventArgs(
+            PythonTextBufferInfoEvents eventType,
+            AnalysisEntry entry
+        ) : this(eventType) {
+            AnalysisEntry = entry;
+        }
+
+        public PythonTextBufferInfoEvents Event { get; }
+        public AnalysisEntry AnalysisEntry { get; }
+    }
+
+    class PythonTextBufferInfoNestedEventArgs : PythonTextBufferInfoEventArgs {
+        public PythonTextBufferInfoNestedEventArgs(PythonTextBufferInfoEvents eventType, EventArgs e)
+            : base(eventType) {
+            NestedEventArgs = e;
+        }
+
+        public EventArgs NestedEventArgs { get; }
+    }
+
+    class PythonNewTextBufferInfoEventArgs : PythonTextBufferInfoEventArgs {
+        public PythonNewTextBufferInfoEventArgs(PythonTextBufferInfoEvents eventType, PythonTextBufferInfo newInfo)
+            : base(eventType) {
+            NewTextBufferInfo = newInfo;
+        }
+
+        public PythonTextBufferInfo NewTextBufferInfo { get; }
+    }
+}

--- a/Python/Product/PythonTools/PythonTools/Editor/PythonEditorServices.cs
+++ b/Python/Product/PythonTools/PythonTools/Editor/PythonEditorServices.cs
@@ -19,9 +19,13 @@ using System.ComponentModel.Composition;
 using Microsoft.PythonTools.Intellisense;
 using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.Editor;
+using Microsoft.VisualStudio.Language.Intellisense;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Classification;
+using Microsoft.VisualStudio.Text.IncrementalSearch;
+using Microsoft.VisualStudio.Text.Operations;
+using Microsoft.VisualStudio.TextManager.Interop;
 using Microsoft.VisualStudio.Utilities;
 using Microsoft.VisualStudioTools;
 
@@ -89,6 +93,23 @@ namespace Microsoft.PythonTools.Editor {
         [Import]
         private Lazy<IVsEditorAdaptersFactoryService> _editorAdaptersFactoryService = null;
         public IVsEditorAdaptersFactoryService EditorAdaptersFactoryService => _editorAdaptersFactoryService.Value;
+
+        [Import]
+        public ICompletionBroker CompletionBroker = null;
+
+        [Import]
+        public IEditorOperationsFactoryService EditOperationsFactory = null;
+
+        [Import]
+        public ISignatureHelpBroker SignatureHelpBroker = null;
+
+        [Import]
+        public IQuickInfoBroker QuickInfoBroker = null;
+
+        [Import]
+        public IIncrementalSearchFactoryService IncrementalSearch = null;
+
+        public IVsTextManager2 VsTextManager2 => (IVsTextManager2)Site.GetService(typeof(SVsTextManager));
 
         #region Task Providers
 

--- a/Python/Product/PythonTools/PythonTools/Editor/PythonTextBufferInfo.cs
+++ b/Python/Product/PythonTools/PythonTools/Editor/PythonTextBufferInfo.cs
@@ -33,7 +33,7 @@ using Microsoft.VisualStudio.Utilities;
 namespace Microsoft.PythonTools.Editor {
     sealed class PythonTextBufferInfo {
         public static PythonTextBufferInfo ForBuffer(PythonEditorServices services, ITextBuffer buffer) {
-            var bi = buffer.Properties.GetOrCreateSingletonProperty(
+            var bi = (buffer ?? throw new ArgumentNullException(nameof(buffer))).Properties.GetOrCreateSingletonProperty(
                 typeof(PythonTextBufferInfo),
                 () => new PythonTextBufferInfo(services, buffer)
             );
@@ -74,16 +74,6 @@ namespace Microsoft.PythonTools.Editor {
             return view.BufferGraph.GetTextBuffers(_ => true)
                 .Select(b => TryGetForBuffer(b))
                 .Where(b => b != null);
-        }
-
-        public static bool TryDisconnect(object owner, ITextBuffer buffer) {
-            PythonTextBufferInfo bi;
-            if (buffer.Properties.TryGetProperty(typeof(PythonTextBufferInfo), out bi)) {
-                buffer.Properties.RemoveProperty(typeof(PythonTextBufferInfo));
-                //bi?.Disconnect(owner);
-                return true;
-            }
-            return false;
         }
 
         private readonly object _lock = new object();
@@ -323,32 +313,6 @@ namespace Microsoft.PythonTools.Editor {
             LastAnalysisReceivedVersion = ver;
             return true;
         }
-
-        //public Task<AnalysisEntry> WaitForAnalysisEntryAsync(CancellationToken cancellationToken) {
-        //    // Return our current entry if we have one
-        //    var entry = AnalysisEntry;
-        //    if (entry != null) {
-        //        return Task.FromResult(entry);
-        //    }
-
-        //    var tcs = new TaskCompletionSource<AnalysisEntry>();
-        //    if (cancellationToken.CanBeCanceled) {
-        //        cancellationToken.Register(() => tcs.TrySetCanceled());
-        //    }
-
-        //    EventHandler handler = null;
-        //    handler = (s, e) => {
-        //        cancellationToken.ThrowIfCancellationRequested();
-        //        var bi = (PythonTextBufferInfo)s;
-        //        var result = bi.AnalysisEntry;
-        //        if (result != null) {
-        //            bi.OnNewAnalysisEntry -= handler;
-        //            tcs.TrySetResult(result);
-        //        }
-        //    };
-
-        //    return tcs.Task;
-        //}
 
         public bool DoNotParse {
             get => Buffer.Properties.ContainsProperty(BufferParser.DoNotParse);

--- a/Python/Product/PythonTools/PythonTools/Intellisense/AnalysisEntryService.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/AnalysisEntryService.cs
@@ -62,12 +62,12 @@ namespace Microsoft.PythonTools.Intellisense {
         /// Returns a task that will be completed when an analyzer is assigned to the text buffer.
         /// </summary>
         /// <exception cref="ArgumentNullException"><paramref name="textBuffer"/> is null.</exception>
-        Task WaitForAnalyzerAsync(ITextBuffer textBuffer, CancellationToken cancellationToken);
+        //Task WaitForAnalyzerAsync(ITextBuffer textBuffer, CancellationToken cancellationToken);
         /// <summary>
         /// Returns a task that will be completed when an analyzer is assigned to the text view.
         /// </summary>
         /// <exception cref="ArgumentNullException"><paramref name="textView"/> is null.</exception>
-        Task WaitForAnalyzerAsync(ITextView textView, CancellationToken cancellationToken);
+        //Task WaitForAnalyzerAsync(ITextView textView, CancellationToken cancellationToken);
 
         /// <summary>
         /// Returns the default analyzer for the Visual Studio session. Must be accessed from
@@ -171,21 +171,21 @@ namespace Microsoft.PythonTools.Intellisense {
 
         public ProjectAnalyzer DefaultAnalyzer => _services.Python?.DefaultAnalyzer;
 
-        public Task WaitForAnalyzerAsync(ITextBuffer textBuffer, CancellationToken cancellationToken) {
-            if (textBuffer == null) {
-                throw new ArgumentNullException(nameof(textBuffer));
-            }
+        //public Task WaitForAnalyzerAsync(ITextBuffer textBuffer, CancellationToken cancellationToken) {
+        //    if (textBuffer == null) {
+        //        throw new ArgumentNullException(nameof(textBuffer));
+        //    }
 
-            return _services.GetBufferInfo(textBuffer).WaitForAnalysisEntryAsync(cancellationToken);
-        }
+        //    return _services.GetBufferInfo(textBuffer).WaitForAnalysisEntryAsync(cancellationToken);
+        //}
 
-        public Task WaitForAnalyzerAsync(ITextView textView, CancellationToken cancellationToken) {
-            if (textView == null) {
-                throw new ArgumentNullException(nameof(textView));
-            }
+        //public Task WaitForAnalyzerAsync(ITextView textView, CancellationToken cancellationToken) {
+        //    if (textView == null) {
+        //        throw new ArgumentNullException(nameof(textView));
+        //    }
 
-            return WaitForAnalyzerAsync(textView.TextBuffer, cancellationToken);
-        }
+        //    return WaitForAnalyzerAsync(textView.TextBuffer, cancellationToken);
+        //}
 
         public bool TryGetAnalyzer(ITextBuffer textBuffer, out ProjectAnalyzer analyzer, out string filename) {
             if (textBuffer == null) {

--- a/Python/Product/PythonTools/PythonTools/Intellisense/AnalysisEntryService.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/AnalysisEntryService.cs
@@ -20,20 +20,15 @@ using System.ComponentModel.Composition;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.PythonTools.Editor;
 using Microsoft.PythonTools.Infrastructure;
 using Microsoft.PythonTools.Projects;
 using Microsoft.PythonTools.Repl;
-using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.InteractiveWindow;
-using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Differencing;
 using Microsoft.VisualStudio.Text.Editor;
-using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.PythonTools.Intellisense {
     public interface IAnalysisEntryService {
@@ -57,17 +52,6 @@ namespace Microsoft.PythonTools.Intellisense {
         /// </summary>
         /// <exception cref="ArgumentNullException"><paramref name="filename"/> is null or empty.</exception>
         IEnumerable<ProjectAnalyzer> GetAnalyzersForFile(string filename);
-
-        /// <summary>
-        /// Returns a task that will be completed when an analyzer is assigned to the text buffer.
-        /// </summary>
-        /// <exception cref="ArgumentNullException"><paramref name="textBuffer"/> is null.</exception>
-        //Task WaitForAnalyzerAsync(ITextBuffer textBuffer, CancellationToken cancellationToken);
-        /// <summary>
-        /// Returns a task that will be completed when an analyzer is assigned to the text view.
-        /// </summary>
-        /// <exception cref="ArgumentNullException"><paramref name="textView"/> is null.</exception>
-        //Task WaitForAnalyzerAsync(ITextView textView, CancellationToken cancellationToken);
 
         /// <summary>
         /// Returns the default analyzer for the Visual Studio session. Must be accessed from
@@ -94,25 +78,6 @@ namespace Microsoft.PythonTools.Intellisense {
             } catch (ImportCardinalityMismatchException) {
             }
         }
-
-        //public void SetAnalyzer(ITextBuffer textBuffer, VsProjectAnalyzer analyzer) {
-        //    if (textBuffer == null) {
-        //        throw new ArgumentNullException(nameof(textBuffer));
-        //    }
-        //
-        //    if (analyzer == null) {
-        //        textBuffer.Properties.RemoveProperty(typeof(VsProjectAnalyzer));
-        //        return;
-        //    }
-        //
-        //    textBuffer.Properties[typeof(VsProjectAnalyzer)] = analyzer;
-        //
-        //    TaskCompletionSource<object> tcs;
-        //    if (textBuffer.Properties.TryGetProperty(_waitForAnalyzerKey, out tcs)) {
-        //        tcs.TrySetResult(null);
-        //        textBuffer.Properties.RemoveProperty(_waitForAnalyzerKey);
-        //    }
-        //}
 
         /// <summary>
         /// Gets the analysis entry for the given view and buffer.
@@ -170,22 +135,6 @@ namespace Microsoft.PythonTools.Intellisense {
         #region IAnalysisEntryService members
 
         public ProjectAnalyzer DefaultAnalyzer => _services.Python?.DefaultAnalyzer;
-
-        //public Task WaitForAnalyzerAsync(ITextBuffer textBuffer, CancellationToken cancellationToken) {
-        //    if (textBuffer == null) {
-        //        throw new ArgumentNullException(nameof(textBuffer));
-        //    }
-
-        //    return _services.GetBufferInfo(textBuffer).WaitForAnalysisEntryAsync(cancellationToken);
-        //}
-
-        //public Task WaitForAnalyzerAsync(ITextView textView, CancellationToken cancellationToken) {
-        //    if (textView == null) {
-        //        throw new ArgumentNullException(nameof(textView));
-        //    }
-
-        //    return WaitForAnalyzerAsync(textView.TextBuffer, cancellationToken);
-        //}
 
         public bool TryGetAnalyzer(ITextBuffer textBuffer, out ProjectAnalyzer analyzer, out string filename) {
             if (textBuffer == null) {

--- a/Python/Product/PythonTools/PythonTools/Intellisense/BufferParser.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/BufferParser.cs
@@ -27,14 +27,13 @@ using Microsoft.VisualStudio.Text;
 namespace Microsoft.PythonTools.Intellisense {
     using AP = AnalysisProtocol;
 
-    sealed class BufferParser : IDisposable {
+    sealed class BufferParser : IPythonTextBufferInfoEventSink, IDisposable {
         private readonly Timer _timer;
         internal readonly PythonEditorServices _services;
-        internal readonly AnalysisEntry AnalysisEntry;
+        private readonly VsProjectAnalyzer _analyzer;
 
         private IList<PythonTextBufferInfo> _buffers;
         private bool _parsing, _requeue, _textChange, _parseImmediately;
-        private ITextDocument _document;
 
         /// <summary>
         /// Maps between buffer ID and buffer info.
@@ -46,14 +45,17 @@ namespace Microsoft.PythonTools.Intellisense {
         public static readonly object DoNotParse = new object();
         public static readonly object ParseImmediately = new object();
 
-        public BufferParser(AnalysisEntry entry) {
-            Debug.Assert(entry != null);
-
-            _services = entry.Analyzer._services;
-            _timer = new Timer(ReparseTimer, null, Timeout.Infinite, Timeout.Infinite);
+        public BufferParser(PythonEditorServices services, VsProjectAnalyzer analyzer, string filePath) {
+            _services = services ?? throw new ArgumentNullException(nameof(services));
+            _analyzer = analyzer ?? throw new ArgumentNullException(nameof(analyzer));
+            FilePath = filePath;
             _buffers = Array.Empty<PythonTextBufferInfo>();
-            AnalysisEntry = entry;
+            _timer = new Timer(ReparseTimer, null, Timeout.Infinite, Timeout.Infinite);
         }
+
+        public string FilePath { get; }
+        public bool IsTemporaryFile { get; set; }
+        public bool SuppressErrorList { get; set; }
 
         public PythonTextBufferInfo GetBuffer(ITextBuffer buffer) {
             return buffer == null ? null : _services.GetBufferInfo(buffer);
@@ -91,13 +93,10 @@ namespace Microsoft.PythonTools.Intellisense {
             return GetBuffer(buffer)?.LastSentSnapshot;
         }
 
-        internal void SetLastSentSnapshot(ITextSnapshot snapshot) {
-            if (snapshot == null) {
-                Debug.Fail("null snapshot");
-                return;
+        public ITextBuffer[] AllBuffers {
+            get {
+                return _buffers.Select(x => x.Buffer).ToArray();
             }
-
-            GetBuffer(snapshot.TextBuffer).LastSentSnapshot = snapshot;
         }
 
         public ITextBuffer[] Buffers {
@@ -108,8 +107,15 @@ namespace Microsoft.PythonTools.Intellisense {
 
         internal void AddBuffer(ITextBuffer textBuffer) {
             int newId;
+            var bi = _services.GetBufferInfo(textBuffer);
+
+            var entry = bi.AnalysisEntry;
+
+            if (entry == null) {
+                throw new InvalidOperationException("buffer must have a project entry before parsing");
+            }
+
             lock (this) {
-                var bi = _services.GetBufferInfo(textBuffer);
                 if (_buffers.Contains(bi)) {
                     return;
                 }
@@ -117,12 +123,37 @@ namespace Microsoft.PythonTools.Intellisense {
                 EnsureMutableBuffers();
                 _buffers.Add(bi);
                 newId = _buffers.Count - 1;
-                if (bi.ParseImmediately) {
-                    _parseImmediately = true;
+
+                if (!bi.SetAnalysisBufferId(newId)) {
+                    // Raced, and now the buffer belongs somewhere else.
+                    Debug.Fail("Race condition adding the buffer to a parser");
+                    _buffers[newId] = null;
+                    return;
                 }
+                _bufferIdMapping[newId] = bi;
             }
 
-            InitBuffer(textBuffer, newId);
+            if (bi.ParseImmediately) {
+                // Any buffer requesting immediate parsing enables it for
+                // the whole file.
+                _parseImmediately = true;
+            }
+
+            bi.AddSink(this, this);
+            VsProjectAnalyzer.ConnectErrorList(bi);
+        }
+
+        internal void ClearBuffers() {
+            lock (this) {
+                _bufferIdMapping.Clear();
+                foreach (var bi in _buffers) {
+                    bi.SetAnalysisBufferId(-1);
+                    bi.ClearAnalysisEntry();
+                    bi.RemoveSink(this);
+                    VsProjectAnalyzer.DisconnectErrorList(bi);
+                }
+                _buffers = Array.Empty<PythonTextBufferInfo>();
+            }
         }
 
         internal int RemoveBuffer(ITextBuffer subjectBuffer) {
@@ -133,59 +164,19 @@ namespace Microsoft.PythonTools.Intellisense {
                 if (bi != null) {
                     EnsureMutableBuffers();
                     _buffers.Remove(bi);
+
+                    bi.RemoveSink(this);
+
+                    VsProjectAnalyzer.DisconnectErrorList(bi);
+                    _bufferIdMapping.Remove(bi.AnalysisBufferId);
+                    bi.SetAnalysisBufferId(-1);
+
+                    bi.Buffer.Properties.RemoveProperty(typeof(PythonTextBufferInfo));
                 }
                 result = _buffers.Count;
             }
 
-            if (bi != null) {
-                UninitBuffer(bi);
-            }
-
             return result;
-        }
-
-        private void UninitBuffer(PythonTextBufferInfo subjectBuffer) {
-            if (subjectBuffer == null) {
-                throw new ArgumentNullException(nameof(subjectBuffer));
-            }
-            subjectBuffer.OnChangedLowPriority -= BufferChangedLowPriority;
-            VsProjectAnalyzer.DisconnectErrorList(subjectBuffer);
-            lock (this) {
-                _bufferIdMapping.Remove(subjectBuffer.AnalysisEntryId);
-                subjectBuffer.SetAnalysisEntryId(-1);
-            }
-
-
-            if (_document != null) {
-                _document.EncodingChanged -= EncodingChanged;
-                _document = null;
-            }
-        }
-
-        private void InitBuffer(ITextBuffer buffer, int id = 0) {
-            var bi = _services.GetBufferInfo(buffer);
-            if (!bi.SetAnalysisEntryId(id)) {
-                Debug.Fail("Buffer is already initialized");
-                return;
-            }
-
-            bi.OnChangedLowPriority += BufferChangedLowPriority;
-            VsProjectAnalyzer.ConnectErrorList(bi);
-
-            lock (this) {
-                _bufferIdMapping[id] = bi;
-            }
-
-            ITextDocument doc;
-            if (buffer.Properties.TryGetProperty(typeof(ITextDocument), out doc) && doc != _document) {
-                if (_document != null) {
-                    _document.EncodingChanged -= EncodingChanged;
-                }
-                _document = doc;
-                if (_document != null) {
-                    _document.EncodingChanged += EncodingChanged;
-                }
-            }
         }
 
         private void EnsureMutableBuffers() {
@@ -229,7 +220,7 @@ namespace Microsoft.PythonTools.Intellisense {
         }
 
         private Task ParseBuffers(IEnumerable<ITextSnapshot> snapshots) {
-            return ParseBuffersAsync(_services, AnalysisEntry, snapshots);
+            return ParseBuffersAsync(_services, _analyzer, snapshots);
         }
 
         private static IEnumerable<ITextVersion> GetVersions(ITextVersion from, ITextVersion to) {
@@ -240,7 +231,7 @@ namespace Microsoft.PythonTools.Intellisense {
 
         private static AP.FileUpdate GetUpdateForSnapshot(PythonEditorServices services, ITextSnapshot snapshot) {
             var buffer = services.GetBufferInfo(snapshot.TextBuffer);
-            if (buffer.DoNotParse || snapshot.IsReplBufferWithCommand() || buffer.AnalysisEntryId < 0) {
+            if (buffer.DoNotParse || snapshot.IsReplBufferWithCommand() || buffer.AnalysisBufferId < 0) {
                 return null;
             }
 
@@ -267,7 +258,7 @@ namespace Microsoft.PythonTools.Intellisense {
                 return new AP.FileUpdate {
                     content = snapshot.GetText(),
                     version = snapshot.Version.VersionNumber,
-                    bufferId = buffer.AnalysisEntryId,
+                    bufferId = buffer.AnalysisBufferId,
                     kind = AP.FileUpdateKind.reset
                 };
             }
@@ -279,7 +270,7 @@ namespace Microsoft.PythonTools.Intellisense {
             return new AP.FileUpdate() {
                 versions = versions,
                 version = snapshot.Version.VersionNumber,
-                bufferId = buffer.AnalysisEntryId,
+                bufferId = buffer.AnalysisBufferId,
                 kind = AP.FileUpdateKind.changes
             };
         }
@@ -293,7 +284,7 @@ namespace Microsoft.PythonTools.Intellisense {
                 }
 
                 string newCode;
-                if (!code.TryGetValue(bi.AnalysisEntryId, out newCode)) {
+                if (!code.TryGetValue(bi.AnalysisBufferId, out newCode)) {
                     continue;
                 }
 
@@ -303,31 +294,37 @@ namespace Microsoft.PythonTools.Intellisense {
 
         internal static async Task ParseBuffersAsync(
             PythonEditorServices services,
-            AnalysisEntry entry,
+            VsProjectAnalyzer analyzer,
             IEnumerable<ITextSnapshot> snapshots
         ) {
-            var updates = snapshots.Select(s => GetUpdateForSnapshot(services, s)).Where(u => u != null).ToList();
+            var updates = snapshots
+                .GroupBy(s => PythonTextBufferInfo.TryGetForBuffer(s.TextBuffer)?.AnalysisEntry.FileId ?? -1)
+                .Where(g => g.Key >= 0)
+                .Select(g => Tuple.Create(g.Key, g.Select(s => GetUpdateForSnapshot(services, s)).ToArray()))
+                .Where(u => u != null).ToList();
 
             if (!updates.Any()) {
                 return;
             }
 
-            entry.Analyzer._analysisComplete = false;
-            Interlocked.Increment(ref entry.Analyzer._parsePending);
+            analyzer._analysisComplete = false;
+            Interlocked.Increment(ref analyzer._parsePending);
 
-            var res = await entry.Analyzer.SendRequestAsync(
-                new AP.FileUpdateRequest() {
-                    fileId = entry.FileId,
-                    updates = updates.ToArray()
+            foreach (var update in updates) {
+                var res = await analyzer.SendRequestAsync(
+                    new AP.FileUpdateRequest() {
+                        fileId = update.Item1,
+                        updates = update.Item2
+                    }
+                );
+
+                if (res != null) {
+                    Debug.Assert(res.failed != true);
+                    analyzer.OnAnalysisStarted();
+                    ValidateBufferContents(snapshots, res.newCode);
+                } else {
+                    Interlocked.Decrement(ref analyzer._parsePending);
                 }
-            );
-
-            if (res != null) {
-                Debug.Assert(res.failed != true);
-                entry.Analyzer.OnAnalysisStarted();
-                ValidateBufferContents(snapshots, res.newCode);
-            } else {
-                Interlocked.Decrement(ref entry.Analyzer._parsePending);
             }
         }
 
@@ -348,40 +345,6 @@ namespace Microsoft.PythonTools.Intellisense {
                 }
             }
             return changes.ToArray();
-        }
-
-        internal void EncodingChanged(object sender, EncodingChangedEventArgs e) {
-            lock (this) {
-                if (_parsing) {
-                    // we are currently parsing, just reque when we complete
-                    _requeue = true;
-                    _timer.Change(Timeout.Infinite, Timeout.Infinite);
-                } else {
-                    Requeue();
-                }
-            }
-        }
-
-        internal void BufferChangedLowPriority(object sender, TextContentChangedEventArgs e) {
-            lock (this) {
-                // only immediately re-parse on line changes after we've seen a text change.
-
-                if (_parsing) {
-                    // we are currently parsing, just reque when we complete
-                    _requeue = true;
-                    _timer.Change(Timeout.Infinite, Timeout.Infinite);
-                } else if (_parseImmediately) {
-                    // we are a test buffer, we should requeue immediately
-                    Requeue();
-                } else if (LineAndTextChanges(e)) {
-                    // user pressed enter, we should requeue immediately
-                    Requeue();
-                } else {
-                    // parse if the user doesn't do anything for a while.
-                    _textChange = IncludesTextChanges(e);
-                    _timer.Change(ReparseDelay, Timeout.Infinite);
-                }
-            }
         }
 
         internal void Requeue() {
@@ -430,17 +393,53 @@ namespace Microsoft.PythonTools.Intellisense {
         }
 
         public void Dispose() {
-            foreach (var buffer in _buffers) {
-                UninitBuffer(buffer);
+            foreach (var buffer in _buffers.ToArray()) {
+                RemoveBuffer(buffer.Buffer);
             }
             _timer.Dispose();
-            AnalysisEntry.ClearBufferParser(this);
         }
 
-        internal ITextDocument Document {
-            get {
-                return _document;
+        Task IPythonTextBufferInfoEventSink.PythonTextBufferEventAsync(PythonTextBufferInfo sender, PythonTextBufferInfoEventArgs e) {
+            switch (e.Event) {
+                case PythonTextBufferInfoEvents.TextContentChangedLowPriority:
+                    lock (this) {
+                        // only immediately re-parse on line changes after we've seen a text change.
+                        var ne = (e as PythonTextBufferInfoNestedEventArgs)?.NestedEventArgs as TextContentChangedEventArgs;
+
+                        if (_parsing) {
+                            // we are currently parsing, just reque when we complete
+                            _requeue = true;
+                            _timer.Change(Timeout.Infinite, Timeout.Infinite);
+                        } else if (_parseImmediately) {
+                            // we are a test buffer, we should requeue immediately
+                            Requeue();
+                        } else if (ne == null) {
+                            // failed to get correct type for this event
+                            Debug.Fail("Failed to get correct event type");
+                        } else if (LineAndTextChanges(ne)) {
+                            // user pressed enter, we should requeue immediately
+                            Requeue();
+                        } else {
+                            // parse if the user doesn't do anything for a while.
+                            _textChange = IncludesTextChanges(ne);
+                            _timer.Change(ReparseDelay, Timeout.Infinite);
+                        }
+                    }
+                    break;
+
+                case PythonTextBufferInfoEvents.DocumentEncodingChanged:
+                    lock (this) {
+                        if (_parsing) {
+                            // we are currently parsing, just reque when we complete
+                            _requeue = true;
+                            _timer.Change(Timeout.Infinite, Timeout.Infinite);
+                        } else {
+                            Requeue();
+                        }
+                    }
+                    break;
             }
+            return Task.CompletedTask;
         }
     }
 }

--- a/Python/Product/PythonTools/PythonTools/Intellisense/BufferParser.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/BufferParser.cs
@@ -300,8 +300,11 @@ namespace Microsoft.PythonTools.Intellisense {
             var updates = snapshots
                 .GroupBy(s => PythonTextBufferInfo.TryGetForBuffer(s.TextBuffer)?.AnalysisEntry.FileId ?? -1)
                 .Where(g => g.Key >= 0)
-                .Select(g => Tuple.Create(g.Key, g.Select(s => GetUpdateForSnapshot(services, s)).ToArray()))
-                .Where(u => u != null).ToList();
+                .Select(g => Tuple.Create(
+                    g.Key,
+                    g.Select(s => GetUpdateForSnapshot(services, s)).Where(u => u != null).ToArray()
+                ))
+                .ToList();
 
             if (!updates.Any()) {
                 return;

--- a/Python/Product/PythonTools/PythonTools/Intellisense/IntellisenseController.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/IntellisenseController.cs
@@ -190,7 +190,7 @@ namespace Microsoft.PythonTools.Intellisense {
                 entry = await vsAnalyzer.AnalyzeFileAsync(bi.Filename, null, isTemporaryFile, suppressErrorList);
 
                 if (entry == null) {
-                    throw new InvalidOperationException("Failed to create entry for buffer");
+                    return;
                 }
 
                 entry = bi.TrySetAnalysisEntry(entry, null);

--- a/Python/Product/PythonTools/PythonTools/Intellisense/IntellisenseControllerProvider.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/IntellisenseControllerProvider.cs
@@ -19,6 +19,7 @@ using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Linq;
 using System.Runtime.InteropServices;
+using Microsoft.PythonTools.Editor;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.Editor;
@@ -40,27 +41,7 @@ namespace Microsoft.PythonTools.Intellisense {
     [TextViewRole(PredefinedTextViewRoles.Editable)]
     class IntellisenseControllerProvider : IIntellisenseControllerProvider {
         [Import]
-        internal ICompletionBroker _CompletionBroker = null; // Set via MEF
-        [Import]
-        internal IEditorOperationsFactoryService _EditOperationsFactory = null; // Set via MEF
-        [Import]
-        internal IVsEditorAdaptersFactoryService _adaptersFactory { get; set; }
-        [Import]
-        internal ISignatureHelpBroker _SigBroker = null; // Set via MEF
-        [Import]
-        internal IQuickInfoBroker _QuickInfoBroker = null; // Set via MEF
-        [Import]
-        internal IIncrementalSearchFactoryService _IncrementalSearch = null; // Set via MEF
-        [Import]
-        internal AnalysisEntryService _EntryService = null; // Set via MEF
-        internal IServiceProvider _ServiceProvider;
-        internal PythonToolsService PythonService;
-
-        [ImportingConstructor]
-        public IntellisenseControllerProvider([Import(typeof(SVsServiceProvider))] IServiceProvider serviceProvider) {
-            _ServiceProvider = serviceProvider;
-            PythonService = serviceProvider.GetPythonToolsService();
-        }
+        internal PythonEditorServices Services = null;
 
         readonly Dictionary<ITextView, Tuple<BufferParser, VsProjectAnalyzer>> _hookedCloseEvents =
             new Dictionary<ITextView, Tuple<BufferParser, VsProjectAnalyzer>>();
@@ -68,7 +49,7 @@ namespace Microsoft.PythonTools.Intellisense {
         public IIntellisenseController TryCreateIntellisenseController(ITextView textView, IList<ITextBuffer> subjectBuffers) {
             IntellisenseController controller;
             if (!textView.Properties.TryGetProperty(typeof(IntellisenseController), out controller)) {
-                controller = new IntellisenseController(this, textView, _ServiceProvider);
+                controller = new IntellisenseController(this, textView);
             }
 
             foreach (var subjectBuffer in subjectBuffers) {
@@ -97,7 +78,7 @@ namespace Microsoft.PythonTools.Intellisense {
                    where exportedContentType == PythonCoreConstants.ContentType && export.Value.GetType() == typeof(IntellisenseControllerProvider)
                    select export.Value
                 ).First();
-                controller = new IntellisenseController((IntellisenseControllerProvider)intellisenseControllerProvider, textView, serviceProvider);
+                controller = new IntellisenseController((IntellisenseControllerProvider)intellisenseControllerProvider, textView);
             }
             return controller;
         }

--- a/Python/Product/PythonTools/PythonTools/Intellisense/ProjectAnalyzer.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/ProjectAnalyzer.cs
@@ -702,26 +702,6 @@ namespace Microsoft.PythonTools.Intellisense {
             return Array.Empty<AP.ModuleInfo>();
         }
 
-        private void OnModulesChanged(object sender, EventArgs e) {
-            SendEvent(new AP.ModulesChangedEvent());
-        }
-
-        internal void ReanalyzeEntry(AnalysisEntry entry) {
-            var parser = entry.TryGetBufferParser();
-            if (parser == null) {
-                return;
-            }
-            var buffers = parser.Buffers;
-            if (!buffers.Any()) {
-                return;
-            }
-
-            foreach (var buffer in buffers) {
-                parser.RemoveBuffer(buffer);
-            }
-            
-        }
-
         internal async Task TransferFromOldAnalyzer(VsProjectAnalyzer oldAnalyzer) {
             var oldFileAndEntry = oldAnalyzer.LoadedFiles.ToArray();
             var oldFiles = oldFileAndEntry.Select(kv => kv.Key);
@@ -750,8 +730,7 @@ namespace Microsoft.PythonTools.Intellisense {
                     continue;
                 }
 
-                ITextBuffer[] buffers;
-                if (oldBuffers.TryGetValue(e.Path, out buffers)) {
+                if (oldBuffers.TryGetValue(e.Path, out ITextBuffer[] buffers)) {
                     foreach (var b in buffers) {
                         PythonTextBufferInfo.MarkForReplacement(b);
                         e.GetOrCreateBufferParser(_services).AddBuffer(b);
@@ -818,47 +797,6 @@ namespace Microsoft.PythonTools.Intellisense {
         internal void OnAnalysisStarted() {
             AnalysisStarted?.Invoke(this, EventArgs.Empty);
         }
-
-        /// <summary>
-        /// Starts monitoring a buffer for changes so we will re-parse the buffer to update the analysis
-        /// as the text changes.
-        /// </summary>
-        //internal async Task<BufferParser> MonitorTextBufferAsync(ITextBuffer textBuffer, bool isTemporaryFile = false, bool suppressErrorList = false) {
-        //    var bi = _services.GetBufferInfo(textBuffer);
-        //    var existingEntry = bi.AnalysisEntry;
-
-        //    // Create a new entry if the current one is not ours
-        //    var entry = existingEntry;
-        //    if (entry == null || entry.Analyzer != this) {
-        //        entry = await CreateProjectEntryAsync(bi, isTemporaryFile, suppressErrorList).ConfigureAwait(false);
-        //    }
-        //    if (entry == null) {
-        //        return null;
-        //    }
-
-        //    try {
-        //        if (!bi.TrySetAnalysisEntry(entry, existingEntry)) {
-        //            // Raced with another monitor
-        //            Debug.Fail("MonitorTextBufferAsync race occurred");
-        //            return null;
-        //        }
-        //    } catch (ObjectDisposedException) {
-        //        // Buffer has gone away already
-        //        return null;
-        //    }
-
-        //    var bufferParser = new BufferParser(entry);
-        //    bufferParser.AddBuffer(textBuffer);
-
-        //    var snapshot = (entry.AnalysisCookie as SnapshotCookie)?.Snapshot;
-        //    // File cannot be parsed from disk, so sync the code from the current buffer
-        //    // This should be rare in normal use, but very frequent in tests
-        //    if (snapshot != null && (isTemporaryFile || !File.Exists(entry.Path))) {
-        //        await BufferParser.ParseBuffersAsync(_services, this, Enumerable.Repeat(snapshot, 1));
-        //    }
-
-        //    return bufferParser;
-        //}
 
         internal void BufferDetached(AnalysisEntry entry, ITextBuffer buffer) {
             if (entry == null) {

--- a/Python/Product/PythonTools/PythonTools/Intellisense/ProjectAnalyzer.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/ProjectAnalyzer.cs
@@ -1132,17 +1132,16 @@ namespace Microsoft.PythonTools.Intellisense {
         }
 
         internal static SourceLocation TranslateIndex(int index, ITextSnapshot fromSnapshot, AnalysisEntry toAnalysisSnapshot) {
-            SnapshotCookie snapshotCookie;
+            ITextSnapshot analysisSnapshot;
             // TODO: buffers differ in the REPL window case, in the future we should handle this better
             if (toAnalysisSnapshot != null &&
                 fromSnapshot != null &&
-                (snapshotCookie = toAnalysisSnapshot.AnalysisCookie as SnapshotCookie) != null &&
-                snapshotCookie.Snapshot != null &&
-                snapshotCookie.Snapshot.TextBuffer == fromSnapshot.TextBuffer) {
+                (analysisSnapshot = (toAnalysisSnapshot.AnalysisCookie as SnapshotCookie)?.Snapshot) != null &&
+                analysisSnapshot.TextBuffer == fromSnapshot.TextBuffer) {
 
                 var fromPoint = new SnapshotPoint(fromSnapshot, index);
                 var fromLine = fromPoint.GetContainingLine();
-                var toPoint = fromPoint.TranslateTo(snapshotCookie.Snapshot, PointTrackingMode.Negative);
+                var toPoint = fromPoint.TranslateTo(analysisSnapshot, PointTrackingMode.Negative);
                 var toLine = toPoint.GetContainingLine();
 
                 Debug.Assert(fromLine != null, "Unable to get 'from' line from " + fromPoint.ToString());

--- a/Python/Product/PythonTools/PythonTools/Intellisense/ProjectAnalyzer.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/ProjectAnalyzer.cs
@@ -900,7 +900,7 @@ namespace Microsoft.PythonTools.Intellisense {
             }
 
             if (string.IsNullOrEmpty(path)) {
-                return null;
+                throw new ArgumentNullException(nameof(path));
             }
 
             AnalysisEntry entry;
@@ -920,7 +920,8 @@ namespace Microsoft.PythonTools.Intellisense {
 
             if (response == null || response.fileId == -1) {
                 Interlocked.Decrement(ref _parsePending);
-                return null;
+                // TODO: Get SendRequestAsync to return more useful information
+                throw new InvalidOperationException("Failed to create entry for file");
             }
 
             // we awaited between the check and the AddFileRequest, another add could

--- a/Python/Product/PythonTools/PythonTools/Intellisense/ProjectAnalyzer.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/ProjectAnalyzer.cs
@@ -746,6 +746,10 @@ namespace Microsoft.PythonTools.Intellisense {
             }
 
             foreach (var e in entries) {
+                if (e == null) {
+                    continue;
+                }
+
                 ITextBuffer[] buffers;
                 if (oldBuffers.TryGetValue(e.Path, out buffers)) {
                     foreach (var b in buffers) {

--- a/Python/Product/PythonTools/PythonTools/Intellisense/ReverseExpressionParser.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/ReverseExpressionParser.cs
@@ -48,7 +48,7 @@ namespace Microsoft.PythonTools.Intellisense {
 
             var targetSpan = new Span(line.Start.Position, span.GetEndPoint(snapshot).Position - line.Start.Position);
 
-            _classifier = PythonTextBufferInfo.TryGetForBuffer(_buffer)?.Classifier;
+            _classifier = _buffer.GetPythonClassifier();
             if (_classifier == null) {
                 throw new ArgumentException(Strings.ReverseExpressionParserFailedToGetClassifierFromBufferException);
             }

--- a/Python/Product/PythonTools/PythonTools/Intellisense/SnapshotCookie.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/SnapshotCookie.cs
@@ -19,15 +19,16 @@ using Microsoft.VisualStudio.Text;
 
 namespace Microsoft.PythonTools.Intellisense {
     class SnapshotCookie : IIntellisenseCookie {
-        private readonly ITextSnapshot _snapshot;
+        private readonly WeakReference<ITextSnapshot> _snapshot;
         
         public SnapshotCookie(ITextSnapshot snapshot) {
-            _snapshot = snapshot;
+            _snapshot = new WeakReference<ITextSnapshot>(snapshot);
         }
 
         public ITextSnapshot Snapshot {
             get {
-                return _snapshot;
+                ITextSnapshot value;
+                return _snapshot.TryGetTarget(out value) ? value : null;
             }
         }
 
@@ -35,7 +36,7 @@ namespace Microsoft.PythonTools.Intellisense {
 
         public string GetLine(int lineNo) {
             try {
-                return _snapshot.GetLineFromLineNumber(lineNo - 1).GetText();
+                return Snapshot?.GetLineFromLineNumber(lineNo - 1).GetText() ?? string.Empty;
             } catch (ArgumentOutOfRangeException) {
                 return string.Empty;
             }

--- a/Python/Product/PythonTools/PythonTools/Intellisense/XamlTextViewCreationListener.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/XamlTextViewCreationListener.cs
@@ -16,6 +16,8 @@
 
 using System;
 using System.ComponentModel.Composition;
+using System.Diagnostics;
+using Microsoft.PythonTools.Editor;
 using Microsoft.PythonTools.Infrastructure;
 using Microsoft.VisualStudio.Editor;
 using Microsoft.VisualStudio.Shell;
@@ -31,35 +33,29 @@ namespace Microsoft.PythonTools.Intellisense {
     [TextViewRole(PredefinedTextViewRoles.Editable)]
     [ContentType("xaml")]
     class XamlTextViewCreationListener : IVsTextViewCreationListener {
-        internal readonly IVsEditorAdaptersFactoryService AdapterService;
-        private readonly IServiceProvider _serviceProvider;
-        private readonly AnalysisEntryService _entryService;
+        private readonly PythonEditorServices _services;
 
         [ImportingConstructor]
-        public XamlTextViewCreationListener(
-            [Import(typeof(SVsServiceProvider))] IServiceProvider serviceProvider,
-            IVsEditorAdaptersFactoryService adapterService,
-            AnalysisEntryService entryService
-        ) {
-            _serviceProvider = serviceProvider;
-            AdapterService = adapterService;
-            _entryService = entryService;
+        public XamlTextViewCreationListener(PythonEditorServices services) {
+            _services = services;
         }
 
-        public void VsTextViewCreated(VisualStudio.TextManager.Interop.IVsTextView textViewAdapter) {
+        public async void VsTextViewCreated(VisualStudio.TextManager.Interop.IVsTextView textViewAdapter) {
             // TODO: We should probably only track text views in Python projects or loose files.
-            ITextView textView = AdapterService.GetWpfTextView(textViewAdapter);
+            var textView = _services.EditorAdaptersFactoryService.GetWpfTextView(textViewAdapter);
             
             if (textView != null) {
-                var entryService = _serviceProvider.GetEntryService();
-                var analyzer = entryService.GetVsAnalyzer(textView, null);
-                if (analyzer != null) {
-                    var monitorResult = analyzer.MonitorTextBufferAsync(textView.TextBuffer)
-                        .ContinueWith(
-                            task => {
-                                textView.Closed += TextView_Closed;
-                            }
-                        );
+                var analyzer = _services.AnalysisEntryService.GetVsAnalyzer(textView, null);
+                var bi = _services.GetBufferInfo(textView.TextBuffer);
+                if (analyzer != null && bi != null && bi.AnalysisEntry == null) {
+                    var entry = await analyzer.AnalyzeFileAsync(bi.Filename);
+                    if (bi.TrySetAnalysisEntry(entry, null) != entry) {
+                        // Failed to start analyzing
+                        Debug.Fail("Failed to analyze xaml file");
+                        return;
+                    }
+                    await entry.EnsureCodeSyncedAsync(bi.Buffer);
+                    textView.Closed += TextView_Closed;
                 }
             }
         }
@@ -67,10 +63,10 @@ namespace Microsoft.PythonTools.Intellisense {
         private void TextView_Closed(object sender, EventArgs e) {
             var textView = (ITextView)sender;
 
-            AnalysisEntry entry;
-            if (_entryService.TryGetAnalysisEntry(textView, textView.TextBuffer, out entry)) {
-                entry.Analyzer.BufferDetached(entry, textView.TextBuffer);
-            }
+            //AnalysisEntry entry;
+            //if (_entryService.TryGetAnalysisEntry(textView, textView.TextBuffer, out entry)) {
+            //    entry.Analyzer.BufferDetached(entry, textView.TextBuffer);
+            //}
             
             textView.Closed -= TextView_Closed;
         }

--- a/Python/Product/PythonTools/PythonTools/Navigation/EditFilter.cs
+++ b/Python/Product/PythonTools/PythonTools/Navigation/EditFilter.cs
@@ -751,12 +751,12 @@ namespace Microsoft.PythonTools.Language {
                         }
                         break;
                     case VSConstants.VSStd2KCmdID.OUTLN_STOP_HIDING_ALL:
-                        _textView.GetOutliningTagger()?.Disable();
+                        _textView.GetOutliningTagger()?.Disable(_textView.TextSnapshot);
                         // let VS get the event as well
                         break;
 
                     case VSConstants.VSStd2KCmdID.OUTLN_START_AUTOHIDING:
-                        _textView.GetOutliningTagger()?.Enable();
+                        _textView.GetOutliningTagger()?.Enable(_textView.TextSnapshot);
                         // let VS get the event as well
                         break;
                     case VSConstants.VSStd2KCmdID.COMMENT_BLOCK:

--- a/Python/Product/PythonTools/PythonTools/Project/PythonProjectNode.cs
+++ b/Python/Product/PythonTools/PythonTools/Project/PythonProjectNode.cs
@@ -1375,7 +1375,7 @@ namespace Microsoft.PythonTools.Project {
 
                 if (oldAnalyzer != null) {
                     if (analyzer != null) {
-                        analyzer.SwitchAnalyzers(oldAnalyzer);
+                        await analyzer.TransferFromOldAnalyzer(oldAnalyzer);
                     }
                     if (oldAnalyzer.RemoveUser()) {
                         oldAnalyzer.Dispose();
@@ -1386,11 +1386,11 @@ namespace Microsoft.PythonTools.Project {
 
                 var defAnalyzer = Site.GetPythonToolsService().MaybeDefaultAnalyzer;
                 if (defAnalyzer != null) {
-                    foreach (var entry in files
-                        .Select(p => defAnalyzer.GetAnalysisEntryFromPath(p))
-                        .Where(e => e != null)) {
-
-                        await defAnalyzer.UnloadFileAsync(entry);
+                    foreach (var f in files) {
+                        var entry = defAnalyzer.GetAnalysisEntryFromPath(f);
+                        if (entry != null) {
+                            await defAnalyzer.UnloadFileAsync(entry);
+                        }
                     }
                 }
 

--- a/Python/Product/PythonTools/PythonTools/PythonAnalysisClassifier.cs
+++ b/Python/Product/PythonTools/PythonTools/PythonAnalysisClassifier.cs
@@ -18,6 +18,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Threading.Tasks;
 using Microsoft.PythonTools.Editor;
 using Microsoft.PythonTools.Intellisense;
 using Microsoft.VisualStudio.Language.StandardClassification;
@@ -40,23 +41,17 @@ namespace Microsoft.PythonTools {
     /// <summary>
     /// Provides classification based upon the AST and analysis.
     /// </summary>
-    internal class PythonAnalysisClassifier : IClassifier {
+    internal class PythonAnalysisClassifier : IClassifier, IPythonTextBufferInfoEventSink {
         private AP.AnalysisClassification[] _spanCache;
         private readonly object _spanCacheLock = new object();
         private readonly PythonAnalysisClassifierProvider _provider;
-        private readonly PythonTextBufferInfo _buffer;
         private LocationTracker _spanTranslator;
 
-        internal PythonAnalysisClassifier(PythonAnalysisClassifierProvider provider, PythonTextBufferInfo buffer) {
+        internal PythonAnalysisClassifier(PythonAnalysisClassifierProvider provider) {
             _provider = provider;
-            _buffer = buffer;
-            _buffer.OnNewAnalysis += OnNewAnalysis;
-            _buffer.OnContentTypeChanged += BufferContentTypeChanged;
         }
 
-        private async void OnNewAnalysis(object sender, EventArgs e) {
-            var entry = _buffer.AnalysisEntry;
-
+        private async Task OnNewAnalysisAsync(PythonTextBufferInfo sender, AnalysisEntry entry) {
             if (!_provider._colorNames || entry == null) {
                 bool raise = false;
                 lock (_spanCacheLock) {
@@ -67,7 +62,7 @@ namespace Microsoft.PythonTools {
                 }
 
                 if (raise) {
-                    OnNewClassifications(_buffer.Buffer.CurrentSnapshot);
+                    OnNewClassifications(sender.CurrentSnapshot);
                 }
                 return;
             }
@@ -75,7 +70,7 @@ namespace Microsoft.PythonTools {
 
             var classifications = await entry.Analyzer.GetAnalysisClassificationsAsync(
                 entry,
-                _buffer.Buffer,
+                sender.Buffer,
                 _provider._colorNamesWithAnalysis
             );
 
@@ -93,16 +88,13 @@ namespace Microsoft.PythonTools {
                 }
 
                 if (_spanTranslator != null) {
-                    OnNewClassifications(_buffer.Buffer.CurrentSnapshot);
+                    OnNewClassifications(sender.CurrentSnapshot);
                 }
             }
         }
 
         private void OnNewClassifications(ITextSnapshot snapshot) {
-            var changed = ClassificationChanged;
-            if (changed != null) {
-                changed(this, new ClassificationChangedEventArgs(new SnapshotSpan(snapshot, 0, snapshot.Length)));
-            }
+            ClassificationChanged?.Invoke(this, new ClassificationChangedEventArgs(new SnapshotSpan(snapshot, 0, snapshot.Length)));
         }
 
         public event EventHandler<ClassificationChangedEventArgs> ClassificationChanged;
@@ -196,21 +188,17 @@ namespace Microsoft.PythonTools {
             return typeName;
         }
 
+        Task IPythonTextBufferInfoEventSink.PythonTextBufferEventAsync(PythonTextBufferInfo sender, PythonTextBufferInfoEventArgs e) {
+            if (e.Event == PythonTextBufferInfoEvents.NewAnalysis) {
+                return OnNewAnalysisAsync(sender, e.AnalysisEntry);
+            }
+            return Task.CompletedTask;
+        }
+
         public PythonAnalysisClassifierProvider Provider {
             get {
                 return _provider;
             }
         }
-
-        #region Private Members
-
-        private void BufferContentTypeChanged(object sender, ContentTypeChangedEventArgs e) {
-            // TODO: Should we be detaching here?
-            _spanCache = null;
-            _buffer.OnContentTypeChanged -= BufferContentTypeChanged;
-            _buffer.OnNewAnalysis -= OnNewAnalysis;
-        }
-
-        #endregion
     }
 }

--- a/Python/Product/PythonTools/PythonTools/PythonAnalysisClassifierProvider.cs
+++ b/Python/Product/PythonTools/PythonTools/PythonAnalysisClassifierProvider.cs
@@ -98,7 +98,8 @@ namespace Microsoft.PythonTools {
                 _categoryMap = FillCategoryMap(_classificationRegistry);
             }
 
-            return _services.GetBufferInfo(buffer).GetOrCreateAnalysisClassifier(b => new PythonAnalysisClassifier(this, b));
+            return _services.GetBufferInfo(buffer)
+                .GetOrCreateSink(typeof(PythonAnalysisClassifier), _ => new PythonAnalysisClassifier(this));
         }
 
         public virtual IContentType ContentType {

--- a/Python/Product/PythonTools/PythonTools/PythonClassifierProvider.cs
+++ b/Python/Product/PythonTools/PythonTools/PythonClassifierProvider.cs
@@ -92,7 +92,8 @@ namespace Microsoft.PythonTools {
                 _categoryMap = FillCategoryMap(_services.ClassificationTypeRegistryService);
             }
 
-            return _services.GetBufferInfo(buffer).GetOrCreateClassifier(b => new PythonClassifier(this, b));
+            return _services.GetBufferInfo(buffer)
+                .GetOrCreateSink(typeof(PythonClassifier), _ => new PythonClassifier(this));
         }
 
         public virtual IContentType ContentType {

--- a/Python/Product/PythonTools/PythonToolsService.cs
+++ b/Python/Product/PythonTools/PythonToolsService.cs
@@ -168,11 +168,11 @@ namespace Microsoft.PythonTools {
                 return;
             }
 
-            _container.GetUIThread().InvokeAsync(() => {
+            _container.GetUIThread().InvokeTask(async () => {
                 var analyzer = CreateAnalyzer();
                 var oldAnalyzer = Interlocked.Exchange(ref _analyzer, analyzer);
                 if (oldAnalyzer != null) {
-                    analyzer.SwitchAnalyzers(oldAnalyzer);
+                    await analyzer.TransferFromOldAnalyzer(oldAnalyzer);
                     if (oldAnalyzer.RemoveUser()) {
                         oldAnalyzer.Dispose();
                     }

--- a/Python/Tests/Core/CodeFormatterTests.cs
+++ b/Python/Tests/Core/CodeFormatterTests.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Linq;
 using Microsoft.PythonTools;
+using Microsoft.PythonTools.Infrastructure;
 using Microsoft.PythonTools.Intellisense;
 using Microsoft.PythonTools.Interpreter;
 using Microsoft.PythonTools.Interpreter.Default;
@@ -178,7 +179,10 @@ class Oar(object):
                 var buffer = new MockTextBuffer(input, PythonCoreConstants.ContentType, "C:\\fob.py");
                 buffer.AddProperty(typeof(VsProjectAnalyzer), analyzer);
                 var view = new MockTextView(buffer);
-                analyzer.MonitorTextBufferAsync(buffer).Wait();
+                var bi = services.GetBufferInfo(buffer);
+                var entry = analyzer.AnalyzeFileAsync(bi.Filename).WaitAndUnwrapExceptions();
+                entry.GetOrCreateBufferParser(services).AddBuffer(buffer);
+
                 var selectionSpan = new SnapshotSpan(
                     buffer.CurrentSnapshot,
                     ExtractMethodTests.GetSelectionSpan(input, selection)

--- a/Python/Tests/Core/CodeFormatterTests.cs
+++ b/Python/Tests/Core/CodeFormatterTests.cs
@@ -181,6 +181,7 @@ class Oar(object):
                 var view = new MockTextView(buffer);
                 var bi = services.GetBufferInfo(buffer);
                 var entry = analyzer.AnalyzeFileAsync(bi.Filename).WaitAndUnwrapExceptions();
+                Assert.AreEqual(entry, bi.TrySetAnalysisEntry(entry, null), "Failed to set analysis entry");
                 entry.GetOrCreateBufferParser(services).AddBuffer(buffer);
 
                 var selectionSpan = new SnapshotSpan(

--- a/Python/Tests/Core/ExtractMethodTests.cs
+++ b/Python/Tests/Core/ExtractMethodTests.cs
@@ -20,6 +20,7 @@ using System.IO;
 using System.Linq;
 using AnalysisTests;
 using Microsoft.PythonTools;
+using Microsoft.PythonTools.Infrastructure;
 using Microsoft.PythonTools.Intellisense;
 using Microsoft.PythonTools.Interpreter;
 using Microsoft.PythonTools.Parsing;
@@ -1704,7 +1705,11 @@ async def f():
                 var buffer = new MockTextBuffer(input, "Python", "C:\\fob.py");
                 var view = new MockTextView(buffer);
                 buffer.Properties.AddProperty(typeof(VsProjectAnalyzer), analyzer);
-                analyzer.MonitorTextBufferAsync(buffer).Wait();
+
+                var bi = services.GetBufferInfo(buffer);
+                var entry = analyzer.AnalyzeFileAsync(bi.Filename).WaitAndUnwrapExceptions();
+                entry.GetOrCreateBufferParser(services).AddBuffer(buffer);
+
                 var extractInput = new ExtractMethodTestInput(true, scopeName, targetName, parameters ?? new string[0]);
 
                 view.Selection.Select(

--- a/Python/Tests/Core/ExtractMethodTests.cs
+++ b/Python/Tests/Core/ExtractMethodTests.cs
@@ -1708,6 +1708,7 @@ async def f():
 
                 var bi = services.GetBufferInfo(buffer);
                 var entry = analyzer.AnalyzeFileAsync(bi.Filename).WaitAndUnwrapExceptions();
+                Assert.AreEqual(entry, bi.TrySetAnalysisEntry(entry, null));
                 entry.GetOrCreateBufferParser(services).AddBuffer(buffer);
 
                 var extractInput = new ExtractMethodTestInput(true, scopeName, targetName, parameters ?? new string[0]);

--- a/Python/Tests/PythonToolsMockTests/ClassifierTests.cs
+++ b/Python/Tests/PythonToolsMockTests/ClassifierTests.cs
@@ -257,8 +257,7 @@ def f() -> int:
                 AnalysisClassifier.ClassificationChanged += (s, e) => {
                     try {
                         var bi = PythonTextBufferInfo.TryGetForBuffer(_view.View.TextView.TextBuffer);
-                        Assert.IsNotNull(bi, "Expected non-null buffer info");
-                        if (bi.LastAnalysisReceivedVersion == null) {
+                        if (bi?.LastAnalysisReceivedVersion == null) {
                             return;
                         }
                         // make sure we have classifications from the version we analyzed after

--- a/Python/Tests/PythonToolsMockTests/PythonEditor.cs
+++ b/Python/Tests/PythonToolsMockTests/PythonEditor.cs
@@ -90,6 +90,7 @@ namespace PythonToolsMockTests {
                     view = vs.CreateTextView(PythonCoreConstants.ContentType, content ?? "",
                     v => {
                         v.TextView.TextBuffer.Properties[BufferParser.ParseImmediately] = true;
+                        v.TextView.TextBuffer.Properties[IntellisenseController.SuppressErrorLists] = IntellisenseController.SuppressErrorLists;
                         v.TextView.TextBuffer.Properties[VsProjectAnalyzer._testAnalyzer] = analyzer;
                         v.TextView.TextBuffer.Properties[VsProjectAnalyzer._testFilename] = filename;
                     },
@@ -101,7 +102,7 @@ namespace PythonToolsMockTests {
                         entry = analyzer.GetAnalysisEntryFromPath(filename);
                     }
 
-                    if (!cancel.IsCancellationRequested && !entry.IsAnalyzed) {
+                    if (!string.IsNullOrEmpty(content) && !cancel.IsCancellationRequested && !entry.IsAnalyzed) {
                         EventHandler evt = (s, e) => mre.SetIfNotDisposed();
 
                         try {

--- a/Python/Tests/Utilities.Python/PythonToolsTestUtilities.cs
+++ b/Python/Tests/Utilities.Python/PythonToolsTestUtilities.cs
@@ -113,7 +113,9 @@ namespace TestUtilities.Python {
         private static PythonEditorServices CreatePythonEditorServices(IServiceContainer site, MockComponentModel model) {
             var services = new PythonEditorServices(site);
 
-            //services.ComponentModel.DefaultCompositionService.SatisfyImportsOnce(services);
+            // We don't have a full composition service availabe, to this code emulates
+            // ComponentModel.DefaultCompositionService.SatisfyImportsOnce(services)
+            // *just* enough for PythonEditorServices.
             foreach (var field in services.GetType().GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)) {
                 if (!field.GetCustomAttributes().OfType<ImportAttribute>().Any()) {
                     continue;

--- a/Python/Tests/Utilities.Python/PythonToolsTestUtilities.cs
+++ b/Python/Tests/Utilities.Python/PythonToolsTestUtilities.cs
@@ -17,12 +17,14 @@
 using System;
 using System.ComponentModel.Composition;
 using System.ComponentModel.Design;
+using System.Linq;
 using System.Reflection;
 using Microsoft.PythonTools;
 using Microsoft.PythonTools.Editor;
 using Microsoft.PythonTools.Intellisense;
 using Microsoft.PythonTools.Interpreter;
 using Microsoft.PythonTools.Options;
+using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.InteractiveWindow.Commands;
 using Microsoft.VisualStudio.Text.Adornments;
 using Microsoft.VisualStudio.Utilities;
@@ -81,7 +83,7 @@ namespace TestUtilities.Python {
             serviceProvider.ComponentModel.AddExtension<IInterpreterRegistryService>(() => optService.Value);
             serviceProvider.ComponentModel.AddExtension<IInterpreterOptionsService>(() => optService.Value);
 
-            var editorServices = CreatePythonEditorServices(serviceProvider);
+            var editorServices = CreatePythonEditorServices(serviceProvider, serviceProvider.ComponentModel);
             serviceProvider.ComponentModel.AddExtension(() => editorServices);
 
             var analysisEntryServiceCreator = new Lazy<AnalysisEntryService>(() => new AnalysisEntryService(editorServices));
@@ -104,9 +106,29 @@ namespace TestUtilities.Python {
             return serviceProvider;
         }
 
-        private static PythonEditorServices CreatePythonEditorServices(IServiceContainer site) {
+        class LazyComponentGetter<T> : Lazy<T> {
+            public LazyComponentGetter(MockComponentModel model) : base(() => (T)model.GetService(typeof(T))) { }
+        }
+
+        private static PythonEditorServices CreatePythonEditorServices(IServiceContainer site, MockComponentModel model) {
             var services = new PythonEditorServices(site);
-            services.ComponentModel.DefaultCompositionService.SatisfyImportsOnce(services);
+
+            //services.ComponentModel.DefaultCompositionService.SatisfyImportsOnce(services);
+            foreach (var field in services.GetType().GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)) {
+                if (!field.GetCustomAttributes().OfType<ImportAttribute>().Any()) {
+                    continue;
+                }
+                if (!field.FieldType.IsGenericType || field.FieldType.GetGenericTypeDefinition() != typeof(Lazy<>)) {
+                    field.SetValue(services, model.GetService(field.FieldType));
+                } else {
+                    var svcType = field.FieldType.GetGenericArguments()[0];
+                    var svc = model.GetService(svcType);
+                    field.SetValue(
+                        services,
+                        Activator.CreateInstance(typeof(LazyComponentGetter<>).MakeGenericType(svcType), model)
+                    );
+                }
+            }
             return services;
         }
 


### PR DESCRIPTION
Fixes #2924 Assert, then unexpected error when using New Window
Reorders the relationships between our various buffer using/wrapping classes.

Key points:
* nothing should keep `PythonTextBufferInfo` alive except the text buffer itself (circular references are okay)
 * (this is why we now have a sink interface instead of event handlers)
* all files are analyzed on disk, and then we add buffer info if/when we have it

Still some things to fix, tests to run, etc., but the core change that needs reviewing is here.
