### PR TITLE
Fixes #2949 Unexpected error after closing split view

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Intellisense/AnalysisEntryService.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/AnalysisEntryService.cs
@@ -168,6 +168,11 @@ namespace Microsoft.PythonTools.Intellisense {
                 return analyzer as VsProjectAnalyzer;
             }
 
+            // If we have a REPL evaluator we'll use its analyzer
+            IPythonInteractiveIntellisense evaluator;
+            if ((evaluator = buffer.GetInteractiveWindow()?.Evaluator as IPythonInteractiveIntellisense) != null) {
+                return evaluator.Analyzer;
+            }
 
             AnalysisEntry entry;
             if (TryGetAnalysisEntry(view, buffer, out entry)) {
@@ -222,6 +227,14 @@ namespace Microsoft.PythonTools.Intellisense {
             if (TryGetAnalysisEntry(textView, null, out entry)) {
                 analyzer = entry.Analyzer;
                 filename = entry.Path;
+                return true;
+            }
+
+            // If we have a REPL evaluator we'll use its analyzer
+            IPythonInteractiveIntellisense evaluator;
+            if ((evaluator = textView.TextBuffer.GetInteractiveWindow()?.Evaluator as IPythonInteractiveIntellisense) != null) {
+                analyzer = evaluator.Analyzer;
+                filename = evaluator.AnalysisFilename;
                 return true;
             }
 

--- a/Python/Product/PythonTools/PythonTools/Intellisense/IntellisenseController.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/IntellisenseController.cs
@@ -92,10 +92,7 @@ namespace Microsoft.PythonTools.Intellisense {
             _textView.MouseHover -= TextViewMouseHover;
             _textView.Closed -= TextView_Closed;
             _textView.Properties.RemoveProperty(typeof(IntellisenseController));
-
-            foreach (var buffer in _textView.BufferGraph.GetTextBuffers(_ => true)) {
-                DisconnectSubjectBuffer(buffer);
-            }
+            // Do not disconnect subject buffers here - VS will handle that for us
         }
 
         private void TextViewMouseHover(object sender, MouseHoverEventArgs e) {

--- a/Python/Product/PythonTools/PythonTools/Intellisense/ProjectAnalyzer.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/ProjectAnalyzer.cs
@@ -731,7 +731,7 @@ namespace Microsoft.PythonTools.Intellisense {
                 }
 
                 if (oldBuffers.TryGetValue(e.Path, out ITextBuffer[] buffers)) {
-                    foreach (var b in buffers) {
+                    foreach (var b in buffers.MaybeEnumerate()) {
                         PythonTextBufferInfo.MarkForReplacement(b);
                         e.GetOrCreateBufferParser(_services).AddBuffer(b);
                     }

--- a/Python/Product/PythonTools/PythonTools/PythonClassifier.cs
+++ b/Python/Product/PythonTools/PythonTools/PythonClassifier.cs
@@ -382,7 +382,13 @@ namespace Microsoft.PythonTools {
 
     internal static partial class ClassifierExtensions {
         public static PythonClassifier GetPythonClassifier(this ITextBuffer buffer) {
-            return PythonTextBufferInfo.TryGetForBuffer(buffer)?.TryGetSink(typeof(PythonClassifier)) as PythonClassifier;
+            var bi = PythonTextBufferInfo.TryGetForBuffer(buffer);
+            if (bi == null) {
+                return null;
+            }
+
+            var provider = bi.Services.ComponentModel.GetService<PythonClassifierProvider>();
+            return provider.GetClassifier(buffer) as PythonClassifier;
         }
     }
 }

--- a/Python/Product/PythonTools/PythonTools/PythonClassifier.cs
+++ b/Python/Product/PythonTools/PythonTools/PythonClassifier.cs
@@ -47,7 +47,7 @@ namespace Microsoft.PythonTools {
         private Task OnNewAnalysisEntryAsync(PythonTextBufferInfo sender, AnalysisEntry entry) {
             var analyzer = entry?.Analyzer;
             if (analyzer == null) {
-                Debug.Fail("Should not have new analysis entry without an analyzer");
+                Debug.Assert(entry == null, "Should not have new analysis entry without an analyzer");
                 return Task.CompletedTask;
             }
             _tokenCache.Clear();

--- a/Python/Product/PythonTools/PythonTools/PythonClassifierProvider.cs
+++ b/Python/Product/PythonTools/PythonTools/PythonClassifierProvider.cs
@@ -38,6 +38,7 @@ namespace Microsoft.PythonTools {
     /// which it is applicable to.
     /// </summary>
     [Export(typeof(IClassifierProvider)), ContentType(PythonCoreConstants.ContentType)]
+    [Export(typeof(PythonClassifierProvider))]
     internal class PythonClassifierProvider : IClassifierProvider {
         private Dictionary<TokenCategory, IClassificationType> _categoryMap;
         private IClassificationType _comment;

--- a/Python/Product/PythonTools/PythonTools/Repl/PythonCommonInteractiveEvaluator.cs
+++ b/Python/Product/PythonTools/PythonTools/Repl/PythonCommonInteractiveEvaluator.cs
@@ -70,7 +70,7 @@ namespace Microsoft.PythonTools.Repl {
         internal const string DoNotResetConfigurationLaunchOption = "DoNotResetConfiguration";
 
         public PythonCommonInteractiveEvaluator(IServiceProvider serviceProvider) {
-            _serviceProvider = serviceProvider;
+            _serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
             _deferredOutput = new StringBuilder();
             _analysisFilename = Guid.NewGuid().ToString() + ".py";
         }
@@ -487,6 +487,14 @@ namespace Microsoft.PythonTools.Repl {
             ).Replace("&#x1b;", "\x1b");
 
             WriteOutput(msg, addNewline: true);
+
+            var langBuffer = _window.CurrentLanguageBuffer;
+            if (langBuffer != null) {
+                // Reinitializing, and our new language buffer does not automatically
+                // get connected to the Intellisense controller. Let's fix that.
+                var controller = IntellisenseControllerProvider.GetController(_window.TextView);
+                controller?.ConnectSubjectBuffer(langBuffer);
+            }
 
             _window.TextView.Options.SetOptionValue(InteractiveWindowOptions.SmartUpDown, UseSmartHistoryKeys);
             _commands = GetInteractiveCommands(_serviceProvider, _window, this);

--- a/Python/Product/PythonTools/PythonTools/Repl/PythonInteractiveEvaluator.cs
+++ b/Python/Product/PythonTools/PythonTools/Repl/PythonInteractiveEvaluator.cs
@@ -217,7 +217,13 @@ namespace Microsoft.PythonTools.Repl {
         }
 
         public override async Task<ExecutionResult> ExecuteCodeAsync(string text) {
-            var cmdRes = _commands.TryExecuteCommand();
+            var cmds = _commands;
+            if (cmds == null) {
+                WriteError(Strings.ReplDisconnected);
+                return ExecutionResult.Failure;
+            }
+
+            var cmdRes = cmds.TryExecuteCommand();
             if (cmdRes != null) {
                 return await cmdRes;
             }

--- a/Python/Product/PythonTools/PythonTools/Repl/SelectableReplEvaluator.cs
+++ b/Python/Product/PythonTools/PythonTools/Repl/SelectableReplEvaluator.cs
@@ -16,7 +16,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -200,15 +199,6 @@ namespace Microsoft.PythonTools.Repl {
 
         private async Task DoInitializeAsync(IInteractiveEvaluator eval) {
             await eval.InitializeAsync();
-
-            var view = eval?.CurrentWindow?.TextView;
-            var buffer = PythonTextBufferInfo.TryGetForBuffer(eval?.CurrentWindow?.CurrentLanguageBuffer);
-            var pyEval = eval as IPythonInteractiveIntellisense;
-            if (view != null && buffer != null && pyEval != null) {
-                var controller = IntellisenseControllerProvider.GetOrCreateController(_serviceProvider, _serviceProvider.GetComponentModel(), view);
-                var entry = pyEval.Analyzer.GetAnalysisEntryFromPath(pyEval.AnalysisFilename);
-                Debug.Assert(entry == buffer.TrySetAnalysisEntry(entry, buffer.AnalysisEntry));
-            }
         }
 
         private void DetachWindow(IInteractiveEvaluator oldEval) {

--- a/Python/Product/PythonTools/PythonTools/Repl/SelectableReplEvaluator.cs
+++ b/Python/Product/PythonTools/PythonTools/Repl/SelectableReplEvaluator.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -201,11 +202,12 @@ namespace Microsoft.PythonTools.Repl {
             await eval.InitializeAsync();
 
             var view = eval?.CurrentWindow?.TextView;
-            var buffer = eval?.CurrentWindow?.CurrentLanguageBuffer;
-            if (view != null && buffer != null) {
+            var buffer = PythonTextBufferInfo.TryGetForBuffer(eval?.CurrentWindow?.CurrentLanguageBuffer);
+            var pyEval = eval as IPythonInteractiveIntellisense;
+            if (view != null && buffer != null && pyEval != null) {
                 var controller = IntellisenseControllerProvider.GetOrCreateController(_serviceProvider, _serviceProvider.GetComponentModel(), view);
-                controller.DisconnectSubjectBuffer(buffer);
-                controller.ConnectSubjectBuffer(buffer);
+                var entry = pyEval.Analyzer.GetAnalysisEntryFromPath(pyEval.AnalysisFilename);
+                Debug.Assert(entry == buffer.TrySetAnalysisEntry(entry, buffer.AnalysisEntry));
             }
         }
 


### PR DESCRIPTION
Fixes #2949 Unexpected error after closing split view
Correctly counts references to buffers so they are not released too soon.
Also fixes a double-free and an incorrect assertion.