### PR TITLE
Fixes #1651 How to cross debug python and C++

### DIFF
--- a/Python/Setup/dirs.proj
+++ b/Python/Setup/dirs.proj
@@ -10,8 +10,8 @@
     <ProjectFile Include="loclayout.proj" />
     <ProjectFile Include="signlayout.proj" />
     <ProjectFile Include="msi.proj" Condition="'$(IncludeMSI)' == 'true'" />
-    <ProjectFile Include="swix\dirs.proj" />
     <ProjectFile Include="vsix.proj" />
+    <ProjectFile Include="swix\dirs.proj" />
     <ProjectFile Include="release.proj"/>
   </ItemGroup>
 

--- a/Python/Setup/swix/Packages/Microsoft.PythonTools.NativeDevelopment.VCDebugLauncher.Vsix.swixproj
+++ b/Python/Setup/swix/Packages/Microsoft.PythonTools.NativeDevelopment.VCDebugLauncher.Vsix.swixproj
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <OutputType>manifest</OutputType>
+  </PropertyGroup>
+
+  <Import Project="SetupProjectBefore.settings" />
+
+  <ItemGroup>
+    <Payload Include="$(SetupOutputPath)Microsoft.PythonTools.Debugger.VCLauncher.vsix" />
+  </ItemGroup>
+
+  <Import Project="SetupProjectAfter.settings" />
+</Project>
+

--- a/Python/Setup/swix/Packages/dirs.proj
+++ b/Python/Setup/swix/Packages/dirs.proj
@@ -24,6 +24,7 @@
     <ProjectFile Include="Microsoft.PythonTools.IronPython.Vsix.swixproj" Condition="'$(IncludeIronPython)' == 'True'"/>
     <ProjectFile Include="Microsoft.PythonTools.IronPython.Templates.Vsix.swixproj" Condition="'$(IncludeIronPython)' == 'True'"/>
     <ProjectFile Include="Microsoft.PythonTools.NativeDevelopment.Templates.Vsix.swixproj"/>
+    <ProjectFile Include="Microsoft.PythonTools.NativeDevelopment.VCDebugLauncher.Vsix.swixproj"/>
     <ProjectFile Include="Microsoft.PythonTools.Profiling.Vsix.swixproj"/>
     <ProjectFile Include="Microsoft.PythonTools.Uwp.Vsix.swixproj" Condition="'$(IncludeUwp)' == 'True'"/>
     <ProjectFile Include="Microsoft.PythonTools.Uwp.Templates.Vsix.swixproj" Condition="'$(IncludeUwp)' == 'True'"/>

--- a/Python/Setup/swix/swix.generate.targets
+++ b/Python/Setup/swix/swix.generate.targets
@@ -5,6 +5,7 @@
     <SwrFile Condition="$(OutputLocalized)">$(IntermediateOutputPath)package.g.$(lang).swr</SwrFile>
     <SwixPackageType Condition="$(SwixPackageType) == ''">component</SwixPackageType>
     <SwixVersion Condition="$(SwixVersion) == ''">$(VSTarget).$(BuildNumber)</SwixVersion>
+    <Python Condition="$(Python) == ''">"$(PackagesPath)python\tools\python.exe"</Python>
   </PropertyGroup>
 
   <ItemDefinitionGroup>
@@ -17,6 +18,10 @@
       <Type>Required</Type>
     </Dependency>
   </ItemDefinitionGroup>
+
+  <ItemGroup>
+    <Package Include="$(SwrFile)" />
+  </ItemGroup>
 
   <ItemGroup Condition="'$(SourcePath)' != ''">
     <SwrSource Include="$(SourcePath)" />
@@ -36,16 +41,22 @@
 
   <Target Name="_GenerateSwrFromSources" Condition="@(SwrSource) != ''">
     <PropertyGroup>
-      <Python>"$(PackagesPath)python\tools\python.exe"</Python>
       <GenerateCommand>$(Python) "$(MSBuildThisFileDirectory)\swix_generate.py" $(GenerateCommand)</GenerateCommand>
       <GenerateCommand Condition="$(Configuration) != 'Debug'">$(GenerateCommand) -x "\.pdb$"</GenerateCommand>
     </PropertyGroup>
     <Exec Command="$(GenerateCommand) %(SwrSource.ExtraOptions) -s &quot;%(SwrSource.FullPath)&quot; -b &quot;%(SwrSource.BaseInstall)&quot; -o &quot;$(SwrFile).tmp&quot;" />
   </Target>
 
+  <Target Name="_GenerateSwrFromPayloads" Condition="@(Payload) != ''">
+    <MakeDir Directories="$([System.IO.Path]::GetDirectoryName($(SwrFile)))" />
+
+    <Exec Command="$(Python) &quot;$(MSBuildThisFileDirectory)\swix_vsix_payload.py&quot; -n $(MSBuildProjectName) --version $(SwixVersion) -p &quot;%(Payload.Identity)&quot; -o &quot;$(SwrFile).tmp&quot;"
+          Condition="%(Payload.Extension) == '.vsix'" />
+  </Target>
+
   <Target Name="_GeneratePackage"
           BeforeTargets="Build"
-          DependsOnTargets="$(GenerateSwrDependsOnTargets);_GenerateSwrMetadata;_GenerateSwrFromSources"
+          DependsOnTargets="$(GenerateSwrDependsOnTargets);_GenerateSwrMetadata;_GenerateSwrFromSources;_GenerateSwrFromPayloads"
           Condition="'$(MicrosoftSimplifiedWixPropertiesImported)' == 'true'">
     <PropertyGroup>
       <_Orig Condition="Exists($(SwrFile))">$([System.IO.File]::ReadAllText($(SwrFile)))</_Orig>
@@ -55,10 +66,6 @@
     <Message Text="Updating $(SwrFile)" Importance="High" Condition="$(_Orig) != $(_New)" />
     <WriteLinesToFile File="$(SwrFile)" Lines="$(_New)" Condition="$(_Orig) != $(_New)" Overwrite="yes" Encoding="UTF-8" />
     <Delete Files="$(SwrFile).tmp" />
-
-    <ItemGroup>
-      <Package Include="$(SwrFile)" Condition="Exists($(SwrFile))" />
-    </ItemGroup>
   </Target>
 </Project>
 

--- a/Python/Setup/swix/swix.targets
+++ b/Python/Setup/swix/swix.targets
@@ -11,5 +11,13 @@
   <Import Project="swix.generate.targets" />
 
   <Import Project="..\SetupProjectAfter.settings" />
+
+  <Target Name="_CopyPayloads"
+          AfterTargets="Build"
+          Inputs="@(Payload)"
+          Outputs="@(Payload->'$(OutputPath)%(Filename)%(Extension)')">
+    <Copy SourceFiles="@(Payload)"
+          DestinationFolder="$(OutputPath)" />
+  </Target>
 </Project>
 

--- a/Python/Setup/swix/swix_vsix_payload.py
+++ b/Python/Setup/swix/swix_vsix_payload.py
@@ -1,0 +1,86 @@
+#! /usr/bin/env python3
+
+from __future__ import print_function
+
+import argparse
+import json
+import os
+import re
+import sys
+import zipfile
+
+from pathlib import Path
+
+def adjust_path(path, root, base):
+    rel = os.path.relpath(path, start=root)
+    return base if rel == '.' else os.path.join(base, rel)
+
+class StdOutContext(object):
+    def __enter__(self): return sys.stdout
+    def __exit__(self, et, ev, etb): pass
+
+def get_dirs(root):
+    if not root:
+        return
+    yield root
+    for d in root.glob("*"):
+        if d.is_dir():
+            yield from get_dirs(d)
+
+def quote(s):
+    if not s:
+        return '""'
+    if not isinstance(s, str):
+        s = str(s)
+    if ' ' not in s:
+        return s
+    if '"' not in s:
+        return '"' + s + '"'
+    if "'" not in s:
+        return "'" + s + "'"
+    return '"' + s.replace('"', '\\"') + '"'
+
+def open_or_stdout(filename):
+    if filename:
+        return open(filename, 'w', encoding='utf-8')
+    return StdOutContext()
+
+def main():
+    parser = argparse.ArgumentParser(description="Generates SWR lines from a directory")
+    parser.add_argument('--payload', '-p', dest='payload', type=Path, help='path to VSIX file')
+    parser.add_argument('--name', '-n', dest='name', type=str, help='name of the generated package')
+    parser.add_argument('--version', dest='version', type=str, help='version of the generated package')
+    parser.add_argument('--out', '-o', dest='output', type=Path, default=None, help='append output to this file')
+
+    args = parser.parse_args()
+
+    with open_or_stdout(args.output) as out:
+        with zipfile.ZipFile(str(args.payload), 'r') as z:
+            with z.open('manifest.json') as f:
+                manifest = json.load(f)
+        
+        print("use vs", file=out)
+        print("", file=out)
+        print("package name={}".format(quote(args.name)), file=out)
+        print("        version={}".format(quote(args.version)), file=out)
+        print("        vs.package.type=vsix", file=out)
+
+        try:
+            install_sizes = manifest['installSizes']
+        except LookupError:
+            install_sizes = {'targetDrive': manifest['installSize']}
+
+        if install_sizes:
+            print("", file=out)
+            print("vs.installSize", file=out)
+            for i in install_sizes.items():
+                print("  {}={}".format(*i), file=out)
+
+        print("", file=out)
+
+        print("vs.payloads", file=out)
+        print("  vs.payload source={}".format(quote(args.payload.resolve())), file=out)
+        print("             size={}".format(args.payload.stat().st_size), file=out)
+
+if __name__ == '__main__':
+    sys.exit(main() or 0)


### PR DESCRIPTION
Fixes #1651 How to cross debug python and C++
Adds the VC debug launcher to the generated manifest file.

This required a bit of infrastructure for handling payload files (where we reference a normal VSIX file), so future additions (and if/when we convert the entire project to use the VSSDK build) won't require so much code.