### PR TITLE
Prevent duplicate results in peek definition

### DIFF
--- a/Python/Product/Analysis/AnalysisVariable.cs
+++ b/Python/Product/Analysis/AnalysisVariable.cs
@@ -42,6 +42,19 @@ namespace Microsoft.PythonTools.Analysis {
         }
 
         #endregion
-    }
 
+        public override bool Equals(object obj) {
+            AnalysisVariable other = obj as AnalysisVariable;
+            if (other != null) {
+                return LocationInfo.FullComparer.Equals(Location, other.Location) &&
+                       LocationInfo.FullComparer.Equals(DefinitionLocation, other.DefinitionLocation) &&
+                       Type.Equals(other.Type);
+            }
+            return false;
+        }
+
+        public override int GetHashCode() {
+            return _type.GetHashCode() ^ _loc.GetHashCode() ^ _defLoc?.GetHashCode() ?? 0;
+        }
+    }
 }

--- a/Python/Tests/PythonToolsMockTests/NavigableTests.cs
+++ b/Python/Tests/PythonToolsMockTests/NavigableTests.cs
@@ -37,13 +37,25 @@ namespace PythonToolsMockTests {
 
         private static PythonVersion Version => PythonPaths.Python27 ?? PythonPaths.Python27_x64;
 
+        [TestInitialize]
+        public void TestInit() {
+            MockPythonToolsPackage.SuppressTaskProvider = true;
+            VsProjectAnalyzer.SuppressTaskProvider = true;
+        }
+
+        [TestCleanup]
+        public void TestCleanup() {
+            MockPythonToolsPackage.SuppressTaskProvider = false;
+            VsProjectAnalyzer.SuppressTaskProvider = false;
+        }
+
         [TestMethod, Priority(1)]
         public async Task ModuleDefinition() {
             var code = @"import os
 ";
             using (var helper = new NavigableHelper(code, Version)) {
                 // os
-                await helper.CheckDefinitionLocation(7, 2, ExternalLocation(1, 1, "os.py"));
+                await helper.CheckDefinitionLocations(7, 2, ExternalLocation(1, 1, "os.py"));
             }
         }
 
@@ -55,10 +67,10 @@ sys.version
 ";
             using (var helper = new NavigableHelper(code, Version)) {
                 // sys
-                await helper.CheckDefinitionLocation(15, 3, Location(1, 8));
+                await helper.CheckDefinitionLocations(15, 3, Location(1, 8));
 
                 // version
-                await helper.CheckDefinitionLocation(18, 7, null);
+                await helper.CheckDefinitionLocations(18, 7, null);
             }
         }
 
@@ -75,19 +87,19 @@ obj
 ";
             using (var helper = new NavigableHelper(code, Version)) {
                 // ClassBase
-                await helper.CheckDefinitionLocation(57, 9, Location(1, 7));
+                await helper.CheckDefinitionLocations(57, 9, Location(1, 7));
                 
                 // ClassDerived
-                await helper.CheckDefinitionLocation(88, 12, Location(4, 7));
+                await helper.CheckDefinitionLocations(88, 12, Location(4, 7));
 
                 // object
-                await helper.CheckDefinitionLocation(16, 6, null);
+                await helper.CheckDefinitionLocations(16, 6, null);
 
                 // obj
-                await helper.CheckDefinitionLocation(82, 3, Location(7, 1));
+                await helper.CheckDefinitionLocations(82, 3, Location(7, 1));
 
                 // obj
-                await helper.CheckDefinitionLocation(104, 3, Location(7, 1));
+                await helper.CheckDefinitionLocations(104, 3, Location(7, 1));
             }
         }
 
@@ -102,18 +114,18 @@ my_func(2, param2=False)
 ";
             using (var helper = new NavigableHelper(code, Version)) {
                 // param1
-                await helper.CheckDefinitionLocation(12, 6, Location(1, 13));
-                await helper.CheckDefinitionLocation(47, 6, Location(1, 13));
+                await helper.CheckDefinitionLocations(12, 6, Location(1, 13));
+                await helper.CheckDefinitionLocations(47, 6, Location(1, 13));
                 
                 // param2
-                await helper.CheckDefinitionLocation(20, 6, Location(1, 21));
-                await helper.CheckDefinitionLocation(66, 6, Location(1, 21));
-                await helper.CheckDefinitionLocation(100, 6, Location(1, 21));
+                await helper.CheckDefinitionLocations(20, 6, Location(1, 21));
+                await helper.CheckDefinitionLocations(66, 6, Location(1, 21));
+                await helper.CheckDefinitionLocations(100, 6, Location(1, 21));
                 
                 // my_func
-                await helper.CheckDefinitionLocation(4, 7, Location(1, 5));
-                await helper.CheckDefinitionLocation(77, 7, Location(1, 5));
-                await helper.CheckDefinitionLocation(89, 7, Location(1, 5));
+                await helper.CheckDefinitionLocations(4, 7, Location(1, 5));
+                await helper.CheckDefinitionLocations(77, 7, Location(1, 5));
+                await helper.CheckDefinitionLocations(89, 7, Location(1, 5));
             }
         }
 
@@ -138,15 +150,15 @@ obj.my_class_func2(param3=False)
 ";
             using (var helper = new NavigableHelper(code, Version)) {
                 // param3 in my_func(param3=False)
-                await helper.CheckDefinitionLocation(197, 6, Location(8, 13));
+                await helper.CheckDefinitionLocations(197, 6, Location(8, 13));
 
                 // BUG: can't go to definition
                 // param2 in obj.my_class_func1(param2=False)
-                await helper.CheckDefinitionLocation(250, 6, Location(2, 30));
+                await helper.CheckDefinitionLocations(250, 6, Location(2, 30));
 
                 // BUG: goes to my_func instead of my_class_func2
                 // param3 in obj.my_class_func2(param3=False)
-                await helper.CheckDefinitionLocation(284, 6, Location(5, 30));
+                await helper.CheckDefinitionLocations(284, 6, Location(5, 30));
             }
         }
 
@@ -170,27 +182,39 @@ print(obj._my_attr_val)
 ";
             using (var helper = new NavigableHelper(code, Version)) {
                 // my_attr
-                await helper.CheckDefinitionLocation(71, 7, Location(9, 9));
-                await helper.CheckDefinitionLocation(128, 7, Location(9, 9));
-                await helper.CheckDefinitionLocation(152, 7, Location(9, 9));
-                await helper.CheckDefinitionLocation(229, 7, Location(13, 5));
-                await helper.CheckDefinitionLocation(252, 7, Location(13, 5));
+                await helper.CheckDefinitionLocations(71, 7, Location(9, 9));
+                await helper.CheckDefinitionLocations(128, 7, Location(9, 9));
+                await helper.CheckDefinitionLocations(152, 7, Location(9, 9));
+                await helper.CheckDefinitionLocations(229, 7, Location(13, 5), Location(9, 9));
+                await helper.CheckDefinitionLocations(252, 7, Location(13, 5), Location(9, 9));
 
                 // val
-                await helper.CheckDefinitionLocation(166, 3, Location(9, 23));
-                await helper.CheckDefinitionLocation(201, 3, Location(9, 23));
+                await helper.CheckDefinitionLocations(166, 3, Location(9, 23));
+                await helper.CheckDefinitionLocations(201, 3, Location(9, 23));
 
                 // _my_attr_val
-                await helper.CheckDefinitionLocation(28, 12, Location(2, 5));
-                await helper.CheckDefinitionLocation(107, 12, Location(10, 14));
-                await helper.CheckDefinitionLocation(186, 12, Location(10, 14));
-                await helper.CheckDefinitionLocation(272, 12, Location(10, 14));
+                await helper.CheckDefinitionLocations(28, 12, Location(2, 5));
+                await helper.CheckDefinitionLocations(107, 12, Location(10, 14), Location(2, 5));
+                await helper.CheckDefinitionLocations(186, 12, Location(10, 14), Location(2, 5));
+                await helper.CheckDefinitionLocations(272, 12, Location(10, 14), Location(2, 5));
 
                 // self
-                await helper.CheckDefinitionLocation(79, 4, Location(5, 17));
-                await helper.CheckDefinitionLocation(102, 4, Location(5, 17));
-                await helper.CheckDefinitionLocation(160, 4, Location(9, 17));
-                await helper.CheckDefinitionLocation(181, 4, Location(9, 17));
+                await helper.CheckDefinitionLocations(79, 4, Location(5, 17));
+                await helper.CheckDefinitionLocations(102, 4, Location(5, 17));
+                await helper.CheckDefinitionLocations(160, 4, Location(9, 17));
+                await helper.CheckDefinitionLocations(181, 4, Location(9, 17));
+            }
+        }
+
+        [TestMethod, Priority(1)]
+        public async Task VariableDefinition() {
+            var code = @"my_var = 0
+my_var = 1
+res = my_var * 10
+";
+            using (var helper = new NavigableHelper(code, Version)) {
+                // 2 definitions for my_var
+                await helper.CheckDefinitionLocations(30, 6, Location(1, 1), Location(2, 1));
             }
         }
 
@@ -215,22 +239,31 @@ print(obj._my_attr_val)
                 _view.Dispose();
             }
 
-            public async Task CheckDefinitionLocation(int pos, int length, AnalysisLocation expected) {
+            public async Task CheckDefinitionLocations(int pos, int length, params AnalysisLocation[] expectedLocations) {
                 var entry = (AnalysisEntry)_view.GetAnalysisEntry();
                 entry.Analyzer.WaitForCompleteAnalysis(_ => true);
 
                 var trackingSpan = _view.CurrentSnapshot.CreateTrackingSpan(pos, length, SpanTrackingMode.EdgeInclusive);
                 var snapshotSpan = trackingSpan.GetSpan(_view.CurrentSnapshot);
-                var results = await NavigableSymbolSource.GetDefinitionLocationsAsync(entry, snapshotSpan.Start);
-                if (expected != null) {
-                    Assert.IsNotNull(results);
-                    Assert.AreEqual(expected.Line, results[0].Line);
-                    Assert.AreEqual(expected.Column, results[0].Column);
-                    if (expected.FilePath != null) {
-                        Assert.AreEqual(expected.FilePath, Path.GetFileName(results[0].FilePath));
+                var actualLocations = await NavigableSymbolSource.GetDefinitionLocationsAsync(entry, snapshotSpan.Start);
+                if (expectedLocations != null) {
+                    Assert.IsNotNull(actualLocations);
+
+                    Console.WriteLine($"Actual locations for pos={pos}, length={length}:");
+                    foreach (var actualLocation in actualLocations) {
+                        Console.WriteLine($"{actualLocation.Line}, {actualLocation.Column}");
+                    }
+
+                    Assert.AreEqual(expectedLocations.Length, actualLocations.Length);
+                    for (int i = 0; i < expectedLocations.Length; i++) {
+                        Assert.AreEqual(expectedLocations[i].Line, actualLocations[i].Line);
+                        Assert.AreEqual(expectedLocations[i].Column, actualLocations[i].Column);
+                        if (expectedLocations[i].FilePath != null) {
+                            Assert.AreEqual(expectedLocations[i].FilePath, Path.GetFileName(actualLocations[i].FilePath));
+                        }
                     }
                 } else {
-                    Assert.AreEqual(0, results.Length);
+                    Assert.AreEqual(0, actualLocations.Length);
                 }
             }
         }


### PR DESCRIPTION
Fix #2973 Peek definition shows duplicate entries

I ran all of AnalysisTest test class and there's no regression there.

In the navigable tests, `ParameterDefinition` test was a repro for this bug. The tests now validate all results instead of just first one, so without the fix, that test would now fail.

