### PR TITLE
Analysis fixes

### DIFF
--- a/Common/Product/SharedProject/Navigation/LibraryManager.cs
+++ b/Common/Product/SharedProject/Navigation/LibraryManager.cs
@@ -97,7 +97,7 @@ namespace Microsoft.VisualStudioTools.Navigation {
 
         #region ILibraryManager Members
 
-        public void RegisterHierarchy(IVsHierarchy hierarchy) {
+        public virtual void RegisterHierarchy(IVsHierarchy hierarchy) {
             if ((null == hierarchy) || _hierarchies.ContainsKey(hierarchy)) {
                 return;
             }
@@ -125,7 +125,7 @@ namespace Microsoft.VisualStudioTools.Navigation {
             }
         }
 
-        public void UnregisterHierarchy(IVsHierarchy hierarchy) {
+        public virtual void UnregisterHierarchy(IVsHierarchy hierarchy) {
             if ((null == hierarchy) || !_hierarchies.ContainsKey(hierarchy)) {
                 return;
             }

--- a/Python/Product/PythonTools/PythonTools/Extensions.cs
+++ b/Python/Product/PythonTools/PythonTools/Extensions.cs
@@ -312,14 +312,15 @@ namespace Microsoft.PythonTools {
         /// Returns null if the caret isn't in Python code or an analysis doesn't exist for some reason.
         /// </summary>
         internal static AnalysisEntry GetAnalysisAtCaret(this ITextView textView, IServiceProvider serviceProvider) {
-            var buffer = textView.GetPythonBufferAtCaret();
-            if (buffer == null) {
-                return null;
-            }
-
             var service = serviceProvider.GetEntryService();
             AnalysisEntry entry = null;
-            service?.TryGetAnalysisEntry(textView, buffer, out entry);
+
+            var buffer = textView.GetPythonBufferAtCaret();
+            if (buffer == null) {
+                service?.TryGetAnalysisEntry(textView, out entry);
+            } else {
+                service?.TryGetAnalysisEntry(buffer, out entry);
+            }
             return entry;
         }
 

--- a/Python/Product/PythonTools/PythonTools/Intellisense/ExtractMethodSuggestedActionSourceProvider.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/ExtractMethodSuggestedActionSourceProvider.cs
@@ -158,7 +158,7 @@ namespace Microsoft.PythonTools.Intellisense {
 
                 public async Task<object> GetPreviewAsync(CancellationToken cancellationToken) {
                     AnalysisEntry entry;
-                    if (_parent._entryService.Value == null || !_parent._entryService.Value.TryGetAnalysisEntry(_view, _view.TextBuffer, out entry)) {
+                    if (_parent._entryService.Value == null || !_parent._entryService.Value.TryGetAnalysisEntry(_view, out entry)) {
                         return null;
                     }
 

--- a/Python/Product/PythonTools/PythonTools/Intellisense/IntellisenseController.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/IntellisenseController.cs
@@ -117,7 +117,7 @@ namespace Microsoft.PythonTools.Intellisense {
                 }
 
                 AnalysisEntry entry;
-                if (!_services.AnalysisEntryService.TryGetAnalysisEntry(_textView, pt.Value.Snapshot.TextBuffer, out entry)) {
+                if (!_services.AnalysisEntryService.TryGetAnalysisEntry(pt.Value.Snapshot.TextBuffer, out entry)) {
                     return;
                 }
                 var t = entry.Analyzer.GetQuickInfoAsync(entry, _textView, pt.Value);
@@ -374,7 +374,7 @@ namespace Microsoft.PythonTools.Intellisense {
             }
 
             AnalysisEntry entry;
-            if (!_services.AnalysisEntryService.TryGetAnalysisEntry(_textView, snapshot.TextBuffer, out entry)) {
+            if (!_services.AnalysisEntryService.TryGetAnalysisEntry(snapshot.TextBuffer, out entry)) {
                 return false;
             }
 

--- a/Python/Product/PythonTools/PythonTools/Intellisense/ProjectAnalyzer.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/ProjectAnalyzer.cs
@@ -1167,7 +1167,7 @@ namespace Microsoft.PythonTools.Intellisense {
 
             var entryService = serviceProvider.GetEntryService();
             AnalysisEntry entry;
-            if (entryService == null || !entryService.TryGetAnalysisEntry(view, snapshot.TextBuffer, out entry)) {
+            if (entryService == null || !entryService.TryGetAnalysisEntry(snapshot.TextBuffer, out entry)) {
                 return MissingImportAnalysis.Empty;
             }
 
@@ -1601,7 +1601,7 @@ namespace Microsoft.PythonTools.Intellisense {
             }
 
             AnalysisEntry entry;
-            if (services.AnalysisEntryService.TryGetAnalysisEntry(view, snapshot.TextBuffer, out entry)) {
+            if (services.AnalysisEntryService.TryGetAnalysisEntry(snapshot.TextBuffer, out entry)) {
                 return new NormalCompletionAnalysis(
                     services,
                     session,
@@ -1980,7 +1980,7 @@ namespace Microsoft.PythonTools.Intellisense {
 
         internal async Task FormatCodeAsync(SnapshotSpan span, ITextView view, CodeFormattingOptions options, bool selectResult) {
             AnalysisEntry entry;
-            if (!_services.AnalysisEntryService.TryGetAnalysisEntry(view, span.Snapshot.TextBuffer, out entry)) {
+            if (!_services.AnalysisEntryService.TryGetAnalysisEntry(span.Snapshot.TextBuffer, out entry)) {
                 return;
             }
             var buffer = span.Snapshot.TextBuffer;
@@ -2045,7 +2045,7 @@ namespace Microsoft.PythonTools.Intellisense {
 
         internal async Task RemoveImportsAsync(ITextView view, ITextBuffer textBuffer, int index, bool allScopes) {
             AnalysisEntry entry;
-            if (!_services.AnalysisEntryService.TryGetAnalysisEntry(view, textBuffer, out entry)) {
+            if (!_services.AnalysisEntryService.TryGetAnalysisEntry(textBuffer, out entry)) {
                 return;
             }
             await entry.EnsureCodeSyncedAsync(textBuffer);
@@ -2165,7 +2165,7 @@ namespace Microsoft.PythonTools.Intellisense {
         internal async Task<NavigationInfo> GetNavigationsAsync(ITextView view) {
             AnalysisEntry entry;
             var textBuffer = view.TextBuffer;
-            if (_services.AnalysisEntryService.TryGetAnalysisEntry(view, textBuffer, out entry)) {
+            if (_services.AnalysisEntryService.TryGetAnalysisEntry(textBuffer, out entry)) {
                 var lastVersion = entry.GetAnalysisVersion(textBuffer);
 
                 var navigations = await SendRequestAsync(
@@ -2407,7 +2407,7 @@ namespace Microsoft.PythonTools.Intellisense {
         ) {
             var entryService = serviceProvider.GetEntryService();
             AnalysisEntry entry;
-            if (entryService == null || !entryService.TryGetAnalysisEntry(view, span.Snapshot.TextBuffer, out entry)) {
+            if (entryService == null || !entryService.TryGetAnalysisEntry(span.Snapshot.TextBuffer, out entry)) {
                 return Task.FromResult<string>(null);
             }
             var analysis = GetApplicableExpression(entry, span.Start);

--- a/Python/Product/PythonTools/PythonTools/Intellisense/PythonSuggestedImportAction.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/PythonSuggestedImportAction.cs
@@ -113,7 +113,7 @@ namespace Microsoft.PythonTools.Intellisense {
             Debug.Assert(!string.IsNullOrEmpty(_name));
 
             AnalysisEntry entry;
-            if (!_source._services.AnalysisEntryService.TryGetAnalysisEntry(null, _buffer, out entry)) {
+            if (!_source._services.AnalysisEntryService.TryGetAnalysisEntry(_buffer, out entry)) {
                 return;
             }
 

--- a/Python/Product/PythonTools/PythonTools/Navigation/CodeWindowManager.cs
+++ b/Python/Product/PythonTools/PythonTools/Navigation/CodeWindowManager.cs
@@ -92,7 +92,7 @@ namespace Microsoft.PythonTools.Navigation {
 
             AnalysisEntry entry;
             var entryService = _serviceProvider.GetEntryService();
-            if (entryService == null || !entryService.TryGetAnalysisEntry(wpfTextView, wpfTextView.TextBuffer, out entry)) {
+            if (entryService == null || !entryService.TryGetAnalysisEntry(wpfTextView, out entry)) {
                 return VSConstants.E_FAIL;
             }
 

--- a/Python/Product/PythonTools/PythonTools/Navigation/EditFilter.cs
+++ b/Python/Product/PythonTools/PythonTools/Navigation/EditFilter.cs
@@ -818,7 +818,7 @@ namespace Microsoft.PythonTools.Language {
 
         private async void FormatCode(SnapshotSpan span, bool selectResult) {
             AnalysisEntry entry;
-            if (_entryService == null || !_entryService.TryGetAnalysisEntry(_textView, span.Snapshot.TextBuffer, out entry)) {
+            if (_entryService == null || !_entryService.TryGetAnalysisEntry(span.Snapshot.TextBuffer, out entry)) {
                 return;
             }
 

--- a/Python/Product/PythonTools/PythonTools/Navigation/Navigable/NavigableSymbolSource.cs
+++ b/Python/Product/PythonTools/PythonTools/Navigation/Navigable/NavigableSymbolSource.cs
@@ -33,7 +33,6 @@ using Microsoft.VisualStudio.Text.Operations;
 namespace Microsoft.PythonTools.Navigation.Navigable {
     class NavigableSymbolSource : INavigableSymbolSource {
         private readonly IServiceProvider _serviceProvider;
-        private readonly ITextView _textView;
         private readonly ITextBuffer _buffer;
         private readonly IClassifier _classifier;
         private readonly ITextStructureNavigator _textNavigator;
@@ -47,9 +46,8 @@ namespace Microsoft.PythonTools.Navigation.Navigable {
             PythonPredefinedClassificationTypeNames.Parameter,
         };
 
-        public NavigableSymbolSource(IServiceProvider serviceProvider, ITextView textView, ITextBuffer buffer, IClassifier classifier, ITextStructureNavigator textNavigator) {
+        public NavigableSymbolSource(IServiceProvider serviceProvider, ITextBuffer buffer, IClassifier classifier, ITextStructureNavigator textNavigator) {
             _serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
-            _textView = textView ?? throw new ArgumentNullException(nameof(textView));
             _buffer = buffer ?? throw new ArgumentNullException(nameof(buffer));
             _classifier = classifier ?? throw new ArgumentNullException(nameof(classifier));
             _textNavigator = textNavigator ?? throw new ArgumentNullException(nameof(textNavigator));
@@ -72,7 +70,7 @@ namespace Microsoft.PythonTools.Navigation.Navigable {
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
             AnalysisEntry entry = null;
-            _entryService?.TryGetAnalysisEntry(_textView, _buffer, out entry);
+            _entryService?.TryGetAnalysisEntry(_buffer, out entry);
             if (entry == null) {
                 return null;
             }

--- a/Python/Product/PythonTools/PythonTools/Navigation/Navigable/NavigableSymbolSourceProvider.cs
+++ b/Python/Product/PythonTools/PythonTools/Navigation/Navigable/NavigableSymbolSourceProvider.cs
@@ -48,7 +48,6 @@ namespace Microsoft.PythonTools.Navigation.Navigable {
             return buffer.Properties.GetOrCreateSingletonProperty<INavigableSymbolSource>(
                 () => new NavigableSymbolSource(
                     _serviceProvider,
-                    textView,
                     buffer,
                     _classifierFactory.GetClassifier(buffer),
                     _navigatorService.GetTextStructureNavigator(buffer))

--- a/Python/Product/PythonTools/PythonTools/Navigation/PythonLibraryManager.cs
+++ b/Python/Product/PythonTools/PythonTools/Navigation/PythonLibraryManager.cs
@@ -116,7 +116,7 @@ namespace Microsoft.PythonTools.Navigation {
             public AnalysisCompleteHandler(PythonLibraryManager owner, PythonProjectNode project) {
                 Project = project ?? throw new ArgumentNullException(nameof(project));
                 _owner = owner ?? throw new ArgumentNullException(nameof(owner));
-                _tasks = new Dictionary<string, LibraryTask>();
+                _tasks = new Dictionary<string, LibraryTask>(StringComparer.OrdinalIgnoreCase);
                 Project.ProjectAnalyzerChanging += Project_ProjectAnalyzerChanging;
                 _analyzer = Project.TryGetAnalyzer();
                 if (_analyzer != null) {

--- a/Python/Product/PythonTools/PythonTools/Navigation/PythonLibraryManager.cs
+++ b/Python/Product/PythonTools/PythonTools/Navigation/PythonLibraryManager.cs
@@ -15,9 +15,13 @@
 // permissions and limitations under the License.
 
 using System;
+using System.Collections.Generic;
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 using Microsoft.PythonTools.Infrastructure;
 using Microsoft.PythonTools.Intellisense;
+using Microsoft.PythonTools.Project;
+using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudioTools;
 using Microsoft.VisualStudioTools.Navigation;
 using Microsoft.VisualStudioTools.Project;
@@ -41,13 +45,44 @@ namespace Microsoft.PythonTools.Navigation {
     internal class PythonLibraryManager : LibraryManager, IPythonLibraryManager {
         private readonly PythonToolsPackage/*!*/ _package;
 
+        private readonly Dictionary<PythonProjectNode, AnalysisCompleteHandler> _handlers;
+
         public PythonLibraryManager(PythonToolsPackage/*!*/ package)
             : base(package) {
             _package = package;
+            _handlers = new Dictionary<PythonProjectNode, AnalysisCompleteHandler>();
         }
 
         public override LibraryNode CreateFileLibraryNode(LibraryNode parent, HierarchyNode hierarchy, string name, string filename) {
             return new PythonFileLibraryNode(parent, hierarchy, hierarchy.Caption, filename);
+        }
+
+        public override void RegisterHierarchy(IVsHierarchy hierarchy) {
+            var project = hierarchy.GetProject().GetPythonProject();
+            if (project != null) {
+                lock (_handlers) {
+                    if (!_handlers.ContainsKey(project)) {
+                        _handlers[project] = new AnalysisCompleteHandler(this, project);
+                    }
+                }
+            }
+
+            base.RegisterHierarchy(hierarchy);
+        }
+
+        public override void UnregisterHierarchy(IVsHierarchy hierarchy) {
+            var project = hierarchy.GetProject().GetPythonProject();
+            if (project != null) {
+                lock (_handlers) {
+                    AnalysisCompleteHandler handler;
+                    if (_handlers.TryGetValue(project, out handler)) {
+                        _handlers.Remove(project);
+                        handler.Dispose();
+                    }
+                }
+            }
+
+            base.UnregisterHierarchy(hierarchy);
         }
 
         protected override void OnNewFile(LibraryTask task) {
@@ -55,28 +90,77 @@ namespace Microsoft.PythonTools.Navigation {
                 return;
             }
 
-            var analyzer = task.ModuleID.Hierarchy
+            var project = task.ModuleID.Hierarchy
                     .GetProject()
-                    .GetPythonProject()
-                    .GetAnalyzer();
+                    .GetPythonProject();
+            if (project == null) {
+                return;
+            }
 
-            AnalysisEntry item;
-            if (analyzer.GetAnalysisEntryFromPath(task.FileName) == null) {
-                analyzer.AnalyzeFileAsync(task.FileName).ContinueWith(x => {
-                    item = x.Result;
+            AnalysisCompleteHandler handler;
+            lock (_handlers) {
+                if (!_handlers.TryGetValue(project, out handler)) {
+                    _handlers[project] = handler = new AnalysisCompleteHandler(this, project);
+                }
+            }
 
-                    if (item != null) {
-                        // We subscribe to OnNewAnalysis here instead of OnNewParseTree so that 
-                        // in the future we can use the analysis to include type information in the
-                        // object browser (for example we could include base type information with
-                        // links elsewhere in the object browser).
-                        item.AnalysisComplete += (sender, args) => {
-                            _package.GetUIThread().InvokeAsync(() => FileParsed(task))
-                                .HandleAllExceptions(_package, GetType())
-                                .DoNotWait();
-                        };
+            handler.AddTask(task);
+        }
+
+        sealed class AnalysisCompleteHandler : IDisposable {
+            public readonly PythonProjectNode Project;
+            private readonly PythonLibraryManager _owner;
+            private readonly Dictionary<string, LibraryTask> _tasks;
+            private VsProjectAnalyzer _analyzer;
+
+            public AnalysisCompleteHandler(PythonLibraryManager owner, PythonProjectNode project) {
+                Project = project ?? throw new ArgumentNullException(nameof(project));
+                _owner = owner ?? throw new ArgumentNullException(nameof(owner));
+                _tasks = new Dictionary<string, LibraryTask>();
+                Project.ProjectAnalyzerChanging += Project_ProjectAnalyzerChanging;
+                _analyzer = Project.TryGetAnalyzer();
+                if (_analyzer != null) {
+                    _analyzer.AnalysisComplete += Analyzer_AnalysisComplete;
+                }
+            }
+
+            public void AddTask(LibraryTask task) {
+                lock (_tasks) {
+                    _tasks[task.FileName] = task;
+                }
+            }
+
+            public void Dispose() {
+                lock (this) {
+                    Project.ProjectAnalyzerChanging -= Project_ProjectAnalyzerChanging;
+                    if (_analyzer != null) {
+                        _analyzer.AnalysisComplete -= Analyzer_AnalysisComplete;
                     }
-                });
+                }
+            }
+
+            private void Project_ProjectAnalyzerChanging(object sender, AnalyzerChangingEventArgs e) {
+                lock (this) {
+                    if (_analyzer != null) {
+                        Debug.Assert(_analyzer == e.Old, "Changing from wrong analyzer");
+                        _analyzer.AnalysisComplete -= Analyzer_AnalysisComplete;
+                    }
+                    _analyzer = e.New;
+                    if (_analyzer != null) {
+                        _analyzer.AnalysisComplete += Analyzer_AnalysisComplete;
+                    }
+                }
+            }
+
+            public void Analyzer_AnalysisComplete(object sender, Projects.AnalysisCompleteEventArgs e) {
+                LibraryTask task;
+                lock (_tasks) {
+                    if (!_tasks.TryGetValue(e.Path, out task)) {
+                        return;
+                    }
+                }
+
+                _owner.FileParsed(task);
             }
         }
     }

--- a/Python/Product/PythonTools/PythonToolsService.cs
+++ b/Python/Product/PythonTools/PythonToolsService.cs
@@ -563,7 +563,7 @@ namespace Microsoft.PythonTools {
 
         public SignatureAnalysis GetSignatures(ITextView view, ITextSnapshot snapshot, ITrackingSpan span) {
             AnalysisEntry entry;
-            if (_entryService == null || !_entryService.TryGetAnalysisEntry(view, snapshot.TextBuffer, out entry)) {
+            if (_entryService == null || !_entryService.TryGetAnalysisEntry(snapshot.TextBuffer, out entry)) {
                 return new SignatureAnalysis("", 0, new ISignature[0]);
             }
             return entry.Analyzer.WaitForRequest(entry.Analyzer.GetSignaturesAsync(entry, view, snapshot, span), "GetSignatures");
@@ -571,7 +571,7 @@ namespace Microsoft.PythonTools {
 
         public Task<SignatureAnalysis> GetSignaturesAsync(ITextView view, ITextSnapshot snapshot, ITrackingSpan span) {
             AnalysisEntry entry;
-            if (_entryService == null || !_entryService.TryGetAnalysisEntry(view, snapshot.TextBuffer, out entry)) {
+            if (_entryService == null || !_entryService.TryGetAnalysisEntry(snapshot.TextBuffer, out entry)) {
                 return Task.FromResult(new SignatureAnalysis("", 0, new ISignature[0]));
             }
             return entry.Analyzer.GetSignaturesAsync(entry, view, snapshot, span);
@@ -579,7 +579,7 @@ namespace Microsoft.PythonTools {
 
         public ExpressionAnalysis AnalyzeExpression(ITextView view, ITextSnapshot snapshot, ITrackingSpan span, bool forCompletion = true) {
             AnalysisEntry entry;
-            if (_entryService == null || !_entryService.TryGetAnalysisEntry(view, snapshot.TextBuffer, out entry)) {
+            if (_entryService == null || !_entryService.TryGetAnalysisEntry(snapshot.TextBuffer, out entry)) {
                 return null;
             }
             return entry.Analyzer.WaitForRequest(entry.Analyzer.AnalyzeExpressionAsync(entry, span.GetStartPoint(snapshot)), "AnalyzeExpression");

--- a/Python/Tests/Core.UI/BasicProjectTests.cs
+++ b/Python/Tests/Core.UI/BasicProjectTests.cs
@@ -1013,7 +1013,7 @@ namespace PythonToolsUITests {
             var index = snapshot.GetText().IndexOf(variable + " =");
             var entryService = serviceProvider.GetEntryService();
             AnalysisEntry entry;
-            if (!entryService.TryGetAnalysisEntry(view, snapshot.TextBuffer, out entry)) {
+            if (!entryService.TryGetAnalysisEntry(snapshot.TextBuffer, out entry)) {
                 return Enumerable.Empty<string>();
             }
             return VsProjectAnalyzer.GetValueDescriptionsAsync(entry, variable, new SnapshotPoint(snapshot, index)).WaitAndUnwrapExceptions();

--- a/Python/Tests/PythonToolsMockTests/PythonEditor.cs
+++ b/Python/Tests/PythonToolsMockTests/PythonEditor.cs
@@ -316,10 +316,12 @@ namespace PythonToolsMockTests {
         public object GetAnalysisEntry(ITextBuffer buffer = null) {
             var entryService = VS.ComponentModel.GetService<AnalysisEntryService>();
             AnalysisEntry entry;
-            if (!entryService.TryGetAnalysisEntry(View.TextView, buffer, out entry)) {
-                throw new ArgumentException("no AnalysisEntry available");
+            if (buffer == null) {
+                entryService.TryGetAnalysisEntry(View.TextView, out entry);
+            } else {
+                entryService.TryGetAnalysisEntry(buffer, out entry);
             }
-            return entry;
+            return entry ?? throw new ArgumentException("no AnalysisEntry available");
         }
 
         public void Dispose() {


### PR DESCRIPTION
Fixes #2976 Failed to get classifier from buffer
Fixes #2978 Unable to resolve package defined inside project
Ensures that analyzer and filename are returned from GetAnalyzer even when the file has not yet been loaded.

Fixes #2968 Failed to create entry for file
Fixes #2982 Typing in a text file causes InvalidOperationException
Uses the shared AnalysisComplete event from the analyzer rather than hooking each file individually.