### PR TITLE
Fixes #16 Tests with decorators do not appear in the test explorer view

### DIFF
--- a/Python/Product/Analysis/LocationInfo.cs
+++ b/Python/Product/Analysis/LocationInfo.cs
@@ -26,13 +26,13 @@ namespace Microsoft.PythonTools.Analysis {
 
         private static readonly IEqualityComparer<LocationInfo> _fullComparer = new FullLocationComparer();
 
-        internal LocationInfo(string path, int line, int column) {
+        public LocationInfo(string path, int line, int column) {
             _path = path;
             _line = line;
             _column = column;
         }
 
-        internal LocationInfo(string path, int line, int column, int? endLine, int? endColumn) {
+        public LocationInfo(string path, int line, int column, int? endLine, int? endColumn) {
             _path = path;
             _line = line;
             _column = column;

--- a/Python/Product/TestAdapter.Analysis/TestAdapter.Analysis.csproj
+++ b/Python/Product/TestAdapter.Analysis/TestAdapter.Analysis.csproj
@@ -61,6 +61,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TestAnalysisExtension.cs" />
     <Compile Include="TestCaseInfo.cs" />
+    <Compile Include="TestMethodWalker.cs" />
   </ItemGroup>
   <ItemGroup>
   </ItemGroup>

--- a/Python/Product/TestAdapter.Analysis/TestMethodWalker.cs
+++ b/Python/Product/TestAdapter.Analysis/TestMethodWalker.cs
@@ -1,0 +1,81 @@
+﻿// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABLITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using Microsoft.PythonTools.Analysis;
+using Microsoft.PythonTools.Infrastructure;
+using Microsoft.PythonTools.Parsing.Ast;
+
+namespace Microsoft.PythonTools.TestAdapter {
+    class TestMethodWalker : PythonWalker {
+        private readonly PythonAst _tree;
+        private readonly string _filename;
+        private readonly IReadOnlyList<LocationInfo> _spans;
+        private bool _inClass;
+
+        public readonly List<KeyValuePair<string, LocationInfo>> Methods = new List<KeyValuePair<string, LocationInfo>>();
+
+        public TestMethodWalker(PythonAst tree, string filename, IEnumerable<LocationInfo> spans) {
+            _tree = tree;
+            _filename = filename;
+            _spans = spans.ToArray();
+        }
+
+        public override bool Walk(ClassDefinition node) {
+            var start = node.GetStart(_tree);
+            var end = node.GetEnd(_tree);
+
+            foreach (var span in _spans) {
+                if (span.StartLine <= end.Line &&
+                    (!span.EndLine.HasValue || span.EndLine.Value >= start.Line)) {
+                    _inClass = true;
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        public override void PostWalk(ClassDefinition node) {
+            _inClass = false;
+            base.PostWalk(node);
+        }
+
+        private LocationInfo GetLoc(FunctionDefinition node) {
+            var s = node.Header;
+            var e = node.GetEnd(_tree);
+            return new LocationInfo(
+                _filename,
+                s.Line, s.Column,
+                e.Line, e.Column
+            );
+        }
+
+        public override bool Walk(FunctionDefinition node) {
+            if (_inClass) {
+                try {
+                    Methods.Add(new KeyValuePair<string, LocationInfo>(node.Name, GetLoc(node)));
+                } catch (Exception ex) when (!ex.IsCriticalException()) {
+                    Debug.Fail(ex.ToUnhandledExceptionMessage(GetType()));
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/Python/Tests/TestAdapterTests/TestDiscovererTests.cs
+++ b/Python/Tests/TestAdapterTests/TestDiscovererTests.cs
@@ -113,19 +113,29 @@ class MyTest(unittest.TestCase):
     @decorator
     def testAbc(self):
         pass
+
+    @fake_decorator
+    def testDef(self):
+        pass
 ";
                 var entry = AddModule(analyzer, "Fob", code);
 
                 entry.Analyze(CancellationToken.None, true);
                 analyzer.AnalyzeQueuedEntries(CancellationToken.None);
 
-                var test = TestAnalyzer.GetTestCasesFromAnalysis(entry).Single();
-                Assert.AreEqual("testAbc", test.MethodName);
-                Assert.AreEqual(10, test.StartLine);
+                var tests = TestAnalyzer.GetTestCasesFromAnalysis(entry)
+                    .Select(t => $"{t.MethodName}:{t.StartLine}");
+                AssertUtil.ArrayEquals(
+                    new[] { "testAbc:10", "testDef:14" },
+                    tests.ToArray()
+                );
 
-                test = GetTestCasesFromAst(code, analyzer).Single();
-                Assert.AreEqual("testAbc", test.MethodName);
-                Assert.AreEqual(10, test.StartLine);
+                tests = GetTestCasesFromAst(code, analyzer)
+                    .Select(t => $"{t.MethodName}:{t.StartLine}");
+                AssertUtil.ArrayEquals(
+                    new[] { "testAbc:9", "testDef:13" },
+                    tests.ToArray()
+                );
             }
         }
 


### PR DESCRIPTION
Fixes #16 Tests with decorators do not appear in the test explorer view
Enhances the code path that extracts test names using analysis to also use the current AST.