### PR TITLE
Fix #3000, #3004

### DIFF
--- a/Python/Product/Debugger/DkmDebugger/ExpressionEvaluator.cs
+++ b/Python/Product/Debugger/DkmDebugger/ExpressionEvaluator.cs
@@ -161,9 +161,9 @@ namespace Microsoft.PythonTools.DkmDebugger {
                         // "0x1e120d50 {python33_d.dll!list_dealloc(PyListObject *)}". If we are lucky, one of those functions will have
                         // the first argument declared as a strongly typed pointer, rather than PyObject* or void*.
                         CppTypeName = "PyObject";
-                        CppTypeModuleName = null;
+                        CppTypeModuleName = Process.GetPythonRuntimeInfo().DLLs.Python.Name;
                         foreach (string methodField in _methodFields) {
-                            var funcPtrEvalResult = cppEval.TryEvaluateObject(null, "PyObject", obj.Address, ".ob_type->" + methodField) as DkmSuccessEvaluationResult;
+                            var funcPtrEvalResult = cppEval.TryEvaluateObject(CppTypeModuleName, "PyObject", obj.Address, ".ob_type->" + methodField) as DkmSuccessEvaluationResult;
                             if (funcPtrEvalResult == null || funcPtrEvalResult.Value.IndexOf('{') < 0) {
                                 continue;
                             }

--- a/Python/Product/Debugger/DkmDebugger/Proxies/Structs/PyDictObject.cs
+++ b/Python/Product/Debugger/DkmDebugger/Proxies/Structs/PyDictObject.cs
@@ -18,6 +18,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.VisualStudio.Debugger;
 using Microsoft.VisualStudio.Debugger.Evaluation;
+using Microsoft.PythonTools.Parsing;
 
 namespace Microsoft.PythonTools.DkmDebugger.Proxies.Structs {
     internal abstract class PyDictObject : PyObject {
@@ -57,6 +58,8 @@ namespace Microsoft.PythonTools.DkmDebugger.Proxies.Structs {
         }
     }
 
+    [StructProxy(MaxVersion = PythonLanguageVersion.V27, StructName = "PyDictEntry")]
+    [StructProxy(MinVersion = PythonLanguageVersion.V33)]
     internal class PyDictKeyEntry : StructProxy {
         private class Fields {
             public StructField<PointerProxy<PyObject>> me_key;


### PR DESCRIPTION
Fix #3000: C++ nodes not displaying

Use module-qualified name for PyObject when determining the object type for [C++ view] node.

Fix #3004: MMD: PyDictKeyEntry not found on 2.7

Re-add StructProxy attributes to look up PyDictEntry instead on 2.7.