### PR TITLE
Fixes #3010 Crash collecting output from pip

### DIFF
--- a/Python/Product/VSInterpreters/StringListReader.cs
+++ b/Python/Product/VSInterpreters/StringListReader.cs
@@ -60,16 +60,11 @@ namespace Microsoft.PythonTools.Interpreter {
         }
 
         public override string ReadLine() {
-            if (_peekBuffer == 0) {
-                _peekBuffer = -1;
-                return string.Empty;
-            }
-
             var r = _current?.ReadLine();
             if (r == null && Next()) {
                 r = _current.ReadLine();
             }
-            if (_peekBuffer > 0) {
+            if (_peekBuffer >= 0) {
                 r = $"{(char)_peekBuffer}{r ?? ""}";
                 _peekBuffer = -1;
             }

--- a/Python/Product/VSInterpreters/StringListReader.cs
+++ b/Python/Product/VSInterpreters/StringListReader.cs
@@ -120,7 +120,17 @@ namespace Microsoft.PythonTools.Interpreter {
         }
 
         public override int ReadBlock(char[] buffer, int index, int count) {
-            return Read(buffer, index, count);
+            int totalCount = 0;
+            while (totalCount < count) {
+                int newCount = Read(buffer, index, count);
+                if (newCount == 0) {
+                    break;
+                }
+                index += newCount;
+                count -= newCount;
+                totalCount += newCount;
+            }
+            return totalCount;
         }
 
         public override string ReadToEnd() {

--- a/Python/Product/VSInterpreters/StringListReader.cs
+++ b/Python/Product/VSInterpreters/StringListReader.cs
@@ -1,0 +1,97 @@
+﻿// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABLITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+
+namespace Microsoft.PythonTools.Interpreter {
+    class StringListReader : TextReader {
+        private readonly IEnumerator<string> _strings;
+        private StringReader _current;
+
+        public StringListReader(IEnumerable<string> strings) {
+            _strings = strings.GetEnumerator();
+            if (_strings.MoveNext()) {
+                _current = new StringReader(_strings.Current);
+            }
+        }
+
+        protected override void Dispose(bool disposing) {
+            base.Dispose(disposing);
+            if (disposing) {
+                _strings.Dispose();
+            }
+        }
+
+        private bool Next() {
+            if (_current != null) {
+                if (_strings.MoveNext()) {
+                    _current = new StringReader(_strings.Current);
+                    return true;
+                } else {
+                    _current = null;
+                }
+            }
+            return false;
+        }
+
+        public override string ReadLine() {
+            var r = _current?.ReadLine();
+            if (r == null && Next()) {
+                return _current.ReadLine();
+            }
+            return r;
+        }
+
+        public override int Read() {
+            if (_current == null) {
+                return -1;
+            }
+
+            var i = _current.Read();
+            if (i < 0 && Next()) {
+                return _current.Read();
+            }
+            return i;
+        }
+
+        public override int Read(char[] buffer, int index, int count) {
+            if (_current == null) {
+                return 0;
+            }
+            var i = _current.Read(buffer, index, count);
+            if (i == 0 && Next()) {
+                i = _current.Read(buffer, index, count);
+            }
+            return i;
+        }
+
+        public override int ReadBlock(char[] buffer, int index, int count) {
+            return Read(buffer, index, count);
+        }
+
+        public override string ReadToEnd() {
+            Debug.Fail("Please don't do this - it's why I wrote this reader in the first place!");
+            var sb = new StringBuilder(_current.ReadToEnd());
+            while (Next()) {
+                sb.Append(_current.ReadToEnd());
+            }
+            return sb.ToString();
+        }
+    }
+}

--- a/Python/Product/VSInterpreters/VSInterpreters.csproj
+++ b/Python/Product/VSInterpreters/VSInterpreters.csproj
@@ -89,6 +89,7 @@
     <Compile Include="PythonInterpreterInformation.cs" />
     <Compile Include="PythonRegistrySearch.cs" />
     <Compile Include="RegistryWatcher.cs" />
+    <Compile Include="StringListReader.cs" />
   </ItemGroup>
   <Import Project="..\ProjectAfter.settings" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/Python/Tests/VSInterpretersTests/StringListReaderTests.cs
+++ b/Python/Tests/VSInterpretersTests/StringListReaderTests.cs
@@ -61,19 +61,34 @@ namespace VSInterpretersTests {
         public void PartialReadTest() {
             using (var r = new StringListReader(new[] { "0123456789", "ABCDEFGHIJ" })) {
                 var buffer = new char[7];
-                Assert.AreEqual(7, r.ReadBlock(buffer, 0, 7));
+                Assert.AreEqual(7, r.Read(buffer, 0, 7));
                 Assert.AreEqual("0123456", ToString(buffer));
                 
                 // We do not get a full read here, by design
-                Assert.AreEqual(3, r.ReadBlock(buffer, 0, 7));
+                Assert.AreEqual(3, r.Read(buffer, 0, 7));
                 Assert.AreEqual("789", ToString(buffer.Take(3)));
 
-                Assert.AreEqual(7, r.ReadBlock(buffer, 0, 7));
+                Assert.AreEqual(7, r.Read(buffer, 0, 7));
                 Assert.AreEqual("ABCDEFG", ToString(buffer));
 
                 // We do not get a full read here, by design
-                Assert.AreEqual(3, r.ReadBlock(buffer, 0, 7));
+                Assert.AreEqual(3, r.Read(buffer, 0, 7));
                 Assert.AreEqual("HIJ", ToString(buffer.Take(3)));
+            }
+        }
+
+        [TestMethod]
+        public void ReadBlockTest() {
+            using (var r = new StringListReader(new[] { "0123456789", "ABCDEFGHIJ" })) {
+                var buffer = new char[7];
+                Assert.AreEqual(7, r.ReadBlock(buffer, 0, 7));
+                Assert.AreEqual("0123456", ToString(buffer));
+                
+                Assert.AreEqual(7, r.ReadBlock(buffer, 0, 7));
+                Assert.AreEqual("789ABCD", ToString(buffer));
+
+                Assert.AreEqual(6, r.ReadBlock(buffer, 0, 7));
+                Assert.AreEqual("EFGHIJ", ToString(buffer.Take(6)));
             }
         }
 

--- a/Python/Tests/VSInterpretersTests/StringListReaderTests.cs
+++ b/Python/Tests/VSInterpretersTests/StringListReaderTests.cs
@@ -1,0 +1,135 @@
+﻿// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABLITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.PythonTools.Interpreter;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace VSInterpretersTests {
+    [TestClass]
+    public class StringListReaderTests {
+        private static void AssertReadLines(IList<string> lines) {
+            using (var r = new StringListReader(lines)) {
+                int lineno = 0;
+                foreach (var expected in lines) {
+                    lineno += 1;
+                    var actual = r.ReadLine();
+                    Assert.AreEqual(expected, actual, $"Line #{lineno}");
+                }
+                Assert.IsNull(r.ReadLine(), "Did not reach EOF");
+            }
+        }
+
+        private static void AssertRead(IList<string> lines) {
+            using (var r = new StringListReader(lines)) {
+                int charno = 0;
+                foreach (var expected in lines.SelectMany(s => s.AsEnumerable())) {
+                    charno += 1;
+                    var actual = r.Read();
+                    Assert.AreEqual((int)expected, actual, $"Character #{charno}");
+                }
+                Assert.IsTrue(r.Read() < 0, "Did not reach EOF");
+            }
+        }
+
+        [TestMethod]
+        public void BasicReadTest() {
+            var str = "A;B;C".Split(';');
+            AssertReadLines(str);
+            AssertRead(str);
+        }
+
+        private static string ToString(IEnumerable<char> chars) {
+            return chars.Aggregate("", (s, c) => s + c);
+        }
+
+        [TestMethod]
+        public void PartialReadTest() {
+            using (var r = new StringListReader(new[] { "0123456789", "ABCDEFGHIJ" })) {
+                var buffer = new char[7];
+                Assert.AreEqual(7, r.ReadBlock(buffer, 0, 7));
+                Assert.AreEqual("0123456", ToString(buffer));
+                
+                // We do not get a full read here, by design
+                Assert.AreEqual(3, r.ReadBlock(buffer, 0, 7));
+                Assert.AreEqual("789", ToString(buffer.Take(3)));
+
+                Assert.AreEqual(7, r.ReadBlock(buffer, 0, 7));
+                Assert.AreEqual("ABCDEFG", ToString(buffer));
+
+                // We do not get a full read here, by design
+                Assert.AreEqual(3, r.ReadBlock(buffer, 0, 7));
+                Assert.AreEqual("HIJ", ToString(buffer.Take(3)));
+            }
+        }
+
+        [TestMethod]
+        public void PeekTest() {
+            var buffer = new char[10];
+
+            using (var r = new StringListReader(new[] { "AB", "CD", "EF" })) {
+                Assert.AreEqual('A', r.Peek());
+                Assert.AreEqual('A', r.Peek());
+                Assert.AreEqual('A', r.Read());
+            }
+
+            using (var r = new StringListReader(new[] { "AB", "CD", "EF" })) {
+                Assert.AreEqual('A', r.Peek());
+                Assert.AreEqual(2, r.Read(buffer, 0, 5));
+                Assert.AreEqual('A', buffer[0]);
+                Assert.AreEqual('B', buffer[1]);
+            }
+
+            using (var r = new StringListReader(new[] { "AB", "CD", "EF" })) {
+                Assert.AreEqual('A', r.Read());
+                Assert.AreEqual('B', r.Peek());
+                // Read after peeking the last char in a line will get us
+                // the next line too.
+                Assert.AreEqual(3, r.Read(buffer, 0, 5));
+                Assert.AreEqual('B', buffer[0]);
+                Assert.AreEqual('C', buffer[1]);
+                Assert.AreEqual('D', buffer[2]);
+            }
+
+            using (var r = new StringListReader(new[] { "AB", "CD", "EF" })) {
+                Assert.AreEqual('A', r.Read());
+                Assert.AreEqual('B', r.Peek());
+                // Read after peeking the last char in a line will get us
+                // the next line too.
+                Assert.AreEqual("BCD", r.ReadLine());
+            }
+
+        }
+
+        [TestMethod]
+        public void ReadToEndTest() {
+            using (var r = new StringListReader(new[] { "A", "B", "C" })) {
+                Assert.AreEqual("ABC", r.ReadToEndWithoutAssert());
+            }
+
+            using (var r = new StringListReader(new[] { "A", "B", "C" })) {
+                Assert.AreEqual('A', r.Read());
+                Assert.AreEqual("BC", r.ReadToEndWithoutAssert());
+            }
+
+            using (var r = new StringListReader(new[] { "A", "B", "C" })) {
+                Assert.AreEqual('A', r.Peek());
+                Assert.AreEqual("ABC", r.ReadToEndWithoutAssert());
+            }
+        }
+    }
+}

--- a/Python/Tests/VSInterpretersTests/VSInterpretersTests.csproj
+++ b/Python/Tests/VSInterpretersTests/VSInterpretersTests.csproj
@@ -54,6 +54,7 @@
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="StringListReaderTests.cs" />
     <Compile Include="VSInterpretersTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>


### PR DESCRIPTION
Fixes #3010 Crash collecting output from pip
Uses a reader subclass to avoid concatenating large JSON files in memory.

Tests are still coming, but I was so pleased that this worked first time I figured I'd get the PR out so someone can tell me what I missed :)