### PR TITLE
Fixes #3023 Failed to scrape builtins for Python 2

### DIFF
--- a/Python/Product/Analysis/Interpreter/Ast/AstPythonInterpreterFactory.cs
+++ b/Python/Product/Analysis/Interpreter/Ast/AstPythonInterpreterFactory.cs
@@ -34,6 +34,7 @@ namespace Microsoft.PythonTools.Interpreter.Ast {
         private IReadOnlyDictionary<string, string> _searchPathPackages;
 
         private bool _disposed;
+        private readonly bool _skipCache;
 
         public AstPythonInterpreterFactory(
             InterpreterConfiguration config,
@@ -44,6 +45,7 @@ namespace Microsoft.PythonTools.Interpreter.Ast {
 
             options = options ?? new InterpreterFactoryCreationOptions();
             _databasePath = options.DatabasePath;
+            _skipCache = !options.UseExistingCache;
 
             if (!GlobalInterpreterOptions.SuppressPackageManagers) {
                 try {
@@ -118,6 +120,10 @@ namespace Microsoft.PythonTools.Interpreter.Ast {
         #region Cache File Management
 
         public Stream ReadCachedModule(string filePath) {
+            if (_skipCache) {
+                return null;
+            }
+
             FileStream file = null;
             var path = GetCacheFilePath(filePath);
             if (string.IsNullOrEmpty(path)) {

--- a/Python/Product/Analysis/Interpreter/InterpreterFactoryCreationOptions.cs
+++ b/Python/Product/Analysis/Interpreter/InterpreterFactoryCreationOptions.cs
@@ -33,5 +33,7 @@ namespace Microsoft.PythonTools.Interpreter {
         public IPackageManager PackageManager { get; set; }
 
         public bool NoDatabase { get; set; }
+
+        public bool UseExistingCache { get; set; } = true;
     }
 }

--- a/Python/Tests/Analysis/AstAnalysisTests.cs
+++ b/Python/Tests/Analysis/AstAnalysisTests.cs
@@ -43,7 +43,17 @@ namespace AnalysisTests {
 
         private static PythonAnalysis CreateAnalysis(PythonVersion version) {
             version.AssertInstalled();
-            return new PythonAnalysis(() => new AstPythonInterpreterFactory(version.Configuration, null));
+            var opts = new InterpreterFactoryCreationOptions {
+                DatabasePath = TestData.GetTempPath("AstAnalysisCache"),
+                UseExistingCache = false
+            };
+
+            Trace.TraceInformation("Cache Path: " + opts.DatabasePath);
+
+            return new PythonAnalysis(() => new AstPythonInterpreterFactory(
+                version.Configuration,
+                opts
+            ));
         }
 
         private static PythonAnalysis CreateAnalysis() {
@@ -197,8 +207,36 @@ R_A3 = R_A1.r_A()");
         }
 
         [TestMethod, Priority(0)]
-        public void AstBuiltinScrape() {
-            using (var analysis = CreateAnalysis()) {
+        public void AstBuiltinScrapeV36() => AstBuiltinScrape(PythonPaths.Python36_x64 ?? PythonPaths.Python36);
+
+        [TestMethod, Priority(0)]
+        public void AstBuiltinScrapeV35() => AstBuiltinScrape(PythonPaths.Python35_x64 ?? PythonPaths.Python35);
+
+        [TestMethod, Priority(0)]
+        public void AstBuiltinScrapeV34() => AstBuiltinScrape(PythonPaths.Python34_x64 ?? PythonPaths.Python34);
+
+        [TestMethod, Priority(0)]
+        public void AstBuiltinScrapeV33() => AstBuiltinScrape(PythonPaths.Python33_x64 ?? PythonPaths.Python33);
+
+        [TestMethod, Priority(0)]
+        public void AstBuiltinScrapeV32() => AstBuiltinScrape(PythonPaths.Python32_x64 ?? PythonPaths.Python32);
+
+        [TestMethod, Priority(0)]
+        public void AstBuiltinScrapeV31() => AstBuiltinScrape(PythonPaths.Python31_x64 ?? PythonPaths.Python31);
+
+        [TestMethod, Priority(0)]
+        public void AstBuiltinScrapeV30() => AstBuiltinScrape(PythonPaths.Python30);
+
+        [TestMethod, Priority(0)]
+        public void AstBuiltinScrapeV27() => AstBuiltinScrape(PythonPaths.Python27_x64 ?? PythonPaths.Python27);
+
+        [TestMethod, Priority(0)]
+        public void AstBuiltinScrapeV26() => AstBuiltinScrape(PythonPaths.Python26_x64 ?? PythonPaths.Python26);
+
+
+        private void AstBuiltinScrape(PythonVersion version) {
+            version.AssertInstalled();
+            using (var analysis = CreateAnalysis(version)) {
                 var fact = (AstPythonInterpreterFactory)analysis.Analyzer.InterpreterFactory;
                 var interp = (AstPythonInterpreter)analysis.Analyzer.Interpreter;
 


### PR DESCRIPTION
Fixes #3023 Failed to scrape builtins for Python 2
Updates module scraper to handle Python 2 builtins properly.
Adds tests for supported CPython versions