### PR TITLE
Fixes #1638 Support PEP 530 syntax

### DIFF
--- a/Python/Product/Analysis/Parsing/Ast/ComprehensionFor.cs
+++ b/Python/Product/Analysis/Parsing/Ast/ComprehensionFor.cs
@@ -19,10 +19,16 @@ using System.Text;
 namespace Microsoft.PythonTools.Parsing.Ast {
     public class ComprehensionFor : ComprehensionIterator {
         private readonly Expression _lhs, _list;
+        private readonly bool _isAsync;
 
         public ComprehensionFor(Expression lhs, Expression list) {
             _lhs = lhs;
             _list = list;
+        }
+
+        public ComprehensionFor(Expression lhs, Expression list, bool isAsync)
+            : this(lhs, list) {
+            _isAsync = isAsync;
         }
 
         public Expression Left {
@@ -32,6 +38,9 @@ namespace Microsoft.PythonTools.Parsing.Ast {
         public Expression List {
             get { return _list; }
         }
+
+        public bool IsAsync => _isAsync;
+
         public override void Walk(PythonWalker walker) {
             if (walker.Walk(this)) {
                 if (_lhs != null) {
@@ -45,6 +54,10 @@ namespace Microsoft.PythonTools.Parsing.Ast {
         }
 
         internal override void AppendCodeString(StringBuilder res, PythonAst ast, CodeFormattingOptions format) {
+            if (_isAsync) {
+                res.Append(this.GetThirdWhiteSpace(ast));
+                res.Append("async");
+            }
             res.Append(this.GetProceedingWhiteSpace(ast));
             res.Append("for");
             _lhs.AppendCodeString(res, ast, format);

--- a/Python/Product/Analysis/Parsing/Parser.cs
+++ b/Python/Product/Analysis/Parsing/Parser.cs
@@ -4295,7 +4295,7 @@ namespace Microsoft.PythonTools.Parsing {
             }
         }
 
-        // comp_for: 'for target_list 'in' or_test [comp_iter]
+        // comp_for: '[async] for target_list 'in' or_test [comp_iter]
         private ComprehensionFor ParseCompFor() {
             bool isAsync = false;
             string firstWhitespace = null, asyncWhitespace = null;

--- a/Python/Product/Analyzer/Intellisense/ClassifierWalker.cs
+++ b/Python/Product/Analyzer/Intellisense/ClassifierWalker.cs
@@ -267,6 +267,11 @@ namespace Microsoft.PythonTools.Intellisense {
 
         public override bool Walk(ComprehensionFor node) {
             AddParameter(node.Left);
+
+            if (node.IsAsync) {
+                AddSpan(Tuple.Create("", new Span(node.StartIndex, 5)), Classifications.Keyword);
+            }
+
             return base.Walk(node);
         }
 

--- a/Python/Tests/Core.UI/FormattingUITests.cs
+++ b/Python/Tests/Core.UI/FormattingUITests.cs
@@ -97,7 +97,7 @@ def g():
     # comment before
     async   with x:
         pass
-", new Span[] { }, null, null, new Version(3, 5));
+    [  x   async for x  in await    x]", new Span[] { }, null, null, new Version(3, 6));
         }
 
 

--- a/Python/Tests/TestData/FormattingTests/async.py
+++ b/Python/Tests/TestData/FormattingTests/async.py
@@ -4,3 +4,4 @@ async  def f(x):
     # comment before
     async   with x:
         pass
+    [  x   async for x  in await    x]

--- a/Python/Tests/TestData/Grammar/AsyncFor.py
+++ b/Python/Tests/TestData/Grammar/AsyncFor.py
@@ -1,0 +1,8 @@
+async def f():
+    [fob async for fob in oar]
+    (fob async for fob in oar)
+    {fob async for fob in oar}
+    {fob: fob async for fob in oar}
+    [fob for fob in oar async for oar in baz]
+    (fob for fob in oar async for oar in baz)
+    [await fob async for fob in oar]


### PR DESCRIPTION
Fixes #1638 Support PEP 530 syntax
Adds parser support for "async for" in comprehension syntax
Add classifier support for "async" in comprehensions
Adds tests