### PR TITLE
Detects open dialogs at the start of a test and closes them.

### DIFF
--- a/Common/Tests/Utilities.UI/UI/AutomationWrapper.cs
+++ b/Common/Tests/Utilities.UI/UI/AutomationWrapper.cs
@@ -405,6 +405,13 @@ namespace TestUtilities.UI {
             }
         }
 
+        public void CloseWindow() {
+            object pattern;
+            if (Element.TryGetCurrentPattern(WindowPattern.Pattern, out pattern)) {
+                ((WindowPattern)pattern).Close();
+            }
+        }
+
         public void WaitForClosed(TimeSpan timeout, Action closeCommand = null) {
             using (var closed = new AutoResetEvent(false)) {
                 AutomationEventHandler handler = (s, e) => {

--- a/Common/Tests/Utilities.UI/UI/VisualStudioApp.cs
+++ b/Common/Tests/Utilities.UI/UI/VisualStudioApp.cs
@@ -56,6 +56,17 @@ namespace TestUtilities.UI {
             foreach (var p in ((DTE2)_dte).ToolWindows.OutputWindow.OutputWindowPanes.OfType<OutputWindowPane>()) {
                 p.Clear();
             }
+
+            var uiShell = GetService<IVsUIShell>(typeof(IVsUIShell));
+            IntPtr hwnd;
+            ErrorHandler.ThrowOnFailure(uiShell.GetDialogOwnerHwnd(out hwnd));
+            if (hwnd != _mainWindowHandle) {
+                using (var dlg = new AutomationDialog(this, AutomationElement.FromHandle(hwnd))) {
+                    Console.WriteLine("Unexpected dialog at start of test");
+                    DumpElement(dlg.Element);
+                    dlg.WaitForClosed(TimeSpan.FromSeconds(5), dlg.CloseWindow);
+                }
+            }
         }
 
         private VisualStudioApp(IntPtr windowHandle)


### PR DESCRIPTION
Detects open dialogs at the start of a test and closes them.
This should prevent one failed test from causing many subsequent failures.