### PR TITLE
Fixes #622 Don't show tooltips for string literals

### DIFF
--- a/Python/Product/Analysis/ModuleAnalysis.cs
+++ b/Python/Product/Analysis/ModuleAnalysis.cs
@@ -896,7 +896,7 @@ namespace Microsoft.PythonTools.Analysis {
             }
         }
 
-        private PythonAst GetAstFromText(string exprText, string privatePrefix) {
+        internal PythonAst GetAstFromText(string exprText, string privatePrefix) {
             using (var parser = Parser.CreateParser(new StringReader(exprText), _unit.ProjectState.LanguageVersion, new ParserOptions() { PrivatePrefix = privatePrefix, Verbatim = true })) {
                 return parser.ParseTopExpression();
             }

--- a/Python/Product/PythonTools/PythonTools/Intellisense/ProjectAnalyzer.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/ProjectAnalyzer.cs
@@ -2373,7 +2373,7 @@ namespace Microsoft.PythonTools.Intellisense {
 
                 var quickInfo = await SendRequestAsync(req).ConfigureAwait(false);
 
-                if (quickInfo != null) {
+                if (!string.IsNullOrEmpty(quickInfo?.text)) {
                     return new QuickInfo(quickInfo.text, analysis.Span);
                 }
             }


### PR DESCRIPTION
Fixes #622 Don't show tooltips for string literals
Check the expression when generating quick info to not include literal or error expressions in result

There are no regressions from this, but we still do not correctly display str/Unicode/bytes for multiline triple-quoted strings. This requires ReverseExpressionParser to do a much better job of parsing to see whether we're in a string, which is certainly not worth the churn right now.