### PR TITLE
Remove Python 2.5 and 3.0 related tests.

### DIFF
--- a/Python/Tests/Analysis/AstAnalysisTests.cs
+++ b/Python/Tests/Analysis/AstAnalysisTests.cs
@@ -225,9 +225,6 @@ R_A3 = R_A1.r_A()");
         public void AstBuiltinScrapeV31() => AstBuiltinScrape(PythonPaths.Python31_x64 ?? PythonPaths.Python31);
 
         [TestMethod, Priority(0)]
-        public void AstBuiltinScrapeV30() => AstBuiltinScrape(PythonPaths.Python30);
-
-        [TestMethod, Priority(0)]
         public void AstBuiltinScrapeV27() => AstBuiltinScrape(PythonPaths.Python27_x64 ?? PythonPaths.Python27);
 
         [TestMethod, Priority(0)]

--- a/Python/Tests/Analysis/CompletionDBTest.cs
+++ b/Python/Tests/Analysis/CompletionDBTest.cs
@@ -111,11 +111,6 @@ namespace PythonToolsTests {
         }
 
         [TestMethod, Priority(1)]
-        public void TestOpen25() {
-            TestOpen(PythonPaths.Python25 ?? PythonPaths.Python25_x64);
-        }
-
-        [TestMethod, Priority(1)]
         public void TestOpen26() {
             TestOpen(PythonPaths.Python26 ?? PythonPaths.Python26_x64);
         }

--- a/Python/Tests/Analysis/CompletionDBTest.cs
+++ b/Python/Tests/Analysis/CompletionDBTest.cs
@@ -126,11 +126,6 @@ namespace PythonToolsTests {
         }
 
         [TestMethod, Priority(1)]
-        public void TestOpen30() {
-            TestOpen(PythonPaths.Python30 ?? PythonPaths.Python30_x64);
-        }
-
-        [TestMethod, Priority(1)]
         public void TestOpen31() {
             TestOpen(PythonPaths.Python31 ?? PythonPaths.Python31_x64);
         }

--- a/Python/Tests/Analysis/DatabaseTest.cs
+++ b/Python/Tests/Analysis/DatabaseTest.cs
@@ -239,13 +239,6 @@ namespace AnalysisTests {
     }
 
     [TestClass]
-    public class DatabaseTest25 : DatabaseTest27 {
-        public override PythonVersion Python {
-            get { return PythonPaths.Python25 ?? PythonPaths.Python25_x64; }
-        }
-    }
-
-    [TestClass]
     public class DatabaseTest26 : DatabaseTest27 {
         public override PythonVersion Python {
             get { return PythonPaths.Python26 ?? PythonPaths.Python26_x64; }

--- a/Python/Tests/Analysis/DatabaseTest.cs
+++ b/Python/Tests/Analysis/DatabaseTest.cs
@@ -253,13 +253,6 @@ namespace AnalysisTests {
     }
 
     [TestClass]
-    public class DatabaseTest30 : DatabaseTest27 {
-        public override PythonVersion Python {
-            get { return PythonPaths.Python30 ?? PythonPaths.Python30_x64; }
-        }
-    }
-
-    [TestClass]
     public class DatabaseTest31 : DatabaseTest27 {
         public override PythonVersion Python {
             get { return PythonPaths.Python31 ?? PythonPaths.Python31_x64; }

--- a/Python/Tests/Analysis/MutateStdLibTest.cs
+++ b/Python/Tests/Analysis/MutateStdLibTest.cs
@@ -47,12 +47,6 @@ namespace AnalysisTests {
 
         [TestMethod, Priority(2)]
         [TestCategory("10s"), TestCategory("60s")]
-        public void TestMutateStdLibV30() {
-            TestMutateStdLib(PythonPaths.Python30_x64 ?? PythonPaths.Python30);
-        }
-
-        [TestMethod, Priority(2)]
-        [TestCategory("10s"), TestCategory("60s")]
         public void TestMutateStdLibV31() {
             TestMutateStdLib(PythonPaths.Python31_x64 ?? PythonPaths.Python31);
         }

--- a/Python/Tests/Analysis/MutateStdLibTest.cs
+++ b/Python/Tests/Analysis/MutateStdLibTest.cs
@@ -29,12 +29,6 @@ namespace AnalysisTests {
 
         [TestMethod, Priority(2)]
         [TestCategory("10s"), TestCategory("60s")]
-        public void TestMutateStdLibV25() {
-            TestMutateStdLib(PythonPaths.Python25_x64 ?? PythonPaths.Python25);
-        }
-
-        [TestMethod, Priority(2)]
-        [TestCategory("10s"), TestCategory("60s")]
         public void TestMutateStdLibV26() {
             TestMutateStdLib(PythonPaths.Python26_x64 ?? PythonPaths.Python26);
         }

--- a/Python/Tests/Core/DebugReplEvaluatorTests.cs
+++ b/Python/Tests/Core/DebugReplEvaluatorTests.cs
@@ -431,21 +431,6 @@ NameError: name 'does_not_exist' is not defined
     }
 
     [TestClass]
-    public class DebugReplEvaluatorTests30 : DebugReplEvaluatorTests {
-        [ClassInitialize]
-        public static new void DoDeployment(TestContext context) {
-            AssertListener.Initialize();
-            PythonTestData.Deploy();
-        }
-
-        internal override PythonVersion Version {
-            get {
-                return PythonPaths.Python30 ?? PythonPaths.Python30_x64;
-            }
-        }
-    }
-
-    [TestClass]
     public class DebugReplEvaluatorTests31 : DebugReplEvaluatorTests {
         [ClassInitialize]
         public static new void DoDeployment(TestContext context) {

--- a/Python/Tests/DebuggerTests/AttachTests.cs
+++ b/Python/Tests/DebuggerTests/AttachTests.cs
@@ -1279,18 +1279,6 @@ int main(int argc, char* argv[]) {
     }
 
     [TestClass]
-    public class AttachTests30 : AttachTests {
-        internal override PythonVersion Version {
-            get {
-                return PythonPaths.Python30 ?? PythonPaths.Python30_x64;
-            }
-        }
-
-        // 3.0 does not support packages as scripts (__main__.py)
-        protected override bool HasPtvsdCommandLine => false;
-    }
-
-    [TestClass]
     public class AttachTests31 : AttachTests {
         internal override PythonVersion Version {
             get {

--- a/Python/Tests/DebuggerTests/DebuggerTests.cs
+++ b/Python/Tests/DebuggerTests/DebuggerTests.cs
@@ -2227,15 +2227,6 @@ namespace DebuggerTests {
     }
 
     [TestClass]
-    public class DebuggerTests30 : DebuggerTests3x {
-        internal override PythonVersion Version {
-            get {
-                return PythonPaths.Python30 ?? PythonPaths.Python30_x64;
-            }
-        }
-    }
-
-    [TestClass]
     public class DebuggerTests31 : DebuggerTests3x {
         internal override PythonVersion Version {
             get {

--- a/Python/Tests/IpcJsonTests/IpcJsonPacketReadPythonTests.cs
+++ b/Python/Tests/IpcJsonTests/IpcJsonPacketReadPythonTests.cs
@@ -280,21 +280,6 @@ namespace IpcJsonTests {
     }
 
     [TestClass]
-    public class IpcJsonPacketReadPythonTests30 : IpcJsonPacketReadPythonTests {
-        [ClassInitialize]
-        public static new void DoDeployment(TestContext context) {
-            AssertListener.Initialize();
-            PythonTestData.Deploy();
-        }
-
-        internal override PythonVersion Version {
-            get {
-                return PythonPaths.Python30 ?? PythonPaths.Python30_x64;
-            }
-        }
-    }
-
-    [TestClass]
     public class IpcJsonPacketReadPythonTests31 : IpcJsonPacketReadPythonTests {
         [ClassInitialize]
         public static new void DoDeployment(TestContext context) {

--- a/Python/Tests/ProfilingUITests/ProfilingUITests.cs
+++ b/Python/Tests/ProfilingUITests/ProfilingUITests.cs
@@ -1229,7 +1229,7 @@ namespace ProfilingUITests {
         public void OldClassProfile() {
             bool anyMissing = false;
 
-            foreach (var version in new[] { PythonPaths.Python25, PythonPaths.Python27, PythonPaths.Python27 }) {
+            foreach (var version in new[] { PythonPaths.Python26, PythonPaths.Python27 }) {
                 if (version == null) {
                     anyMissing = true;
                     continue;
@@ -1376,16 +1376,6 @@ namespace ProfilingUITests {
                     profiling.RemoveSession(session, false);
                 }
             }
-        }
-
-        [TestMethod, Priority(1)]
-        [HostType("VSTestHost"), TestCategory("Installed")]
-        public void BuiltinsProfilePython25() {
-            BuiltinsProfile(
-                PythonPaths.Python25,
-                new[] { "str.startswith", "isinstance", "marshal.dumps", "array.array.tostring" },
-                null
-            );
         }
 
         [TestMethod, Priority(1)]

--- a/Python/Tests/ReplWindowUITests/ReplWindowPythonTestEntryPoints.cs
+++ b/Python/Tests/ReplWindowUITests/ReplWindowPythonTestEntryPoints.cs
@@ -23,18 +23,6 @@ namespace ReplWindowUITests {
     #region Python 32-bit tests
 
     [TestClass]
-    public class ReplWindowPython25Tests : ReplWindowPythonSmokeTests {
-        internal override ReplWindowProxySettings Settings {
-            get {
-                return new ReplWindowProxySettings {
-                    Version = PythonPaths.Python25,
-                    IntFirstMember = "__abs__",
-                };
-            }
-        }
-    }
-
-    [TestClass]
     public class ReplWindowPython26Tests : ReplWindowPythonTests {
         internal override ReplWindowProxySettings Settings {
             get {

--- a/Python/Tests/TestAdapterTests/TestExecutorTests.cs
+++ b/Python/Tests/TestAdapterTests/TestExecutorTests.cs
@@ -608,17 +608,6 @@ namespace TestAdapterTests {
     }
 
     [TestClass]
-    public class TestExecutorTests30 : TestExecutorTests {
-        [ClassInitialize]
-        public static void DoDeployment(TestContext context) {
-            AssertListener.Initialize();
-            PythonTestData.Deploy();
-        }
-
-        protected override PythonVersion Version => PythonPaths.Python30 ?? PythonPaths.Python30_x64;
-    }
-
-    [TestClass]
     public class TestExecutorTests31 : TestExecutorTests {
         [ClassInitialize]
         public static void DoDeployment(TestContext context) {

--- a/Python/Tests/Utilities.Python.Analysis/PythonPaths.cs
+++ b/Python/Tests/Utilities.Python.Analysis/PythonPaths.cs
@@ -32,10 +32,8 @@ namespace TestUtilities {
             .Where(pii => pii.Configuration.Id.Contains("PythonCore|") || pii.Configuration.Id.Contains("ContinuumAnalytics|"))
             .ToList();
 
-        public static readonly PythonVersion Python25 = GetCPythonVersion(PythonLanguageVersion.V25, InterpreterArchitecture.x86);
         public static readonly PythonVersion Python26 = GetCPythonVersion(PythonLanguageVersion.V26, InterpreterArchitecture.x86);
         public static readonly PythonVersion Python27 = GetCPythonVersion(PythonLanguageVersion.V27, InterpreterArchitecture.x86);
-        public static readonly PythonVersion Python30 = GetCPythonVersion(PythonLanguageVersion.V30, InterpreterArchitecture.x86);
         public static readonly PythonVersion Python31 = GetCPythonVersion(PythonLanguageVersion.V31, InterpreterArchitecture.x86);
         public static readonly PythonVersion Python32 = GetCPythonVersion(PythonLanguageVersion.V32, InterpreterArchitecture.x86);
         public static readonly PythonVersion Python33 = GetCPythonVersion(PythonLanguageVersion.V33, InterpreterArchitecture.x86);
@@ -44,10 +42,8 @@ namespace TestUtilities {
         public static readonly PythonVersion Python36 = GetCPythonVersion(PythonLanguageVersion.V36, InterpreterArchitecture.x86);
         public static readonly PythonVersion Python37 = GetCPythonVersion(PythonLanguageVersion.V37, InterpreterArchitecture.x86);
         public static readonly PythonVersion IronPython27 = GetIronPythonVersion(false);
-        public static readonly PythonVersion Python25_x64 = GetCPythonVersion(PythonLanguageVersion.V25, InterpreterArchitecture.x64);
         public static readonly PythonVersion Python26_x64 = GetCPythonVersion(PythonLanguageVersion.V26, InterpreterArchitecture.x64);
         public static readonly PythonVersion Python27_x64 = GetCPythonVersion(PythonLanguageVersion.V27, InterpreterArchitecture.x64);
-        public static readonly PythonVersion Python30_x64 = GetCPythonVersion(PythonLanguageVersion.V30, InterpreterArchitecture.x64);
         public static readonly PythonVersion Python31_x64 = GetCPythonVersion(PythonLanguageVersion.V31, InterpreterArchitecture.x64);
         public static readonly PythonVersion Python32_x64 = GetCPythonVersion(PythonLanguageVersion.V32, InterpreterArchitecture.x64);
         public static readonly PythonVersion Python33_x64 = GetCPythonVersion(PythonLanguageVersion.V33, InterpreterArchitecture.x64);
@@ -200,10 +196,8 @@ namespace TestUtilities {
 
         public static IEnumerable<PythonVersion> Versions {
             get {
-                if (Python25 != null) yield return Python25;
                 if (Python26 != null) yield return Python26;
                 if (Python27 != null) yield return Python27;
-                if (Python30 != null) yield return Python30;
                 if (Python31 != null) yield return Python31;
                 if (Python32 != null) yield return Python32;
                 if (Python33 != null) yield return Python33;
@@ -212,10 +206,8 @@ namespace TestUtilities {
                 if (Python36 != null) yield return Python36;
                 if (Python37 != null) yield return Python37;
                 if (IronPython27 != null) yield return IronPython27;
-                if (Python25_x64 != null) yield return Python25_x64;
                 if (Python26_x64 != null) yield return Python26_x64;
                 if (Python27_x64 != null) yield return Python27_x64;
-                if (Python30_x64 != null) yield return Python30_x64;
                 if (Python31_x64 != null) yield return Python31_x64;
                 if (Python32_x64 != null) yield return Python32_x64;
                 if (Python33_x64 != null) yield return Python33_x64;


### PR DESCRIPTION
Don't waste time running tests on Python 2.5 and 3.0 which we've decided not to support anymore.
Some of them were previously failing (Python 3.0), so removing them helps our test results.
