### PR TITLE
Fix #2031: Cannot import subpackages from zip file

### DIFF
--- a/Python/Product/Analysis/Interpreter/Default/CPythonInterpreter.cs
+++ b/Python/Product/Analysis/Interpreter/Default/CPythonInterpreter.cs
@@ -291,7 +291,7 @@ namespace Microsoft.PythonTools.Interpreter.Default {
                 name = ModulePath.FromBasePathAndName(
                     "",
                     moduleName,
-                    packages.Contains,
+                    packageName => packages.Contains(packageName + '\\'),
                     new GetModuleCallable(packages).GetModule
                 );
             } catch (ArgumentException) {

--- a/Python/Tests/Core/CPythonInterpreterTests.cs
+++ b/Python/Tests/Core/CPythonInterpreterTests.cs
@@ -119,14 +119,17 @@ namespace PythonToolsTests {
         [TestMethod, Priority(0)]
         public void ImportFromZipFile() {
             var analyzer = new PythonAnalysis(PythonLanguageVersion.V35);
-            analyzer.AddModule("test-module", "from test_package import *");
+            analyzer.AddModule("test-module", "from test_package import *; from test_package.sub_package import *");
             analyzer.WaitForAnalysis();
-            AssertUtil.CheckCollection(analyzer.GetAllNames(), null, new[] { "package_method", "package_method_two", "test_package" });
+            AssertUtil.CheckCollection(analyzer.GetAllNames(), null,
+                new[] { "package_method", "package_method_two", "test_package", "subpackage_method", "subpackage_method_two" });
 
             analyzer.SetSearchPaths(TestData.GetPath("TestData\\AddImport.zip"));
             analyzer.ReanalyzeAll();
 
-            AssertUtil.CheckCollection(analyzer.GetAllNames(), new[] { "package_method", "package_method_two" }, new[] { "test_package" });
+            AssertUtil.CheckCollection(analyzer.GetAllNames(),
+                new[] { "package_method", "package_method_two", "subpackage_method", "subpackage_method_two" },
+                new[] { "test_package" });
         }
 
         private static void AnalyzeCode(


### PR DESCRIPTION
Fix missing terminating slash when looking up directory entries inside .zip files