### PR TITLE
Fixes #3067 "Reports" in profiling is not localized

### DIFF
--- a/Python/Product/Profiling/Profiling/SessionNode.cs
+++ b/Python/Product/Profiling/Profiling/SessionNode.cs
@@ -220,7 +220,7 @@ namespace Microsoft.PythonTools.Profiling {
                     if (itemid == VSConstants.VSITEMID_ROOT) {
                         pvar = Caption;
                     } else if (itemid == ReportsItemId) {
-                        pvar = "Reports";
+                        pvar = Strings.Reports;
                     } else if (IsReportItem(itemid)) {
                         pvar = Path.GetFileNameWithoutExtension(GetReport(itemid).Filename);
                     }

--- a/Python/Product/Profiling/Strings.Designer.cs
+++ b/Python/Product/Profiling/Strings.Designer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.PythonTools.Profiling {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Strings {
@@ -475,6 +475,15 @@ namespace Microsoft.PythonTools.Profiling {
         public static string PythonFilesFilter {
             get {
                 return ResourceManager.GetString("PythonFilesFilter", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Reports.
+        /// </summary>
+        public static string Reports {
+            get {
+                return ResourceManager.GetString("Reports", resourceCulture);
             }
         }
         

--- a/Python/Product/Profiling/Strings.resx
+++ b/Python/Product/Profiling/Strings.resx
@@ -288,4 +288,8 @@ Error:
   <data name="LaunchProfiling_WorkingDirectoryBrowseButtonDescription" xml:space="preserve">
     <value>Browse folder dialog for working directory</value>
   </data>
+  <data name="Reports" xml:space="preserve">
+    <value>Reports</value>
+    <comment>Tree view node that contains the set of profiling reports</comment>
+  </data>
 </root>


### PR DESCRIPTION
Fixes #3067 "Reports" in profiling is not localized
Moves string literal into resource.

Ideally should be ported to 3.2.1, but we need to wait for the loc team to merge their translations first.