### PR TITLE
Fixes non-UI tests

### DIFF
--- a/Python/Tests/Core/CodeFormatterTests.cs
+++ b/Python/Tests/Core/CodeFormatterTests.cs
@@ -15,15 +15,11 @@
 // permissions and limitations under the License.
 
 using System;
-using System.Linq;
 using Microsoft.PythonTools;
 using Microsoft.PythonTools.Infrastructure;
 using Microsoft.PythonTools.Intellisense;
 using Microsoft.PythonTools.Interpreter;
-using Microsoft.PythonTools.Interpreter.Default;
 using Microsoft.PythonTools.Parsing;
-using Microsoft.PythonTools.Parsing.Ast;
-using Microsoft.PythonTools.Refactoring;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.VisualStudio.Text;
 using TestUtilities;

--- a/Python/Tests/Core/ExtractMethodTests.cs
+++ b/Python/Tests/Core/ExtractMethodTests.cs
@@ -1699,7 +1699,7 @@ async def f():
 
         private void ExtractMethodTest(string input, Func<Span> extract, TestResult expected, string scopeName = null, string targetName = "g", Version version = null, params string[] parameters) {
             var fact = InterpreterFactoryCreator.CreateAnalysisInterpreterFactory(version ?? new Version(2, 7));
-            var services = PythonToolsTestUtilities.CreateMockServiceProvider(suppressTaskProvider: true).GetEditorServices();
+            var services = PythonToolsTestUtilities.CreateMockServiceProvider().GetEditorServices();
             using (var analyzer = new VsProjectAnalyzer(services, fact)) {
                 var buffer = new MockTextBuffer(input, "Python", "C:\\fob.py");
                 var view = new MockTextView(buffer);

--- a/Python/Tests/Utilities.Python/PythonToolsTestUtilities.cs
+++ b/Python/Tests/Utilities.Python/PythonToolsTestUtilities.cs
@@ -61,7 +61,7 @@ namespace TestUtilities.Python {
         /// VS but is suitable for simple test cases which need just some base functionality.
         /// </summary>
         public static MockServiceProvider CreateMockServiceProvider(
-            bool suppressTaskProvider = false
+            bool suppressTaskProvider = true
         ) {
             var serviceProvider = new MockServiceProvider();
 


### PR DESCRIPTION
Disables task provider in mock tests by default.
Makes MockServiceProvider properly handle lazy creation.