### PR TITLE
CompletionTests fixes.

### DIFF
--- a/Common/Tests/MockVsTests/MockCodeWindow.cs
+++ b/Common/Tests/MockVsTests/MockCodeWindow.cs
@@ -22,7 +22,7 @@ using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.TextManager.Interop;
 
 namespace Microsoft.VisualStudioTools.MockVsTests {
-    class MockCodeWindow : IVsCodeWindow, Microsoft.VisualStudio.OLE.Interop.IConnectionPointContainer {
+    class MockCodeWindow : IVsCodeWindow, IVsDropdownBarManager, Microsoft.VisualStudio.OLE.Interop.IConnectionPointContainer {
         private readonly IServiceProvider _serviceProvider;
         private readonly ITextView _view;
 
@@ -81,6 +81,19 @@ namespace Microsoft.VisualStudioTools.MockVsTests {
 
         public void FindConnectionPoint(ref Guid riid, out VisualStudio.OLE.Interop.IConnectionPoint ppCP) {
             ppCP = null;
+        }
+
+        public int AddDropdownBar(int cCombos, IVsDropdownBarClient pClient) {
+            return VSConstants.E_FAIL;
+        }
+
+        public int GetDropdownBar(out IVsDropdownBar ppDropdownBar) {
+            ppDropdownBar = null;
+            return VSConstants.E_FAIL;
+        }
+
+        public int RemoveDropdownBar() {
+            return VSConstants.E_FAIL;
         }
     }
 }

--- a/Python/Tests/PythonToolsMockTests/CompletionTests.cs
+++ b/Python/Tests/PythonToolsMockTests/CompletionTests.cs
@@ -486,11 +486,10 @@ f(1, 2, 3, 4,")) {
                     "api_version"           // Contains data members
                 );
 
-                view.Text = "from sys.";
-                // There will be one completion saying that there are no completions
-                Assert.AreEqual(1, view.GetCompletions(-1).Count());
-
                 // Error case - no completions
+                view.Text = "from sys.";
+                AssertUtil.ContainsExactly(view.GetCompletions(-1));
+
                 view.Text = "from sys. import ";
                 AssertUtil.ContainsExactly(view.GetCompletions(-1));
 
@@ -675,7 +674,7 @@ while True:
 lambda larg1, larg2: None";
 
 
-            using (var view = new PythonEditor(code)) {
+            using (var view = new PythonEditor(code, filename:"file.py")) {
                 // we get the appropriate subexpression
                 TestQuickInfo(view, code.IndexOf("cls."), code.IndexOf("cls.") + 4, "cls: <unknown type>");
                 TestQuickInfo(view, code.IndexOf("cls.") + 4 + 1, code.IndexOf("cls.") + 4 + 1 + 11, "cls._parse_block: <unknown type>");


### PR DESCRIPTION
All CompletionTests were broken after #3133, this restores them and fixes 2 that were previously failing. It's down to 2 "failed to see entry finish analyzing" failures now (MemberCompletions and SignatureHelp)