### PR TITLE
Enable go to definition when caret is on the right of identifier

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Intellisense/ProjectAnalyzer.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/ProjectAnalyzer.cs
@@ -974,7 +974,7 @@ namespace Microsoft.PythonTools.Intellisense {
         }
 
         internal static async Task<string[]> GetValueDescriptionsAsync(AnalysisEntry file, string expr, SnapshotPoint point) {
-            var analysis = GetApplicableExpression(file, point);
+            var analysis = GetApplicableExpression(file, point, checkLeftAndRightOfPoint: false);
 
             if (analysis != null) {
                 return await GetValueDescriptionsAsync(file, analysis.Text, analysis.Location).ConfigureAwait(false);
@@ -1038,7 +1038,7 @@ namespace Microsoft.PythonTools.Intellisense {
         internal async Task<ExpressionAnalysis> AnalyzeExpressionAsync(AnalysisEntry entry, SnapshotPoint point) {
             Debug.Assert(entry.Analyzer == this);
 
-            var analysis = GetApplicableExpression(entry, point);
+            var analysis = GetApplicableExpression(entry, point, checkLeftAndRightOfPoint: true);
 
             if (analysis != null) {
                 var location = analysis.Location;
@@ -2374,7 +2374,7 @@ namespace Microsoft.PythonTools.Intellisense {
         internal async Task<QuickInfo> GetQuickInfoAsync(AnalysisEntry entry, ITextView view, SnapshotPoint point) {
             Debug.Assert(entry.Analyzer == this);
 
-            var analysis = GetApplicableExpression(entry, point);
+            var analysis = GetApplicableExpression(entry, point, checkLeftAndRightOfPoint: false);
 
             if (analysis != null) {
                 var location = analysis.Location;
@@ -2427,7 +2427,7 @@ namespace Microsoft.PythonTools.Intellisense {
             if (entryService == null || !entryService.TryGetAnalysisEntry(span.Snapshot.TextBuffer, out entry)) {
                 return Task.FromResult<string>(null);
             }
-            var analysis = GetApplicableExpression(entry, span.Start);
+            var analysis = GetApplicableExpression(entry, span.Start, checkLeftAndRightOfPoint: false);
             if (analysis == null) {
                 return Task.FromResult<string>(null);
             }
@@ -2471,45 +2471,70 @@ namespace Microsoft.PythonTools.Intellisense {
             }
         }
 
-        private static ApplicableExpression GetApplicableExpression(AnalysisEntry entry, SnapshotPoint point) {
+        private static ApplicableExpression GetApplicableExpression(AnalysisEntry entry, SnapshotPoint point, bool checkLeftAndRightOfPoint) {
             if (entry != null) {
                 var snapshot = point.Snapshot;
                 var buffer = snapshot.TextBuffer;
-                var span = snapshot.CreateTrackingSpan(
-                    point.Position == snapshot.Length ?
-                        new Span(point.Position, 0) :
-                        new Span(point.Position, 1),
-                    SpanTrackingMode.EdgeInclusive
-                );
+                var spans = new List<ITrackingSpan>();
 
-                ReverseExpressionParser parser;
-                try {
-                    parser = new ReverseExpressionParser(snapshot, buffer, span);
-                } catch (ArgumentException) {
-                    return null;
+                if (checkLeftAndRightOfPoint) {
+                    // Covers the point after and in middle of identifier
+                    spans.Add(snapshot.CreateTrackingSpan(
+                        new Span(point.Position, 0),
+                        SpanTrackingMode.EdgeInclusive
+                    ));
+
+                    // Covers the point before and in middle of identifier
+                    if (point.Position < snapshot.Length) {
+                        spans.Add(snapshot.CreateTrackingSpan(
+                            new Span(point.Position, 1),
+                            SpanTrackingMode.EdgeInclusive
+                        ));
+                    }
+                } else {
+                    spans.Add(snapshot.CreateTrackingSpan(
+                        point.Position == snapshot.Length ?
+                            new Span(point.Position, 0) :
+                            new Span(point.Position, 1),
+                        SpanTrackingMode.EdgeInclusive
+                    ));
                 }
 
-                var exprRange = parser.GetExpressionRange(false);
-                if (exprRange != null) {
-                    string text = exprRange.Value.GetText();
+                SnapshotSpan? exprRange = null;
+                ReverseExpressionParser parser = null;
+                string exprText = null;
+                foreach (var span in spans) {
+                    try {
+                        parser = new ReverseExpressionParser(snapshot, buffer, span);
+                    } catch (ArgumentException) {
+                        continue;
+                    }
 
+                    exprRange = parser.GetExpressionRange(forCompletion: false);
+                    if (exprRange != null) {
+                        exprText = exprRange.Value.GetText();
+                        if (exprText.Length > 0) {
+                            break;
+                        }
+                    }
+                }
+
+                if (exprRange != null) {
                     var applicableTo = parser.Snapshot.CreateTrackingSpan(
                         exprRange.Value.Span,
                         SpanTrackingMode.EdgeExclusive
                     );
 
-                    if (text.Length > 0) {
-                        var loc = parser.Span.GetSpan(parser.Snapshot.Version);
-                        var lineNo = parser.Snapshot.GetLineNumberFromPosition(loc.Start);
+                    var loc = parser.Span.GetSpan(parser.Snapshot.Version);
+                    var lineNo = parser.Snapshot.GetLineNumberFromPosition(loc.Start);
 
-                        var location = TranslateIndex(loc.Start, parser.Snapshot, entry);
-                        return new ApplicableExpression(
-                            entry,
-                            text,
-                            applicableTo,
-                            location
-                        );
-                    }
+                    var location = TranslateIndex(loc.Start, parser.Snapshot, entry);
+                    return new ApplicableExpression(
+                        entry,
+                        exprText,
+                        applicableTo,
+                        location
+                    );
                 }
             }
 

--- a/Python/Tests/PythonToolsMockTests/CompletionTests.cs
+++ b/Python/Tests/PythonToolsMockTests/CompletionTests.cs
@@ -631,22 +631,17 @@ sys.
                 string code = @"
 class C:
     def fff(self): pass
-
+i=1+2
 C().fff";
 
-                //var emptyAnalysis = AnalyzeExpression(0, code);
-                //AreEqual(emptyAnalysis.Expression, "");
-
-                for (int i = -1; i >= -3; i--) {
-                    var analysis = AnalyzeExpression(vs, i, code);
-                    Assert.AreEqual("C().fff", analysis.Expression);
-                }
-
-                var classAnalysis = AnalyzeExpression(vs, -6, code);
-                Assert.AreEqual("C()", classAnalysis.Expression);
-
-                var defAnalysis = AnalyzeExpression(vs, code.IndexOf("def fff") + 4, code);
-                Assert.AreEqual("fff", defAnalysis.Expression);
+                AnalyzeAndValidateExpression(vs, code.IndexOf("fff("), 3, code, "fff");
+                AnalyzeAndValidateExpression(vs, code.IndexOf("self)"), 4, code, "self");
+                AnalyzeAndValidateExpression(vs, code.IndexOf("C:"), 1, code, "C");
+                AnalyzeAndValidateExpression(vs, code.IndexOf("1"), 1, code, "1");
+                AnalyzeAndValidateExpression(vs, code.IndexOf("2"), 1, code, "2");
+                AnalyzeAndValidateExpression(vs, code.IndexOf("C()."), 1, code, "C");
+                AnalyzeAndValidateExpression(vs, code.IndexOf("C().") + 2, 2, code, "C()");
+                AnalyzeAndValidateExpression(vs, code.IndexOf(".fff") + 2, 2, code, "C().fff");
             }
         }
 
@@ -1158,6 +1153,15 @@ async def g():
                 for (int j = 0; j < expected.Length; j++) {
                     Assert.AreEqual(expected[j], quickInfo[j]);
                 }
+            }
+        }
+
+        private static void AnalyzeAndValidateExpression(MockVs vs, int start, int charCount, string code, string expectedExpr) {
+            // We check charCount + 1 positions to ensure that go to definition
+            // works when caret is on the left AND right of identifier (and in between)
+            for (int i = 0; i <= charCount; i++) {
+                var defAnalysis = AnalyzeExpression(vs, start + i, code);
+                Assert.AreEqual(expectedExpr, defAnalysis.Expression);
             }
         }
 


### PR DESCRIPTION
Fix #2548 Can not goto definition

This final implementation is what I started with initially, then explored the idea of changing ReverseExpressionParser instead, but that wasn't working out.

The logic "check left and right of caret" is nicely expressed the way it is, so I feel alright about it.

I made it conditional because there are other use cases than go to definition that call `GetApplicableExpression` and I didn't want to potentially affect them.

There are no regressions in `CompletionTests` but they are as flaky as they were (run them enough times and they pass).

I did a bunch of manual testing around go to definition for identifiers around operators and such, as well as test editor/debugger tooltips and it all seems fine.
