### PR TITLE
Attempts to make WPF proxy-based tests less likely to time out.

### DIFF
--- a/Python/Product/VSInterpreters/PythonRegistrySearch.cs
+++ b/Python/Product/VSInterpreters/PythonRegistrySearch.cs
@@ -148,10 +148,16 @@ namespace Microsoft.PythonTools.Interpreter {
             }
             if (pythonCoreCompatibility && !string.IsNullOrEmpty(prefixPath)) {
                 if (string.IsNullOrEmpty(exePath)) {
-                    exePath = PathUtils.GetAbsoluteFilePath(prefixPath, CPythonInterpreterFactoryConstants.ConsoleExecutable);
+                    try {
+                        exePath = PathUtils.GetAbsoluteFilePath(prefixPath, CPythonInterpreterFactoryConstants.ConsoleExecutable);
+                    } catch (ArgumentException) {
+                    }
                 }
                 if (string.IsNullOrEmpty(exewPath)) {
-                    exewPath = PathUtils.GetAbsoluteFilePath(prefixPath, CPythonInterpreterFactoryConstants.WindowsExecutable);
+                    try {
+                        exewPath = PathUtils.GetAbsoluteFilePath(prefixPath, CPythonInterpreterFactoryConstants.WindowsExecutable);
+                    } catch (ArgumentException) {
+                    }
                 }
             }
 

--- a/Python/Tests/Analysis/AstAnalysisTests.cs
+++ b/Python/Tests/Analysis/AstAnalysisTests.cs
@@ -433,6 +433,12 @@ R_A3 = R_A1.r_A()");
             });
             var modules = ModulePath.GetModulesInLib(v.PrefixPath).ToList();
 
+            var skip = new HashSet<string>(skipModules);
+            skip.UnionWith(new[] {
+                "matplotlib.backends._backend_gdk",
+                "matplotlib.backends._backend_gtkagg",
+            });
+
             bool anySuccess = false;
             bool anyExtensionSuccess = false, anyExtensionSeen = false;
             bool anyParseError = false;
@@ -442,7 +448,7 @@ R_A3 = R_A1.r_A()");
 
                 var interp = analyzer.Analyzer.Interpreter;
                 foreach(var r in modules.AsParallel()
-                    .Where(m => !skipModules.Contains(m.ModuleName))
+                    .Where(m => !skip.Contains(m.ModuleName))
                     .Select(m => Tuple.Create(m, interp.ImportModule(m.ModuleName)))
                 ) {
                     var modName = r.Item1;


### PR DESCRIPTION
Attempts to make WPF proxy-based tests less likely to time out.
Protects against crashes due to corrupted registry keys
Skips some regularly failing modules when doing scrape test.