### PR TITLE
Fixes #2756 Escape to cancel completions also clears REPL text

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Intellisense/IntellisenseController.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/IntellisenseController.cs
@@ -876,7 +876,7 @@ namespace Microsoft.PythonTools.Intellisense {
         }
 
         internal void TriggerCompletionSession(bool completeWord, bool? commitByDefault = null) {
-            Dismiss();
+            DismissCompletionSession();
 
             var session = _services.CompletionBroker.TriggerCompletion(_textView);
 
@@ -948,10 +948,13 @@ namespace Microsoft.PythonTools.Intellisense {
             }
         }
 
-        private void Dismiss() {
-            if (_activeSession != null) {
-                _activeSession.Dismiss();
+        internal bool DismissCompletionSession() {
+            var session = Volatile.Read(ref _activeSession);
+            if (session != null && !session.IsDismissed) {
+                session.Dismiss();
+                return true;
             }
+            return false;
         }
 
         #region IOleCommandTarget Members

--- a/Python/Product/PythonTools/PythonTools/Repl/ReplEditFilter.cs
+++ b/Python/Product/PythonTools/PythonTools/Repl/ReplEditFilter.cs
@@ -22,6 +22,8 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
 using Microsoft.PythonTools.Infrastructure;
+using Microsoft.PythonTools.Intellisense;
+using Microsoft.PythonTools.Language;
 using Microsoft.PythonTools.Parsing;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.ComponentModelHost;
@@ -165,7 +167,7 @@ namespace Microsoft.PythonTools.Repl {
         }
 
         private int ExecWorker(ref Guid pguidCmdGroup, uint nCmdID, uint nCmdexecopt, IntPtr pvaIn, IntPtr pvaOut) {
-                var eval = _interactive.Evaluator;
+            var eval = _interactive.Evaluator;
             
             // preprocessing
             if (pguidCmdGroup == VSConstants.GUID_VSStandardCommandSet97) {
@@ -194,8 +196,14 @@ namespace Microsoft.PythonTools.Repl {
                         break;
                 }
             } else if (pguidCmdGroup == CommonConstants.Std2KCmdGroupGuid) {
-                //switch ((VSConstants.VSStd2KCmdID)nCmdID) {
-                //}
+                switch ((VSConstants.VSStd2KCmdID)nCmdID) {
+                    case VSConstants.VSStd2KCmdID.CANCEL:
+                        var controller = IntellisenseControllerProvider.GetController(_textView);
+                        if (controller != null && controller.DismissCompletionSession()) {
+                            return VSConstants.S_OK;
+                        }
+                        break;
+                }
             } else if (pguidCmdGroup == GuidList.guidPythonToolsCmdSet) {
                 switch (nCmdID) {
                     case PkgCmdIDList.comboIdReplScopes:


### PR DESCRIPTION
Fixes #2756 Escape to cancel completions also clears REPL text
Intercept Esc command and do not forward if we just closed a session.