### PR TITLE
Send to REPL when prior selection in REPL

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Editor/EditorExtensions.cs
+++ b/Python/Product/PythonTools/PythonTools/Editor/EditorExtensions.cs
@@ -87,6 +87,29 @@ namespace Microsoft.PythonTools.Editor.Core {
         }
 
         /// <summary>
+        /// Maps down to the buffer using positive point tracking and successor position affinity
+        /// </summary>
+        public static SnapshotPoint? MapDownToBuffer(this ITextView textView, int position, ITextBuffer buffer)
+        {
+            if (textView.BufferGraph == null) {
+                // Unit test case
+                if (position <= buffer.CurrentSnapshot.Length) {
+                    return new SnapshotPoint(buffer.CurrentSnapshot, position);
+                }
+                return null;
+            }
+            if (position <= textView.TextBuffer.CurrentSnapshot.Length) {
+                return textView.BufferGraph.MapDownToBuffer(
+                    new SnapshotPoint(textView.TextBuffer.CurrentSnapshot, position),
+                    PointTrackingMode.Positive,
+                    buffer,
+                    PositionAffinity.Successor
+                );
+            }
+            return null;
+        }
+
+        /// <summary>
         /// Adds comment characters (#) to the start of each line.  If there is a selection the comment is applied
         /// to each selected line.  Otherwise the comment is applied to the current line.
         /// </summary>

--- a/Python/Tests/ReplWindowUITests/ReplWindowSendUITests.cs
+++ b/Python/Tests/ReplWindowUITests/ReplWindowSendUITests.cs
@@ -141,6 +141,24 @@ namespace ReplWindowUITests {
            );
         }
 
+        /// <summary>
+        /// Submit when read-only text is selected in REPL.
+        /// </summary>
+        public void SendToInteractiveOutputSelected(PythonVisualStudioApp app) {
+            RunOne(app, "SelectOutput.py",
+                Input("print('first')").Complete.Outputs("first"),
+                SelectReplLine(1),
+                Input("print('second')").Complete.Outputs("second"),
+                SelectReplLine(2),
+                Input("if True:"),
+                Input("    x = 1"),
+                SelectReplLine(2),
+                Input("    y = 2"),
+                Input("print('hi')").Complete.Outputs("hi").SubmitsPrevious,
+                EndOfInput
+            );
+        }
+
         #endregion
 
         #region Helpers
@@ -214,6 +232,14 @@ namespace ReplWindowUITests {
             return new OutputStep(text);
         }
 
+        /// <summary>
+        /// Select a whole line in the REPL.
+        /// </summary>
+        private static SelectReplLineStep SelectReplLine(int line) {
+            return new SelectReplLineStep(line);
+        }
+
+        /// <summary>
         /// Checks that we've skipped blank lines after executing a previous input.
         /// </summary>
         private static SendToStep Skipped(int targetLine) {
@@ -491,6 +517,23 @@ namespace ReplWindowUITests {
                 Assert.AreEqual(_targetLine, curLine.LineNumber + 1);
 
                 state.CheckOutput();
+            }
+        }
+
+        class SelectReplLineStep : SendToStep {
+            private readonly int _targetLine;
+
+            public SelectReplLineStep(int targetLine) {
+                _targetLine = targetLine;
+            }
+
+            public override void Execute(StepState state) {
+                state.Editor.Invoke(() => {
+                    var view = state.Interactive.TextView;
+                    var line = view.TextSnapshot.GetLineFromLineNumber(_targetLine - 1);
+                    var span = new SnapshotSpan(line.Start, line.End);
+                    view.Selection.Select(span, false);
+                });
             }
         }
 

--- a/Python/Tests/ReplWindowUITestsRunner/ReplWindowSendUITests.cs
+++ b/Python/Tests/ReplWindowUITestsRunner/ReplWindowSendUITests.cs
@@ -68,5 +68,11 @@ namespace ReplWindowUITestsRunner {
         public void SendToInteractiveSelectionNoWait() {
             _vs.RunTest(nameof(ReplWindowUITests.ReplWindowSendUITests.SendToInteractiveSelectionNoWait));
         }
+
+        [TestMethod, Priority(2)]
+        [TestCategory("Installed")]
+        public void SendToInteractiveOutputSelected() {
+            _vs.RunTest(nameof(ReplWindowUITests.ReplWindowSendUITests.SendToInteractiveOutputSelected));
+        }
     }
 }

--- a/Python/Tests/TestData/SendToInteractive/SelectOutput.py
+++ b/Python/Tests/TestData/SendToInteractive/SelectOutput.py
@@ -1,0 +1,6 @@
+print('first')
+print('second')
+if True:
+    x = 1
+    y = 2
+print('hi')

--- a/Python/Tests/TestData/SendToInteractive/SendToInteractive.pyproj
+++ b/Python/Tests/TestData/SendToInteractive/SendToInteractive.pyproj
@@ -28,6 +28,7 @@
     <None Include="Program.py" />
     <None Include="Delayed.py" />
     <None Include="Cells.py" />
+    <None Include="SelectOutput.py" />
   </ItemGroup>
   <ItemGroup>
     <InterpreterReference Include="Global|PythonCore|3.5-32" />


### PR DESCRIPTION
Fix #2454 

Port back some improvements that were made in RTVS so submission works even when there's selected read-only text.