### PR TITLE
Fix timing issue with creation of virtual environment

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Project/AddVirtualEnvironment.xaml.cs
+++ b/Python/Product/PythonTools/PythonTools/Project/AddVirtualEnvironment.xaml.cs
@@ -124,6 +124,8 @@ namespace Microsoft.PythonTools.Project {
         }
 
         private async void Save_Executed(object sender, ExecutedRoutedEventArgs e) {
+            await _view.WaitForReady();
+
             Debug.Assert(_currentOperation == null);
             _currentOperation = _view.Create().HandleAllExceptions(_site, GetType());
             

--- a/Python/Product/PythonTools/PythonTools/Project/AddVirtualEnvironmentView.cs
+++ b/Python/Product/PythonTools/PythonTools/Project/AddVirtualEnvironmentView.cs
@@ -520,8 +520,6 @@ namespace Microsoft.PythonTools.Project {
             }
         }
 
-
-
         private object SafeGetValue(DependencyProperty property) {
             if (Dispatcher.CheckAccess()) {
                 return GetValue(property);


### PR DESCRIPTION
Fix #526 

Once you know how to repro, it was pretty easy to trigger the bug as it may take up to 2 secs for the detection of venv/virtualenv to finish. That's enough time to change the base interpreter combo box selection from Python 2 to Python 3, and click Create.