### PR TITLE
A range of threading and concurrency fixes

### DIFF
--- a/Common/Tests/MockVsTests/MockVs.cs
+++ b/Common/Tests/MockVsTests/MockVs.cs
@@ -27,6 +27,7 @@ using System.Reflection;
 using System.Runtime.ExceptionServices;
 using System.Runtime.InteropServices;
 using System.Threading;
+using System.Threading.Tasks;
 using System.Windows.Input;
 using EnvDTE;
 using Microsoft.VisualStudio;
@@ -50,31 +51,31 @@ namespace Microsoft.VisualStudioTools.MockVsTests {
         public CompositionContainer Container;
         private IContentTypeRegistryService _contentTypeRegistry;
         private Dictionary<Guid, Package> _packages = new Dictionary<Guid, Package>();
-        internal readonly MockVsTextManager TextManager;
+        internal MockVsTextManager TextManager;
         internal readonly MockActivityLog ActivityLog = new MockActivityLog();
         internal readonly MockSettingsManager SettingsManager = new MockSettingsManager();
         internal readonly MockLocalRegistry LocalRegistry = new MockLocalRegistry();
         internal readonly MockVsDebugger Debugger = new MockVsDebugger();
         internal readonly MockVsTrackProjectDocuments TrackDocs = new MockVsTrackProjectDocuments();
         internal readonly MockVsShell Shell = new MockVsShell();
-        internal readonly MockVsUIShell UIShell;
+        internal MockVsUIShell UIShell;
         public readonly MockVsSolution Solution = new MockVsSolution();
-        private readonly MockVsServiceProvider _serviceProvider;
+        private MockVsServiceProvider _serviceProvider;
         private readonly List<MockVsTextView> _views = new List<MockVsTextView>();
         private readonly MockVsProfferCommands _proferredCommands = new MockVsProfferCommands();
         private readonly MockOleComponentManager _compManager = new MockOleComponentManager();
         private readonly MockOutputWindow _outputWindow = new MockOutputWindow();
         private readonly MockVsBuildManagerAccessor _buildManager = new MockVsBuildManagerAccessor();
         private readonly MockUIHierWinClipboardHelper _hierClipHelper = new MockUIHierWinClipboardHelper();
-        internal readonly MockVsMonitorSelection _monSel;
-        internal readonly uint _monSelCookie;
-        internal readonly MockVsUIHierarchyWindow _uiHierarchy;
+        internal MockVsMonitorSelection _monSel;
+        internal uint _monSelCookie;
+        internal MockVsUIHierarchyWindow _uiHierarchy;
         private readonly MockVsQueryEditQuerySave _queryEditSave = new MockVsQueryEditQuerySave();
-        private readonly MockVsRunningDocumentTable _rdt;
+        private MockVsRunningDocumentTable _rdt;
         private readonly MockVsUIShellOpenDocument _shellOpenDoc = new MockVsUIShellOpenDocument();
         private readonly MockVsSolutionBuildManager _slnBuildMgr = new MockVsSolutionBuildManager();
         private readonly MockVsExtensibility _extensibility = new MockVsExtensibility();
-        private readonly MockDTE _dte;
+        private MockDTE _dte;
         private bool _shutdown;
         private AutoResetEvent _uiEvent = new AutoResetEvent(false);
         private readonly List<Action> _uiEvents = new List<Action>();
@@ -93,50 +94,6 @@ namespace Microsoft.VisualStudioTools.MockVsTests {
         private readonly Thread UIThread;
 
         public MockVs() {
-            TextManager = new MockVsTextManager(this);
-            Container = CreateCompositionContainer();
-            var serviceProvider = _serviceProvider = Container.GetExportedValue<MockVsServiceProvider>();
-            UIShell = new MockVsUIShell(this);
-            _monSel = new MockVsMonitorSelection(this);
-            _uiHierarchy = new MockVsUIHierarchyWindow(this);
-            _rdt = new MockVsRunningDocumentTable(this);
-            _dte = new MockDTE(this);
-            _serviceProvider.AddService(typeof(SVsTextManager), TextManager);
-            _serviceProvider.AddService(typeof(SVsActivityLog), ActivityLog);
-            _serviceProvider.AddService(typeof(SVsSettingsManager), SettingsManager);
-            _serviceProvider.AddService(typeof(SLocalRegistry), LocalRegistry);
-            _serviceProvider.AddService(typeof(SComponentModel), this);
-            _serviceProvider.AddService(typeof(IVsDebugger), Debugger);
-            _serviceProvider.AddService(typeof(SVsSolution), Solution);
-            _serviceProvider.AddService(typeof(SVsRegisterProjectTypes), Solution);
-            _serviceProvider.AddService(typeof(SVsCreateAggregateProject), Solution);
-            _serviceProvider.AddService(typeof(SVsTrackProjectDocuments), TrackDocs);
-            _serviceProvider.AddService(typeof(SVsShell), Shell);
-            _serviceProvider.AddService(typeof(SOleComponentManager), _compManager);
-            _serviceProvider.AddService(typeof(SVsProfferCommands), _proferredCommands);
-            _serviceProvider.AddService(typeof(SVsOutputWindow), _outputWindow);
-            _serviceProvider.AddService(typeof(SVsBuildManagerAccessor), _buildManager);
-            _serviceProvider.AddService(typeof(SVsUIHierWinClipboardHelper), _hierClipHelper);
-            _serviceProvider.AddService(typeof(IVsUIShell), UIShell);
-            _serviceProvider.AddService(typeof(IVsMonitorSelection), _monSel);
-            _serviceProvider.AddService(typeof(SVsQueryEditQuerySave), _queryEditSave);
-            _serviceProvider.AddService(typeof(SVsRunningDocumentTable), _rdt);
-            _serviceProvider.AddService(typeof(SVsUIShellOpenDocument), _shellOpenDoc);
-            _serviceProvider.AddService(typeof(SVsSolutionBuildManager), _slnBuildMgr);
-            _serviceProvider.AddService(typeof(EnvDTE.IVsExtensibility), _extensibility);
-            _serviceProvider.AddService(typeof(EnvDTE.DTE), _dte);
-
-            Shell.SetProperty((int)__VSSPROPID4.VSSPROPID_ShellInitialized, true);
-
-            UIShell.AddToolWindow(new Guid(ToolWindowGuids80.SolutionExplorer), new MockToolWindow(_uiHierarchy));
-
-            ErrorHandler.ThrowOnFailure(
-                _monSel.AdviseSelectionEvents(
-                    new SelectionEvents(this),
-                    out _monSelCookie
-                )
-            );
-
 #if DEV15_OR_LATER
             // If we are not in Visual Studio, we need to set MSBUILD_EXE_PATH
             // to use any project support.
@@ -166,6 +123,7 @@ namespace Microsoft.VisualStudioTools.MockVsTests {
 
             using (var e = new AutoResetEvent(false)) {
                 UIThread = new Thread(UIThreadWorker);
+                UIThread.SetApartmentState(ApartmentState.STA);
                 UIThread.Name = "Mock UI Thread";
                 UIThread.Start((object)e);
                 // Wait for UI thread to start before returning. This ensures that
@@ -187,17 +145,17 @@ namespace Microsoft.VisualStudioTools.MockVsTests {
                 package.Dispose();
             }
 
-            _shutdown = true;
+            _monSel.UnadviseSelectionEvents(_monSelCookie);
             Shell.SetProperty((int)__VSSPROPID6.VSSPROPID_ShutdownStarted, true);
+            _serviceProvider.Dispose();
+            Container.Dispose();
+            _shutdown = true;
             _uiEvent.Set();
             if (!UIThread.Join(TimeSpan.FromSeconds(30))) {
                 Console.WriteLine("Failed to wait for UI thread to terminate");
             }
             ThrowPendingException();
-            _monSel.UnadviseSelectionEvents(_monSelCookie);
             AssertListener.ThrowUnhandled();
-            _serviceProvider.Dispose();
-            Container.Dispose();
         }
 
 
@@ -243,9 +201,55 @@ namespace Microsoft.VisualStudioTools.MockVsTests {
         }
 
         private void UIThreadWorker(object evt) {
+            Console.WriteLine($"Started UIThreadWorker on {Thread.CurrentThread.ManagedThreadId}");
             try {
                 try {
                     SynchronizationContext.SetSynchronizationContext(new MockSyncContext(this));
+
+                    TextManager = new MockVsTextManager(this);
+                    Container = CreateCompositionContainer();
+                    var serviceProvider = _serviceProvider = Container.GetExportedValue<MockVsServiceProvider>();
+                    UIShell = new MockVsUIShell(this);
+                    _monSel = new MockVsMonitorSelection(this);
+                    _uiHierarchy = new MockVsUIHierarchyWindow(this);
+                    _rdt = new MockVsRunningDocumentTable(this);
+                    _dte = new MockDTE(this);
+                    _serviceProvider.AddService(typeof(SVsTextManager), TextManager);
+                    _serviceProvider.AddService(typeof(SVsActivityLog), ActivityLog);
+                    _serviceProvider.AddService(typeof(SVsSettingsManager), SettingsManager);
+                    _serviceProvider.AddService(typeof(SLocalRegistry), LocalRegistry);
+                    _serviceProvider.AddService(typeof(SComponentModel), this);
+                    _serviceProvider.AddService(typeof(IVsDebugger), Debugger);
+                    _serviceProvider.AddService(typeof(SVsSolution), Solution);
+                    _serviceProvider.AddService(typeof(SVsRegisterProjectTypes), Solution);
+                    _serviceProvider.AddService(typeof(SVsCreateAggregateProject), Solution);
+                    _serviceProvider.AddService(typeof(SVsTrackProjectDocuments), TrackDocs);
+                    _serviceProvider.AddService(typeof(SVsShell), Shell);
+                    _serviceProvider.AddService(typeof(SOleComponentManager), _compManager);
+                    _serviceProvider.AddService(typeof(SVsProfferCommands), _proferredCommands);
+                    _serviceProvider.AddService(typeof(SVsOutputWindow), _outputWindow);
+                    _serviceProvider.AddService(typeof(SVsBuildManagerAccessor), _buildManager);
+                    _serviceProvider.AddService(typeof(SVsUIHierWinClipboardHelper), _hierClipHelper);
+                    _serviceProvider.AddService(typeof(IVsUIShell), UIShell);
+                    _serviceProvider.AddService(typeof(IVsMonitorSelection), _monSel);
+                    _serviceProvider.AddService(typeof(SVsQueryEditQuerySave), _queryEditSave);
+                    _serviceProvider.AddService(typeof(SVsRunningDocumentTable), _rdt);
+                    _serviceProvider.AddService(typeof(SVsUIShellOpenDocument), _shellOpenDoc);
+                    _serviceProvider.AddService(typeof(SVsSolutionBuildManager), _slnBuildMgr);
+                    _serviceProvider.AddService(typeof(EnvDTE.IVsExtensibility), _extensibility);
+                    _serviceProvider.AddService(typeof(EnvDTE.DTE), _dte);
+
+                    Shell.SetProperty((int)__VSSPROPID4.VSSPROPID_ShellInitialized, true);
+
+                    UIShell.AddToolWindow(new Guid(ToolWindowGuids80.SolutionExplorer), new MockToolWindow(_uiHierarchy));
+
+                    ErrorHandler.ThrowOnFailure(
+                        _monSel.AdviseSelectionEvents(
+                            new SelectionEvents(this),
+                            out _monSelCookie
+                        )
+                    );
+
                     foreach (var package in Container.GetExportedValues<IMockPackage>()) {
                         _loadedPackages.Add(package);
                         package.Initialize();
@@ -316,6 +320,12 @@ namespace Microsoft.VisualStudioTools.MockVsTests {
                 action();
                 return 0;
             });
+        }
+
+        public T InvokeTask<T>(Func<Task<T>> taskCreator) {
+            var t = Invoke(taskCreator);
+            t.Wait();
+            return t.Result;
         }
 
         public T Invoke<T>(Func<T> func) {

--- a/Common/Tests/MockVsTests/MockVsTests.csproj
+++ b/Common/Tests/MockVsTests/MockVsTests.csproj
@@ -58,6 +58,9 @@
     <Reference Include="Microsoft.VisualStudio.Text.UI.Wpf, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.VisualStudio.TextManager.Interop, Version=7.1.40304.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
     <Reference Include="Microsoft.VisualStudio.TextManager.Interop.8.0, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+    <Reference Include="Microsoft.VisualStudio.Threading, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="System" />

--- a/Python/Product/Analysis/Values/MemberReferences.cs
+++ b/Python/Product/Analysis/Values/MemberReferences.cs
@@ -162,8 +162,9 @@ namespace Microsoft.PythonTools.Analysis.Values {
 
         public IEnumerable<EncodedLocation> Definitions {
             get {
-
-                yield return new EncodedLocation(_location, null);
+                if (_location != null) {
+                    yield return new EncodedLocation(_location, null);
+                }
             }
         }
 

--- a/Python/Product/Analyzer/Intellisense/AnalysisProtocol.cs
+++ b/Python/Product/Analyzer/Intellisense/AnalysisProtocol.cs
@@ -282,7 +282,8 @@ namespace Microsoft.PythonTools.Intellisense {
         public sealed class FormatCodeResponse : Response {
             public ChangeInfo[] changes;
 
-            public int startIndex, endIndex, version;
+            public int startIndex, endIndex;
+            public int version = -1;
         }
 
         public struct CodeSpan {
@@ -386,7 +387,7 @@ namespace Microsoft.PythonTools.Intellisense {
 
         public sealed class AddImportResponse : Response {
             public ChangeInfo[] changes;
-            public int version;
+            public int version = -1;
         }
 
         public sealed class IsMissingImportRequest : Request<IsMissingImportResponse> {
@@ -455,7 +456,7 @@ namespace Microsoft.PythonTools.Intellisense {
         }
 
         public sealed class UnresolvedImportsResponse : Response {
-            public int version;
+            public int version = -1;
             public UnresolvedImport[] unresolved;
         }
 
@@ -543,7 +544,7 @@ namespace Microsoft.PythonTools.Intellisense {
 
         public sealed class RemoveImportsResponse : Response {
             public ChangeInfo[] changes;
-            public int version;
+            public int version = -1;
         }
 
         public sealed class ExtractMethodRequest : Request<ExtractMethodResponse> {
@@ -865,7 +866,7 @@ namespace Microsoft.PythonTools.Intellisense {
         }
 
         public sealed class OutliningRegionsResponse : Response {
-            public int version;
+            public int version = -1;
             public OutliningTag[] tags;
         }
 

--- a/Python/Product/Analyzer/Intellisense/ProjectEntryMap.cs
+++ b/Python/Product/Analyzer/Intellisense/ProjectEntryMap.cs
@@ -98,8 +98,24 @@ namespace Microsoft.PythonTools.Intellisense {
             }
         }
 
+        public IProjectEntry Get(int itemId) {
+            var r = this[itemId];
+            if (r == null) {
+                throw new ProjectEntryNotFoundException(itemId);
+            }
+            return r;
+        }
+
+        public T Get<T>(int itemId) where T : class, IProjectEntry {
+            return Get(itemId) as T;
+        }
+
         public bool TryGetValue(string path, out IProjectEntry item) {
             return _projectFiles.TryGetValue(path, out item);
         }
+    }
+
+    sealed class ProjectEntryNotFoundException : KeyNotFoundException {
+        public ProjectEntryNotFoundException(int itemId) : base($"Entry Id {itemId}") { }
     }
 }

--- a/Python/Product/Ipc.Json/Connection.cs
+++ b/Python/Product/Ipc.Json/Connection.cs
@@ -361,6 +361,7 @@ namespace Microsoft.PythonTools.Ipc.Json {
             } catch (Exception e) {
                 success = false;
                 message = e.ToString();
+                Trace.TraceError(message);
                 await SendResponseAsync(seq.Value, command, success, message, null, CancellationToken.None).ConfigureAwait(false);
             }
         }

--- a/Python/Product/PythonTools/PythonTools/Intellisense/BufferParser.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/BufferParser.cs
@@ -286,10 +286,15 @@ namespace Microsoft.PythonTools.Intellisense {
                 return;
             }
 
-            analyzer._analysisComplete = false;
-            Interlocked.Increment(ref analyzer._parsePending);
 
             foreach (var update in updates) {
+                if (update.Item1 < 0) {
+                    continue;
+                }
+
+                analyzer._analysisComplete = false;
+                Interlocked.Increment(ref analyzer._parsePending);
+
                 var res = await analyzer.SendRequestAsync(
                     new AP.FileUpdateRequest() {
                         fileId = update.Item1,

--- a/Python/Product/PythonTools/PythonTools/Intellisense/CompletionAnalysis.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/CompletionAnalysis.cs
@@ -104,7 +104,8 @@ namespace Microsoft.PythonTools.Intellisense {
         }
 
         internal AnalysisEntry GetAnalysisEntry() {
-            var bi = _services.GetBufferInfo(TextBuffer);
+            var bi = PythonTextBufferInfo.TryGetForBuffer(TextBuffer);
+            Debug.Assert(bi != null, "Getting completions from uninitialized buffer " + TextBuffer.ToString());
             Debug.Assert(bi?.AnalysisEntry != null, "Failed to get project entry for buffer " + TextBuffer.ToString());
             return bi?.AnalysisEntry;
         }

--- a/Python/Product/PythonTools/PythonTools/Intellisense/ProjectAnalyzer.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/ProjectAnalyzer.cs
@@ -97,7 +97,7 @@ namespace Microsoft.PythonTools.Intellisense {
         // Used by tests to avoid creating TaskProvider objects
         internal static bool SuppressTaskProvider = false;
 
-        internal static async Task<VsProjectAnalyzer> CreateDefault(
+        internal static async Task<VsProjectAnalyzer> CreateDefaultAsync(
             PythonEditorServices services,
             IPythonInterpreterFactory factory,
             bool inProcess = false
@@ -107,7 +107,7 @@ namespace Microsoft.PythonTools.Intellisense {
             return analyzer;
         }
 
-        internal static async Task<VsProjectAnalyzer> CreateForProject(
+        internal static async Task<VsProjectAnalyzer> CreateForProjectAsync(
             PythonEditorServices services,
             IPythonInterpreterFactory factory,
             MSBuild.Project project,
@@ -118,7 +118,7 @@ namespace Microsoft.PythonTools.Intellisense {
             return analyzer;
         }
 
-        internal static async Task<VsProjectAnalyzer> CreateForInteractive(
+        internal static async Task<VsProjectAnalyzer> CreateForInteractiveAsync(
             PythonEditorServices services,
             IPythonInterpreterFactory factory,
             string displayName,
@@ -130,7 +130,7 @@ namespace Microsoft.PythonTools.Intellisense {
             return analyzer;
         }
 
-        internal static async Task<VsProjectAnalyzer> CreateForTests(
+        internal static async Task<VsProjectAnalyzer> CreateForTestsAsync(
             PythonEditorServices services,
             IPythonInterpreterFactory factory,
             bool inProcess = true

--- a/Python/Product/PythonTools/PythonTools/Intellisense/ProjectAnalyzer.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/ProjectAnalyzer.cs
@@ -51,7 +51,7 @@ namespace Microsoft.PythonTools.Intellisense {
     using AP = AnalysisProtocol;
 
     public sealed class VsProjectAnalyzer : ProjectAnalyzer, IDisposable {
-        internal readonly AnalysisProcessInfo _analysisProcess;
+        private AnalysisProcessInfo _analysisProcess;
         private Connection _conn;
 
         // Enables analyzers to be put directly into ITextBuffer.Properties for the purposes of testing
@@ -92,19 +92,58 @@ namespace Microsoft.PythonTools.Intellisense {
 
         private readonly IPythonToolsLogger _logger;
 
-        internal Task ReloadTask;
         internal int _parsePending;
 
         // Used by tests to avoid creating TaskProvider objects
         internal static bool SuppressTaskProvider = false;
 
-        internal VsProjectAnalyzer(
+        internal static async Task<VsProjectAnalyzer> CreateDefault(
             PythonEditorServices services,
             IPythonInterpreterFactory factory,
-            bool implicitProject = true,
-            MSBuild.Project projectFile = null,
-            string comment = null,
-            bool outOfProcAnalyzer = true
+            bool inProcess = false
+        ) {
+            var analyzer = new VsProjectAnalyzer(services, factory, true);
+            await analyzer.InitializeAsync(!inProcess, null, null);
+            return analyzer;
+        }
+
+        internal static async Task<VsProjectAnalyzer> CreateForProject(
+            PythonEditorServices services,
+            IPythonInterpreterFactory factory,
+            MSBuild.Project project,
+            bool inProcess = false
+        ) {
+            var analyzer = new VsProjectAnalyzer(services, factory, false);
+            await analyzer.InitializeAsync(!inProcess, project.FullPath, project);
+            return analyzer;
+        }
+
+        internal static async Task<VsProjectAnalyzer> CreateForInteractive(
+            PythonEditorServices services,
+            IPythonInterpreterFactory factory,
+            string displayName,
+            MSBuild.Project project = null,
+            bool inProcess = false
+        ) {
+            var analyzer = new VsProjectAnalyzer(services, factory, true);
+            await analyzer.InitializeAsync(!inProcess, $"{displayName} Interactive", project);
+            return analyzer;
+        }
+
+        internal static async Task<VsProjectAnalyzer> CreateForTests(
+            PythonEditorServices services,
+            IPythonInterpreterFactory factory,
+            bool inProcess = true
+        ) {
+            var analyzer = new VsProjectAnalyzer(services, factory, true);
+            await analyzer.InitializeAsync(!inProcess, "PTVS_TEST", null);
+            return analyzer;
+        }
+
+        private VsProjectAnalyzer(
+            PythonEditorServices services,
+            IPythonInterpreterFactory factory,
+            bool implicitProject
         ) {
             _services = services ?? throw new ArgumentNullException(nameof(services));
             _implicitProject = implicitProject;
@@ -122,22 +161,20 @@ namespace Microsoft.PythonTools.Intellisense {
             if (_services.CommentTaskProvider != null) {
                 _services.CommentTaskProvider.TokensChanged += CommentTaskTokensChanged;
             }
+        }
 
-            if (outOfProcAnalyzer) {
-                _conn = StartSubprocessConnection(
-                    comment.IfNullOrEmpty(projectFile?.FullPath).IfNullOrEmpty(implicitProject ? "Global Analysis" : "Misc. Non Project Analysis"),
-                    out _analysisProcess
-                );
+        private string DefaultComment => _implicitProject ? "Global Analysis" : "Misc. Non Project Analysis";
+
+        private async Task InitializeAsync(bool outOfProc, string comment, MSBuild.Project projectFile) {
+            if (outOfProc) {
+                _conn = StartSubprocessConnection(comment.IfNullOrEmpty(DefaultComment), out _analysisProcess);
             } else {
-                _conn = StartThreadConnection(
-                    comment.IfNullOrEmpty(projectFile?.FullPath).IfNullOrEmpty(implicitProject ? "Global Analysis" : "Misc. Non Project Analysis"),
-                    out _analysisProcess
-                );
+                _conn = StartThreadConnection(comment.IfNullOrEmpty(DefaultComment), out _analysisProcess);
             }
+
+            Task.Run(() => _conn.ProcessMessages()).DoNotWait();
+
             _userCount = 1;
-
-            Task.Run(() => _conn.ProcessMessages());
-
             // load the interpreter factories available inside of VS into the remote process
             var providers = new HashSet<string>(
                 _services.ComponentModel.GetExtensions<IPythonInterpreterFactoryProvider>()
@@ -146,9 +183,8 @@ namespace Microsoft.PythonTools.Intellisense {
             );
             providers.Add(typeof(IInterpreterOptionsService).Assembly.Location);
 
-
             var initialize = new AP.InitializeRequest() {
-                interpreterId = factory.Configuration.Id,
+                interpreterId = _interpreterFactory.Configuration.Id,
                 mefExtensions = providers.ToArray()
             };
 
@@ -174,24 +210,25 @@ namespace Microsoft.PythonTools.Intellisense {
                 ).ToArray();
             }
 
-            SendRequestAsync(initialize).ContinueWith(
-                task => {
-                    var result = task.Result;
-                    if (result == null) {
-                        _conn.Dispose();
-                        _conn = null;
-                    } else if (!String.IsNullOrWhiteSpace(result.error)) {
-                        Debug.Fail("Analyzer initialization failed with " + result.error);
-                        _logger?.LogEvent(Logging.PythonLogEvent.AnalysisOperationFailed, "Initialization: " + result.error);
-                        _conn.Dispose();
-                        _conn = null;
-                    } else {
-                        SendEvent(
-                            new AP.OptionsChangedEvent() {
-                                indentation_inconsistency_severity = _services.Python?.GeneralOptions.IndentationInconsistencySeverity ?? Severity.Ignore
-                            }
-                        );
-                    }
+            var result = await SendRequestAsync(initialize);
+            if (result == null || !string.IsNullOrWhiteSpace(result.error)) {
+                Debug.Fail("Analyzer initialization failed with " + result?.error ?? "(null)");
+                if (result != null) {
+                    _logger?.LogEvent(PythonLogEvent.AnalysisOperationFailed, "Initialization: " + result.error);
+                } else {
+                    _logger?.LogEvent(PythonLogEvent.AnalysisOperationFailed, "Initialization");
+                }
+                _analysisProcess.Kill();
+                _analysisProcess.Dispose();
+                _analysisProcess = null;
+                _conn.Dispose();
+                _conn = null;
+                throw new InvalidOperationException("Failed to initialize analyzer");
+            } 
+
+            SendEvent(
+                new AP.OptionsChangedEvent() {
+                    indentation_inconsistency_severity = _services.Python?.GeneralOptions.IndentationInconsistencySeverity ?? Severity.Ignore
                 }
             );
 
@@ -207,6 +244,8 @@ namespace Microsoft.PythonTools.Intellisense {
         }
 
         internal IServiceProvider Site => _services.Site;
+
+        public bool IsActive => _conn != null;
 
         #region Asynchronous request handling
         /// <summary>
@@ -2509,11 +2548,17 @@ namespace Microsoft.PythonTools.Intellisense {
                     }
 
                     exprRange = parser.GetExpressionRange(forCompletion: false);
-                    if (exprRange != null) {
-                        exprText = exprRange.Value.GetText();
-                        if (exprText.Length > 0) {
-                            break;
-                        }
+                    if (!exprRange.HasValue) {
+                        continue;
+                    }
+
+                    if (exprRange.Value.End.Position < point.Position) {
+                        continue;
+                    }
+
+                    exprText = exprRange.Value.GetText();
+                    if (exprText.Length > 0) {
+                        break;
                     }
                 }
 

--- a/Python/Product/PythonTools/PythonTools/Project/PythonProjectNode.cs
+++ b/Python/Product/PythonTools/PythonTools/Project/PythonProjectNode.cs
@@ -1131,7 +1131,7 @@ namespace Microsoft.PythonTools.Project {
                 }
             }
 
-            var res = await VsProjectAnalyzer.CreateForProject(
+            var res = await VsProjectAnalyzer.CreateForProjectAsync(
                 model.GetService<PythonEditorServices>(),
                 factory,
                 BuildProject,

--- a/Python/Product/PythonTools/PythonTools/Project/PythonProjectNode.cs
+++ b/Python/Product/PythonTools/PythonTools/Project/PythonProjectNode.cs
@@ -1109,7 +1109,7 @@ namespace Microsoft.PythonTools.Project {
                 }
                 return service.DefaultAnalyzer;
             } else if (_analyzer == null) {
-                _analyzer = CreateAnalyzer();
+                _analyzer = Site.GetUIThread().InvokeTaskSync(CreateAnalyzerAsync, CancellationToken.None);
             }
             return _analyzer;
         }
@@ -1118,7 +1118,7 @@ namespace Microsoft.PythonTools.Project {
             return _analyzer;
         }
 
-        private VsProjectAnalyzer CreateAnalyzer() {
+        private async Task<VsProjectAnalyzer> CreateAnalyzerAsync() {
             var model = Site.GetComponentModel();
             var interpreterService = model.GetService<IInterpreterRegistryService>();
             var factory = GetInterpreterFactory();
@@ -1131,12 +1131,11 @@ namespace Microsoft.PythonTools.Project {
                 }
             }
 
-            var res = new VsProjectAnalyzer(
+            var res = await VsProjectAnalyzer.CreateForProject(
                 model.GetService<PythonEditorServices>(),
                 factory,
-                false,
                 BuildProject,
-                outOfProcAnalyzer: !inProc
+                inProcess: inProc
             );
             res.AbnormalAnalysisExit += AnalysisProcessExited;
             res.AnalyzerNeedsRestart += OnActiveInterpreterChanged;
@@ -1362,7 +1361,7 @@ namespace Microsoft.PythonTools.Project {
                 if (_analyzer != null) {
                     UnHookErrorsAndWarnings(_analyzer);
                 }
-                var analyzer = CreateAnalyzer();
+                var analyzer = await CreateAnalyzerAsync();
                 Debug.Assert(analyzer != null);
 
                 ProjectAnalyzerChanging?.Invoke(this, new AnalyzerChangingEventArgs(_analyzer, analyzer));

--- a/Python/Product/PythonTools/PythonTools/Repl/PythonCommonInteractiveEvaluator.cs
+++ b/Python/Product/PythonTools/PythonTools/Repl/PythonCommonInteractiveEvaluator.cs
@@ -158,7 +158,7 @@ namespace Microsoft.PythonTools.Repl {
                     _analyzer = _serviceProvider.GetPythonToolsService().DefaultAnalyzer;
                 } else {
                     var projectFile = GetAssociatedPythonProject(config.Interpreter)?.BuildProject;
-                    _analyzer = _serviceProvider.GetUIThread().InvokeTaskSync(() => VsProjectAnalyzer.CreateForInteractive(
+                    _analyzer = _serviceProvider.GetUIThread().InvokeTaskSync(() => VsProjectAnalyzer.CreateForInteractiveAsync(
                         _serviceProvider.GetComponentModel().GetService<PythonEditorServices>(),
                         factory,
                         DisplayName.IfNullOrEmpty("Unnamed"),

--- a/Python/Product/PythonTools/PythonTools/Repl/PythonCommonInteractiveEvaluator.cs
+++ b/Python/Product/PythonTools/PythonTools/Repl/PythonCommonInteractiveEvaluator.cs
@@ -21,6 +21,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.PythonTools.Editor;
 using Microsoft.PythonTools.Infrastructure;
@@ -157,12 +158,12 @@ namespace Microsoft.PythonTools.Repl {
                     _analyzer = _serviceProvider.GetPythonToolsService().DefaultAnalyzer;
                 } else {
                     var projectFile = GetAssociatedPythonProject(config.Interpreter)?.BuildProject;
-                    _analyzer = new VsProjectAnalyzer(
+                    _analyzer = _serviceProvider.GetUIThread().InvokeTaskSync(() => VsProjectAnalyzer.CreateForInteractive(
                         _serviceProvider.GetComponentModel().GetService<PythonEditorServices>(),
                         factory,
-                        projectFile: projectFile,
-                        comment: "{0} Interactive".FormatInvariant(DisplayName.IfNullOrEmpty("Unnamed"))
-                    );
+                        DisplayName.IfNullOrEmpty("Unnamed"),
+                        projectFile
+                    ), CancellationToken.None);
                 }
                 return _analyzer;
             }

--- a/Python/Product/PythonTools/PythonToolsService.cs
+++ b/Python/Product/PythonTools/PythonToolsService.cs
@@ -216,12 +216,12 @@ namespace Microsoft.PythonTools {
 
             // may not available in some test cases
             if (interpreters == null) {
-                return VsProjectAnalyzer.CreateDefault(EditorServices, InterpreterFactoryCreator.CreateAnalysisInterpreterFactory(new Version(2, 7)));
+                return VsProjectAnalyzer.CreateDefaultAsync(EditorServices, InterpreterFactoryCreator.CreateAnalysisInterpreterFactory(new Version(2, 7)));
             }
 
             var defaultFactory = interpreters.DefaultInterpreter;
             EnsureCompletionDb(defaultFactory);
-            return VsProjectAnalyzer.CreateDefault(EditorServices, defaultFactory);
+            return VsProjectAnalyzer.CreateDefaultAsync(EditorServices, defaultFactory);
         }
 
         internal PythonToolsLogger Logger => _logger;

--- a/Python/Product/PythonTools/PythonToolsService.cs
+++ b/Python/Product/PythonTools/PythonToolsService.cs
@@ -172,7 +172,7 @@ namespace Microsoft.PythonTools {
             }
 
             _container.GetUIThread().InvokeTask(async () => {
-                var analyzer = CreateAnalyzer();
+                var analyzer = await CreateAnalyzerAsync();
                 var oldAnalyzer = Interlocked.Exchange(ref _analyzer, analyzer);
                 if (oldAnalyzer != null) {
                     await analyzer.TransferFromOldAnalyzer(oldAnalyzer);
@@ -211,17 +211,17 @@ namespace Microsoft.PythonTools {
             return service;
         }
 
-        private VsProjectAnalyzer CreateAnalyzer() {
+        private Task<VsProjectAnalyzer> CreateAnalyzerAsync() {
             var interpreters = _interpreterOptionsService.Value;
 
             // may not available in some test cases
             if (interpreters == null) {
-                return new VsProjectAnalyzer(EditorServices, InterpreterFactoryCreator.CreateAnalysisInterpreterFactory(new Version(2, 7)));
+                return VsProjectAnalyzer.CreateDefault(EditorServices, InterpreterFactoryCreator.CreateAnalysisInterpreterFactory(new Version(2, 7)));
             }
 
             var defaultFactory = interpreters.DefaultInterpreter;
             EnsureCompletionDb(defaultFactory);
-            return new VsProjectAnalyzer(EditorServices, defaultFactory);
+            return VsProjectAnalyzer.CreateDefault(EditorServices, defaultFactory);
         }
 
         internal PythonToolsLogger Logger => _logger;
@@ -231,7 +231,7 @@ namespace Microsoft.PythonTools {
         public VsProjectAnalyzer DefaultAnalyzer {
             get {
                 if (_analyzer == null) {
-                    _analyzer = _container.GetUIThread().Invoke(() => CreateAnalyzer());
+                    _analyzer = _container.GetUIThread().InvokeTask(() => CreateAnalyzerAsync()).WaitAndUnwrapExceptions();
                 }
                 return _analyzer;
             }

--- a/Python/Product/PythonTools/PythonToolsService.cs
+++ b/Python/Product/PythonTools/PythonToolsService.cs
@@ -231,7 +231,7 @@ namespace Microsoft.PythonTools {
         public VsProjectAnalyzer DefaultAnalyzer {
             get {
                 if (_analyzer == null) {
-                    _analyzer = _container.GetUIThread().InvokeTask(() => CreateAnalyzerAsync()).WaitAndUnwrapExceptions();
+                    _analyzer = _container.GetUIThread().InvokeTaskSync(() => CreateAnalyzerAsync(), CancellationToken.None);
                 }
                 return _analyzer;
             }

--- a/Python/Product/VSCommon/Infrastructure/UIThreadBase.cs
+++ b/Python/Product/VSCommon/Infrastructure/UIThreadBase.cs
@@ -38,6 +38,8 @@ namespace Microsoft.VisualStudioTools {
         public abstract Task<T> InvokeAsync<T>(Func<T> func, CancellationToken cancellationToken);
         public abstract Task InvokeTask(Func<Task> func);
         public abstract Task<T> InvokeTask<T>(Func<Task<T>> func);
+        public abstract void InvokeTaskSync(Func<Task> func, CancellationToken cancellationToken);
+        public abstract T InvokeTaskSync<T>(Func<Task<T>> func, CancellationToken cancellationToken);
         public abstract void MustBeCalledFromUIThreadOrThrow();
 
         public abstract bool InvokeRequired {
@@ -118,6 +120,13 @@ namespace Microsoft.VisualStudioTools {
         }
 
         public override void MustBeCalledFromUIThreadOrThrow() { }
+
+        public override void InvokeTaskSync(Func<Task> func, CancellationToken cancellationToken) {
+        }
+
+        public override T InvokeTaskSync<T>(Func<Task<T>> func, CancellationToken cancellationToken) {
+            return default(T);
+        }
 
         public override bool InvokeRequired {
             get { return false; }

--- a/Python/Tests/Core/CodeFormatterTests.cs
+++ b/Python/Tests/Core/CodeFormatterTests.cs
@@ -172,7 +172,7 @@ class Oar(object):
         private static async Task CodeFormattingTest(string input, object selection, string expected, object expectedSelection, CodeFormattingOptions options, bool selectResult = true) {
             var fact = InterpreterFactoryCreator.CreateAnalysisInterpreterFactory(new Version(2, 7));
             var services = PythonToolsTestUtilities.CreateMockServiceProvider().GetEditorServices();
-            using (var analyzer = await VsProjectAnalyzer.CreateForTests(services, fact)) {
+            using (var analyzer = await VsProjectAnalyzer.CreateForTestsAsync(services, fact)) {
                 var buffer = new MockTextBuffer(input, PythonCoreConstants.ContentType, Path.Combine(TestData.GetTempPath(), "fob.py"));
                 buffer.AddProperty(typeof(VsProjectAnalyzer), analyzer);
                 var view = new MockTextView(buffer);

--- a/Python/Tests/Core/ExtractMethodTests.cs
+++ b/Python/Tests/Core/ExtractMethodTests.cs
@@ -1701,7 +1701,7 @@ async def f():
         private async Task ExtractMethodTest(string input, Func<Span> extract, TestResult expected, string scopeName = null, string targetName = "g", Version version = null, params string[] parameters) {
             var fact = InterpreterFactoryCreator.CreateAnalysisInterpreterFactory(version ?? new Version(2, 7));
             var services = PythonToolsTestUtilities.CreateMockServiceProvider().GetEditorServices();
-            using (var analyzer = await VsProjectAnalyzer.CreateForTests(services, fact)) {
+            using (var analyzer = await VsProjectAnalyzer.CreateForTestsAsync(services, fact)) {
                 var buffer = new MockTextBuffer(input, PythonCoreConstants.ContentType, Path.Combine(TestData.GetTempPath(), "fob.py"));
                 var view = new MockTextView(buffer);
                 buffer.Properties.AddProperty(typeof(VsProjectAnalyzer), analyzer);

--- a/Python/Tests/Core/ExtractMethodTests.cs
+++ b/Python/Tests/Core/ExtractMethodTests.cs
@@ -18,6 +18,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using AnalysisTests;
 using Microsoft.PythonTools;
 using Microsoft.PythonTools.Infrastructure;
@@ -51,8 +52,8 @@ namespace PythonToolsTests {
         }
 
         [TestMethod, Priority(0)]
-        public void TestGlobalNonLocalVars() {
-            SuccessTest("ABC = 42",
+        public async Task TestGlobalNonLocalVars() {
+            await SuccessTest("ABC = 42",
 @"def f():
     ABC = 42
     def f():
@@ -72,7 +73,7 @@ def f():
         print(ABC)
     return f");
 
-            SuccessTest("ABC = 42",
+            await SuccessTest("ABC = 42",
 @"def f():
     ABC = 42
     def f():
@@ -88,7 +89,7 @@ def f():
         print(ABC)
     return f");
 
-            SuccessTest("ABC = 42",
+            await SuccessTest("ABC = 42",
 @"def f():
     global ABC
     ABC = 42",
@@ -103,8 +104,8 @@ def f():
         }
 
         [TestMethod, Priority(0)]
-        public void TestDefinitions() {
-            SuccessTest("x = .. = h()",
+        public async Task TestDefinitions() {
+            await SuccessTest("x = .. = h()",
 @"def f():
     def g():
         return 42
@@ -127,7 +128,7 @@ def f():
     g(g, h)
 ");
 
-            SuccessTest("x = .. = h()",
+            await SuccessTest("x = .. = h()",
 @"def f():
     class g():
         pass
@@ -150,7 +151,7 @@ def f():
     g(g, h)
 ");
 
-            SuccessTest("@ .. pass",
+            await SuccessTest("@ .. pass",
 @"@property
 def f(): pass",
 @"def g():
@@ -162,8 +163,8 @@ f = g()");
         }
 
         [TestMethod, Priority(0)]
-        public void TestLeadingComment() {
-            SuccessTest("x = 41",
+        public async Task TestLeadingComment() {
+            await SuccessTest("x = 41",
 @"# fob
 x = 41",
 @"# fob
@@ -175,8 +176,8 @@ x = g()");
         }
 
         [TestMethod, Priority(0)]
-        public void AssignInIfStatementReadAfter() {
-            ExtractMethodTest(@"class C:
+        public async Task AssignInIfStatementReadAfter() {
+            await ExtractMethodTest(@"class C:
     def fob(self):
         if False: # fob
             oar = player = Player()
@@ -196,7 +197,7 @@ x = g()");
  ), scopeName: "C");
 
 
-            ExtractMethodTest(@"class C:
+            await ExtractMethodTest(@"class C:
     def fob(self):
         if False: 
             oar = player = Player()
@@ -215,7 +216,7 @@ x = g()");
 "
  ), scopeName: "C");
 
-            ExtractMethodTest(@"class C:
+            await ExtractMethodTest(@"class C:
     def fob(self):
         if False: 
             oar = player = Player()
@@ -239,8 +240,8 @@ x = g()");
         }
 
         [TestMethod, Priority(0)]
-        public void ExtractMethodIndexExpr() {
-            ExtractMethodTest(@"class C:
+        public async Task ExtractMethodIndexExpr() {
+            await ExtractMethodTest(@"class C:
     def process_kinect_event(self, e):
         for skeleton in e.skeletons:
             fob[skeleton.dwTrackingID] = Player()
@@ -257,9 +258,9 @@ x = g()");
         }
 
         [TestMethod, Priority(0)]
-        public void TestExtractLambda() {
+        public async Task TestExtractLambda() {
             // lambda is present in the code
-            ExtractMethodTest(
+            await ExtractMethodTest(
 @"def f():
     pass
 
@@ -275,7 +276,7 @@ def x():
     abc = lambda x: 42"));
 
             // lambda is being extracted
-            ExtractMethodTest(
+            await ExtractMethodTest(
 @"def f():
     abc = lambda x: 42", "lambda x: 42", TestResult.Success(
 @"def g():
@@ -286,11 +287,11 @@ def f():
         }
 
         [TestMethod, Priority(0)]
-        public void TestExtractGenerator() {
+        public async Task TestExtractGenerator() {
             var code = @"def f(imp = imp):
     yield 42";
 
-            ExtractMethodTest(
+            await ExtractMethodTest(
 code, () => new Span(code.IndexOf("= imp") + 2, 3), TestResult.Success(
 @"def g():
     return imp
@@ -300,11 +301,11 @@ def f(imp = g()):
         }
 
         [TestMethod, Priority(0)]
-        public void TestExtractDefaultValue() {
+        public async Task TestExtractDefaultValue() {
             var code = @"def f(imp = imp):
     pass";
 
-            ExtractMethodTest(
+            await ExtractMethodTest(
 code, () => new Span(code.IndexOf("= imp") + 2, 3), TestResult.Success(
 @"def g():
     return imp
@@ -314,15 +315,15 @@ def f(imp = g()):
         }
 
         [TestMethod, Priority(0)]
-        public void TestFromImportStar() {
-            ExtractMethodTest(
+        public async Task TestFromImportStar() {
+            await ExtractMethodTest(
 @"def f():
     from sys import *", "from sys import *", TestResult.Error(ErrorImportStar));
         }
 
         [TestMethod, Priority(0)]
-        public void TestExtractDefiniteAssignmentAfter() {
-            SuccessTest("x = 42",
+        public async Task TestExtractDefiniteAssignmentAfter() {
+            await SuccessTest("x = 42",
 @"def f():
     x = 42
 
@@ -339,8 +340,8 @@ def f():
         }
 
         [TestMethod, Priority(0)]
-        public void TestExtractDefiniteAssignmentAfterStmtList() {
-            SuccessTest("x = 42",
+        public async Task TestExtractDefiniteAssignmentAfterStmtList() {
+            await SuccessTest("x = 42",
 @"def f():
     x = 42; x = 100
 
@@ -360,8 +361,8 @@ def f():
 
 
         [TestMethod, Priority(0)]
-        public void TestExtractDefiniteAssignmentAfterStmtListRead() {
-            SuccessTest("x = 100",
+        public async Task TestExtractDefiniteAssignmentAfterStmtListRead() {
+            await SuccessTest("x = 100",
 @"def f():
     x = 100; x
 
@@ -380,7 +381,7 @@ def f():
 
         [TestMethod, Priority(0)]
         [TestCategory("10s")]
-        public void TestAllNodes() {
+        public async Task TestAllNodes() {
             var prefixes = new string[] { " # fob\r\n", "" };
             var suffixes = new string[] { " # oar", "" };
             foreach (var suffix in suffixes) {
@@ -393,7 +394,7 @@ def f():
 
                         var text = prefix + testCase + suffix;
                         string expected = String.Format("{1}def g():\r\n    return {0}\r\n\r\ng(){2}", testCase, prefix, suffix);
-                        SuccessTest(new Span(prefix.Length, testCase.Length), text, expected);
+                        await SuccessTest(new Span(prefix.Length, testCase.Length), text, expected);
                     }
                 }
             }
@@ -429,7 +430,7 @@ def f():
                             );
                         }
 
-                        SuccessTest(new Span(prefix.Length, stmtTest.Text.Length), text, expected, null, stmtTest.Version.ToVersion());
+                        await SuccessTest(new Span(prefix.Length, stmtTest.Text.Length), text, expected, null, stmtTest.Version.ToVersion());
                     }
                 }
             }
@@ -499,8 +500,8 @@ def f():
         }
 
         [TestMethod, Priority(0)]
-        public void TestExtractDefiniteAssignmentAfterStmtListMultipleAssign() {
-            SuccessTest("x = 100; x = 200",
+        public async Task TestExtractDefiniteAssignmentAfterStmtListMultipleAssign() {
+            await SuccessTest("x = 100; x = 200",
 @"def f():
     x = 100; x = 200; x
     
@@ -520,16 +521,16 @@ def f():
 
 
         [TestMethod, Priority(0)]
-        public void TestExtractFromClass() {
-            ExtractMethodTest(
+        public async Task TestExtractFromClass() {
+            await ExtractMethodTest(
 @"class C:
     abc = 42
     oar = 100", "abc .. 100", TestResult.Error(ErrorExtractFromClass));
         }
 
         [TestMethod, Priority(0)]
-        public void TestExtractSuiteWhiteSpace() {
-            SuccessTest("x .. 200",
+        public async Task TestExtractSuiteWhiteSpace() {
+            await SuccessTest("x .. 200",
 @"def f():
 
 
@@ -544,7 +545,7 @@ def f():
 
     g()");
 
-            SuccessTest("x .. 200",
+            await SuccessTest("x .. 200",
 @"def f():
     a = 300
 
@@ -564,8 +565,8 @@ def f():
         /// Test cases that verify we correctly identify when not all paths contain return statements.
         /// </summary>
         [TestMethod, Priority(0)]
-        public void TestNotAllCodePathsReturn() {            
-            TestMissingReturn("for i .. 23", @"def f(x):
+        public async Task TestNotAllCodePathsReturn() {            
+            await TestMissingReturn("for i .. 23", @"def f(x):
     for i in xrange(100):
         break
         return 42
@@ -574,14 +575,14 @@ def f():
 ");
 
             
-            TestMissingReturn("if x .. Exception()", @"def f(x):
+            await TestMissingReturn("if x .. Exception()", @"def f(x):
     if x:
         return 42
     elif x:
         raise Exception()
 ");
 
-            TestMissingReturn("if x .. 200", @"def f(x):
+            await TestMissingReturn("if x .. 200", @"def f(x):
     if x:
         def abc():
              return 42
@@ -591,14 +592,14 @@ def f():
         return 200
 ");
 
-            TestMissingReturn("if x .. 100", @"def f(x):
+            await TestMissingReturn("if x .. 100", @"def f(x):
     if x:
         return 42
     elif x:
         return 100
 ");
 
-            TestMissingReturn("if x .. pass", @"def f(x):
+            await TestMissingReturn("if x .. pass", @"def f(x):
     if x:
         return 42
     elif x:
@@ -607,7 +608,7 @@ def f():
         pass
 ");
 
-            TestMissingReturn("if True .. pass", @"def f():
+            await TestMissingReturn("if True .. pass", @"def f():
     abc = 100
     if True:
         return 100
@@ -615,7 +616,7 @@ def f():
         pass
     print('hello')");
 
-            TestMissingReturn("if x .. aaa",
+            await TestMissingReturn("if x .. aaa",
 @"class C:
     def f(self):
         if x == 0:
@@ -624,8 +625,8 @@ def f():
 
 
         [TestMethod, Priority(0)]
-        public void TestReturnWithOutputVars() {
-            TestReturnWithOutputs("if x .. 100", @"def f(x):
+        public async Task TestReturnWithOutputVars() {
+            await TestReturnWithOutputs("if x .. 100", @"def f(x):
     if x:
         x = 200
         return 42
@@ -636,28 +637,28 @@ def f():
         }
 
         [TestMethod, Priority(0)]
-        public void TestCannotRefactorYield() {
-            TestBadYield("yield 42", @"def f(x):
+        public async Task TestCannotRefactorYield() {
+            await TestBadYield("yield 42", @"def f(x):
     yield 42
 ");
 
-            TestBadYield("yield 42", @"def f(x):
+            await TestBadYield("yield 42", @"def f(x):
     for i in xrange(100):
         yield 42
 ");
         }
 
         [TestMethod, Priority(0)]
-        public void TestContinueWithoutLoop() {
-            TestBadContinue("continue", @"def f(x):
+        public async Task TestContinueWithoutLoop() {
+            await TestBadContinue("continue", @"def f(x):
     for i in xrange(100):
         continue
 ");
         }
 
         [TestMethod, Priority(0)]
-        public void TestBreakWithoutLoop() {
-            TestBadBreak("break", @"def f(x):
+        public async Task TestBreakWithoutLoop() {
+            await TestBadBreak("break", @"def f(x):
     for i in xrange(100):
         break
 ");
@@ -668,8 +669,8 @@ def f():
         /// and that we don't mess up the code before/after the statement.
         /// </summary>
         [TestMethod, Priority(0)]
-        public void StatementTests() {
-            SuccessTest("b",
+        public async Task StatementTests() {
+            await SuccessTest("b",
 @"def f():
     return (a or
             b or 
@@ -682,7 +683,7 @@ def f():
             g() or 
             c)");
 
-            SuccessTest("assert False",
+            await SuccessTest("assert False",
 @"x = 1
 
 assert False
@@ -698,7 +699,7 @@ g()
 x = 2");
 
 
-            SuccessTest("x += 2",
+            await SuccessTest("x += 2",
 @"x = 1
 
 x += 2
@@ -713,7 +714,7 @@ g()
 
 x = 2");
 
-            SuccessTest("x = 100",
+            await SuccessTest("x = 100",
 @"x = 1
 
 x = 100
@@ -728,7 +729,7 @@ g()
 
 x = 2");
 
-            SuccessTest("class C: pass",
+            await SuccessTest("class C: pass",
 @"x = 1
 
 class C: pass
@@ -744,7 +745,7 @@ C = g()
 
 x = 2");
 
-            SuccessTest("del fob",
+            await SuccessTest("del fob",
 @"x = 1
 
 del fob
@@ -759,7 +760,7 @@ g()
 
 x = 2");
 
-            SuccessTest("pass",
+            await SuccessTest("pass",
 @"x = 1
 
 pass
@@ -774,7 +775,7 @@ g()
 
 x = 2");
 
-            SuccessTest("def f(): pass",
+            await SuccessTest("def f(): pass",
 @"x = 1
 
 def f(): pass
@@ -791,7 +792,7 @@ f = g()
 x = 2");
 
 
-            SuccessTest("for .. pass",
+            await SuccessTest("for .. pass",
 @"x = 1
 
 for i in xrange(100):
@@ -809,7 +810,7 @@ i = g()
 
 x = 2");
 
-            SuccessTest("if True: .. pass",
+            await SuccessTest("if True: .. pass",
 @"x = 1
 
 if True:
@@ -826,7 +827,7 @@ g()
 
 x = 2");
 
-            SuccessTest("if True: .. pass",
+            await SuccessTest("if True: .. pass",
 @"x = 1
 
 if True:
@@ -847,7 +848,7 @@ g()
 
 x = 2");
 
-            SuccessTest("if True: .. pass",
+            await SuccessTest("if True: .. pass",
 @"x = 1
 
 if True:
@@ -868,7 +869,7 @@ g()
 
 x = 2");
 
-            SuccessTest("import sys",
+            await SuccessTest("import sys",
 @"x = 1
 
 import sys
@@ -884,7 +885,7 @@ sys = g()
 
 x = 2");
 
-            SuccessTest("print 42",
+            await SuccessTest("print 42",
 @"x = 1
 
 print 42
@@ -900,7 +901,7 @@ g()
 x = 2");
 
 
-            SuccessTest("raise Exception()",
+            await SuccessTest("raise Exception()",
 @"x = 1
 
 raise Exception()
@@ -915,7 +916,7 @@ g()
 
 x = 2");
 
-            SuccessTest("return 100",
+            await SuccessTest("return 100",
 @"x = 1
 
 return 100
@@ -930,7 +931,7 @@ return g()
 
 x = 2");
 
-            SuccessTest("try: .. pass",
+            await SuccessTest("try: .. pass",
 @"x = 1
 
 try:
@@ -951,7 +952,7 @@ g()
 
 x = 2");
 
-            SuccessTest("try: .. pass",
+            await SuccessTest("try: .. pass",
 @"x = 1
 
 try:
@@ -972,7 +973,7 @@ g()
 
 x = 2");
 
-            SuccessTest("try: .. pass",
+            await SuccessTest("try: .. pass",
 @"x = 1
 
 try:
@@ -997,7 +998,7 @@ g()
 
 x = 2");
 
-            SuccessTest("while .. pass",
+            await SuccessTest("while .. pass",
 @"x = 1
 
 while True:
@@ -1014,7 +1015,7 @@ g()
 
 x = 2");
 
-            SuccessTest("while .. pass",
+            await SuccessTest("while .. pass",
 @"x = 1
 
 while True:
@@ -1035,7 +1036,7 @@ g()
 
 x = 2");
 
-            SuccessTest("with .. pass",
+            await SuccessTest("with .. pass",
 @"x = 1
 
 with abc:
@@ -1052,7 +1053,7 @@ g()
 
 x = 2");
 
-            SuccessTest("with .. pass",
+            await SuccessTest("with .. pass",
 @"x = 1
 
 with abc as fob:
@@ -1069,7 +1070,7 @@ g()
 
 x = 2");
 
-            SuccessTest("with .. (name)",
+            await SuccessTest("with .. (name)",
 @"def f():
     name = 'hello'
     with open('Fob', 'rb') as f:
@@ -1084,7 +1085,7 @@ def f():
     g(name)
 ");
 
-            SuccessTest("x .. Oar()",
+            await SuccessTest("x .. Oar()",
 @"class C:
     def f():
         if True:
@@ -1107,8 +1108,8 @@ class C:
         }
 
         [TestMethod, Priority(0)]
-        public void ClassTests() {
-            SuccessTest("x = fob",
+        public async Task ClassTests() {
+            await SuccessTest("x = fob",
 @"class C(object):
     '''Doc string'''
 
@@ -1127,7 +1128,7 @@ class C:
         print(x)", scopeName: "C");
 
 
-            SuccessTest("print(self.abc)",
+            await SuccessTest("print(self.abc)",
 @"class C:
     def f(self):
         print(self.abc)",
@@ -1138,7 +1139,7 @@ class C:
     def f(self):
         self.g()", scopeName:"C");
 
-            SuccessTest("print(self.abc, aaa)",
+            await SuccessTest("print(self.abc, aaa)",
 @"class C:
     def f(self):
         aaa = 42
@@ -1151,7 +1152,7 @@ class C:
         aaa = 42
         self.g(aaa)", scopeName: "C");
 
-            SuccessTest("aaa = 42",
+            await SuccessTest("aaa = 42",
 @"class C:
     def f(self):
         aaa = 42",
@@ -1162,7 +1163,7 @@ class C:
     def f(self):
         self.g()", scopeName: "C");
 
-            SuccessTest("aaa = 42",
+            await SuccessTest("aaa = 42",
 @"class C:
     @staticmethod
     def f():
@@ -1176,7 +1177,7 @@ class C:
     def f():
         C.g()", scopeName: "C");
 
-            SuccessTest("aaa = 42",
+            await SuccessTest("aaa = 42",
 @"class C:
     @classmethod
     def f(cls):
@@ -1190,7 +1191,7 @@ class C:
     def f(cls):
         cls.g()", scopeName: "C");
 
-            SuccessTest("aaa = 42",
+            await SuccessTest("aaa = 42",
 @"class C:
     def f(weird):
         aaa = 42",
@@ -1201,7 +1202,7 @@ class C:
     def f(weird):
         weird.g()", scopeName: "C");
 
-            SuccessTest("print('hello')",
+            await SuccessTest("print('hello')",
 @"class C:
     class D:
         def f(self):
@@ -1217,29 +1218,29 @@ class C:
         }
 
         [TestMethod, Priority(0)]
-        public void TestComprehensions() {
-            SuccessTest("i % 2 == 0", @"def f():
+        public async Task TestComprehensions() {
+            await SuccessTest("i % 2 == 0", @"def f():
     x = [i for i in range(100) if i % 2 == 0]", @"def g(i):
     return i % 2 == 0
 
 def f():
     x = [i for i in range(100) if g(i)]");
 
-            SuccessTest("i % 2 == 0", @"def f():
+            await SuccessTest("i % 2 == 0", @"def f():
     x = (i for i in range(100) if i % 2 == 0)", @"def g(i):
     return i % 2 == 0
 
 def f():
     x = (i for i in range(100) if g(i))");
 
-            SuccessTest("i % 2 == 0", @"def f():
+            await SuccessTest("i % 2 == 0", @"def f():
     x = {i for i in range(100) if i % 2 == 0}", @"def g(i):
     return i % 2 == 0
 
 def f():
     x = {i for i in range(100) if g(i)}", version: new Version(3, 2));
 
-            SuccessTest("(k+v) % 2 == 0", @"def f():
+            await SuccessTest("(k+v) % 2 == 0", @"def f():
     x = {k:v for k,v in range(100) if (k+v) % 2 == 0}", @"def g(k, v):
     return (k+v) % 2 == 0
 
@@ -1248,8 +1249,8 @@ def f():
         }
 
         [TestMethod, Priority(0)]
-        public void SuccessfulTests() {
-            SuccessTest("x .. 100",
+        public async Task SuccessfulTests() {
+            await SuccessTest("x .. 100",
 @"def f():
     z = 200
     x = z
@@ -1267,7 +1268,7 @@ def f():
     x, y = g(z)
     print(x, y)");
 
-            SuccessTest("x .. 100",
+            await SuccessTest("x .. 100",
 @"def f():
     x = 42
     y = 100
@@ -1281,7 +1282,7 @@ def f():
     x, y = g()
     print(x, y)");
 
-            SuccessTest("42",
+            await SuccessTest("42",
 @"def f():
     x = 42",
 @"def g():
@@ -1290,7 +1291,7 @@ def f():
 def f():
     x = g()");
 
-            SuccessTest("oar;baz",
+            await SuccessTest("oar;baz",
 @"def f():
     fob;oar;baz;quox",
 @"def g():
@@ -1299,7 +1300,7 @@ def f():
 def f():
     fob;g();quox");
 
-            SuccessTest("x() .. = 100",
+            await SuccessTest("x() .. = 100",
 @"x = 42
 while True:
     x()
@@ -1314,7 +1315,7 @@ while True:
     x = g(x)", parameters: new[] { "x" });
 
 
-            SuccessTest("x = 2 .. x)", 
+            await SuccessTest("x = 2 .. x)", 
 @"def f():
     x = 1
     x = 2
@@ -1327,7 +1328,7 @@ def f():
     x = 1
     g()");
 
-            SuccessTest("for i in .. return 42",
+            await SuccessTest("for i in .. return 42",
 @"def f():
     for i in xrange(100):
         break
@@ -1340,7 +1341,7 @@ def f():
 def f():
     g()");
 
-            SuccessTest("if x .. 100",
+            await SuccessTest("if x .. 100",
 @"def f(x):
     if x:
         return 42
@@ -1353,7 +1354,7 @@ def f():
 def f(x):
     return g(x)");
 
-            SuccessTest("if x .. 200",
+            await SuccessTest("if x .. 200",
 @"def f(x):
     if x:
         return 42
@@ -1372,7 +1373,7 @@ def f(x):
 def f(x):
     return g(x)");
 
-            SuccessTest("if x .. 200",
+            await SuccessTest("if x .. 200",
 @"def f(x):
     if x:
         return 42
@@ -1391,7 +1392,7 @@ def f(x):
 def f(x):
     return g(x)");
 
-            SuccessTest("if x .. Exception()",
+            await SuccessTest("if x .. Exception()",
 @"def f(x):
     if x:
         return 42
@@ -1406,7 +1407,7 @@ def f(x):
 def f(x):
     return g(x)");
 
-            SuccessTest("print(x)",
+            await SuccessTest("print(x)",
 @"def f():
     x = 1
     print(x)",
@@ -1417,7 +1418,7 @@ def f():
     x = 1
     g(x)");
 
-            SuccessTest("x = 2 .. x)",
+            await SuccessTest("x = 2 .. x)",
 @"def f():
     x = 1
     x = 2
@@ -1430,7 +1431,7 @@ def f():
     x = 1
     g()");
 
-            SuccessTest("class C: pass",
+            await SuccessTest("class C: pass",
 @"def f():
     class C: pass
     print C",
@@ -1442,7 +1443,7 @@ def f():
     C = g()
     print C");
 
-            SuccessTest("def x(): pass",
+            await SuccessTest("def x(): pass",
 @"def f():
     def x(): pass
     print x",
@@ -1454,7 +1455,7 @@ def f():
     x = g()
     print x");
 
-            SuccessTest("import sys",
+            await SuccessTest("import sys",
 @"def f():
     import sys
     print sys",
@@ -1466,7 +1467,7 @@ def f():
     sys = g()
     print sys");
 
-            SuccessTest("import sys as oar",
+            await SuccessTest("import sys as oar",
 @"def f():
     import sys as oar
     print oar",
@@ -1478,7 +1479,7 @@ def f():
     oar = g()
     print oar");
 
-            SuccessTest("from sys import oar",
+            await SuccessTest("from sys import oar",
 @"def f():
     from sys import oar
     print oar",
@@ -1490,7 +1491,7 @@ def f():
     oar = g()
     print oar");
 
-            SuccessTest("from sys import oar as baz",
+            await SuccessTest("from sys import oar as baz",
 @"def f():
     from sys import oar as baz
     print baz",
@@ -1503,7 +1504,7 @@ def f():
     print baz");
 
 
-            SuccessTest("return 42",
+            await SuccessTest("return 42",
 @"def f():
     return 42",
 @"def g():
@@ -1512,7 +1513,7 @@ def f():
 def f():
     return g()");
 
-            SuccessTest("return x",
+            await SuccessTest("return x",
 @"def f():
     x = 42
     return x",
@@ -1523,7 +1524,7 @@ def f():
     x = 42
     return g(x)");
 
-            SuccessTest("x = .. = 100",
+            await SuccessTest("x = .. = 100",
 @"def f():
     x = 42
     y = 100
@@ -1537,7 +1538,7 @@ def f():
     x, y = g()
     return x, y");
 
-            SuccessTest("x()",
+            await SuccessTest("x()",
 @"x = 42
 while True:
     x()
@@ -1551,7 +1552,7 @@ while True:
     x = 100",
             parameters: new[] { "x"});
 
-            SuccessTest("x()",
+            await SuccessTest("x()",
 @"x = 42
 while True:
     x()
@@ -1564,7 +1565,7 @@ while True:
     g()
     x = 100");
 
-            SuccessTest("x = 42",
+            await SuccessTest("x = 42",
 @"x = 42
 print(x)",
 @"def g():
@@ -1574,7 +1575,7 @@ print(x)",
 x = g()
 print(x)");
 
-            SuccessTest("l = .. return r",
+            await SuccessTest("l = .. return r",
 @"def f():
     r = None
     l = fob()
@@ -1591,7 +1592,7 @@ def f():
     r = None
     return g(r)");
 
-            SuccessTest("42",
+            await SuccessTest("42",
 @"def f(x):
     return (42)",
 @"def g():
@@ -1602,11 +1603,11 @@ def f(x):
         }
 
         [TestMethod, Priority(0)]
-        public void ExtractAsyncFunction() {
+        public async Task ExtractAsyncFunction() {
             // Ensure extracted bodies that use await generate async functions
 
             var V35 = new Version(3, 5);
-            SuccessTest("x",
+            await SuccessTest("x",
 @"async def f():
     return await x",
 @"def g():
@@ -1615,7 +1616,7 @@ def f(x):
 async def f():
     return await g()", version: V35);
 
-            SuccessTest("await x",
+            await SuccessTest("await x",
 @"async def f():
     return await x",
 @"async def g():
@@ -1625,12 +1626,12 @@ async def f():
     return await g()", version: V35);
         }
 
-        private void SuccessTest(Span extract, string input, string result, string scopeName = null, Version version = null, string[] parameters = null) {
-            ExtractMethodTest(input, extract, TestResult.Success(result), scopeName: scopeName, version: version, parameters: parameters);
+        private Task SuccessTest(Span extract, string input, string result, string scopeName = null, Version version = null, string[] parameters = null) {
+            return ExtractMethodTest(input, extract, TestResult.Success(result), scopeName: scopeName, version: version, parameters: parameters);
         }
 
-        private void SuccessTest(string extract, string input, string result, string scopeName = null, Version version = null, string[] parameters = null) {
-            ExtractMethodTest(input, extract, TestResult.Success(result), scopeName: scopeName, version: version, parameters: parameters);
+        private Task SuccessTest(string extract, string input, string result, string scopeName = null, Version version = null, string[] parameters = null) {
+            return ExtractMethodTest(input, extract, TestResult.Success(result), scopeName: scopeName, version: version, parameters: parameters);
         }
 
 
@@ -1652,32 +1653,32 @@ async def f():
             }
         }
 
-        private void TestMissingReturn(string extract, string input) {
-            ExtractMethodTest(input, extract, TestResult.Error(ErrorReturn));
+        private Task TestMissingReturn(string extract, string input) {
+            return ExtractMethodTest(input, extract, TestResult.Error(ErrorReturn));
         }
 
-        private void TestReturnWithOutputs(string extract, string input) {
-            ExtractMethodTest(input, extract, TestResult.Error(ErrorReturnWithOutputs));
+        private Task TestReturnWithOutputs(string extract, string input) {
+            return ExtractMethodTest(input, extract, TestResult.Error(ErrorReturnWithOutputs));
         }
 
-        private void TestBadYield(string extract, string input) {
-            ExtractMethodTest(input, extract, TestResult.Error(ErrorYield));
+        private Task TestBadYield(string extract, string input) {
+            return ExtractMethodTest(input, extract, TestResult.Error(ErrorYield));
         }
 
-        private void TestBadContinue(string extract, string input) {
-            ExtractMethodTest(input, extract, TestResult.Error(ErrorContinue));
+        private Task TestBadContinue(string extract, string input) {
+            return ExtractMethodTest(input, extract, TestResult.Error(ErrorContinue));
         }
 
-        private void TestBadBreak(string extract, string input) {
-            ExtractMethodTest(input, extract, TestResult.Error(ErrorBreak));
+        private Task TestBadBreak(string extract, string input) {
+            return ExtractMethodTest(input, extract, TestResult.Error(ErrorBreak));
         }
 
-        private void ExtractMethodTest(string input, object extract, TestResult expected, string scopeName = null, string targetName = "g", Version version = null, params string[] parameters) {
+        private Task ExtractMethodTest(string input, object extract, TestResult expected, string scopeName = null, string targetName = "g", Version version = null, params string[] parameters) {
             Func<Span> textRange = () => {
                 return GetSelectionSpan(input, extract);
             };
 
-            ExtractMethodTest(input, textRange, expected, scopeName, targetName, version, parameters);
+            return ExtractMethodTest(input, textRange, expected, scopeName, targetName, version, parameters);
         }
 
         internal static Span GetSelectionSpan(string input, object extract) {
@@ -1697,16 +1698,16 @@ async def f():
             return (Span)extract;
         }
 
-        private void ExtractMethodTest(string input, Func<Span> extract, TestResult expected, string scopeName = null, string targetName = "g", Version version = null, params string[] parameters) {
+        private async Task ExtractMethodTest(string input, Func<Span> extract, TestResult expected, string scopeName = null, string targetName = "g", Version version = null, params string[] parameters) {
             var fact = InterpreterFactoryCreator.CreateAnalysisInterpreterFactory(version ?? new Version(2, 7));
             var services = PythonToolsTestUtilities.CreateMockServiceProvider().GetEditorServices();
-            using (var analyzer = new VsProjectAnalyzer(services, fact, outOfProcAnalyzer: false, comment: "PTVS_TEST")) {
+            using (var analyzer = await VsProjectAnalyzer.CreateForTests(services, fact)) {
                 var buffer = new MockTextBuffer(input, PythonCoreConstants.ContentType, Path.Combine(TestData.GetTempPath(), "fob.py"));
                 var view = new MockTextView(buffer);
                 buffer.Properties.AddProperty(typeof(VsProjectAnalyzer), analyzer);
 
                 var bi = services.GetBufferInfo(buffer);
-                var entry = analyzer.AnalyzeFileAsync(bi.Filename).WaitAndUnwrapExceptions();
+                var entry = await analyzer.AnalyzeFileAsync(bi.Filename);
                 Assert.AreEqual(entry, bi.TrySetAnalysisEntry(entry, null));
                 entry.GetOrCreateBufferParser(services).AddBuffer(buffer);
 
@@ -1717,7 +1718,7 @@ async def f():
                     false
                 );
 
-                new MethodExtractor(services.Site, view).ExtractMethod(extractInput).Wait();
+                await new MethodExtractor(services.Site, view).ExtractMethod(extractInput);
 
                 if (expected.IsError) {
                     Assert.AreEqual(expected.Text, extractInput.FailureReason);

--- a/Python/Tests/Core/PythonProjectTests.cs
+++ b/Python/Tests/Core/PythonProjectTests.cs
@@ -266,7 +266,7 @@ namespace PythonToolsTests {
         public async Task LoadAndUnloadModule() {
             var factories = new[] { InterpreterFactoryCreator.CreateAnalysisInterpreterFactory(new Version(3, 3)) };
             var services = PythonToolsTestUtilities.CreateMockServiceProvider().GetEditorServices();
-            using (var analyzer = await VsProjectAnalyzer.CreateForTests(services, factories[0])) {
+            using (var analyzer = await VsProjectAnalyzer.CreateForTestsAsync(services, factories[0])) {
                 var m1Path = TestData.GetPath("TestData\\SimpleImport\\module1.py");
                 var m2Path = TestData.GetPath("TestData\\SimpleImport\\module2.py");
 
@@ -322,7 +322,7 @@ namespace PythonToolsTests {
         public async Task AnalyzeBadEgg() {
             var factories = new[] { InterpreterFactoryCreator.CreateAnalysisInterpreterFactory(new Version(3, 4)) };
             var services = PythonToolsTestUtilities.CreateMockServiceProvider().GetEditorServices();
-            using (var analyzer = await VsProjectAnalyzer.CreateForTests(services, factories[0])) {
+            using (var analyzer = await VsProjectAnalyzer.CreateForTestsAsync(services, factories[0])) {
                 await analyzer.SetSearchPathsAsync(new[] { TestData.GetPath(@"TestData\BadEgg.egg") });
                 analyzer.WaitForCompleteAnalysis(_ => true);
 

--- a/Python/Tests/PythonToolsMockTests/ClassifierTests.cs
+++ b/Python/Tests/PythonToolsMockTests/ClassifierTests.cs
@@ -296,8 +296,12 @@ def f() -> int:
                     var bp = ((AnalysisEntry)_view.GetAnalysisEntry()).TryGetBufferParser();
                     if (bp != null) {
                         _classificationsReady2.Reset();
-                        bp.Requeue();
-                        _classificationsReady2.Wait();
+                        for (int retries = 10; retries > 0; --retries) {
+                            bp.Requeue();
+                            if (_classificationsReady2.Wait(1000)) {
+                                break;
+                            }
+                        }
                     }
 
                     return AnalysisClassifier.GetClassificationSpans(

--- a/Python/Tests/PythonToolsMockTests/CompletionTests.cs
+++ b/Python/Tests/PythonToolsMockTests/CompletionTests.cs
@@ -1074,16 +1074,16 @@ def g():
 
             using (var view = new PythonEditor(code, PythonLanguageVersion.V35)) {
                 AssertUtil.CheckCollection(view.GetCompletionsAfter("f()."),
-                    new[] { "next", "send", "throw" },
+                    new[] { "send", "throw" },
                     new[] { "real", "imag" }
                 );
                 AssertUtil.CheckCollection(view.GetCompletionsAfter("yield from f()."),
-                    new[] { "next", "send", "throw" },
+                    new[] { "send", "throw" },
                     new[] { "real", "imag" }
                 );
                 AssertUtil.CheckCollection(view.GetCompletionsAfter("(yield from f())."),
                     new[] { "real", "imag" },
-                    new[] { "next", "send", "throw" }
+                    new[] { "send", "throw" }
                 );
             }
         }
@@ -1101,16 +1101,16 @@ async def g():
 
             using (var view = new PythonEditor(code, PythonLanguageVersion.V35)) {
                 AssertUtil.CheckCollection(view.GetCompletionsAfter("f()."),
-                    new[] { "next", "send", "throw" },
+                    new[] { "send", "throw" },
                     new[] { "real", "imag" }
                 );
                 AssertUtil.CheckCollection(view.GetCompletionsAfter("await f()."),
-                    new[] { "next", "send", "throw" },
+                    new[] { "send", "throw" },
                     new[] { "real", "imag" }
                 );
                 AssertUtil.CheckCollection(view.GetCompletionsAfter("(await f())."),
                     new[] { "real", "imag" },
-                    new[] { "next", "send", "throw" }
+                    new[] { "send", "throw" }
                 );
             }
         }

--- a/Python/Tests/PythonToolsMockTests/EditorTests.cs
+++ b/Python/Tests/PythonToolsMockTests/EditorTests.cs
@@ -182,12 +182,12 @@ namespace PythonToolsMockTests {
                 view.AdvancedOptions.AutoListIdentifiers = false;
                 view.AdvancedOptions.HideAdvancedMembers = false;
 
-                view.Type("min.");
+                view.Type("min.__");
 
                 using (var sh = view.View.WaitForSession<ICompletionSession>()) {
                     AssertUtil.ContainsAtLeast(sh.Session.Completions(), "__class__");
 
-                    view.Type("__class__\r");
+                    view.Type("class__\r");
                 }
                 Assert.AreEqual("min.__class__\r\n", view.Text);
             }

--- a/Python/Tests/PythonToolsMockTests/ProjectTests.cs
+++ b/Python/Tests/PythonToolsMockTests/ProjectTests.cs
@@ -27,6 +27,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.VisualStudioTools;
 using Microsoft.VisualStudioTools.MockVsTests;
 using Microsoft.VisualStudioTools.Project.Automation;
+using pythontools::Microsoft.PythonTools.Editor;
 using pythontools::Microsoft.PythonTools.Project;
 using TestUtilities;
 using TestUtilities.Python;
@@ -51,7 +52,13 @@ namespace PythonToolsMockTests {
                 Assert.IsNotNull(vs.WaitForItem("HelloWorld", "server.py"));
                 var view = vs.OpenItem("HelloWorld", "server.py");
 
-                view.Invoke(() => view.Type("import "));
+                var bi = PythonTextBufferInfo.TryGetForBuffer(view.TextView.TextBuffer);
+                for (int retries = 20; retries > 0 && bi.AnalysisEntry == null; --retries) {
+                    Thread.Sleep(500);
+                }
+
+                view.Invoke(() => view.Type("import"));
+                view.Invoke(() => view.Type(" "));
 
                 using (var sh = view.WaitForSession<ICompletionSession>()) {
                     AssertUtil.Contains(sh.Session.Completions(), "sys");

--- a/Python/Tests/PythonToolsMockTests/PythonEditor.cs
+++ b/Python/Tests/PythonToolsMockTests/PythonEditor.cs
@@ -83,7 +83,7 @@ namespace PythonToolsMockTests {
                 }
                 if (analyzer == null) {
                     _disposeAnalyzer = true;
-                    analyzer = vs.InvokeTask(() => VsProjectAnalyzer.CreateForTests(vs.ComponentModel.GetService<PythonEditorServices>(), factory, inProcAnalyzer));
+                    analyzer = vs.InvokeTask(() => VsProjectAnalyzer.CreateForTestsAsync(vs.ComponentModel.GetService<PythonEditorServices>(), factory, inProcAnalyzer));
                 }
                 if (string.IsNullOrEmpty(filename)) {
                     do {

--- a/Python/Tests/PythonToolsMockTests/PythonEditor.cs
+++ b/Python/Tests/PythonToolsMockTests/PythonEditor.cs
@@ -49,7 +49,8 @@ namespace PythonToolsMockTests {
             MockVs vs = null,
             IPythonInterpreterFactory factory = null,
             VsProjectAnalyzer analyzer = null,
-            string filename = null
+            string filename = null,
+            bool inProcAnalyzer = true
         ) {
             if (vs == null) {
                 _disposeVS = true;
@@ -82,13 +83,7 @@ namespace PythonToolsMockTests {
                 }
                 if (analyzer == null) {
                     _disposeAnalyzer = true;
-                    vs.InvokeSync(() => {
-                        analyzer = new VsProjectAnalyzer(vs.ComponentModel.GetService<PythonEditorServices>(), factory, outOfProcAnalyzer: false, comment: "PTVS_TEST");
-                    });
-                    var task = analyzer.ReloadTask;
-                    if (task != null) {
-                        task.WaitAndUnwrapExceptions();
-                    }
+                    analyzer = vs.InvokeTask(() => VsProjectAnalyzer.CreateForTests(vs.ComponentModel.GetService<PythonEditorServices>(), factory, inProcAnalyzer));
                 }
                 if (string.IsNullOrEmpty(filename)) {
                     do {

--- a/Python/Tests/Utilities.Python/PythonProjectProcessor.cs
+++ b/Python/Tests/Utilities.Python/PythonProjectProcessor.cs
@@ -27,6 +27,7 @@ namespace TestUtilities.Python {
         public void PreProcess(MSBuild.Project project) {
             project.SetProperty("ProjectHome", ".");
             project.SetProperty("WorkingDirectory", ".");
+            project.SetProperty("_InProcessPythonAnalyzer", "true");
 
             var installPath = PathUtils.GetParent(PythonToolsInstallPath.GetFile("Microsoft.PythonTools.dll", typeof(PythonToolsPackage).Assembly));
             project.SetProperty("_PythonToolsPath", installPath);


### PR DESCRIPTION
Fixes VsProjectAnalyzer to be created safely and awaitable on successful initialization
Changes UIThread to use JoinableTaskContext, creating one for the current thread if the global one does not exist
Change random failures due to out-of-order messages into more sensible errors when arguments are known invalid
Fixes MockVs to create everything on its UI thread and to dispose everything correctly
Disable registry watchers when container is disposed
Validates caret position in refactor rename tests
Avoid ArgumentNullException for member references with no location