### PR TITLE
Fixes #2675 Module names in the Modules debugger window are unqualified

### DIFF
--- a/Python/Product/Debugger/Debugger/DebugEngine/AD7Module.cs
+++ b/Python/Product/Debugger/Debugger/DebugEngine/AD7Module.cs
@@ -116,9 +116,6 @@ namespace Microsoft.PythonTools.Debugger.DebugEngine {
             return VSConstants.S_OK;
         }
 
-        // Used to support the JustMyCode features of the debugger.
-        // the sample debug engine does not support JustMyCode and therefore all modules
-        // are considered "My Code"
         int IDebugModule3.IsUserCode(out int pfUser) {
             pfUser = DebuggedModule.IsUserCode ? 1 : 0;
             return VSConstants.S_OK;

--- a/Python/Product/Debugger/Debugger/DebugEngine/AD7Module.cs
+++ b/Python/Product/Debugger/Debugger/DebugEngine/AD7Module.cs
@@ -16,6 +16,8 @@
 
 using System;
 using System.Diagnostics;
+using System.IO;
+using Microsoft.PythonTools.Analysis;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Debugger.Interop;
 
@@ -48,6 +50,14 @@ namespace Microsoft.PythonTools.Debugger.DebugEngine {
             if ((dwFields & enum_MODULE_INFO_FIELDS.MIF_LOADORDER) != 0) {
                 info.m_dwLoadOrder = (uint)this.DebuggedModule.ModuleId;
                 info.dwValidFields |= enum_MODULE_INFO_FIELDS.MIF_LOADORDER;
+            }
+            if ((dwFields & enum_MODULE_INFO_FIELDS.MIF_URLSYMBOLLOCATION) != 0) {
+                if (ModulePath.IsPythonSourceFile(DebuggedModule.Filename)) {
+                    info.m_bstrUrlSymbolLocation = DebuggedModule.Filename;
+                } else {
+                    info.m_bstrUrlSymbolLocation = string.Empty;
+                }
+                info.dwValidFields |= enum_MODULE_INFO_FIELDS.MIF_URLSYMBOLLOCATION;
             }
 
             infoArray[0] = info;
@@ -110,7 +120,7 @@ namespace Microsoft.PythonTools.Debugger.DebugEngine {
         // the sample debug engine does not support JustMyCode and therefore all modules
         // are considered "My Code"
         int IDebugModule3.IsUserCode(out int pfUser) {
-            pfUser = 1;
+            pfUser = DebuggedModule.IsUserCode ? 1 : 0;
             return VSConstants.S_OK;
         }
 

--- a/Python/Product/Debugger/Debugger/LegacyDebuggerProtocol.cs
+++ b/Python/Product/Debugger/Debugger/LegacyDebuggerProtocol.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using Microsoft.PythonTools.Ipc.Json;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
@@ -405,6 +406,10 @@ namespace Microsoft.PythonTools.Debugger {
 
             public int moduleId;
             public string moduleFileName;
+            [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+            public string moduleName;
+            [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+            public int isStdLib;
         }
 
         public sealed class StepDoneEvent : Event {

--- a/Python/Product/Debugger/Debugger/LegacyDebuggerProtocol.cs
+++ b/Python/Product/Debugger/Debugger/LegacyDebuggerProtocol.cs
@@ -408,8 +408,8 @@ namespace Microsoft.PythonTools.Debugger {
             public string moduleFileName;
             [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
             public string moduleName;
-            [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
-            public int isStdLib;
+            [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore, NullValueHandling = NullValueHandling.Ignore)]
+            public bool isStdLib;
         }
 
         public sealed class StepDoneEvent : Event {

--- a/Python/Product/Debugger/Debugger/PythonModule.cs
+++ b/Python/Product/Debugger/Debugger/PythonModule.cs
@@ -19,34 +19,30 @@ using Microsoft.PythonTools.Infrastructure;
 
 namespace Microsoft.PythonTools.Debugger {
     class PythonModule {
-        private readonly int _moduleId;
-        private readonly string _filename;
-
-        public PythonModule(int moduleId, string filename) {
-            _moduleId = moduleId;
-            _filename = filename;
+        public PythonModule(int moduleId, string filename, string moduleName, bool isUserCode) {
+            ModuleId = moduleId;
+            Filename = filename;
+            ModuleName = moduleName;
+            IsUserCode = isUserCode;
         }
 
-        public int ModuleId {
-            get {
-                return _moduleId;
-            }
-        }
+        public int ModuleId { get; }
+        public string Filename { get; }
+        public string ModuleName { get; }
+        public bool IsUserCode { get; }
 
         public string Name {
             get {
-                
-                if (PathUtils.IsValidPath(_filename)) {
-                    return Path.GetFileNameWithoutExtension(_filename);
+                if (!string.IsNullOrEmpty(ModuleName)) {
+                    return ModuleName;
                 }
-                return _filename;
+
+                if (PathUtils.IsValidPath(Filename)) {
+                    return Path.GetFileNameWithoutExtension(Filename);
+                }
+                return Filename;
             }
         }
 
-        public string Filename {
-            get {
-                return _filename;
-            }
-        }
     }
 }

--- a/Python/Product/Debugger/Debugger/PythonProcess.cs
+++ b/Python/Product/Debugger/Debugger/PythonProcess.cs
@@ -701,8 +701,8 @@ namespace Microsoft.PythonTools.Debugger {
         private void OnLegacyModuleLoad(object sender, LDP.ModuleLoadEvent e) {
             // module load
             if (e.moduleFileName != null) {
-                Debug.WriteLine(String.Format("Module Loaded ({0}): {1}", e.moduleId, e.moduleFileName));
-                var module = new PythonModule(e.moduleId, e.moduleFileName);
+                Debug.WriteLine(String.Format("Module Loaded ({0}): {2} : {1}", e.moduleId, e.moduleFileName, e.moduleName));
+                var module = new PythonModule(e.moduleId, e.moduleFileName, e.moduleName, e.isStdLib == 0);
 
                 ModuleLoaded?.Invoke(this, new ModuleLoadedEventArgs(module));
             }

--- a/Python/Product/Debugger/Debugger/PythonProcess.cs
+++ b/Python/Product/Debugger/Debugger/PythonProcess.cs
@@ -702,7 +702,7 @@ namespace Microsoft.PythonTools.Debugger {
             // module load
             if (e.moduleFileName != null) {
                 Debug.WriteLine(String.Format("Module Loaded ({0}): {2} : {1}", e.moduleId, e.moduleFileName, e.moduleName));
-                var module = new PythonModule(e.moduleId, e.moduleFileName, e.moduleName, e.isStdLib == 0);
+                var module = new PythonModule(e.moduleId, e.moduleFileName, e.moduleName, !e.isStdLib);
 
                 ModuleLoaded?.Invoke(this, new ModuleLoadedEventArgs(module));
             }

--- a/Python/Product/Ipc.Json/Connection.cs
+++ b/Python/Product/Ipc.Json/Connection.cs
@@ -289,17 +289,23 @@ namespace Microsoft.PythonTools.Ipc.Json {
             var name = packet["event"].ToObject<string>();
             var eventBody = packet["body"];
             Event eventObj;
-            if (name != null &&
-                _types != null &&
-                _types.TryGetValue("event." + name, out requestType)) {
-                // We have a strongly typed event type registered, use that.
-                eventObj = eventBody.ToObject(requestType) as Event;
-            } else {
-                // We have no strongly typed event type, so give the user a 
-                // GenericEvent and they can look through the body manually.
-                eventObj = new GenericEvent() {
-                    body = eventBody.ToObject<Dictionary<string, object>>()
-                };
+            try {
+                if (name != null &&
+                    _types != null &&
+                    _types.TryGetValue("event." + name, out requestType)) {
+                    // We have a strongly typed event type registered, use that.
+                    eventObj = eventBody.ToObject(requestType) as Event;
+                } else {
+                    // We have no strongly typed event type, so give the user a 
+                    // GenericEvent and they can look through the body manually.
+                    eventObj = new GenericEvent() {
+                        body = eventBody.ToObject<Dictionary<string, object>>()
+                    };
+                }
+            } catch (Exception e) {
+                // TODO: Notify receiver of invalid message
+                Debug.Fail(e.Message);
+                return;
             }
             try {
                 EventReceived?.Invoke(this, new EventReceivedEventArgs(name, eventObj));

--- a/Python/Product/PythonTools/ptvsd/debugger.py
+++ b/Python/Product/PythonTools/ptvsd/debugger.py
@@ -2181,7 +2181,7 @@ def report_module_load(mod):
         moduleId=mod.module_id,
         moduleFileName=mod.filename,
         moduleName=mod.module_name,
-        isStdLib=1 if is_stdlib(path.normcase(mod.filename)) else 0,
+        isStdLib=is_stdlib(path.normcase(mod.filename)),
     )
 
 def report_step_finished(tid):

--- a/Python/Product/PythonTools/ptvsd_launcher.py
+++ b/Python/Product/PythonTools/ptvsd_launcher.py
@@ -80,6 +80,7 @@ filename = sys.argv[0]
 sys.path[0] = ''
 
 # exclude ourselves from being debugged
+vspd.PREFIXES.append(os.path.normcase(ptvs_lib_path))
 vspd.DONT_DEBUG.append(os.path.normcase(__file__))
 
 # remove all state we imported


### PR DESCRIPTION
Fixes #2675 Module names in the Modules debugger window are unqualified
Includes full module name when we have it
Correctly marks non-user modules
Fixes ptvsd directory not being excluded