### PR TITLE
Fixes #2755 Add new line on enter at end of fully typed word option not working in REPL

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Editor/EditorExtensions.cs
+++ b/Python/Product/PythonTools/PythonTools/Editor/EditorExtensions.cs
@@ -87,6 +87,8 @@ namespace Microsoft.PythonTools.Editor.Core {
             );
         }
 
+        public static SnapshotPoint? MapDownToPythonBuffer(this ITextView view, SnapshotPoint point) => MapPoint(view, point);
+
         /// <summary>
         /// Maps down to the buffer using positive point tracking and successor position affinity
         /// </summary>

--- a/Python/Product/PythonTools/PythonTools/Intellisense/IntellisenseController.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/IntellisenseController.cs
@@ -1200,8 +1200,12 @@ namespace Microsoft.PythonTools.Intellisense {
 
         private bool EnterOnCompleteText(ICompletionSession session) {
             var selectionStatus = session.SelectedCompletionSet.SelectionStatus;
-            var caret = _textView.Caret.Position.BufferPosition;
-            var span = session.GetApplicableSpan(_textView.TextBuffer).GetSpan(caret.Snapshot);
+            var mcaret = session.TextView.MapDownToPythonBuffer(session.TextView.Caret.Position.BufferPosition);
+            if (!mcaret.HasValue) {
+                return false;
+            }
+            var caret = mcaret.Value;
+            var span = session.GetApplicableSpan(caret.Snapshot.TextBuffer).GetSpan(caret.Snapshot);
 
             return caret == span.End &&
                 span.Length == selectionStatus.Completion?.InsertionText.Length &&

--- a/Python/Tests/ReplWindowUITestsRunner/ReplWindowAdvancedUITests.cs
+++ b/Python/Tests/ReplWindowUITestsRunner/ReplWindowAdvancedUITests.cs
@@ -100,7 +100,6 @@ namespace ReplWindowUITestsRunner {
             _vs.RunTest(nameof(ReplWindowUITests.ReplWindowUITests.CompletionFullTextWithoutNewLine), Interpreter);
         }
 
-        [Ignore] // https://github.com/Microsoft/PTVS/issues/2755
         [TestMethod, Priority(2)]
         [TestCategory("Interactive")]
         [TestCategory("Installed")]


### PR DESCRIPTION
Fixes #2755 Add new line on enter at end of fully typed word option not working in REPL
Maps positions to correct buffers before comparing locations.
Enables test