### PR TITLE
Fixes #2965 Error on Ctrl+space after string literal

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Intellisense/IntellisenseController.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/IntellisenseController.cs
@@ -867,7 +867,6 @@ namespace Microsoft.PythonTools.Intellisense {
             if (set == null) {
                 return false;
             }
-            set.Filter();
             if (set.SelectSingleBest()) {
                 session.Commit();
                 return true;


### PR DESCRIPTION
Fixes #2965 Error on Ctrl+space after string literal
Hardens SelectSingleBest against unexpected errors
Ensures completions are un-filtered before selecting the best for immediate completion.
Refactor FuzzyCompletionSet.Filter() into more manageable methods.