### PR TITLE
Fixes #3180 Some scraped types lie about their name

### DIFF
--- a/Python/Product/Analysis/Interpreter/Ast/AstBuiltinsPythonModule.cs
+++ b/Python/Product/Analysis/Interpreter/Ast/AstBuiltinsPythonModule.cs
@@ -84,7 +84,7 @@ namespace Microsoft.PythonTools.Interpreter.Ast {
         }
 
         protected override PythonWalker PrepareWalker(IPythonInterpreter interpreter, PythonAst ast) {
-            var walker = new AstAnalysisWalker(interpreter, ast, this, null, _members, false);
+            var walker = new AstAnalysisWalker(interpreter, ast, this, null, _members, false, true);
             walker.CreateBuiltinTypes = true;
             walker.Scope.SuppressBuiltinLookup = true;
             return walker;

--- a/Python/Product/Analysis/Interpreter/Ast/AstNestedPythonModuleMember.cs
+++ b/Python/Product/Analysis/Interpreter/Ast/AstNestedPythonModuleMember.cs
@@ -15,6 +15,7 @@
 // permissions and limitations under the License.
 
 using System;
+using System.Linq;
 using System.Threading;
 using Microsoft.PythonTools.Analysis;
 
@@ -47,13 +48,15 @@ namespace Microsoft.PythonTools.Interpreter.Ast {
                 return m;
             }
 
+            var interp = _context as AstPythonInterpreter;
+
             Module.Imported(_context);
-            m = Module.GetMember(_context, Name);
+            m = Module.GetMember(_context, Name) ?? interp?.ImportModule(Module.Name + "." + Name);
             if (m != null) {
+                (m as IPythonModule)?.Imported(_context);
                 return Interlocked.CompareExchange(ref _realMember, m, null) ?? m;
             }
 
-            var interp = _context as AstPythonInterpreter;
             if (interp == null) {
                 return null;
             }

--- a/Python/Product/Analysis/Interpreter/Ast/AstPythonInterpreter.cs
+++ b/Python/Product/Analysis/Interpreter/Ast/AstPythonInterpreter.cs
@@ -33,7 +33,8 @@ namespace Microsoft.PythonTools.Interpreter.Ast {
         private IReadOnlyList<string> _builtinModuleNames;
         private readonly ConcurrentDictionary<string, IPythonModule> _modules;
         private readonly AstPythonBuiltinType _noneType;
-        private readonly AnalysisLogWriter _log;
+
+        internal readonly AnalysisLogWriter _log;
 
         private readonly object _userSearchPathsLock = new object();
         private IReadOnlyList<string> _userSearchPaths;

--- a/Python/Product/Analysis/Interpreter/Ast/AstPythonModule.cs
+++ b/Python/Product/Analysis/Interpreter/Ast/AstPythonModule.cs
@@ -109,7 +109,7 @@ namespace Microsoft.PythonTools.Interpreter.Ast {
                 _foundChildModules = true;
             }
 
-            var walker = new AstAnalysisWalker(interpreter, ast, this, filePath, _members, true);
+            var walker = new AstAnalysisWalker(interpreter, ast, this, filePath, _members, true, true);
             ast.Walk(walker);
         }
 

--- a/Python/Product/Analysis/Interpreter/Ast/AstScrapedPythonModule.cs
+++ b/Python/Product/Analysis/Interpreter/Ast/AstScrapedPythonModule.cs
@@ -100,7 +100,7 @@ namespace Microsoft.PythonTools.Interpreter.Ast {
         }
 
         protected virtual PythonWalker PrepareWalker(IPythonInterpreter interpreter, PythonAst ast) {
-            return new AstAnalysisWalker(interpreter, ast, this, _filePath, _members, false);
+            return new AstAnalysisWalker(interpreter, ast, this, _filePath, _members, false, true);
         }
 
         protected virtual void PostWalk(PythonWalker walker) {

--- a/Python/Product/Analysis/Values/FunctionInfo.cs
+++ b/Python/Product/Analysis/Values/FunctionInfo.cs
@@ -249,11 +249,19 @@ namespace Microsoft.PythonTools.Analysis.Values {
 
         public IEnumerable<KeyValuePair<string, string>> GetRichDescription() {
             if (FunctionDefinition.IsLambda) {
-                yield return new KeyValuePair<string, string>(WellKnownRichDescriptionKinds.Misc, "lambda ");
+                bool needsLambda = true;
                 foreach (var kv in GetParameterString()) {
+                    if (needsLambda) {
+                        yield return new KeyValuePair<string, string>(WellKnownRichDescriptionKinds.Misc, "lambda ");
+                        needsLambda = false;
+                    }
                     yield return kv;
                 }
-                yield return new KeyValuePair<string, string>(WellKnownRichDescriptionKinds.Misc, ": ");
+                if (needsLambda) {
+                    yield return new KeyValuePair<string, string>(WellKnownRichDescriptionKinds.Misc, "lambda:");
+                } else {
+                    yield return new KeyValuePair<string, string>(WellKnownRichDescriptionKinds.Misc, ":");
+                }
 
                 if (FunctionDefinition.IsGenerator) {
                     var lambdaExpr = ((ExpressionStatement)FunctionDefinition.Body).Expression;

--- a/Python/Tests/Analysis/AnalysisTest.cs
+++ b/Python/Tests/Analysis/AnalysisTest.cs
@@ -6411,7 +6411,7 @@ def update_wrapper(wrapper, wrapped, assigned, updated):
             var entry = ProcessText(code);
 
             Assert.AreEqual(
-                "def test-module.A.fn(self) -> lambda : 123 -> int\ndeclared in A",
+                "def test-module.A.fn(self) -> lambda: 123 -> int\ndeclared in A",
                 entry.GetDescriptions("A.fn", 0).Single().Replace("\r\n", "\n")
             );
         }


### PR DESCRIPTION
Fixes #3180 Some scraped types lie about their name
Adds quick test for numpy.ndarray to detect whether we are handling types with incorrect names
Adds list of known-bad types to scrape_module.py
Fixes "from . import module" pattern
Enhances logging during AST analysis
Enhances handling of common expression types during value lookup