### PR TITLE
Fixes #3027 No IntelliSense info for instance method "pointers"

### DIFF
--- a/Python/Product/Analysis/Analysis.csproj
+++ b/Python/Product/Analysis/Analysis.csproj
@@ -66,6 +66,7 @@
     <Compile Include="Interpreter\Ast\AstBuiltinPythonModule.cs" />
     <Compile Include="Interpreter\Ast\AstBuiltinsPythonModule.cs" />
     <Compile Include="Interpreter\Ast\AstNestedPythonModuleMember.cs" />
+    <Compile Include="Interpreter\Ast\AstPythonBoundMethod.cs" />
     <Compile Include="Interpreter\Ast\AstPythonBuiltinType.cs" />
     <Compile Include="Interpreter\Ast\AstPythonInterpreter.cs" />
     <Compile Include="Interpreter\Ast\AstNestedPythonModule.cs" />

--- a/Python/Product/Analysis/Interpreter/Ast/AstPythonBoundMethod.cs
+++ b/Python/Product/Analysis/Interpreter/Ast/AstPythonBoundMethod.cs
@@ -1,0 +1,32 @@
+﻿// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABLITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System.Collections.Generic;
+using Microsoft.PythonTools.Analysis;
+
+namespace Microsoft.PythonTools.Interpreter.Ast {
+    class AstPythonBoundMethod : IPythonBoundFunction, ILocatedMember {
+        public AstPythonBoundMethod(IPythonFunction function, IPythonType selfType) {
+            Function = function;
+            SelfType = selfType;
+        }
+
+        public IPythonFunction Function { get; }
+        public IPythonType SelfType { get; }
+        public PythonMemberType MemberType => PythonMemberType.Method;
+        public IEnumerable<LocationInfo> Locations => (Function as ILocatedMember)?.Locations;
+    }
+}

--- a/Python/Product/Analysis/Interpreter/IPythonFunction.cs
+++ b/Python/Product/Analysis/Interpreter/IPythonFunction.cs
@@ -56,4 +56,14 @@ namespace Microsoft.PythonTools.Interpreter {
             get;
         }
     }
+
+    /// <summary>
+    /// Represents a bound function. Similar to <see cref="IPythonMethodDescriptor"/>,
+    /// but uses Python 3.x semantics where the first argument of Function is
+    /// assumed to be filled with an instance of SelfType.
+    /// </summary>
+    public interface IPythonBoundFunction : IMember {
+        IPythonType SelfType { get; }
+        IPythonFunction Function { get; }
+    }
 }

--- a/Python/Product/Analysis/PythonAnalyzer.cs
+++ b/Python/Product/Analysis/PythonAnalyzer.cs
@@ -911,6 +911,8 @@ namespace Microsoft.PythonTools.Analysis {
                         return new BuiltinMethodInfo(md, this);
                     }
                 }) ?? _noneInst;
+            } else if (attr is IPythonBoundFunction) {
+                return GetCached(attr, () => new BoundBuiltinMethodInfo((IPythonBoundFunction)attr, this)) ?? _noneInst;
             } else if (attr is IBuiltinProperty) {
                 return GetCached(attr, () => new BuiltinPropertyInfo((IBuiltinProperty)attr, this)) ?? _noneInst;
             } else if (attr is IPythonModule) {

--- a/Python/Product/Analysis/Values/BoundBuiltinMethodInfo.cs
+++ b/Python/Product/Analysis/Values/BoundBuiltinMethodInfo.cs
@@ -28,23 +28,17 @@ namespace Microsoft.PythonTools.Analysis.Values {
             _method = method;
         }
 
-        public override PythonMemberType MemberType {
-            get {
-                return _method.MemberType;
-            }
+        public BoundBuiltinMethodInfo(IPythonBoundFunction function, PythonAnalyzer projectState)
+            : this(new BuiltinMethodInfo(function.Function, PythonMemberType.Method, projectState)) {
         }
 
-        public BuiltinMethodInfo Method {
-            get {
-                return _method;
-            }
-        }
+        public override PythonMemberType MemberType => _method.MemberType;
 
-        public override string Documentation {
-            get {
-                return _method.Documentation;
-            }
-        }
+        public override IPythonType PythonType => base._type;
+
+        public BuiltinMethodInfo Method => _method;
+
+        public override string Documentation => _method.Documentation;
 
         public override string Description {
             get {

--- a/Python/Tests/Analysis/AstAnalysisTests.cs
+++ b/Python/Tests/Analysis/AstAnalysisTests.cs
@@ -235,6 +235,37 @@ R_A3 = R_A1.r_A()");
         }
 
         [TestMethod, Priority(0)]
+        public void AstInstanceMembers() {
+            using (var entry = CreateAnalysis()) {
+                entry.SetSearchPaths(TestData.GetPath(@"TestData\AstAnalysis"));
+                entry.AddModule("test-module", "from InstanceMethod import f1, f2");
+                entry.WaitForAnalysis();
+
+                entry.AssertHasAttr("", "f1", "f2");
+
+                entry.AssertIsInstance("f1", BuiltinTypeId.BuiltinFunction);
+                entry.AssertIsInstance("f2", BuiltinTypeId.BuiltinMethodDescriptor);
+
+                var func = entry.GetValue<BuiltinFunctionInfo>("f1");
+                var method = entry.GetValue<BoundBuiltinMethodInfo>("f2");
+            }
+        }
+        [TestMethod, Priority(0)]
+        public void AstInstanceMembers_Random() {
+            using (var entry = CreateAnalysis()) {
+                entry.AddModule("test-module", "from random import *");
+                entry.WaitForAnalysis();
+
+                foreach (var fnName in new[] { "seed", "randrange", "gauss" }) {
+                    entry.AssertIsInstance(fnName, BuiltinTypeId.BuiltinMethodDescriptor);
+                    var func = entry.GetValue<BoundBuiltinMethodInfo>(fnName);
+                    Assert.AreNotEqual(0, func.Overloads.Count(), $"{fnName} overloads");
+                    Assert.AreNotEqual(0, func.Overloads.ElementAt(0).Parameters.Length, $"{fnName} parameters");
+                }
+            }
+        }
+
+        [TestMethod, Priority(0)]
         public void AstSearchPathsThroughFactory() {
             using (var evt = new ManualResetEvent(false))
             using (var analysis = CreateAnalysis()) {

--- a/Python/Tests/TestData/AstAnalysis/InstanceMethod.py
+++ b/Python/Tests/TestData/AstAnalysis/InstanceMethod.py
@@ -1,0 +1,6 @@
+class C:
+    def f(self): pass
+
+f1 = C.f
+c = C()
+f2 = c.f


### PR DESCRIPTION
Fixes #3027 No IntelliSense info for instance method "pointers"
Enables member lookup via AstPythonConstant
Fixes recursion in lazy members
Fixes bound method info not displaying correctly
Updates tests