### PR TITLE
Fixes #2869 Go to definition fails for named argument

### DIFF
--- a/Python/Product/Analysis/Analyzer/ClassScope.cs
+++ b/Python/Product/Analysis/Analyzer/ClassScope.cs
@@ -31,7 +31,7 @@ namespace Microsoft.PythonTools.Analysis.Analyzer {
         }
 
         public override int GetBodyStart(PythonAst ast) {
-            return ast.IndexToLocation(((ClassDefinition)Node).HeaderIndex).Index;
+            return ((ClassDefinition)Node).HeaderIndex;
         }
 
         public override string Name {

--- a/Python/Product/Analysis/Analyzer/FunctionScope.cs
+++ b/Python/Product/Analysis/Analyzer/FunctionScope.cs
@@ -213,7 +213,7 @@ namespace Microsoft.PythonTools.Analysis.Analyzer {
         }
 
         public override int GetBodyStart(PythonAst ast) {
-            return ast.IndexToLocation(((FunctionDefinition)Node).HeaderIndex).Index;
+            return ((FunctionDefinition)Node).HeaderIndex;
         }
 
         public override string Name {

--- a/Python/Product/Analysis/Analyzer/InterpreterScope.cs
+++ b/Python/Product/Analysis/Analyzer/InterpreterScope.cs
@@ -99,7 +99,7 @@ namespace Microsoft.PythonTools.Analysis.Analyzer {
             if (_node == null) {
                 return 1;
             }
-            return _node.GetStart(ast).Index;
+            return _node.StartIndex;
         }
 
         /// <summary>
@@ -109,7 +109,7 @@ namespace Microsoft.PythonTools.Analysis.Analyzer {
             if (_node == null) {
                 return int.MaxValue;
             }
-            return _node.GetEnd(ast).Index;
+            return _node.EndIndex;
         }
 
         public abstract string Name {

--- a/Python/Product/Analysis/Analyzer/IsInstanceScope.cs
+++ b/Python/Product/Analysis/Analyzer/IsInstanceScope.cs
@@ -35,11 +35,11 @@ namespace Microsoft.PythonTools.Analysis.Analyzer {
         }
 
         public override int GetStart(PythonAst ast) {
-            return ast.IndexToLocation(_startIndex).Index;
+            return _startIndex;
         }
 
         public override int GetStop(PythonAst ast) {
-            return ast.IndexToLocation(_endIndex).Index;
+            return _endIndex;
         }
 
         public override InterpreterScope AddNodeScope(Node node, InterpreterScope scope) {

--- a/Python/Product/Analysis/Analyzer/StatementScope.cs
+++ b/Python/Product/Analysis/Analyzer/StatementScope.cs
@@ -30,11 +30,11 @@ namespace Microsoft.PythonTools.Analysis.Analyzer {
         }
 
         public override int GetStart(PythonAst ast) {
-            return ast.IndexToLocation(_startIndex).Index;
+            return _startIndex;
         }
 
         public override int GetStop(PythonAst ast) {
-            return ast.IndexToLocation(_endIndex).Index;
+            return _endIndex;
         }
 
         public int EndIndex {

--- a/Python/Product/Analysis/ExpressionFinder.cs
+++ b/Python/Product/Analysis/ExpressionFinder.cs
@@ -296,6 +296,14 @@ namespace Microsoft.PythonTools.Analysis {
             Members = true,
             MemberTarget = true,
         };
+        public static GetExpressionOptions FindDefinition => new GetExpressionOptions {
+            Names = true,
+            Members = true,
+            ParameterNames = true,
+            NamedArgumentNames = true,
+            ImportNames = true,
+            ImportAsNames = true,
+        };
         public static GetExpressionOptions Rename => new GetExpressionOptions {
             Names = true,
             MemberName = true,

--- a/Python/Product/Analysis/ExpressionFinder.cs
+++ b/Python/Product/Analysis/ExpressionFinder.cs
@@ -142,6 +142,19 @@ namespace Microsoft.PythonTools.Analysis {
                 }
                 return false;
             }
+
+            public override bool Walk(Arg node) {
+                if (!base.Walk(node)) {
+                    return false;
+                }
+                
+                var n = node.NameExpression;
+                if (_options.NamedArgumentNames && n != null && Location >= n.StartIndex && Location <= n.EndIndex) {
+                    Expression = n;
+                }
+
+                return true;
+            }
         }
 
         private class MemberTargetExpressionWalker : ExpressionWalker {
@@ -191,6 +204,7 @@ namespace Microsoft.PythonTools.Analysis {
         public static GetExpressionOptions Rename => new GetExpressionOptions {
             Names = true,
             MemberName = true,
+            NamedArgumentNames = true,
             ParameterNames = true,
         };
 
@@ -202,6 +216,7 @@ namespace Microsoft.PythonTools.Analysis {
         public bool MemberName { get; set; } = false;
         public bool Literals { get; set; } = false;
         public bool ParenthesisedExpression { get; set; } = false;
+        public bool NamedArgumentNames { get; set; } = false;
         public bool ParameterNames { get; set; } = false;
         public bool ClassDefinition { get; set; } = false;
         public bool FunctionDefinition { get; set; } = false;

--- a/Python/Product/Analysis/Interpreter/Ast/AstPythonInterpreter.cs
+++ b/Python/Product/Analysis/Interpreter/Ast/AstPythonInterpreter.cs
@@ -215,6 +215,8 @@ namespace Microsoft.PythonTools.Interpreter.Ast {
                         mod = newMod;
                     } else if (newMod == null) {
                         _log?.Log(TraceLevel.Warning, "ImportTimeout", name);
+                    } else {
+                        mod = newMod;
                     }
                 }
                 return mod;

--- a/Python/Product/Analysis/ModuleAnalysis.cs
+++ b/Python/Product/Analysis/ModuleAnalysis.cs
@@ -1004,7 +1004,8 @@ namespace Microsoft.PythonTools.Analysis {
                 return false;
             }
 
-            if (location.Index < function.StartIndex || location.Index >= function.Body.StartIndex) {
+            int index = tree.LocationToIndex(location);
+            if (index < function.StartIndex || index >= function.Body.StartIndex) {
                 // Not within the def line
                 return false;
             }
@@ -1012,7 +1013,7 @@ namespace Microsoft.PythonTools.Analysis {
             return function.Parameters != null &&
                 function.Parameters.Any(p => {
                     var paramName = p.GetVerbatimImage(tree) ?? p.Name;
-                    return location.Index >= p.StartIndex && location.Index <= p.StartIndex + paramName.Length;
+                    return index >= p.StartIndex && index <= p.StartIndex + paramName.Length;
                 });
         }
 

--- a/Python/Product/Analysis/Parsing/Ast/PythonAst.cs
+++ b/Python/Product/Analysis/Parsing/Ast/PythonAst.cs
@@ -117,6 +117,14 @@ namespace Microsoft.PythonTools.Parsing.Ast {
             return NewLineLocation.LocationToIndex(_lineLocations, location);
         }
 
+        /// <summary>
+        /// Length of the span (number of characters inside the span).
+        /// </summary>
+        public int GetSpanLength(SourceSpan span) {
+            return LocationToIndex(span.End) - LocationToIndex(span.Start);
+        }
+
+
         internal int GetLineEndFromPosition(int index) {
             var loc = IndexToLocation(index);
             var res = _lineLocations[loc.Line - 1];

--- a/Python/Product/Analysis/Parsing/Parser.cs
+++ b/Python/Product/Analysis/Parsing/Parser.cs
@@ -1694,6 +1694,7 @@ namespace Microsoft.PythonTools.Parsing {
                     args = new Arg[l.Count];
                     for (int i = 0; i < l.Count; i++) {
                         args[i] = new Arg(l[i]);
+                        args[i].SetLoc(l[i].StartIndex, l[i].EndIndex);
                     }
                     
                     ateTerminator = Eat(TokenKind.RightParenthesis);

--- a/Python/Product/Analysis/Parsing/SourceLocation.cs
+++ b/Python/Product/Analysis/Parsing/SourceLocation.cs
@@ -43,6 +43,19 @@ namespace Microsoft.PythonTools.Parsing {
             _column = column;
         }
 
+        /// <summary>
+        /// Creates a new source location.
+        /// </summary>
+        /// <param name="line">The line in the source stream the location represents (1-based).</param>
+        /// <param name="column">The column in the source stream the location represents (1-based).</param>
+        public SourceLocation(int line, int column) {
+            ValidateLocation(0, line, column);
+
+            _index = -1;
+            _line = line;
+            _column = column;
+        }
+
         private static void ValidateLocation(int index, int line, int column) {
             if (index < 0) {
                 throw ErrorOutOfRange("index", 0);
@@ -70,7 +83,12 @@ namespace Microsoft.PythonTools.Parsing {
         /// The index in the source stream the location represents (0-based).
         /// </summary>
         public int Index {
-            get { return _index; }
+            get {
+                if (_index < 0) {
+                    throw new InvalidOperationException("Index is not valid");
+                }
+                return _index;
+            }
         }
 
         /// <summary>

--- a/Python/Product/Analysis/Parsing/SourceSpan.cs
+++ b/Python/Product/Analysis/Parsing/SourceSpan.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Globalization;
+using Microsoft.PythonTools.Parsing.Ast;
 
 namespace Microsoft.PythonTools.Parsing {
 
@@ -62,13 +63,6 @@ namespace Microsoft.PythonTools.Parsing {
         /// </summary>
         public SourceLocation End {
             get { return _end; }
-        }
-
-        /// <summary>
-        /// Length of the span (number of characters inside the span).
-        /// </summary>
-        public int Length {
-            get { return _end.Index - _start.Index; }
         }
 
         /// <summary>

--- a/Python/Product/Analysis/Parsing/Tokenizer.cs
+++ b/Python/Product/Analysis/Parsing/Tokenizer.cs
@@ -213,6 +213,7 @@ namespace Microsoft.PythonTools.Parsing {
             _tokenEnd = -1;
             _multiEolns = !_disableLineFeedLineSeparator;
             _initialLocation = initialLocation;
+            Debug.Assert(_initialLocation.Index >= 0);
 
             _tokenEndIndex = -1;
             _tokenStartIndex = 0;

--- a/Python/Product/Analyzer/Intellisense/AnalysisProtocol.cs
+++ b/Python/Product/Analyzer/Intellisense/AnalysisProtocol.cs
@@ -131,7 +131,7 @@ namespace Microsoft.PythonTools.Intellisense {
 
             public int fileId;
             public string expr;
-            public int line, column, index;
+            public int line, column;
 
             public override string command => Command;
         }
@@ -236,7 +236,7 @@ namespace Microsoft.PythonTools.Intellisense {
 
             public int fileId;
             public string expr;
-            public int line, column, index;
+            public int line, column;
 
             public override string command => Command;
         }
@@ -292,7 +292,7 @@ namespace Microsoft.PythonTools.Intellisense {
 
         public class Error {
             public string message;
-            public int startLine, startColumn, startIndex;
+            public int startLine, startColumn;
             public int endLine, endColumn, length;
         }
 
@@ -462,7 +462,7 @@ namespace Microsoft.PythonTools.Intellisense {
 
         public sealed class UnresolvedImport {
             public string name;
-            public int startIndex, endIndex, startLine, endLine, startColumn, endColumn;
+            public int startLine, endLine, startColumn, endColumn;
         }
 
         public sealed class FileChangedResponse : Response {
@@ -519,7 +519,7 @@ namespace Microsoft.PythonTools.Intellisense {
             public const string Command = "overrides";
 
             public int fileId, bufferId;
-            public int line, column, index;
+            public int line, column;
             public string indentation;
 
             public override string command => Command;
@@ -657,7 +657,7 @@ namespace Microsoft.PythonTools.Intellisense {
 
             public int fileId, bufferId;
             public string text;
-            public int location, column;
+            public int line, column;
             public GetMemberOptions options;
             public bool forceCompletions;
 
@@ -670,7 +670,7 @@ namespace Microsoft.PythonTools.Intellisense {
             public override string command => Command;
 
             public string text;
-            public int location, column;
+            public int line, column;
             public int fileId;
         }
 
@@ -841,7 +841,9 @@ namespace Microsoft.PythonTools.Intellisense {
 
             public int fileId;
             public string expr;
-            public int line, column, index;
+            public int line, column;
+            [Obsolete("only use line and column")]
+            public int index;
 
             public override string command => Command;
         }

--- a/Python/Product/Analyzer/Intellisense/AnalysisProtocol.cs
+++ b/Python/Product/Analyzer/Intellisense/AnalysisProtocol.cs
@@ -924,7 +924,9 @@ namespace Microsoft.PythonTools.Intellisense {
         public enum ExpressionAtPointPurpose : int {
             Hover = 1,
             Evaluate = 2,
-            EvaluateMembers = 3
+            EvaluateMembers = 3,
+            FindDefinition = 4,
+            Rename = 5
         }
 
         public sealed class ExpressionAtPointRequest : Request<ExpressionAtPointResponse> {

--- a/Python/Product/Analyzer/Intellisense/ImportRemover.cs
+++ b/Python/Product/Analyzer/Intellisense/ImportRemover.cs
@@ -73,8 +73,8 @@ namespace Microsoft.PythonTools.Intellisense {
                     var newCode = updatedStatement.ToCodeString(_ast);
 
                     int proceedingLength = (removed.Node.GetLeadingWhiteSpace(_ast) ?? "").Length;
-                    int start = span.Start.Index - proceedingLength;
-                    int length = span.Length + proceedingLength;
+                    int start = _ast.LocationToIndex(span.Start) - proceedingLength;
+                    int length = _ast.GetSpanLength(span) + proceedingLength;
 
                     changes.Add(
                         new AP.ChangeInfo() {
@@ -85,7 +85,7 @@ namespace Microsoft.PythonTools.Intellisense {
                     );
                     changes.Add(
                         new AP.ChangeInfo() {
-                            start = span.Start.Index,
+                            start = _ast.LocationToIndex(span.Start),
                             length = 0,
                             newText = newCode
                         }
@@ -100,8 +100,8 @@ namespace Microsoft.PythonTools.Intellisense {
             // newline and any indentation.
 
 
-            int start = span.Start.Index;
-            int length = span.Length;
+            int start = _ast.LocationToIndex(span.Start);
+            int length = _ast.GetSpanLength(span);
             int cur = start - 1;
             if (!insertPass) {
                 // backup to remove any indentation

--- a/Python/Product/Analyzer/Intellisense/OutOfProcProjectAnalyzer.cs
+++ b/Python/Product/Analyzer/Intellisense/OutOfProcProjectAnalyzer.cs
@@ -1223,6 +1223,12 @@ namespace Microsoft.PythonTools.Intellisense {
                 case AP.ExpressionAtPointPurpose.Hover:
                     options = GetExpressionOptions.Hover;
                     break;
+                case AP.ExpressionAtPointPurpose.FindDefinition:
+                    options = GetExpressionOptions.FindDefinition;
+                    break;
+                case AP.ExpressionAtPointPurpose.Rename:
+                    options = GetExpressionOptions.Rename;
+                    break;
                 default:
                     options = new GetExpressionOptions();
                     break;

--- a/Python/Product/Analyzer/Intellisense/OutOfProcProjectAnalyzer.cs
+++ b/Python/Product/Analyzer/Intellisense/OutOfProcProjectAnalyzer.cs
@@ -362,7 +362,6 @@ namespace Microsoft.PythonTools.Intellisense {
                 var values = entry.Analysis.GetValues(
                     request.expr,
                     new SourceLocation(
-                        request.index,
                         request.line,
                         request.column
                     )
@@ -943,8 +942,8 @@ namespace Microsoft.PythonTools.Intellisense {
             var span = fromImport.GetSpan(curAst);
             int leadingWhiteSpaceLength = (fromImport.GetLeadingWhiteSpace(curAst) ?? "").Length;
             return new AP.ChangeInfo() {
-                start = span.Start.Index - leadingWhiteSpaceLength,
-                length = span.Length + leadingWhiteSpaceLength,
+                start = curAst.LocationToIndex(span.Start) - leadingWhiteSpaceLength,
+                length = curAst.GetSpanLength(span) + leadingWhiteSpaceLength,
                 newText = newCode
             };
         }
@@ -1031,10 +1030,8 @@ namespace Microsoft.PythonTools.Intellisense {
                     name = name,
                     startLine = span.Start.Line,
                     startColumn = span.Start.Column,
-                    startIndex = span.Start.Index,
                     endLine = span.End.Line,
                     endColumn = span.End.Column,
-                    endIndex = span.End.Index
                 };
             }
 
@@ -1253,7 +1250,8 @@ namespace Microsoft.PythonTools.Intellisense {
             string memberName = null;
 
             if (entry.Tree != null) {
-                var w = new ImportedModuleNameWalker(entry.ModuleName, request.index);
+                int index = entry.Tree.LocationToIndex(new SourceLocation(request.line, request.column));
+                var w = new ImportedModuleNameWalker(entry.ModuleName, index);
                 entry.Tree.Walk(w);
                 ModuleReference modRef;
                 if (!string.IsNullOrEmpty(w.ImportedName) &&
@@ -1273,7 +1271,7 @@ namespace Microsoft.PythonTools.Intellisense {
                 var variables = entry.Analysis.GetVariables(
                     request.expr,
                     new SourceLocation(
-                        request.index,
+                        0,
                         request.line,
                         request.column
                     )
@@ -1347,9 +1345,13 @@ namespace Microsoft.PythonTools.Intellisense {
                 return IncorrectFileType();
             }
             string text = null;
+            var loc = new SourceLocation(request.line, request.column);
 
             if (entry.Tree != null) {
-                var w = new ImportedModuleNameWalker(entry.ModuleName, request.index);
+                var w = new ImportedModuleNameWalker(
+                    entry.ModuleName,
+                    entry.Tree.LocationToIndex(loc)
+                );
                 entry.Tree.Walk(w);
                 if (!string.IsNullOrEmpty(w.ImportedName)) {
                     return new AP.QuickInfoResponse {
@@ -1366,7 +1368,6 @@ namespace Microsoft.PythonTools.Intellisense {
                 bool multiline = false;
                 bool includeExpression = true;
 
-                var loc = new SourceLocation(request.index, request.line, request.column);
                 var exprAst = ModuleAnalysis.GetExpression(entry.Analysis.GetAstFromText(request.expr, loc)?.Body);
                 if (exprAst is ConstantExpression || exprAst is ErrorExpression) {
                     includeExpression = false;
@@ -1474,9 +1475,9 @@ namespace Microsoft.PythonTools.Intellisense {
             IEnumerable<IOverloadResult> sigs;
             if (entry.Analysis != null) {
                 using (new DebugTimer("GetSignaturesByIndex")) {
-                    sigs = entry.Analysis.GetSignaturesByIndex(
+                    sigs = entry.Analysis.GetSignatures(
                         request.text,
-                        request.location
+                        new SourceLocation(request.line, request.column)
                     );
                 }
             } else {
@@ -1537,9 +1538,9 @@ namespace Microsoft.PythonTools.Intellisense {
 
             IEnumerable<MemberResult> members;
             if (entry.Analysis != null) {
-                members = entry.Analysis.GetMembersByIndex(
+                members = entry.Analysis.GetMembers(
                     completions.text,
-                    completions.location,
+                    new SourceLocation(completions.line, completions.column),
                     completions.options
                 ).MaybeEnumerate();
             } else {
@@ -1740,7 +1741,7 @@ namespace Microsoft.PythonTools.Intellisense {
                 return new AP.OverridesCompletionResponse();
             }
 
-            var location = new SourceLocation(request.index, request.line, request.column);
+            var location = new SourceLocation(request.line, request.column);
 
             var cls = analysis.GetDefinitionTree(location).LastOrDefault(member => member.MemberType == PythonMemberType.Class);
             var members = analysis.GetOverrideable(location).ToArray();
@@ -1856,17 +1857,6 @@ namespace Microsoft.PythonTools.Intellisense {
                 newCode = newCode
 #endif
             };
-        }
-
-        /// <summary>
-        /// Gets a CompletionList providing a list of possible members the user can dot through.
-        /// </summary>
-        internal AP.CompletionsResponse GetCompletions(AP.CompletionsRequest request) {
-            var file = _projectFiles.Get(request.fileId);
-
-            using (new DebugTimer("GetCompletions")) {
-                return GetNormalCompletions(file, request);
-            }
         }
 
         internal Task ProcessMessages() {
@@ -2228,8 +2218,8 @@ namespace Microsoft.PythonTools.Intellisense {
                         x => new AP.BufferParseInfo() {
                             bufferId = x.Key,
                             version = x.Value.Version,
-                            errors = x.Value.Errors.Errors.Select(MakeError).ToArray(),
-                            warnings = x.Value.Errors.Warnings.Select(MakeError).ToArray(),
+                            errors = x.Value.Errors.Errors.Select(e => MakeError(e, x.Value.Ast)).ToArray(),
+                            warnings = x.Value.Errors.Warnings.Select(e => MakeError(e, x.Value.Ast)).ToArray(),
                             hasErrors = x.Value.Errors.Errors.Any(),
                             tasks = x.Value.Tasks.ToArray()
                         }
@@ -2238,15 +2228,14 @@ namespace Microsoft.PythonTools.Intellisense {
             );
         }
 
-        private static AP.Error MakeError(ErrorResult error) {
+        private static AP.Error MakeError(ErrorResult error, PythonAst ast) {
             return new AP.Error() {
                 message = error.Message,
                 startLine = error.Span.Start.Line,
                 startColumn = error.Span.Start.Column,
-                startIndex = error.Span.Start.Index,
                 endLine = error.Span.End.Line,
                 endColumn = error.Span.End.Column,
-                length = error.Span.Length
+                length = ast.GetSpanLength(error.Span)
             };
         }
 
@@ -2288,10 +2277,9 @@ namespace Microsoft.PythonTools.Intellisense {
                                     message = text.Substring(1).Trim(),
                                     startLine = span.Start.Line,
                                     startColumn = span.Start.Column,
-                                    startIndex = span.Start.Index,
                                     endLine = span.End.Line,
                                     endColumn = span.End.Column,
-                                    length = span.Length,
+                                    length = text.Length,
                                     priority = kv.Value,
                                     category = AP.TaskCategory.comments,
                                     squiggle = false
@@ -2305,44 +2293,6 @@ namespace Microsoft.PythonTools.Intellisense {
 
         #region Implementation Details
 
-
-        private AP.CompletionsResponse GetNormalCompletions(IProjectEntry projectEntry, AP.CompletionsRequest request) {
-            int version;
-            var code = projectEntry.GetCurrentCode(request.bufferId, out version);
-
-            if (IsSpaceCompletion(code, request.location) && !request.forceCompletions) {
-                return new AP.CompletionsResponse() {
-                    completions = new AP.Completion[0]
-                };
-            }
-
-            var analysis = ((IPythonProjectEntry)projectEntry).Analysis;
-            if (analysis != null) {
-                var members = analysis.GetMembers(
-                    request.text,
-                    new SourceLocation(
-                        request.location,
-                        1,
-                        request.column
-                    ),
-                    request.options
-                ).MaybeEnumerate();
-
-                return new AP.CompletionsResponse() {
-                    completions = ToCompletions(members.ToArray(), request.options)
-                };
-            }
-            return new AP.CompletionsResponse() {
-                completions = Array.Empty<AP.Completion>()
-            };
-        }
-
-        private bool IsSpaceCompletion(string text, int location) {
-            if (location > 0 && location < text.Length - 1) {
-                return text[location - 1] == ' ';
-            }
-            return false;
-        }
 
         internal void Cancel() {
             _analysisQueue.Stop();

--- a/Python/Product/PythonTools/PythonTools/Intellisense/ExpressionAtPoint.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/ExpressionAtPoint.cs
@@ -36,7 +36,9 @@ namespace Microsoft.PythonTools.Intellisense {
     internal enum ExpressionAtPointPurpose : int {
         Hover = AP.ExpressionAtPointPurpose.Hover,
         Evaluate = AP.ExpressionAtPointPurpose.Evaluate,
-        EvaluateMembers = AP.ExpressionAtPointPurpose.EvaluateMembers
+        EvaluateMembers = AP.ExpressionAtPointPurpose.EvaluateMembers,
+        FindDefinition = AP.ExpressionAtPointPurpose.FindDefinition,
+        Rename = AP.ExpressionAtPointPurpose.Rename
     }
 
 }

--- a/Python/Product/PythonTools/PythonTools/Intellisense/ProjectAnalyzer.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/ProjectAnalyzer.cs
@@ -1071,7 +1071,6 @@ namespace Microsoft.PythonTools.Intellisense {
             var req = new AP.ValueDescriptionRequest() {
                 expr = expr,
                 column = location.Column,
-                index = location.Index,
                 line = location.Line,
                 fileId = file.FileId
             };
@@ -1098,7 +1097,6 @@ namespace Microsoft.PythonTools.Intellisense {
             var req = new AP.AnalyzeExpressionRequest() {
                 expr = expr,
                 column = location.Column,
-                index = location.Index,
                 line = location.Line,
                 fileId = entry.FileId
             };
@@ -1129,12 +1127,11 @@ namespace Microsoft.PythonTools.Intellisense {
                 var req = new AP.AnalyzeExpressionRequest() {
                     expr = analysis.Text,
                     column = location.Column,
-                    index = location.Index,
                     line = location.Line,
                     fileId = analysis.Entry.FileId
                 };
 
-                var definitions = await SendRequestAsync(req);
+                var definitions = await SendRequestAsync(req).ConfigureAwait(false);
 
                 if (definitions != null) {
                     return new ExpressionAnalysis(
@@ -1200,7 +1197,7 @@ namespace Microsoft.PythonTools.Intellisense {
                 sigs = await SendRequestAsync(
                     new AP.SignaturesRequest() {
                         text = text,
-                        location = location.Index,
+                        line = location.Line,
                         column = location.Column,
                         fileId = entry.FileId
                     }
@@ -1876,7 +1873,7 @@ namespace Microsoft.PythonTools.Intellisense {
                     fileId = entry.FileId,
                     text = text,
                     options = options,
-                    location = location.Index,
+                    line = location.Line,
                     column = location.Column
                 }).ConfigureAwait(false);
             }
@@ -2421,7 +2418,6 @@ namespace Microsoft.PythonTools.Intellisense {
                     fileId = entry.FileId,
                     bufferId = entry.GetBufferId(textBuffer),
                     column = location.Column,
-                    index = location.Index,
                     line = location.Line,
                     indentation = indentation
                 }
@@ -2462,7 +2458,6 @@ namespace Microsoft.PythonTools.Intellisense {
                 var req = new AP.QuickInfoRequest() {
                     expr = analysis.Text,
                     column = location.Column,
-                    index = location.Index,
                     line = location.Line,
                     fileId = analysis.Entry.FileId
                 };

--- a/Python/Product/PythonTools/PythonTools/Intellisense/ProjectAnalyzer.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/ProjectAnalyzer.cs
@@ -1117,10 +1117,10 @@ namespace Microsoft.PythonTools.Intellisense {
             return null;
         }
 
-        internal async Task<ExpressionAnalysis> AnalyzeExpressionAsync(AnalysisEntry entry, SnapshotPoint point) {
+        internal async Task<ExpressionAnalysis> AnalyzeExpressionAsync(AnalysisEntry entry, SnapshotPoint point, ExpressionAtPointPurpose purpose = ExpressionAtPointPurpose.Evaluate) {
             Debug.Assert(entry.Analyzer == this);
 
-            var analysis = await GetExpressionAtPointAsync(point, ExpressionAtPointPurpose.Evaluate, TimeSpan.FromSeconds(1.0)).ConfigureAwait(false);
+            var analysis = await GetExpressionAtPointAsync(point, purpose, TimeSpan.FromSeconds(1.0)).ConfigureAwait(false);
 
             if (analysis != null) {
                 var location = analysis.Location;

--- a/Python/Product/PythonTools/PythonTools/Intellisense/UnresolvedImportSquiggleProvider.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/UnresolvedImportSquiggleProvider.cs
@@ -94,8 +94,8 @@ namespace Microsoft.PythonTools.Intellisense {
                             entry.Analyzer.InterpreterFactory as IPythonInterpreterFactoryWithDatabase,
                             t.name,
                             new SourceSpan(
-                                new SourceLocation(t.startIndex, t.startLine, t.startColumn),
-                                new SourceLocation(t.endIndex, t.endLine, t.endColumn)
+                                new SourceLocation(t.startLine, t.startColumn),
+                                new SourceLocation(t.endLine, t.endColumn)
                             )
                         )).ToList()
                     );

--- a/Python/Product/PythonTools/PythonTools/Navigation/Navigable/NavigableSymbolSource.cs
+++ b/Python/Product/PythonTools/PythonTools/Navigation/Navigable/NavigableSymbolSource.cs
@@ -103,7 +103,7 @@ namespace Microsoft.PythonTools.Navigation.Navigable {
         internal static async Task<AnalysisLocation[]> GetDefinitionLocationsAsync(AnalysisEntry entry, SnapshotPoint pt) {
             var list = new List<AnalysisLocation>();
 
-            var result = await entry.Analyzer.AnalyzeExpressionAsync(entry, pt).ConfigureAwait(false);
+            var result = await entry.Analyzer.AnalyzeExpressionAsync(entry, pt, ExpressionAtPointPurpose.FindDefinition).ConfigureAwait(false);
             foreach (var variable in (result?.Variables).MaybeEnumerate()) {
                 if (variable.Type == Analysis.VariableType.Definition &&
                     !string.IsNullOrEmpty(variable.Location?.FilePath)) {

--- a/Python/Product/PythonTools/PythonTools/PythonClassifier.cs
+++ b/Python/Product/PythonTools/PythonTools/PythonClassifier.cs
@@ -132,6 +132,15 @@ namespace Microsoft.PythonTools {
         }
 
         /// <summary>
+        /// This can only be used with Tokenizer spans. Others do not have valid Index values
+        /// </summary>
+        /// <param name="span"></param>
+        /// <returns></returns>
+        private static int GetSpanLength(SourceSpan span) {
+            return span.End.Index - span.Start.Index;
+        }
+
+        /// <summary>
         /// Adds classification spans to the given collection.
         /// Scans a contiguous sub-<paramref name="span"/> of a larger code span which starts at <paramref name="codeStartLine"/>.
         /// </summary>
@@ -166,7 +175,7 @@ namespace Microsoft.PythonTools {
 
                         TokenInfo startToken = token;
                         int validPrevLine;
-                        int length = startToken.SourceSpan.Length;
+                        int length = GetSpanLength(startToken.SourceSpan);
                         if (i == 0) {
                             length += GetLeadingMultiLineStrings(tokenizer, snapshot, firstLine, currentLine, out validPrevLine, ref startToken);
                         } else {
@@ -228,7 +237,7 @@ namespace Microsoft.PythonTools {
                     }
 
                     startToken = prevLineTokenization.Tokens[prevLineTokenization.Tokens.Length - 1];
-                    length += startToken.SourceSpan.Length;
+                    length += GetSpanLength(startToken.SourceSpan);
                 }
 
                 validPrevLine = prevLine;
@@ -261,7 +270,7 @@ namespace Microsoft.PythonTools {
                         break;
                     }
 
-                    length += nextLineTokenization.Tokens[0].SourceSpan.Length;
+                    length += GetSpanLength(nextLineTokenization.Tokens[0].SourceSpan);
                 }
                 nextLine++;
             }
@@ -362,7 +371,7 @@ namespace Microsoft.PythonTools {
         private static Span SnapshotSpanToSpan(ITextSnapshot snapshot, TokenInfo token, int lineNumber) {
             var line = snapshot.GetLineFromLineNumber(lineNumber);
             var index = line.Start.Position + token.SourceSpan.Start.Column - 1;
-            var tokenSpan = new Span(index, token.SourceSpan.Length);
+            var tokenSpan = new Span(index, GetSpanLength(token.SourceSpan));
             return tokenSpan;
         }
 

--- a/Python/Tests/Analysis/ExpressionFinderTests.cs
+++ b/Python/Tests/Analysis/ExpressionFinderTests.cs
@@ -209,7 +209,7 @@ b = C().f(1)
             var finder = new ExpressionFinder(ast, options);
             var range = new SourceSpan(new SourceLocation(0, startLine, startColumn), new SourceLocation(0, endLine, endColumn));
             var span = finder.GetExpressionSpan(range);
-            if (span == null || span.Value.Length == 0) {
+            if (span == null || span.Value.Start == span.Value.End) {
                 return;
             }
 

--- a/Python/Tests/PythonToolsMockTests/NavigableTests.cs
+++ b/Python/Tests/PythonToolsMockTests/NavigableTests.cs
@@ -128,7 +128,6 @@ my_func(2, param2=False)
             }
         }
 
-        [Ignore] // https://github.com/Microsoft/PTVS/issues/2869
         [TestMethod, Priority(0)]
         public async Task NamedArgumentDefinition() {
             var code = @"class MyClass(object):
@@ -141,6 +140,9 @@ my_func(2, param2=False)
 def my_func(param3 = True):
     pass
 
+def different_func():
+    pass
+
 my_func(param3=False)
 
 obj = MyClass()
@@ -149,15 +151,13 @@ obj.my_class_func2(param3=False)
 ";
             using (var helper = new NavigableHelper(code, Version)) {
                 // param3 in my_func(param3=False)
-                await helper.CheckDefinitionLocations(197, 6, Location(8, 13));
+                await helper.CheckDefinitionLocations(232, 6, Location(8, 13));
 
-                // BUG: can't go to definition
                 // param2 in obj.my_class_func1(param2=False)
-                await helper.CheckDefinitionLocations(250, 6, Location(2, 30));
+                await helper.CheckDefinitionLocations(285, 6, Location(2, 30));
 
-                // BUG: goes to my_func instead of my_class_func2
                 // param3 in obj.my_class_func2(param3=False)
-                await helper.CheckDefinitionLocations(284, 6, Location(5, 30));
+                await helper.CheckDefinitionLocations(319, 6, Location(5, 30));
             }
         }
 
@@ -244,6 +244,7 @@ res = my_var * 10
 
                 var trackingSpan = _view.CurrentSnapshot.CreateTrackingSpan(pos, length, SpanTrackingMode.EdgeInclusive);
                 var snapshotSpan = trackingSpan.GetSpan(_view.CurrentSnapshot);
+                Console.WriteLine("Finding definition of \"{0}\"", snapshotSpan.GetText());
                 var actualLocations = await NavigableSymbolSource.GetDefinitionLocationsAsync(entry, snapshotSpan.Start);
                 if (expectedLocations != null) {
                     Assert.IsNotNull(actualLocations);


### PR DESCRIPTION
Fixes #2869 Go to definition fails for named argument
Enable GTD for argument names.
Fixes bug in FindScopes where we were selecting function scopes incorrectly.