### PR TITLE
Handle missing interpreter when launching with script

### DIFF
--- a/Python/Product/PythonTools/PythonToolsPackage.cs
+++ b/Python/Product/PythonTools/PythonToolsPackage.cs
@@ -283,29 +283,40 @@ namespace Microsoft.PythonTools {
 
         internal static bool LaunchFile(IServiceProvider provider, string filename, bool debug, bool saveDirtyFiles) {
             var project = (IPythonProject)provider.GetProjectFromOpenFile(filename) ?? new DefaultPythonProject(provider, filename);
-            var starter = GetLauncher(provider, project);
-            if (starter == null) {
-                Debug.Fail("Failed to get project launcher");
-                return false;
-            }
+            try {
+                var starter = GetLauncher(provider, project);
+                if (starter == null) {
+                    Debug.Fail("Failed to get project launcher");
+                    return false;
+                }
 
-            if (saveDirtyFiles) {
-                var rdt = provider.GetService(typeof(SVsRunningDocumentTable)) as IVsRunningDocumentTable;
-                if (rdt != null) {
-                    // Consider using (uint)(__VSRDTSAVEOPTIONS.RDTSAVEOPT_SaveIfDirty | __VSRDTSAVEOPTIONS.RDTSAVEOPT_PromptSave)
-                    // when VS settings include prompt for save on build
-                    var saveOpt = (uint)__VSRDTSAVEOPTIONS.RDTSAVEOPT_SaveIfDirty;
-                    var hr = rdt.SaveDocuments(saveOpt, null, VSConstants.VSITEMID_NIL, VSConstants.VSCOOKIE_NIL);
-                    if (hr == VSConstants.E_ABORT) {
-                        return false;
+                if (saveDirtyFiles) {
+                    var rdt = provider.GetService(typeof(SVsRunningDocumentTable)) as IVsRunningDocumentTable;
+                    if (rdt != null) {
+                        // Consider using (uint)(__VSRDTSAVEOPTIONS.RDTSAVEOPT_SaveIfDirty | __VSRDTSAVEOPTIONS.RDTSAVEOPT_PromptSave)
+                        // when VS settings include prompt for save on build
+                        var saveOpt = (uint)__VSRDTSAVEOPTIONS.RDTSAVEOPT_SaveIfDirty;
+                        var hr = rdt.SaveDocuments(saveOpt, null, VSConstants.VSITEMID_NIL, VSConstants.VSCOOKIE_NIL);
+                        if (hr == VSConstants.E_ABORT) {
+                            return false;
+                        }
                     }
                 }
-            }
 
-            try {
                 starter.LaunchFile(filename, debug);
             } catch (MissingInterpreterException ex) {
-                MessageBox.Show(ex.Message, Strings.ProductTitle, MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
+                var interpreterRegistry = provider.GetComponentModel().GetService<IInterpreterRegistryService>();
+                if (project.GetInterpreterFactory() == interpreterRegistry.NoInterpretersValue) {
+                    OpenNoInterpretersHelpPage(provider, ex.HelpPage);
+                } else {
+                    var td = new TaskDialog(provider) {
+                        Title = Strings.ProductTitle,
+                        MainInstruction = Strings.FailedToLaunchDebugger,
+                        Content = ex.Message
+                    };
+                    td.Buttons.Add(TaskDialogButton.Close);
+                    td.ShowModal();
+                }
                 return false;
             } catch (NoInterpretersException ex) {
                 OpenNoInterpretersHelpPage(provider, ex.HelpPage);


### PR DESCRIPTION
Fix #3176 

In launch script (PythonToolsPackage.LaunchFile), match the exception handling that's used in launch project (PythonProjectConfig.DebugLaunch)