### PR TITLE
Relocate parethenses for proper tab completion

### DIFF
--- a/Python/Product/PythonTools/Snippets/Python/class.snippet
+++ b/Python/Product/PythonTools/Snippets/Python/class.snippet
@@ -21,10 +21,10 @@
         <Literal>
           <ID>bases</ID>
           <ToolTip>The base class list for the class</ToolTip>
-          <Default>(object)</Default>
+          <Default>object</Default>
         </Literal>      
       </Declarations>
-      <Code Language="Python"><![CDATA[class $name$$bases$:
+      <Code Language="Python"><![CDATA[class $name$($bases$):
     $selected$]]></Code>
     </Snippet>  
   </CodeSnippet>


### PR DESCRIPTION
Putting the parentheses around `object` in the `<Default>` tag caused them to be overwritten by the tab completion, resulting in a broken class definition like:

```python

class NewFloatfloat:
    pass
```

Placing the parentheses in the `<Code>`  tag we ensure that tab completion only highlights `object` for replacement, and leaves the parentheses in place resulting in a proper class definition like:

```python
class NewFloat(float):
    pass
```