### PR TITLE
Fixes #3076 Some tests do not appear

### DIFF
--- a/Python/Product/Analysis/Analysis.csproj
+++ b/Python/Product/Analysis/Analysis.csproj
@@ -72,7 +72,7 @@
     <Compile Include="Interpreter\Ast\AstNestedPythonModule.cs" />
     <Compile Include="Interpreter\Ast\AstPythonMultipleMembers.cs" />
     <Compile Include="Interpreter\Ast\AstPythonStringLiteral.cs" />
-    <Compile Include="Interpreter\Ast\AstPythonTuple.cs" />
+    <Compile Include="Interpreter\Ast\AstPythonSequence.cs" />
     <Compile Include="Interpreter\Ast\AstPythonType.cs" />
     <Compile Include="Interpreter\Ast\AstPythonConstant.cs" />
     <Compile Include="Interpreter\Ast\AstPythonFunction.cs" />

--- a/Python/Product/Analysis/Analysis.csproj
+++ b/Python/Product/Analysis/Analysis.csproj
@@ -72,6 +72,7 @@
     <Compile Include="Interpreter\Ast\AstNestedPythonModule.cs" />
     <Compile Include="Interpreter\Ast\AstPythonMultipleMembers.cs" />
     <Compile Include="Interpreter\Ast\AstPythonStringLiteral.cs" />
+    <Compile Include="Interpreter\Ast\AstPythonTuple.cs" />
     <Compile Include="Interpreter\Ast\AstPythonType.cs" />
     <Compile Include="Interpreter\Ast\AstPythonConstant.cs" />
     <Compile Include="Interpreter\Ast\AstPythonFunction.cs" />

--- a/Python/Product/Analysis/Interpreter/Ast/AstPythonSequence.cs
+++ b/Python/Product/Analysis/Interpreter/Ast/AstPythonSequence.cs
@@ -28,7 +28,7 @@ namespace Microsoft.PythonTools.Interpreter.Ast {
             IEnumerable<IPythonType> contents
         ) {
             _sequenceType = sequenceType;
-            IndexTypes = contents.ToArray();
+            IndexTypes = (contents ?? throw new ArgumentNullException(nameof(contents))).ToArray();
             DeclaringModule = declaringModule;
         }
 

--- a/Python/Product/Analysis/Interpreter/Ast/AstPythonTuple.cs
+++ b/Python/Product/Analysis/Interpreter/Ast/AstPythonTuple.cs
@@ -1,0 +1,48 @@
+﻿// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABLITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.PythonTools.Interpreter.Ast {
+    class AstPythonSequence : IPythonSequenceType {
+        private readonly IPythonType _sequenceType;
+
+        public AstPythonSequence(
+            IPythonType sequenceType,
+            IPythonModule declaringModule,
+            IEnumerable<IPythonType> contents
+        ) {
+            _sequenceType = sequenceType;
+            IndexTypes = contents.ToArray();
+            DeclaringModule = declaringModule;
+        }
+
+        public IEnumerable<IPythonType> IndexTypes { get; }
+        public IPythonModule DeclaringModule { get; }
+
+        public string Name => _sequenceType?.Name ?? "tuple";
+        public string Documentation => _sequenceType?.Documentation ?? string.Empty;
+        public BuiltinTypeId TypeId => _sequenceType?.TypeId ?? BuiltinTypeId.Tuple;
+        public IList<IPythonType> Mro => _sequenceType?.Mro ?? Array.Empty<IPythonType>();
+        public bool IsBuiltin => _sequenceType?.IsBuiltin ?? true;
+        public PythonMemberType MemberType => _sequenceType?.MemberType ?? PythonMemberType.Class;
+        public IPythonFunction GetConstructors() => _sequenceType?.GetConstructors();
+        public IMember GetMember(IModuleContext context, string name) => _sequenceType?.GetMember(context, name) ?? null;
+        public IEnumerable<string> GetMemberNames(IModuleContext moduleContext) => _sequenceType?.GetMemberNames(moduleContext) ?? Enumerable.Empty<string>();
+    }
+}

--- a/Python/Product/Analysis/Interpreter/Ast/AstPythonType.cs
+++ b/Python/Product/Analysis/Interpreter/Ast/AstPythonType.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using Microsoft.PythonTools.Analysis;
 using Microsoft.PythonTools.Infrastructure;
@@ -25,6 +26,7 @@ namespace Microsoft.PythonTools.Interpreter.Ast {
     class AstPythonType : IPythonType, IMemberContainer, ILocatedMember {
         private readonly string _name;
         protected readonly Dictionary<string, IMember> _members;
+        private IList<IPythonType> _mro;
 
         private static readonly IPythonModule NoDeclModule = new AstPythonModule();
 
@@ -32,7 +34,7 @@ namespace Microsoft.PythonTools.Interpreter.Ast {
             _members = new Dictionary<string, IMember>();
             _name = name ?? throw new ArgumentNullException(nameof(name));
             DeclaringModule = NoDeclModule;
-            Mro = Array.Empty<IPythonType>();
+            _mro = Array.Empty<IPythonType>();
             Locations = Array.Empty<LocationInfo>();
         }
 
@@ -49,6 +51,7 @@ namespace Microsoft.PythonTools.Interpreter.Ast {
             Documentation = doc;
             DeclaringModule = declModule ?? throw new ArgumentNullException(nameof(declModule));
             Locations = loc != null ? new[] { loc } : Array.Empty<LocationInfo>();
+            StartIndex = def?.StartIndex ?? 0;
         }
 
         internal void AddMembers(IEnumerable<KeyValuePair<string, IMember>> members, bool overwrite) {
@@ -65,11 +68,88 @@ namespace Microsoft.PythonTools.Interpreter.Ast {
             }
         }
 
-        internal void SetMro(IEnumerable<IPythonType> mro) {
-            if (Mro != null) {
-                throw new InvalidOperationException("cannot set Mro multiple times");
+        internal void SetBases(IPythonInterpreter interpreter, IEnumerable<IPythonType> bases) {
+            if (Bases != null) {
+                throw new InvalidOperationException("cannot set Bases multiple times");
             }
-            Mro = mro.MaybeEnumerate().ToArray();
+            Bases = bases.MaybeEnumerate().ToArray();
+            lock (_members) {
+                if (Bases.Count > 0) {
+                    _members["__base__"] = Bases[0];
+                }
+                _members["__bases__"] = new AstPythonSequence(interpreter?.GetBuiltinType(BuiltinTypeId.Tuple), DeclaringModule, Bases);
+            }
+        }
+
+        public IList<IPythonType> Mro {
+            get {
+                lock (_members) {
+                    if (_mro != null) {
+                        return _mro;
+                    }
+                    if (Bases == null) {
+                        Debug.Fail("Accessing Mro before SetBases has been called");
+                        return new IPythonType[] { this };
+                    }
+                    _mro = new IPythonType[] { this };
+                    _mro = CalculateMro(this);
+                    return _mro;
+                }
+            }
+        }
+
+        internal static IList<IPythonType> CalculateMro(IPythonType cls, HashSet<IPythonType> recursionProtection = null) {
+            if (cls == null) {
+                return Array.Empty<IPythonType>();
+            }
+            if (recursionProtection == null) {
+                recursionProtection = new HashSet<IPythonType>();
+            }
+            if (!recursionProtection.Add(cls)) {
+                return Array.Empty<IPythonType>();
+            }
+            try {
+                var mergeList = new List<List<IPythonType>> { new List<IPythonType>() };
+                var finalMro = new List<IPythonType> { cls };
+
+                var bases = (cls as AstPythonType)?.Bases ??
+                    (cls.GetMember(null, "__bases__") as IPythonSequenceType)?.IndexTypes ??
+                    Array.Empty<IPythonType>();
+
+                foreach (var b in bases) {
+                    var b_mro = new List<IPythonType>();
+                    b_mro.AddRange(CalculateMro(b, recursionProtection));
+                    mergeList.Add(b_mro);
+                }
+
+                while (mergeList.Any()) {
+                    // Next candidate is the first head that does not appear in
+                    // any other tails.
+                    var nextInMro = mergeList.FirstOrDefault(mro => {
+                        var m = mro.FirstOrDefault();
+                        return m != null && !mergeList.Any(m2 => m2.Skip(1).Contains(m));
+                    })?.FirstOrDefault();
+
+                    if (nextInMro == null) {
+                        // MRO is invalid, so return just this class
+                        return new IPythonType[] { cls };
+                    }
+
+                    finalMro.Add(nextInMro);
+
+                    // Remove all instances of that class from potentially being returned again
+                    foreach (var mro in mergeList) {
+                        mro.RemoveAll(ns => ns == nextInMro);
+                    }
+
+                    // Remove all lists that are now empty.
+                    mergeList.RemoveAll(mro => !mro.Any());
+                }
+
+                return finalMro;
+            } finally {
+                recursionProtection.Remove(cls);
+            }
         }
 
         public string Name {
@@ -85,17 +165,33 @@ namespace Microsoft.PythonTools.Interpreter.Ast {
         }
         public string Documentation { get; }
         public IPythonModule DeclaringModule {get;}
-        public IList<IPythonType> Mro { get; private set; }
+        public IReadOnlyList<IPythonType> Bases { get; private set; }
         public virtual bool IsBuiltin => false;
         public PythonMemberType MemberType => PythonMemberType.Class;
         public virtual BuiltinTypeId TypeId => BuiltinTypeId.Type;
+
+        /// <summary>
+        /// The start index of this class. Used to disambiguate multiple
+        /// class definitions with the same name in the same file.
+        /// </summary>
+        public int StartIndex { get; }
 
         public IEnumerable<LocationInfo> Locations { get; }
 
         public IMember GetMember(IModuleContext context, string name) {
             IMember member;
             lock (_members) {
-                _members.TryGetValue(name, out member);
+                if (!_members.TryGetValue(name, out member)) {
+                    switch (name) {
+                        case "__mro__":
+                            member = _members[name] = new AstPythonSequence(
+                                (context as IPythonInterpreter)?.GetBuiltinType(BuiltinTypeId.Tuple),
+                                DeclaringModule,
+                                Mro
+                            );
+                            break;
+                    }
+                }
             }
             return member;
         }

--- a/Python/Product/Analysis/Interpreter/Ast/NameLookupContext.cs
+++ b/Python/Product/Analysis/Interpreter/Ast/NameLookupContext.cs
@@ -390,6 +390,10 @@ namespace Microsoft.PythonTools.Interpreter.Ast {
                 return Interpreter.GetBuiltinType(BuiltinTypeId.Function);
             }
 
+            if (value is IPythonBoundFunction) {
+                return Interpreter.GetBuiltinType(BuiltinTypeId.Function);
+            }
+
             if (value is IPythonModule) {
                 return Interpreter.GetBuiltinType(BuiltinTypeId.Module);
             }
@@ -471,6 +475,10 @@ namespace Microsoft.PythonTools.Interpreter.Ast {
 
         public void SetInScope(string name, IMember value, bool mergeWithExisting = true) {
             var s = _scopes.Peek();
+            if (value == null) {
+                s.Remove(name);
+                return;
+            }
             if (mergeWithExisting && s.TryGetValue(name, out IMember existing) && existing != null) {
                 s[name] = AstPythonMultipleMembers.Combine(existing, value);
             } else {

--- a/Python/Product/PythonTools/PythonTools/Navigation/TextViewFilter.cs
+++ b/Python/Product/PythonTools/PythonTools/Navigation/TextViewFilter.cs
@@ -118,9 +118,14 @@ namespace Microsoft.PythonTools.Language {
                 return VSConstants.E_FAIL;
             }
 
-            var expr = _serviceProvider.GetUIThread().InvokeTaskSync(async () => {
-                return await analyzer.GetExpressionSpanAtPointAsync(bi, pt, ExpressionAtPointPurpose.Hover, TimeSpan.FromSeconds(1.0));
-            }, CancellationTokens.After1s);
+            SourceSpan? expr;
+            try {
+                expr = _serviceProvider.GetUIThread().InvokeTaskSync(async () => {
+                    return await analyzer.GetExpressionSpanAtPointAsync(bi, pt, ExpressionAtPointPurpose.Hover, TimeSpan.FromSeconds(1.0));
+                }, CancellationTokens.After1s);
+            } catch (OperationCanceledException) {
+                expr = null;
+            }
 
             if (expr == null) {
                 pbstrText = null;

--- a/Python/Tests/Analysis/AstAnalysisTests.cs
+++ b/Python/Tests/Analysis/AstAnalysisTests.cs
@@ -308,6 +308,29 @@ R_A3 = R_A1.r_A()");
             }
         }
 
+        [TestMethod, Priority(0)]
+        public void AstMro() {
+            var O = new AstPythonType("O");
+            var A = new AstPythonType("A");
+            var B = new AstPythonType("B");
+            var C = new AstPythonType("C");
+            var D = new AstPythonType("D");
+            var E = new AstPythonType("E");
+            var F = new AstPythonType("F");
+
+            F.SetBases(null, new[] { O });
+            E.SetBases(null, new[] { O });
+            D.SetBases(null, new[] { O });
+            C.SetBases(null, new[] { D, F });
+            B.SetBases(null, new[] { D, E });
+            A.SetBases(null, new[] { B, C });
+
+            AssertUtil.AreEqual(AstPythonType.CalculateMro(A).Select(t => t.Name), "A", "B", "C", "D", "E", "F", "O");
+            AssertUtil.AreEqual(AstPythonType.CalculateMro(B).Select(t => t.Name), "B", "D", "E", "O");
+            AssertUtil.AreEqual(AstPythonType.CalculateMro(C).Select(t => t.Name), "C", "D", "F", "O");
+            
+        }
+
         private static IPythonModule Parse(string path, PythonLanguageVersion version) {
             var interpreter = InterpreterFactoryCreator.CreateAnalysisInterpreterFactory(version.ToVersion()).CreateInterpreter();
             if (!Path.IsPathRooted(path)) {


### PR DESCRIPTION
Fixes #3076 Some tests do not appear
Adds correct MRO to scraped analysis types.
Fixes handling of multiple definitions of the same class
Fixes minor crash when tool tips time out.

Fixes #3211 GetTypeFromValue() doesn't handle AstPythonBoundMethod type 
Adds IPythonBoundFunction handling