### PR TITLE
Fixes #2488 and #2682

### DIFF
--- a/Python/Product/PythonTools/PythonTools/PythonClassifier.cs
+++ b/Python/Product/PythonTools/PythonTools/PythonClassifier.cs
@@ -118,10 +118,11 @@ namespace Microsoft.PythonTools {
 
                 var tokenizer = GetTokenizer(snapshot);
                 foreach (var change in e.Changes) {
+                    var endLine = snapshot.GetLineNumberFromPosition(change.NewEnd) + 1;
                     if (change.LineCountDelta > 0) {
-                        _tokenCache.InsertLines(snapshot.GetLineNumberFromPosition(change.NewEnd) + 1 - change.LineCountDelta, change.LineCountDelta);
+                        _tokenCache.InsertLines(endLine - change.LineCountDelta, change.LineCountDelta);
                     } else if (change.LineCountDelta < 0) {
-                        _tokenCache.DeleteLines(snapshot.GetLineNumberFromPosition(change.NewEnd) + 1, -change.LineCountDelta);
+                        _tokenCache.DeleteLines(endLine, Math.Min(-change.LineCountDelta, snapshot.LineCount - endLine));
                     }
 
                     ApplyChange(tokenizer, snapshot, change.NewSpan);

--- a/Python/Product/PythonTools/PythonTools/Repl/PythonCommonInteractiveEvaluator.cs
+++ b/Python/Product/PythonTools/PythonTools/Repl/PythonCommonInteractiveEvaluator.cs
@@ -278,21 +278,26 @@ namespace Microsoft.PythonTools.Repl {
         public abstract void AbortExecution();
 
         public bool CanExecuteCode(string text) {
+            return CanExecuteCode(text, out _);
+        }
+
+        protected bool CanExecuteCode(string text, out ParseResult pr) {
+            pr = ParseResult.Complete;
             if (string.IsNullOrEmpty(text)) {
                 return true;
             }
             if (string.IsNullOrWhiteSpace(text) && text.EndsWith("\n")) {
+                pr = ParseResult.Empty;
                 return true;
             }
 
             var config = Configuration;
             using (var parser = Parser.CreateParser(new StringReader(text), LanguageVersion)) {
-                ParseResult pr;
                 parser.ParseInteractiveCode(out pr);
-                if (pr == ParseResult.IncompleteStatement) {
+                if (pr == ParseResult.IncompleteStatement || pr == ParseResult.Empty) {
                     return text.EndsWith("\n");
                 }
-                if (pr == ParseResult.Empty || pr == ParseResult.IncompleteToken) {
+                if (pr == ParseResult.IncompleteToken) {
                     return false;
                 }
             }

--- a/Python/Product/PythonTools/PythonTools/Repl/PythonInteractiveEvaluator.cs
+++ b/Python/Product/PythonTools/PythonTools/Repl/PythonInteractiveEvaluator.cs
@@ -24,6 +24,7 @@ using System.Threading.Tasks;
 using Microsoft.PythonTools.Editor;
 using Microsoft.PythonTools.Infrastructure;
 using Microsoft.PythonTools.Intellisense;
+using Microsoft.PythonTools.Parsing;
 using Microsoft.VisualStudio.InteractiveWindow;
 using Microsoft.VisualStudio.InteractiveWindow.Commands;
 using Microsoft.VisualStudio.Utilities;
@@ -226,6 +227,15 @@ namespace Microsoft.PythonTools.Repl {
             var cmdRes = cmds.TryExecuteCommand();
             if (cmdRes != null) {
                 return await cmdRes;
+            }
+
+            ParseResult pr;
+            if (CanExecuteCode(text, out pr)) {
+                if (pr == ParseResult.Empty) {
+                    // Actually execute "pass", so that we launch the
+                    // interpreter but do not cause any other errors.
+                    text = "pass";
+                }
             }
 
             var thread = await EnsureConnectedAsync();

--- a/Python/Tests/ReplWindowUITests/ReplWindowUITests.cs
+++ b/Python/Tests/ReplWindowUITests/ReplWindowUITests.cs
@@ -1499,8 +1499,9 @@ plot(x, x)");
                 interactive.WaitForText(">" + comment, "." + comment);
 
                 interactive.ClearInput();
+                // Pasting with a newline will submit
                 interactive.Paste(comment + "\r\n" + comment + "\r\n");
-                interactive.WaitForText(">" + comment, "." + comment, ".");
+                interactive.WaitForText(">" + comment, "." + comment, ".", ">");
             }
         }
 

--- a/Python/Tests/ReplWindowUITestsRunner/ReplWindowAdvancedUITests.cs
+++ b/Python/Tests/ReplWindowUITestsRunner/ReplWindowAdvancedUITests.cs
@@ -362,7 +362,6 @@ namespace ReplWindowUITestsRunner {
 
         #region Advanced Clipboard tests
 
-        [Ignore] // https://github.com/Microsoft/PTVS/issues/2682
         [TestMethod, Priority(2)]
         [TestCategory("Installed")]
         public void CommentPaste() {

--- a/Python/Tests/ReplWindowUITestsRunner/ReplWindowBasicUITests.cs
+++ b/Python/Tests/ReplWindowUITestsRunner/ReplWindowBasicUITests.cs
@@ -86,7 +86,6 @@ namespace ReplWindowUITestsRunner {
             _vs.RunTest(nameof(ReplWindowUITests.ReplWindowUITests.ImportCompletions), Interpreter);
         }
 
-        [Ignore] // https://github.com/Microsoft/PTVS/issues/2682
         [TestMethod, Priority(2)]
         [TestCategory("Installed")]
         public void Comments() {


### PR DESCRIPTION
Fixes #2488 Pasting into the REPL triggers immediate execution
Simplify semantics of paste to:
* when REPL buffer is not empty, never submit
* otherwise, submit all except the last statement, unless the source text ends with a newline (when multiline is supported, the whole buffer is "the last statement")

Fixes #2682 REPL comments handling different from command line Python
Exposes reason for being able to execute text so that we can better handle Empty statements
Re-enables tests

Also fixes submitting updates to analyzer to avoid incorrect validation.