### PR TITLE
Fixes #3024 GetAnalyzer() called on closed project assert

### DIFF
--- a/Python/Product/Analysis/Projects/PythonProject.cs
+++ b/Python/Product/Analysis/Projects/PythonProject.cs
@@ -55,7 +55,9 @@ namespace Microsoft.PythonTools.Projects {
 
         public abstract IPythonInterpreterFactory GetInterpreterFactory();
 
-
+        /// <summary>
+        /// Gets the current analyzer for the project, or null if no analyzer is available.
+        /// </summary>
         public abstract ProjectAnalyzer Analyzer {
             get;
         }

--- a/Python/Product/PythonTools/PythonTools/Project/PythonProjectNode.cs
+++ b/Python/Product/PythonTools/PythonTools/Project/PythonProjectNode.cs
@@ -1109,7 +1109,12 @@ namespace Microsoft.PythonTools.Project {
                 }
                 return service.DefaultAnalyzer;
             } else if (_analyzer == null) {
-                _analyzer = Site.GetUIThread().InvokeTaskSync(CreateAnalyzerAsync, CancellationToken.None);
+                return Site.GetUIThread().InvokeTaskSync(async() => {
+                    if (_analyzer == null) {
+                        _analyzer = await CreateAnalyzerAsync();
+                    }
+                    return _analyzer;
+                }, CancellationToken.None);
             }
             return _analyzer;
         }
@@ -2752,6 +2757,9 @@ namespace Microsoft.PythonTools.Project {
 
             public override ProjectAnalyzer Analyzer {
                 get {
+                    if (_node.IsClosing || _node.IsClosed) {
+                        return null;
+                    }
                     return _node.GetAnalyzer();
                 }
             }


### PR DESCRIPTION
Fixes #3024 GetAnalyzer() called on closed project assert
Enhances PythonProject API to allow null return