### PR TITLE
Fixes #3232 Classifications do not cover whole file

### DIFF
--- a/Common/Product/SharedProject/ProjectNode.CopyPaste.cs
+++ b/Common/Product/SharedProject/ProjectNode.CopyPaste.cs
@@ -353,11 +353,8 @@ namespace Microsoft.VisualStudioTools.Project {
         public virtual int OnClear(int wasCut) {
             if (wasCut != 0) {
                 AssertHasParentHierarchy();
-                IVsUIHierarchyWindow w = UIHierarchyUtilities.GetUIHierarchyWindow(this.site, HierarchyNode.SolutionExplorer);
-                if (w != null) {
-                    foreach (HierarchyNode node in ItemsDraggedOrCutOrCopied) {
-                        node.ExpandItem(EXPANDFLAGS.EXPF_UnCutHighlightItem);
-                    }
+                foreach (HierarchyNode node in ItemsDraggedOrCutOrCopied) {
+                    node.ExpandItem(EXPANDFLAGS.EXPF_UnCutHighlightItem);
                 }
             }
 

--- a/Python/Product/Analysis/Parsing/SourceLocation.cs
+++ b/Python/Product/Analysis/Parsing/SourceLocation.cs
@@ -112,7 +112,7 @@ namespace Microsoft.PythonTools.Parsing {
         /// <param name="right">The other location to compare.</param>
         /// <returns>True if the locations are the same, False otherwise.</returns>
         public static bool operator ==(SourceLocation left, SourceLocation right) {
-            return left._index == right._index && left._line == right._line && left._column == right._column;
+            return left._line == right._line && left._column == right._column;
         }
 
         /// <summary>
@@ -122,7 +122,7 @@ namespace Microsoft.PythonTools.Parsing {
         /// <param name="right">The other location to compare.</param>
         /// <returns>True if the locations are not the same, False otherwise.</returns>
         public static bool operator !=(SourceLocation left, SourceLocation right) {
-            return left._index != right._index || left._line != right._line || left._column != right._column;
+            return left._line != right._line || left._column != right._column;
         }
 
         /// <summary>
@@ -132,7 +132,7 @@ namespace Microsoft.PythonTools.Parsing {
         /// <param name="right">The other location to compare.</param>
         /// <returns>True if the first location is before the other location, False otherwise.</returns>
         public static bool operator <(SourceLocation left, SourceLocation right) {
-            return left._index < right._index;
+            return left._line < right._line || (left._line == right._line && left._column < right._column);
         }
 
         /// <summary>
@@ -142,7 +142,7 @@ namespace Microsoft.PythonTools.Parsing {
         /// <param name="right">The other location to compare.</param>
         /// <returns>True if the first location is after the other location, False otherwise.</returns>
         public static bool operator >(SourceLocation left, SourceLocation right) {
-            return left._index > right._index;
+            return left._line > right._line || (left._line == right._line && left._column > right._column);
         }
 
         /// <summary>
@@ -152,7 +152,7 @@ namespace Microsoft.PythonTools.Parsing {
         /// <param name="right">The other location to compare.</param>
         /// <returns>True if the first location is before or the same as the other location, False otherwise.</returns>
         public static bool operator <=(SourceLocation left, SourceLocation right) {
-            return left._index <= right._index;
+            return left._line < right._line || (left._line == right._line && left._column <= right._column);
         }
 
         /// <summary>
@@ -162,7 +162,7 @@ namespace Microsoft.PythonTools.Parsing {
         /// <param name="right">The other location to compare.</param>
         /// <returns>True if the first location is after or the same as the other location, False otherwise.</returns>
         public static bool operator >=(SourceLocation left, SourceLocation right) {
-            return left._index >= right._index;
+            return left._line > right._line || (left._line == right._line && left._column >= right._column);
         }
 
         /// <summary>
@@ -207,7 +207,7 @@ namespace Microsoft.PythonTools.Parsing {
             if (!(obj is SourceLocation)) return false;
 
             SourceLocation other = (SourceLocation)obj;
-            return other._index == _index && other._line == _line && other._column == _column;
+            return other._line == _line && other._column == _column;
         }
 
         public override int GetHashCode() {

--- a/Python/Product/Analysis/PythonKeywords.cs
+++ b/Python/Product/Analysis/PythonKeywords.cs
@@ -78,9 +78,7 @@ namespace Microsoft.PythonTools.Analysis {
                 yield return "await";
             }
             yield return "else";
-            if (version.IsNone() || version.Is3x()) {
-                yield return "False";
-            }
+            yield return "False";   // Not technically a keyword in Python 2.x, but may as well be
             yield return "for";
             if (version.IsNone() || version >= PythonLanguageVersion.V33) {
                 yield return "from";
@@ -92,9 +90,7 @@ namespace Microsoft.PythonTools.Analysis {
             yield return "None";
             yield return "not";
             yield return "or";
-            if (version.IsNone() || version.Is3x()) {
-                yield return "True";
-            }
+            yield return "True";    // Not technically a keyword in Python 2.x, but may as well be
             yield return "yield";
         }
 

--- a/Python/Product/Analyzer/Intellisense/AnalysisProtocol.cs
+++ b/Python/Product/Analyzer/Intellisense/AnalysisProtocol.cs
@@ -394,7 +394,7 @@ namespace Microsoft.PythonTools.Intellisense {
             public const string Command = "isMissingImport";
 
             public string text;
-            public int index, line, column, fileId, bufferId;
+            public int line, column, fileId, bufferId;
 
             public override string command => Command;
         }

--- a/Python/Product/Analyzer/Intellisense/OutOfProcProjectAnalyzer.cs
+++ b/Python/Product/Analyzer/Intellisense/OutOfProcProjectAnalyzer.cs
@@ -802,7 +802,7 @@ namespace Microsoft.PythonTools.Intellisense {
                 return new AP.IsMissingImportResponse();
             }
 
-            var location = new SourceLocation(request.index, request.line, request.column);
+            var location = new SourceLocation(request.line, request.column);
             var nameExpr = GetFirstNameExpression(
                 analysis.GetAstFromText(
                     request.text,
@@ -1230,7 +1230,7 @@ namespace Microsoft.PythonTools.Intellisense {
             }
 
             var exprFinder = new ExpressionFinder(ast, options);
-            var expr = exprFinder.GetExpression(new SourceLocation(0, line, column));
+            var expr = exprFinder.GetExpression(new SourceLocation(line, column));
             if (expr == null) {
                 return false;
             }
@@ -1271,11 +1271,7 @@ namespace Microsoft.PythonTools.Intellisense {
             if (entry.Analysis != null) {
                 var variables = entry.Analysis.GetVariables(
                     request.expr,
-                    new SourceLocation(
-                        0,
-                        request.line,
-                        request.column
-                    )
+                    new SourceLocation(request.line, request.column)
                 );
 
                 var ast = variables.Ast;
@@ -1497,7 +1493,7 @@ namespace Microsoft.PythonTools.Intellisense {
             IEnumerable<MemberResult> members;
             if (entry?.Analysis != null) {
                 members = entry.Analysis.GetAllAvailableMembers(
-                    new SourceLocation(0, topLevelCompletions.line, topLevelCompletions.column),
+                    new SourceLocation(topLevelCompletions.line, topLevelCompletions.column),
                     topLevelCompletions.options
                 );
             } else {

--- a/Python/Product/PythonTools/PythonTools/Editor/BraceMatcher.cs
+++ b/Python/Product/PythonTools/PythonTools/Editor/BraceMatcher.cs
@@ -31,6 +31,7 @@ namespace Microsoft.PythonTools.Editor {
     class BraceMatcher {
         private readonly ITextView _textView;
         private readonly IComponentModel _compModel;
+        private readonly PythonEditorServices _editorServices;
         private ITextBuffer _markedBuffer;
         private static TextMarkerTag _tag = new TextMarkerTag("Brace Matching (Rectangle)");
 
@@ -38,8 +39,8 @@ namespace Microsoft.PythonTools.Editor {
         /// Starts watching the provided text view for brace matching.  When new braces are inserted
         /// in the text or when the cursor moves to a brace the matching braces are highlighted.
         /// </summary>
-        public static void WatchBraceHighlights(ITextView view, IComponentModel componentModel) {
-            var matcher = new BraceMatcher(view, componentModel);
+        public static void WatchBraceHighlights(ITextView view, IComponentModel componentModel, PythonEditorServices editorServices) {
+            var matcher = new BraceMatcher(view, componentModel, editorServices);
 
             // position changed only fires when the caret is explicitly moved, not from normal text edits,
             // so we track both changes and position changed.
@@ -48,9 +49,10 @@ namespace Microsoft.PythonTools.Editor {
             view.Closed += matcher.TextViewClosed;
         }
 
-        public BraceMatcher(ITextView view, IComponentModel componentModel) {
+        public BraceMatcher(ITextView view, IComponentModel componentModel, PythonEditorServices editorServices) {
             _textView = view;
             _compModel = componentModel;
+            _editorServices = editorServices;
         }
 
         private void TextViewClosed(object sender, EventArgs e) {
@@ -133,66 +135,47 @@ namespace Microsoft.PythonTools.Editor {
         }
 
         private bool HighlightBrace(BraceKind brace, SnapshotPoint position, int direction) {
-            var classifier = position.Snapshot.TextBuffer.GetPythonClassifier();
-            
-            if (classifier != null) {
-                var snapshot = position.Snapshot;
-                var span = new SnapshotSpan(snapshot, position.Position - 1, 1);
-                var originalSpan = span;
+            var buffer = _editorServices.GetBufferInfo(position.Snapshot.TextBuffer);
+            if (buffer == null) {
+                return false;
+            }
 
-                var spans = classifier.GetClassificationSpans(span);
-                // we don't highlight braces if we're in a comment or string literal
-                if (spans.Count == 0 ||
-                    (spans.Count == 1 &&
-                    (!spans[0].ClassificationType.IsOfType(PredefinedClassificationTypeNames.String) &&
-                    !spans[0].ClassificationType.IsOfType(PredefinedClassificationTypeNames.Comment)))) {
+            var snapshot = position.Snapshot;
+            var span = new SnapshotSpan(snapshot, position.Position - 1, 1);
+            var originalSpan = span;
 
-                    // find the opening span
-                    var curLine = snapshot.GetLineFromPosition(position);
-                    int curLineNo = curLine.LineNumber;
+            if (!(buffer.GetTokenAtPoint(position)?.Trigger ?? Parsing.TokenTriggers.None).HasFlag(Parsing.TokenTriggers.MatchBraces)) {
+                return false;
+            }
 
-                    if (direction == 1) {
-                        span = new SnapshotSpan(snapshot, position, curLine.End.Position - position);
+            int depth = 0;
+            foreach (var token in (direction > 0 ? buffer.GetTokensForwardFromPoint(position) : buffer.GetTokensInReverseFromPoint(position))) {
+                if (!token.Trigger.HasFlag(Parsing.TokenTriggers.MatchBraces)) {
+                    continue;
+                }
+
+                var tspan = token.SourceSpan.ToSnapshotSpan(snapshot);
+                var txt = tspan.GetText();
+                if (IsSameBraceKind(txt, brace)) {
+                    if (txt.IsCloseGrouping()) {
+                        depth -= direction;
                     } else {
-                        span = new SnapshotSpan(curLine.Start, position - 1);
-                    }
-
-                    int depth = 1;
-                    for (; ; ) {
-                        spans = classifier.GetClassificationSpans(span);
-                        for (int i = direction == -1 ? spans.Count - 1 : 0; i >= 0 && i < spans.Count; i += direction) {
-                            if (spans[i].IsCloseGrouping()) {
-                                if (IsSameBraceKind(spans[i].Span.GetText(), brace)) {
-                                    depth -= direction;
-                                }
-                            } else if (spans[i].IsOpenGrouping()) {
-                                if (IsSameBraceKind(spans[i].Span.GetText(), brace)) {
-                                    depth += direction;
-                                }
-                            }
-
-                            if (depth == 0) {
-                                RemoveExistingHighlights();
-                                _markedBuffer = snapshot.TextBuffer;
-
-                                // left brace
-                                GetTextMarker(snapshot.TextBuffer).CreateTagSpan(snapshot.CreateTrackingSpan(spans[i].Span, SpanTrackingMode.EdgeExclusive), _tag);
-                                // right brace
-                                GetTextMarker(snapshot.TextBuffer).CreateTagSpan(snapshot.CreateTrackingSpan(new SnapshotSpan(snapshot, position - 1, 1), SpanTrackingMode.EdgeExclusive), _tag);
-                                return true;
-                            }
-                        }
-
-                        curLineNo += direction;
-                        if (curLineNo < 0 || curLineNo >= snapshot.LineCount) {
-                            break;
-                        }
-
-                        var line = snapshot.GetLineFromLineNumber(curLineNo);
-                        span = new SnapshotSpan(line.Start, line.End);
+                        depth += direction;
                     }
                 }
+
+                if (depth == 0) {
+                    RemoveExistingHighlights();
+                    _markedBuffer = snapshot.TextBuffer;
+
+                    // left brace
+                    GetTextMarker(snapshot.TextBuffer).CreateTagSpan(snapshot.CreateTrackingSpan(tspan, SpanTrackingMode.EdgeExclusive), _tag);
+                    // right brace
+                    GetTextMarker(snapshot.TextBuffer).CreateTagSpan(snapshot.CreateTrackingSpan(new SnapshotSpan(snapshot, position - 1, 1), SpanTrackingMode.EdgeExclusive), _tag);
+                    return true;
+                }
             }
+
             return false;
         }
 

--- a/Python/Product/PythonTools/PythonTools/Editor/IPythonTextBufferInfoEventSink.cs
+++ b/Python/Product/PythonTools/PythonTools/Editor/IPythonTextBufferInfoEventSink.cs
@@ -41,7 +41,8 @@ namespace Microsoft.PythonTools.Editor {
         TextContentChangedLowPriority,
         ContentTypeChanged,
         DocumentEncodingChanged,
-        NewTextBufferInfo
+        NewTextBufferInfo,
+        TextContentChangedOnBackgroundThread,
     }
 
     class PythonTextBufferInfoEventArgs : EventArgs {

--- a/Python/Product/PythonTools/PythonTools/Editor/PythonEditorServices.cs
+++ b/Python/Product/PythonTools/PythonTools/Editor/PythonEditorServices.cs
@@ -22,6 +22,7 @@ using Microsoft.VisualStudio.Editor;
 using Microsoft.VisualStudio.Language.Intellisense;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Adornments;
 using Microsoft.VisualStudio.Text.Classification;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Text.IncrementalSearch;
@@ -111,7 +112,16 @@ namespace Microsoft.PythonTools.Editor {
         public IQuickInfoBroker QuickInfoBroker = null;
 
         [Import]
+        public IPeekBroker PeekBroker = null;
+
+        [Import]
         public IIncrementalSearchFactoryService IncrementalSearch = null;
+
+        [Import]
+        public ITextMarkerProviderFactory TextMarkerProviderFactory = null;
+
+        [Import]
+        public ITextBufferUndoManagerProvider UndoManagerFactory = null;
 
         public IVsTextManager2 VsTextManager2 => (IVsTextManager2)Site.GetService(typeof(SVsTextManager));
 

--- a/Python/Product/PythonTools/PythonTools/Editor/PythonTextBufferInfo.cs
+++ b/Python/Product/PythonTools/PythonTools/Editor/PythonTextBufferInfo.cs
@@ -655,7 +655,7 @@ namespace Microsoft.PythonTools.Editor {
 
                 var afterState = lineTokenization.State;
 
-                // stop if we visted all affected lines and the current line has no tokenization state
+                // stop if we visited all affected lines and the current line has no tokenization state
                 // or its previous state is the same as the new state.
                 if (lineNo > lastLine && (beforeState == null || beforeState.Equals(afterState))) {
                     break;

--- a/Python/Product/PythonTools/PythonTools/Editor/SmartIndentProvider.cs
+++ b/Python/Product/PythonTools/PythonTools/Editor/SmartIndentProvider.cs
@@ -27,10 +27,15 @@ namespace Microsoft.PythonTools.Editor {
     [ContentType(PythonCoreConstants.ContentType)]
     public sealed class SmartIndentProvider : ISmartIndentProvider {
         private readonly PythonToolsService _pyService;
+        private readonly PythonEditorServices _editorServices;
 
         [ImportingConstructor]
-        internal SmartIndentProvider([Import(typeof(SVsServiceProvider))] IServiceProvider serviceProvider) {
+        internal SmartIndentProvider(
+            [Import(typeof(SVsServiceProvider))] IServiceProvider serviceProvider,
+            PythonEditorServices editorServices
+        ) {
             _pyService = serviceProvider.GetPythonToolsService();
+            _editorServices = editorServices;
         }
 
         private sealed class Indent : ISmartIndent {
@@ -44,7 +49,7 @@ namespace Microsoft.PythonTools.Editor {
 
             public int? GetDesiredIndentation(ITextSnapshotLine line) {
                 if (_provider._pyService.LangPrefs.IndentMode == vsIndentStyle.vsIndentStyleSmart) {
-                    return AutoIndent.GetLineIndentation(line, _textView);
+                    return AutoIndent.GetLineIndentation(_provider._editorServices.GetBufferInfo(line.Snapshot.TextBuffer), line, _textView);
                 } else {
                     return null;
                 }

--- a/Python/Product/PythonTools/PythonTools/Extensions.cs
+++ b/Python/Product/PythonTools/PythonTools/Extensions.cs
@@ -922,14 +922,23 @@ namespace Microsoft.PythonTools {
         internal static bool IsOpenGrouping(this ClassificationSpan span) {
             return span.ClassificationType.IsOfType(PythonPredefinedClassificationTypeNames.Grouping) &&
                 span.Span.Length == 1 &&
-                (span.Span.GetText() == "{" || span.Span.GetText() == "[" || span.Span.GetText() == "(");
+                span.Span.GetText().IsOpenGrouping();
         }
 
         internal static bool IsCloseGrouping(this ClassificationSpan span) {
             return span.ClassificationType.IsOfType(PythonPredefinedClassificationTypeNames.Grouping) &&
                 span.Span.Length == 1 &&
-                (span.Span.GetText() == "}" || span.Span.GetText() == "]" || span.Span.GetText() == ")");
+                span.Span.GetText().IsCloseGrouping();
         }
+
+        internal static bool IsOpenGrouping(this string s) {
+            return s == "{" || s == "[" || s == "(";
+        }
+
+        internal static bool IsCloseGrouping(this string s) {
+            return s == "}" || s == "]" || s == ")";
+        }
+
 
         internal static T Pop<T>(this List<T> list) {
             if (list.Count == 0) {

--- a/Python/Product/PythonTools/PythonTools/Intellisense/ExpansionClient.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/ExpansionClient.cs
@@ -21,6 +21,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using System.Xml.Linq;
 using Microsoft.PythonTools.Editor;
+using Microsoft.PythonTools.Editor.Core;
 using Microsoft.PythonTools.Infrastructure;
 using Microsoft.PythonTools.Parsing;
 using Microsoft.VisualStudio;
@@ -244,12 +245,7 @@ namespace Microsoft.PythonTools.Intellisense {
 
             SourceLocation loc;
             try {
-                var line = point.GetContainingLine();
-                loc = new SourceLocation(
-                    point.Position,
-                    line.LineNumber + 1,
-                    point.Position - line.Start + 1
-                );
+                loc = point.ToSourceLocation();
             } catch (ArgumentException ex) {
                 Debug.Fail(ex.ToUnhandledExceptionMessage(GetType()));
                 return;

--- a/Python/Product/PythonTools/PythonTools/Intellisense/NormalCompletionAnalysis.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/NormalCompletionAnalysis.cs
@@ -71,6 +71,14 @@ namespace Microsoft.PythonTools.Intellisense {
                 return true;
             }
 
+            switch (tok.Value.Category) {
+                case TokenCategory.Delimiter:
+                case TokenCategory.Grouping:
+                case TokenCategory.Operator:
+                    expressionExtent = span;
+                    return true;
+            }
+
             return false;
         }
 

--- a/Python/Product/PythonTools/PythonTools/Intellisense/NormalCompletionAnalysis.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/NormalCompletionAnalysis.cs
@@ -75,6 +75,15 @@ namespace Microsoft.PythonTools.Intellisense {
                 case TokenCategory.Delimiter:
                 case TokenCategory.Grouping:
                 case TokenCategory.Operator:
+                case TokenCategory.WhiteSpace:
+                    // Expect top-level completions after these
+                    expressionExtent = span;
+                    return true;
+                case TokenCategory.BuiltinIdentifier:
+                case TokenCategory.Identifier:
+                case TokenCategory.Keyword:
+                    // Expect filtered top-level completions here
+                    // (but the return value is no different)
                     expressionExtent = span;
                     return true;
             }

--- a/Python/Product/PythonTools/PythonTools/Intellisense/ProjectAnalyzer.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/ProjectAnalyzer.cs
@@ -1227,29 +1227,14 @@ namespace Microsoft.PythonTools.Intellisense {
                 analysisSnapshot.TextBuffer == fromSnapshot.TextBuffer) {
 
                 var fromPoint = new SnapshotPoint(fromSnapshot, index);
-                var fromLine = fromPoint.GetContainingLine();
                 var toPoint = fromPoint.TranslateTo(analysisSnapshot, PointTrackingMode.Negative);
-                var toLine = toPoint.GetContainingLine();
 
-                Debug.Assert(fromLine != null, "Unable to get 'from' line from " + fromPoint.ToString());
-                Debug.Assert(toLine != null, "Unable to get 'to' line from " + toPoint.ToString());
-
-                return new SourceLocation(
-                    toPoint.Position,
-                    (toLine != null ? toLine.LineNumber : fromLine != null ? fromLine.LineNumber : 0) + 1,
-                    index - (fromLine != null ? fromLine.Start.Position : 0) + 1
-                );
+                return toPoint.ToSourceLocation();
             } else if (fromSnapshot != null) {
-                var fromPoint = new SnapshotPoint(fromSnapshot, index);
-                var fromLine = fromPoint.GetContainingLine();
-
-                return new SourceLocation(
-                    index,
-                    fromLine.LineNumber + 1,
-                    index - fromLine.Start.Position + 1
-                );
+                return new SnapshotPoint(fromSnapshot, index).ToSourceLocation();
             } else {
-                return new SourceLocation(index, 1, 1);
+                Debug.Fail("Unable to translate index");
+                return new SourceLocation(index, 1, index + 1);
             }
         }
 
@@ -2556,7 +2541,7 @@ namespace Microsoft.PythonTools.Intellisense {
                 return null;
             }
 
-            return new SourceSpan(new SourceLocation(0, r.startLine, r.startColumn), new SourceLocation(0, r.endLine, r.endColumn));
+            return new SourceSpan(new SourceLocation(r.startLine, r.startColumn), new SourceLocation(r.endLine, r.endColumn));
         }
     }
 }

--- a/Python/Product/PythonTools/PythonTools/Intellisense/ProjectAnalyzer.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/ProjectAnalyzer.cs
@@ -1319,7 +1319,6 @@ namespace Microsoft.PythonTools.Intellisense {
                 new AP.IsMissingImportRequest() {
                     fileId = entry.FileId,
                     text = text,
-                    index = location.Index,
                     line = location.Line,
                     column = location.Column
                 }

--- a/Python/Product/PythonTools/PythonTools/Intellisense/PythonSuggestedActionsSource.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/PythonSuggestedActionsSource.cs
@@ -70,11 +70,11 @@ namespace Microsoft.PythonTools.Intellisense {
 
             var tokens = bi.GetTokens(range).Where(t => t.Category == TokenCategory.Identifier);
             foreach (var t in tokens) {
-                var span = t.SourceSpan.ToSnapshotSpan(range.Snapshot);
+                var span = t.ToSnapshotSpan(range.Snapshot);
                 var isMissing = await entry.Analyzer.IsMissingImportAsync(
                     entry,
                     span.GetText(),
-                    t.SourceSpan.Start
+                    t.ToSourceSpan().Start
                 );
 
                 if (isMissing) {

--- a/Python/Product/PythonTools/PythonTools/Intellisense/PythonSuggestedActionsSource.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/PythonSuggestedActionsSource.cs
@@ -68,18 +68,17 @@ namespace Microsoft.PythonTools.Intellisense {
 
             var needSuggestion = new List<SnapshotSpan>();
 
-            var tokens = textBuffer.GetPythonClassifier()?.GetClassificationSpans(range);
-            foreach (var t in tokens.MaybeEnumerate()) {
-                if (t.ClassificationType.IsOfType(PredefinedClassificationTypeNames.Identifier)) {
-                    var isMissing = await entry.Analyzer.IsMissingImportAsync(
-                        entry,
-                        t.Span.GetText(),
-                        t.Span.Start.ToSourceLocation()
-                    );
+            var tokens = bi.GetTokens(range).Where(t => t.Category == TokenCategory.Identifier);
+            foreach (var t in tokens) {
+                var span = t.SourceSpan.ToSnapshotSpan(range.Snapshot);
+                var isMissing = await entry.Analyzer.IsMissingImportAsync(
+                    entry,
+                    span.GetText(),
+                    t.SourceSpan.Start
+                );
 
-                    if (isMissing) {
-                        needSuggestion.Add(t.Span);
-                    }
+                if (isMissing) {
+                    needSuggestion.Add(span);
                 }
             }
 

--- a/Python/Product/PythonTools/PythonTools/Navigation/CodeWindowManager.cs
+++ b/Python/Product/PythonTools/PythonTools/Navigation/CodeWindowManager.cs
@@ -15,6 +15,7 @@
 // permissions and limitations under the License.
 
 using System;
+using Microsoft.PythonTools.Editor;
 using Microsoft.PythonTools.Infrastructure;
 using Microsoft.PythonTools.Intellisense;
 using Microsoft.PythonTools.Language;
@@ -152,9 +153,9 @@ namespace Microsoft.PythonTools.Navigation {
             _viewCount++;
             var wpfTextView = VsEditorAdaptersFactoryService.GetWpfTextView(vsTextView);
             if (wpfTextView != null) {
-                var factory = ComponentModel.GetService<IEditorOperationsFactoryService>();
-                EditFilter.GetOrCreate(_serviceProvider, ComponentModel, vsTextView);
-                new TextViewFilter(_serviceProvider, vsTextView);
+                var services = ComponentModel.GetService<PythonEditorServices>();
+                EditFilter.GetOrCreate(services, vsTextView);
+                new TextViewFilter(services, vsTextView);
                 wpfTextView.GotAggregateFocus += OnTextViewGotAggregateFocus;
                 wpfTextView.LostAggregateFocus += OnTextViewLostAggregateFocus;
             }

--- a/Python/Product/PythonTools/PythonTools/Navigation/PythonFileLibraryNode.cs
+++ b/Python/Product/PythonTools/PythonTools/Navigation/PythonFileLibraryNode.cs
@@ -85,7 +85,7 @@ namespace Microsoft.PythonTools.Navigation {
                     var exprAnalysis = analysis.Analyzer.WaitForRequest(analysis.Analyzer.AnalyzeExpressionAsync(
                         analysis,
                         criteria.szName.Substring(criteria.szName.LastIndexOf(':') + 1),
-                        new SourceLocation(0, 1, 1)
+                        new SourceLocation(1, 1)
                     ), "PythonFileLibraryNode.DoSearch");
 
                     if (exprAnalysis != null) {
@@ -207,7 +207,7 @@ namespace Microsoft.PythonTools.Navigation {
             var analysis = _hierarchy.GetAnalysisEntry();
             var members = analysis.Analyzer.WaitForRequest(analysis.Analyzer.GetAllAvailableMembersAsync(
                 analysis,
-                new SourceLocation(0, 1, 1),
+                new SourceLocation(1, 1),
                 GetMemberOptions.ExcludeBuiltins | GetMemberOptions.DetailedInformation
             ), "PythonFileChildren.GetChildren");
             return members;
@@ -230,7 +230,7 @@ namespace Microsoft.PythonTools.Navigation {
             var members = analysis.Analyzer.WaitForRequest(analysis.Analyzer.GetMembersAsync(
                 analysis,
                 _member,
-                new SourceLocation(0, 1, 1),
+                new SourceLocation(1, 1),
                 GetMemberOptions.ExcludeBuiltins | GetMemberOptions.DetailedInformation | GetMemberOptions.DeclaredOnly |
                 GetMemberOptions.NoMemberRecursion
             ), "MemberChildren.GetChildren");

--- a/Python/Product/PythonTools/PythonTools/Navigation/PythonLibraryNode.cs
+++ b/Python/Product/PythonTools/PythonTools/Navigation/PythonLibraryNode.cs
@@ -184,7 +184,7 @@ namespace Microsoft.PythonTools.Navigation {
                         var analysis = analyzer.WaitForRequest(analyzer.AnalyzeExpressionAsync(
                             entry, 
                             Name, 
-                            new SourceLocation(0, reference.line, reference.column)
+                            new SourceLocation(reference.line, reference.column)
                         ), "PythonLibraryNode.AnalyzeExpression");
                         vars.AddRange(analysis.Variables);
                     }

--- a/Python/Product/PythonTools/PythonTools/Navigation/TextViewFilter.cs
+++ b/Python/Product/PythonTools/PythonTools/Navigation/TextViewFilter.cs
@@ -109,7 +109,7 @@ namespace Microsoft.PythonTools.Language {
             // Adjust the span to expression boundaries.
 
             var snapshot = _wpfTextView.TextSnapshot;
-            var pt = new SourceLocation(0, pSpan[0].iStartLine + 1, pSpan[0].iStartIndex + 1);
+            var pt = new SourceLocation(pSpan[0].iStartLine + 1, pSpan[0].iStartIndex + 1);
 
             var bi = PythonTextBufferInfo.TryGetForBuffer(snapshot.TextBuffer);
             var analyzer = bi?.AnalysisEntry?.Analyzer;

--- a/Python/Product/PythonTools/PythonTools/PythonClassifier.cs
+++ b/Python/Product/PythonTools/PythonTools/PythonClassifier.cs
@@ -31,14 +31,9 @@ namespace Microsoft.PythonTools {
     /// Provides classification based upon the DLR TokenCategory enum.
     /// </summary>
     internal sealed class PythonClassifier : IClassifier, IPythonTextBufferInfoEventSink {
-        private readonly TokenCache _tokenCache;
         private readonly PythonClassifierProvider _provider;
 
-        [ThreadStatic]
-        private static Dictionary<PythonLanguageVersion, Tokenizer> _tokenizers;    // tokenizer for each version, shared between all buffers
-
         internal PythonClassifier(PythonClassifierProvider provider) {
-            _tokenCache = new TokenCache();
             _provider = provider;
         }
 
@@ -48,7 +43,6 @@ namespace Microsoft.PythonTools {
                 Debug.Assert(entry == null, "Should not have new analysis entry without an analyzer");
                 return Task.CompletedTask;
             }
-            _tokenCache.Clear();
 
             var snapshot = sender.CurrentSnapshot;
             ClassificationChanged?.Invoke(
@@ -68,30 +62,14 @@ namespace Microsoft.PythonTools {
         /// This method classifies the given snapshot span.
         /// </summary>
         public IList<ClassificationSpan> GetClassificationSpans(SnapshotSpan span) {
-            var classifications = new List<ClassificationSpan>();
+            var snapshot = span.Snapshot;
+            var bi = _provider.Services.GetBufferInfo(snapshot.TextBuffer);
 
-            if (span.Length > 0) {
-                // don't add classifications for REPL commands.
-                var snapshot = span.Snapshot;
-                if (!snapshot.IsReplBufferWithCommand()) {
-                    AddClassifications(GetTokenizer(snapshot), classifications, span);
-                }
+            if (span.Length <= 0 || bi == null || snapshot.IsReplBufferWithCommand()) {
+                return Array.Empty<ClassificationSpan>();
             }
 
-            return classifications;
-        }
-
-        private Tokenizer GetTokenizer(ITextSnapshot snapshot) {
-            if (_tokenizers == null) {
-                _tokenizers = new Dictionary<PythonLanguageVersion, Tokenizer>();
-            }
-            Tokenizer res;
-            var bi = PythonTextBufferInfo.TryGetForBuffer(snapshot.TextBuffer);
-            var version = bi?.LanguageVersion ?? PythonLanguageVersion.None;
-            if (!_tokenizers.TryGetValue(version, out res)) {
-                _tokenizers[version] = res = new Tokenizer(version, options: TokenizerOptions.Verbatim | TokenizerOptions.VerbatimCommentsAndLineJoins);
-            }
-            return res;
+            return bi.GetLineTokens(span).Select(kv => ClassifyToken(span, kv.Value, kv.Key)).Where(c => c != null).ToList();
         }
 
         public PythonClassifierProvider Provider {
@@ -111,224 +89,32 @@ namespace Microsoft.PythonTools {
 
             var snapshot = e.After;
 
-            if (!snapshot.IsReplBufferWithCommand()) {
-                _tokenCache.EnsureCapacity(snapshot.LineCount);
+            if (snapshot.IsReplBufferWithCommand()) {
+                return Task.CompletedTask;
+            }
 
-                var tokenizer = GetTokenizer(snapshot);
-                foreach (var change in e.Changes) {
-                    var endLine = snapshot.GetLineNumberFromPosition(change.NewEnd) + 1;
-                    if (change.LineCountDelta > 0) {
-                        _tokenCache.InsertLines(endLine - change.LineCountDelta, change.LineCountDelta);
-                    } else if (change.LineCountDelta < 0) {
-                        _tokenCache.DeleteLines(endLine, Math.Min(-change.LineCountDelta, snapshot.LineCount - endLine));
-                    }
-
-                    ApplyChange(tokenizer, snapshot, change.NewSpan);
+            Span changedSpan = new Span(0, 0);
+            foreach (var change in e.Changes) {
+                if (changedSpan.Length == 0) {
+                    changedSpan = change.NewSpan;
+                } else {
+                    changedSpan = Span.FromBounds(
+                        Math.Min(change.NewSpan.Start, changedSpan.Start),
+                        Math.Max(change.NewSpan.End, changedSpan.End)
+                    );
                 }
+            }
+            if (changedSpan.Length > 0) {
+                ClassificationChanged?.Invoke(
+                    this,
+                    new ClassificationChangedEventArgs(new SnapshotSpan(snapshot, changedSpan))
+                );
             }
 
             return Task.CompletedTask;
         }
 
-        /// <summary>
-        /// Adds classification spans to the given collection.
-        /// Scans a contiguous sub-<paramref name="span"/> of a larger code span which starts at <paramref name="codeStartLine"/>.
-        /// </summary>
-        private void AddClassifications(Tokenizer tokenizer, List<ClassificationSpan> classifications, SnapshotSpan span) {
-            Debug.Assert(span.Length > 0);
-
-            var snapshot = span.Snapshot;
-            int firstLine = snapshot.GetLineNumberFromPosition(span.Start);
-            int lastLine = snapshot.GetLineNumberFromPosition(span.End - 1);
-
-            Contract.Assert(firstLine >= 0);
-
-            var strSpan = default(SourceSpan);
-
-            _tokenCache.EnsureCapacity(snapshot.LineCount);
-
-            for (int line = firstLine; line <= lastLine; ++line) {
-                var lineTokenization = GetTokenizationOfKnownState(tokenizer, snapshot, _tokenCache, line);
-
-                for (int i = 0; i < lineTokenization.Tokens.Length; i++) {
-                    var token = lineTokenization.Tokens[i];
-                    if (token.Category == TokenCategory.IncompleteMultiLineStringLiteral || token.Category == TokenCategory.StringLiteral) {
-                        if (token.SourceSpan.Start >= strSpan.Start && token.SourceSpan.End <= strSpan.End) {
-                            // We are already in the current string span, so do not add any
-                            // more classifications.
-                            continue;
-                        }
-
-                        // Walk both directions to get the full span
-                        if (token.Category == TokenCategory.StringLiteral) {
-                            strSpan = token.SourceSpan;
-                        } else {
-                            strSpan = GetMultiLineString(tokenizer, snapshot, token);
-                        }
-
-                        classifications.Add(new ClassificationSpan(
-                            GetTokenSnapshotSpan(snapshot, strSpan.Start, strSpan.End),
-                            _provider.StringLiteral
-                        ));
-                    } else {
-                        var classification = ClassifyToken(span, token, line);
-
-                        if (classification != null) {
-                            classifications.Add(classification);
-                        }
-                    }
-                }
-            }
-        }
-
-        private static LineTokenization GetTokenizationOfKnownState(Tokenizer tokenizer, ITextSnapshot snapshot, TokenCache cache, int lineNo) {
-            LineTokenization line;
-            int lastLine = cache.IndexOfPreviousTokenization(lineNo + 1, 0, out line);
-            if (lastLine == lineNo) {
-                return line;
-            }
-
-            for (int i = lastLine + 1; i <= lineNo; ++i) {
-                var lineState = line.State;
-                if (!cache.TryGetTokenization(i, out line)) {
-                    cache[i] = line = TokenizeLine(tokenizer, snapshot, lineState, i);
-                }
-            }
-
-            return line;
-        }
-
-        private SourceSpan GetMultiLineString(Tokenizer tokenizer, ITextSnapshot snapshot, TokenInfo initial) {
-            var bestStart = initial.SourceSpan.Start;
-            var bestEnd = initial.SourceSpan.End;
-
-            for (int line = initial.SourceSpan.Start.Line - 1; line >= 0; --line) {
-                var tokens = GetTokenizationOfKnownState(tokenizer, snapshot, _tokenCache, line);
-
-                if (tokens.Tokens.Length == 0) {
-                    continue;
-                }
-
-                int lastIndex = tokens.Tokens.Length - 1;
-                // For the first line, only look up to the start location
-                if (line == initial.SourceSpan.Start.Line - 1) {
-                    lastIndex = tokens.Tokens.Count(t => t.SourceSpan.Start < initial.SourceSpan.Start);
-                    if (lastIndex >= tokens.Tokens.Length) {
-                        lastIndex = tokens.Tokens.Length - 1;
-                    }
-                }
-
-                // If the last token is not a string, the previous best was the start
-                var tok = tokens.Tokens[lastIndex];
-                if (tok.Category != TokenCategory.IncompleteMultiLineStringLiteral) {
-                    break;
-                }
-
-                // We have a new best start point
-                bestStart = tok.SourceSpan.Start;
-
-                // If there are other tokens on this line, we have the start point
-                if (lastIndex > 0) {
-                    break;
-                }
-            }
-
-            for (int line = initial.SourceSpan.End.Line - 1; line < snapshot.LineCount; ++line) {
-                var tokens = GetTokenizationOfKnownState(tokenizer, snapshot, _tokenCache, line);
-
-                if (tokens.Tokens.Length == 0) {
-                    continue;
-                }
-
-                int firstIndex = 0;
-                if (line == initial.SourceSpan.End.Line - 1) {
-                    firstIndex = tokens.Tokens.Count(t => t.SourceSpan.Start < initial.SourceSpan.Start);
-                    if (firstIndex >= tokens.Tokens.Length) {
-                        continue;
-                    }
-                }
-
-                // If the first token is not a string, the previous best was the end
-                var tok = tokens.Tokens[firstIndex];
-                if (tok.Category == TokenCategory.StringLiteral) {
-                    bestEnd = tok.SourceSpan.End;
-                    break;
-                }
-                if (tok.Category != TokenCategory.IncompleteMultiLineStringLiteral) {
-                    break;
-                }
-
-                // We have a new best end point
-                bestEnd = tok.SourceSpan.End;
-
-                // If there are other tokens on this line, we have the end point
-                if (tokens.Tokens.Length - 1> firstIndex) {
-                    break;
-                }
-            }
-
-            return new SourceSpan(bestStart, bestEnd);
-        }
-
-        /// <summary>
-        /// Rescans the part of the buffer affected by a change. 
-        /// Scans a contiguous sub-<paramref name="span"/> of a larger code span which starts at <paramref name="codeStartLine"/>.
-        /// </summary>
-        private void ApplyChange(Tokenizer tokenizer, ITextSnapshot snapshot, Span span) {
-            int firstLine = snapshot.GetLineNumberFromPosition(span.Start);
-            int lastLine = snapshot.GetLineNumberFromPosition(span.Length > 0 ? span.End - 1 : span.End);
-
-            Contract.Assert(firstLine >= 0);
-
-            // find the closest line preceding firstLine for which we know categorizer state, stop at the codeStartLine:
-            LineTokenization lineTokenization;
-            firstLine = _tokenCache.IndexOfPreviousTokenization(firstLine, 0, out lineTokenization) + 1;
-            object state = lineTokenization.State;
-
-            int currentLine = firstLine;
-            object previousState;
-            while (currentLine < snapshot.LineCount) {
-                previousState = _tokenCache.TryGetTokenization(currentLine, out lineTokenization) ? lineTokenization.State : null;
-                _tokenCache[currentLine] = lineTokenization = TokenizeLine(tokenizer, snapshot, state, currentLine);
-                state = lineTokenization.State;
-
-                // stop if we visted all affected lines and the current line has no tokenization state or its previous state is the same as the new state:
-                if (currentLine > lastLine && (previousState == null || previousState.Equals(state))) {
-                    break;
-                }
-
-                currentLine++;
-            }
-
-
-            // classification spans might have changed between the start of the first and end of the last visited line:
-            int changeStart = snapshot.GetLineFromLineNumber(firstLine).Start;
-            int changeEnd = (currentLine < snapshot.LineCount) ? snapshot.GetLineFromLineNumber(currentLine).End : snapshot.Length;
-            if (changeStart < changeEnd) {
-                var classificationChanged = ClassificationChanged;
-                if (classificationChanged != null) {
-                    var args = new ClassificationChangedEventArgs(new SnapshotSpan(snapshot, new Span(changeStart, changeEnd - changeStart)));
-                    classificationChanged(this, args);
-                }
-            }
-        }
-
-        private static LineTokenization TokenizeLine(Tokenizer tokenizer, ITextSnapshot snapshot, object previousLineState, int lineNo) {
-            ITextSnapshotLine line = snapshot.GetLineFromLineNumber(lineNo);
-            SnapshotSpan lineSpan = new SnapshotSpan(snapshot, line.Start, line.LengthIncludingLineBreak);
-
-            var tcp = new SnapshotSpanSourceCodeReader(lineSpan);
-
-            tokenizer.Initialize(previousLineState, tcp, new SourceLocation(line.Start.Position, lineNo + 1, 1));
-            try {
-                var tokens = tokenizer.ReadTokens(lineSpan.Length).ToArray();
-                return new LineTokenization(tokens, tokenizer.CurrentState);
-            } finally {
-                tokenizer.Uninitialize();
-            }
-        }
-
-        private ClassificationSpan ClassifyToken(SnapshotSpan span, TokenInfo token, int lineNumber) {
+        private ClassificationSpan ClassifyToken(SnapshotSpan span, LineToken token, int lineNumber) {
             IClassificationType classification = null;
 
             if (token.Category == TokenCategory.Operator) {
@@ -350,7 +136,7 @@ namespace Microsoft.PythonTools {
             }
 
             if (classification != null) {
-                var tokenSpan = GetTokenSnapshotSpan(span.Snapshot, token.SourceSpan.Start, token.SourceSpan.End);
+                var tokenSpan = GetTokenSnapshotSpan(span.Snapshot, lineNumber, token.Column, token.Length);
                 var intersection = span.Intersection(tokenSpan);
 
                 if (intersection != null && intersection.Value.Length > 0 ||
@@ -362,44 +148,22 @@ namespace Microsoft.PythonTools {
             return null;
         }
 
-        private static SnapshotSpan GetTokenSnapshotSpan(ITextSnapshot snapshot, SourceLocation tokenStart, SourceLocation tokenEnd) {
-            ITextSnapshotLine startLine, endLine;
-            if (tokenStart.Line <= 0) {
-                startLine = snapshot.GetLineFromLineNumber(0);
-            } else if (tokenStart.Line <= snapshot.LineCount) {
-                startLine = snapshot.GetLineFromLineNumber(tokenStart.Line - 1);
-            } else {
-                return new SnapshotSpan(snapshot, snapshot.Length, 0);
+        private static SnapshotSpan GetTokenSnapshotSpan(ITextSnapshot snapshot, int lineNumber, int column, int length) {
+            var tokenLine = snapshot.GetLineFromLineNumber(lineNumber);
+            if (column >= tokenLine.LengthIncludingLineBreak) {
+                return new SnapshotSpan(tokenLine.EndIncludingLineBreak, 0);
+            }
+            var tokenStart = tokenLine.Start + column;
+            if (column + length >= tokenLine.LengthIncludingLineBreak) {
+                return new SnapshotSpan(tokenStart, tokenLine.EndIncludingLineBreak);
             }
 
-            var startCol = tokenStart.Column - 1;
-            var start = (startLine.Start.Position + startCol >= startLine.EndIncludingLineBreak) ?
-                startLine.EndIncludingLineBreak:
-                (startLine.Start + startCol);
-
-            if (tokenEnd.Line == tokenStart.Line) {
-                endLine = startLine;
-            } else if (tokenEnd.Line <= 0) {
-                endLine = snapshot.GetLineFromLineNumber(0);
-            } else if (tokenEnd.Line <= snapshot.LineCount) {
-                endLine = snapshot.GetLineFromLineNumber(tokenEnd.Line - 1);
-            } else {
-                return new SnapshotSpan(snapshot, snapshot.Length, 0);
-            }
-
-            var endCol = tokenEnd.Column - 1;
-            var end = (endLine.Start.Position + endCol >= endLine.EndIncludingLineBreak) ?
-                endLine.EndIncludingLineBreak :
-                (endLine.Start + endCol);
-
-            return new SnapshotSpan(start, end);
+            return new SnapshotSpan(tokenStart, length);
         }
 
         Task IPythonTextBufferInfoEventSink.PythonTextBufferEventAsync(PythonTextBufferInfo sender, PythonTextBufferInfoEventArgs e) {
             if (e.Event == PythonTextBufferInfoEvents.NewAnalysisEntry) {
                 return OnNewAnalysisEntryAsync(sender, e.AnalysisEntry);
-            } else if (e.Event == PythonTextBufferInfoEvents.ContentTypeChanged) {
-                _tokenCache.Clear();
             } else if (e.Event == PythonTextBufferInfoEvents.TextContentChanged) {
                 return OnTextContentChangedAsync(sender, (e as PythonTextBufferInfoNestedEventArgs)?.NestedEventArgs as TextContentChangedEventArgs);
             }

--- a/Python/Product/PythonTools/PythonTools/PythonClassifier.cs
+++ b/Python/Product/PythonTools/PythonTools/PythonClassifier.cs
@@ -83,6 +83,7 @@ namespace Microsoft.PythonTools {
         #region Private Members
 
         private Task OnTextContentChangedAsync(PythonTextBufferInfo sender, TextContentChangedEventArgs e) {
+            // NOTE: Runs on background thread
             if (e == null) {
                 Debug.Fail("Invalid type passed to event");
             }
@@ -151,7 +152,7 @@ namespace Microsoft.PythonTools {
         Task IPythonTextBufferInfoEventSink.PythonTextBufferEventAsync(PythonTextBufferInfo sender, PythonTextBufferInfoEventArgs e) {
             if (e.Event == PythonTextBufferInfoEvents.NewAnalysisEntry) {
                 return OnNewAnalysisEntryAsync(sender, e.AnalysisEntry);
-            } else if (e.Event == PythonTextBufferInfoEvents.TextContentChanged) {
+            } else if (e.Event == PythonTextBufferInfoEvents.TextContentChangedOnBackgroundThread) {
                 return OnTextContentChangedAsync(sender, (e as PythonTextBufferInfoNestedEventArgs)?.NestedEventArgs as TextContentChangedEventArgs);
             }
             return Task.CompletedTask;

--- a/Python/Product/PythonTools/PythonTools/PythonClassifierProvider.cs
+++ b/Python/Product/PythonTools/PythonTools/PythonClassifierProvider.cs
@@ -57,6 +57,8 @@ namespace Microsoft.PythonTools {
             _type = _services.ContentTypeRegistryService.GetContentType(PythonCoreConstants.ContentType);
         }
 
+        internal PythonEditorServices Services => _services;
+
         #region Python Classification Type Definitions
 
         [Export]
@@ -144,6 +146,7 @@ namespace Microsoft.PythonTools {
             categoryMap[TokenCategory.NumericLiteral] = registry.GetClassificationType(PredefinedClassificationTypeNames.Number);
             categoryMap[TokenCategory.CharacterLiteral] = registry.GetClassificationType(PredefinedClassificationTypeNames.Character);
             categoryMap[TokenCategory.StringLiteral] = _stringLiteral = registry.GetClassificationType(PredefinedClassificationTypeNames.String);
+            categoryMap[TokenCategory.IncompleteMultiLineStringLiteral] = _stringLiteral;
             categoryMap[TokenCategory.Keyword] = _keyword = registry.GetClassificationType(PredefinedClassificationTypeNames.Keyword);
             categoryMap[TokenCategory.Directive] = registry.GetClassificationType(PredefinedClassificationTypeNames.Keyword);
             categoryMap[TokenCategory.Identifier] = registry.GetClassificationType(PredefinedClassificationTypeNames.Identifier);

--- a/Python/Product/PythonTools/PythonTools/TokenCache.cs
+++ b/Python/Product/PythonTools/PythonTools/TokenCache.cs
@@ -148,7 +148,6 @@ namespace Microsoft.PythonTools {
             var line = LineSpan.GetSpan(snapshot);
 
             Debug.Assert(line.Start.GetContainingLine().LineNumber == LineNumber, "Mismatched line number");
-            Debug.Assert(line.End.GetContainingLine().LineNumber == LineNumber, "Mismatched line number");
 
             int startCol = Math.Min(LineToken.Column, line.Length);
             int endCol = Math.Min(LineToken.Column + LineToken.Length, line.Length);
@@ -162,8 +161,26 @@ namespace Microsoft.PythonTools {
     internal class TokenCache {
         private LineTokenization[] _map;
 
+        // This lock is only used for reading/writing _map, and not
+        // the contents of the array. Lock the array itself when
+        // using it.
+        private readonly object _mapLock = new object();
+
         internal TokenCache() {
             _map = null;
+        }
+
+        private LineTokenization[] Map {
+            get {
+                LineTokenization[] map;
+                lock (_mapLock) {
+                    map = _map;
+                }
+                if (map == null) {
+                    throw new InvalidOperationException("uninitialized token cache");
+                }
+                return map;
+            }
         }
 
         /// <summary>
@@ -174,15 +191,18 @@ namespace Microsoft.PythonTools {
             if (line < 0) {
                 throw new ArgumentOutOfRangeException("line", "Must be 0 or greater");
             }
-            Utilities.CheckNotNull(_map);
 
-            line--;
-            while (line >= minLine) {
-                if (_map[line].Tokens != null) {
-                    tokenization = _map[line];
-                    return line;
-                }
+            var map = Map;
+
+            lock (map) {
                 line--;
+                while (line >= minLine) {
+                    if (map[line].Tokens != null) {
+                        tokenization = map[line];
+                        return line;
+                    }
+                    line--;
+                }
             }
             tokenization = default(LineTokenization);
             return minLine - 1;
@@ -192,10 +212,9 @@ namespace Microsoft.PythonTools {
             if (line < 0) {
                 throw new ArgumentOutOfRangeException("line", "Must be 0 or greater");
             }
-            Utilities.CheckNotNull(_map);
 
-            if (_map[line].Tokens != null) {
-                tokenization = _map[line];
+            tokenization = this[line];
+            if (tokenization.Tokens != null) {
                 return true;
             } else {
                 tokenization = default(LineTokenization);
@@ -205,10 +224,16 @@ namespace Microsoft.PythonTools {
 
         internal LineTokenization this[int line] {
             get {
-                return _map[line];
+                var map = Map;
+                lock (map) {
+                    return map[line];
+                }
             }
             set {
-                _map[line] = value;
+                var map = Map;
+                lock (map) {
+                    map[line] = value;
+                }
             }
         }
 
@@ -217,31 +242,40 @@ namespace Microsoft.PythonTools {
         }
 
         internal void EnsureCapacity(int capacity) {
-            if (_map == null) {
-                _map = new LineTokenization[capacity];
-            } else if (_map.Length < capacity) {
-                Array.Resize(ref _map, Math.Max(capacity, (_map.Length + 1) * 2));
+            lock (_mapLock) {
+                if (_map == null) {
+                    _map = new LineTokenization[capacity];
+                    return;
+                }
+
+                if (capacity > _map.Length) {
+                    Array.Resize(ref _map, Math.Max(capacity, (_map.Length + 1) * 2));
+                }
             }
         }
 
         internal void DeleteLines(int index, int count) {
-            Utilities.CheckNotNull(_map);
-            if (index > _map.Length - count) {
+            var map = Map;
+            if (index > map.Length - count) {
                 throw new ArgumentOutOfRangeException("line", "Must be 'count' less than the size of the cache");
             }
-            
-            Array.Copy(_map, index + count, _map, index, _map.Length - index - count);
-            for (int i = 0; i < count; i++) {
-                _map[_map.Length - i - 1] = default(LineTokenization);
+
+            lock (map) {
+                Array.Copy(map, index + count, map, index, map.Length - index - count);
+                for (int i = 0; i < count; i++) {
+                    map[map.Length - i - 1] = default(LineTokenization);
+                }
             }
         }
 
         internal void InsertLines(int index, int count) {
-            Utilities.CheckNotNull(_map);
+            var map = Map;
 
-            Array.Copy(_map, index, _map, index + count, _map.Length - index - count);
-            for (int i = 0; i < count; i++) {
-                _map[index + i] = default(LineTokenization);
+            lock (map) {
+                Array.Copy(map, index, map, index + count, map.Length - index - count);
+                for (int i = 0; i < count; i++) {
+                    map[index + i] = default(LineTokenization);
+                }
             }
         }
     }

--- a/Python/Product/PythonTools/PythonTools/TokenCache.cs
+++ b/Python/Product/PythonTools/PythonTools/TokenCache.cs
@@ -82,7 +82,7 @@ namespace Microsoft.PythonTools {
         public int Length;
     }
 
-    public struct TrackingTokenInfo {
+    struct TrackingTokenInfo {
         internal TrackingTokenInfo(LineToken token, int lineNumber, ITrackingSpan lineSpan) {
             LineToken = token;
             LineNumber = lineNumber;

--- a/Python/Tests/Analysis/ExpressionFinderTests.cs
+++ b/Python/Tests/Analysis/ExpressionFinderTests.cs
@@ -201,13 +201,13 @@ b = C().f(1)
             var code = astAndSource.Source;
             var options = astAndSource.Options;
 
-            int start = ast.LocationToIndex(new SourceLocation(0, startLine, 1));
-            int end = ast.LocationToIndex(new SourceLocation(0, endLine + 1, 1));
+            int start = ast.LocationToIndex(new SourceLocation(startLine, 1));
+            int end = ast.LocationToIndex(new SourceLocation(endLine + 1, 1));
             var fullLine = code.Substring(start);
             fullLine = fullLine.Remove("\r\n".Select(c => fullLine.LastIndexOf(c, end - start - 1)).Where(i => i > 0).Min());
 
             var finder = new ExpressionFinder(ast, options);
-            var range = new SourceSpan(new SourceLocation(0, startLine, startColumn), new SourceLocation(0, endLine, endColumn));
+            var range = new SourceSpan(new SourceLocation(startLine, startColumn), new SourceLocation(endLine, endColumn));
             var span = finder.GetExpressionSpan(range);
             if (span == null || span.Value.Start == span.Value.End) {
                 return;
@@ -228,13 +228,13 @@ b = C().f(1)
             var code = astAndSource.Source;
             var options = astAndSource.Options;
 
-            int start = ast.LocationToIndex(new SourceLocation(0, startLine, 1));
-            int end = ast.LocationToIndex(new SourceLocation(0, endLine + 1, 1));
+            int start = ast.LocationToIndex(new SourceLocation(startLine, 1));
+            int end = ast.LocationToIndex(new SourceLocation(endLine + 1, 1));
             var fullLine = code.Substring(start);
             fullLine = fullLine.Remove("\r\n".Select(c => fullLine.LastIndexOf(c, end - start - 1)).Where(i => i > 0).Min());
 
             var finder = new ExpressionFinder(ast, options);
-            var range = new SourceSpan(new SourceLocation(0, startLine, startColumn), new SourceLocation(0, endLine, endColumn));
+            var range = new SourceSpan(new SourceLocation(startLine, startColumn), new SourceLocation(endLine, endColumn));
             var span = finder.GetExpressionSpan(range);
             Assert.IsNotNull(span, $"Did not find any expression at {range} in <{fullLine}>");
 

--- a/Python/Tests/Core/AutoIndentTests.cs
+++ b/Python/Tests/Core/AutoIndentTests.cs
@@ -1,0 +1,74 @@
+﻿// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABLITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using Microsoft.PythonTools.Editor;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.Utilities;
+using TestUtilities.Mocks;
+
+namespace PythonToolsTests {
+    [TestClass]
+    public class AutoIndentTests {
+        public static IContentType PythonContentType = new MockContentType("Python", new IContentType[0]);
+
+        [TestMethod, Priority(0)]
+        public void GetIndentation() {
+            Assert.AreEqual(0, AutoIndent.GetIndentation("", 4));
+            Assert.AreEqual(0, AutoIndent.GetIndentation("p", 4));
+            Assert.AreEqual(4, AutoIndent.GetIndentation("    ", 4));
+            Assert.AreEqual(4, AutoIndent.GetIndentation("    p", 4));
+            Assert.AreEqual(3, AutoIndent.GetIndentation("   p", 4));
+            Assert.AreEqual(5, AutoIndent.GetIndentation("     p", 4));
+            Assert.AreEqual(4, AutoIndent.GetIndentation("\tp", 4));
+            Assert.AreEqual(5, AutoIndent.GetIndentation("\t p", 4));
+            Assert.AreEqual(5, AutoIndent.GetIndentation(" \tp", 4));
+            Assert.AreEqual(6, AutoIndent.GetIndentation(" \t p", 4));
+        }
+
+        [TestMethod, Priority(0)]
+        public void GetLineIndentation() {
+            AssertIndent("pass\n", 2, 0);
+            AssertIndent("def f():\n", 2, 4);
+            AssertIndent("f(x,\n", 2, 2);
+            AssertIndent("f(\n", 2, 4);
+            AssertIndent("[\n", 2, 4);
+            AssertIndent("{\n", 2, 4);
+            AssertIndent("         [\n", 2, 13);
+            AssertIndent("[[[[[[[[[[\n", 2, 4);
+            AssertIndent("         [x,\n", 2, 10);
+            AssertIndent("[[[[[[[[[[x,\n", 2, 10);
+
+            AssertIndent("def f():\n    print('hi')\n\n", 3, 4);
+            AssertIndent("def f():\n    pass\n\n", 3, 0);
+
+            AssertIndent("abc = {'x': [\n\n  ['''str''',\n\n]],\n\n    }", 2, 4);
+            AssertIndent("abc = {'x': [\n\n  ['''str''',\n\n]],\n\n    }", 4, 3);
+            AssertIndent("abc = {'x': [\n\n  ['''str''',\n\n]],\n\n    }", 6, 7);
+        }
+
+        private static void AssertIndent(string code, int lineNumber, int expected, int tabSize = 4, int indentSize = 4) {
+            var buffer = new MockTextBuffer(code, PythonContentType);
+            var view = new MockTextView(buffer);
+            view.Options.SetOptionValue(DefaultOptions.IndentSizeOptionId, indentSize);
+            view.Options.SetOptionValue(DefaultOptions.TabSizeOptionId, tabSize);
+
+            var line = buffer.CurrentSnapshot.GetLineFromLineNumber(lineNumber - 1);
+            var actual = AutoIndent.GetLineIndentation(PythonTextBufferInfo.ForBuffer(null, buffer), line, view);
+            Assert.AreEqual(expected, actual, line.GetText());
+        }
+    }
+}

--- a/Python/Tests/Core/EditorTests.cs
+++ b/Python/Tests/Core/EditorTests.cs
@@ -499,7 +499,7 @@ In [3]: if True:
                 index += content.Length + 1;
             }
             var pt = new SnapshotPoint(buffer.CurrentSnapshot, index);
-            var actual = PythonTextBufferInfo.IsPossibleExpressionAtPoint(pt, version);
+            var actual = PythonTextBufferInfo.ForBuffer(null, buffer).IsPossibleExpressionAtPoint(pt);
             if (expectExpression) {
                 Assert.IsTrue(actual, content);
             } else {
@@ -513,7 +513,7 @@ In [3]: if True:
                 index += content.Length + 1;
             }
             var span = new SnapshotSpan(buffer.CurrentSnapshot, index, 0);
-            var actual = PythonTextBufferInfo.GetExpressionAtPoint(span, version, GetExpressionOptions.Hover);
+            var actual = PythonTextBufferInfo.ForBuffer(null, buffer).GetExpressionAtPoint(span, GetExpressionOptions.Hover);
             Assert.AreEqual(expected, actual?.GetText(), content);
         }
 

--- a/Python/Tests/Core/PythonProjectTests.cs
+++ b/Python/Tests/Core/PythonProjectTests.cs
@@ -277,7 +277,7 @@ namespace PythonToolsTests {
                 analyzer.WaitForCompleteAnalysis(_ => !cancel.IsCancellationRequested);
                 cancel.ThrowIfCancellationRequested();
 
-                var loc = new Microsoft.PythonTools.Parsing.SourceLocation(0, 1, 1);
+                var loc = new Microsoft.PythonTools.Parsing.SourceLocation(1, 1);
                 AssertUtil.ContainsExactly(
                     analyzer.GetEntriesThatImportModuleAsync("module1", true).Result.Select(m => m.moduleName),
                     "module2"

--- a/Python/Tests/Core/PythonToolsTests.csproj
+++ b/Python/Tests/Core/PythonToolsTests.csproj
@@ -102,6 +102,7 @@
     <Compile Include="..\DebuggerTests\DebugExtensions.cs">
       <Link>DebugExtensions.cs</Link>
     </Compile>
+    <Compile Include="AutoIndentTests.cs" />
     <Compile Include="BuildTasksTests.cs" />
     <Compile Include="CodeCellTests.cs" />
     <Compile Include="CoverageTests.cs" />

--- a/Python/Tests/PythonToolsMockTests/ClassifierTests.cs
+++ b/Python/Tests/PythonToolsMockTests/ClassifierTests.cs
@@ -175,11 +175,11 @@ def f(a = A, b : B):
         public void MultilineStringClassification() {
             var code = @"t = '''a
 
-b ''' + c + '''d
+b ''' + c + 'x' + '''d
 
 e'''";
             using (var helper = new ClassifierHelper(code, PythonLanguageVersion.V27)) {
-                helper.CheckAstClassifierSpans("i=s+i+s");
+                helper.CheckAstClassifierSpans("i=sss+i+s+sss");
             }
         }
 

--- a/Python/Tests/PythonToolsMockTests/CompletionTests.cs
+++ b/Python/Tests/PythonToolsMockTests/CompletionTests.cs
@@ -635,7 +635,7 @@ f(1, 2, 3, 4,")) {
             return GetCompletionNames(analysis.GetCompletions(new MockGlyphService()));
         }
 
-        [TestMethod, Priority(2)]
+        [TestMethod, Priority(0)]
         [TestCategory("10s")]
         public void CompletionInTripleQuotedString() {
             string code = @"

--- a/Python/Tests/PythonToolsMockTests/CompletionTests.cs
+++ b/Python/Tests/PythonToolsMockTests/CompletionTests.cs
@@ -212,6 +212,10 @@ l(42)
             foreach (var version in new[] { PythonLanguageVersion.V27, PythonLanguageVersion.V33 }) {
                 using (var view = new PythonEditor(version: version)) {
                     var completionList = view.GetCompletionList(0);
+                    for (int retries = 10; retries > 0 && !completionList.Any(); --retries) {
+                        completionList = view.GetCompletionList(0);
+                    }
+                    Assert.AreNotEqual(0, completionList.Count, $"No completions found for {view.Factory.Configuration.InterpreterPath}");
                     foreach (var c in completionList) {
                         Console.WriteLine(c.DisplayText);
                     }
@@ -222,13 +226,8 @@ l(42)
                     Assert.AreEqual(1, trueItems.Count());
                     Assert.AreEqual(1, falseItems.Count());
                     Assert.AreEqual(1, noneItems.Count());
-                    if (version.Is3x()) {
-                        Assert.AreEqual("Keyword", trueItems[0].IconAutomationText);
-                        Assert.AreEqual("Keyword", falseItems[0].IconAutomationText);
-                    } else {
-                        Assert.AreEqual("Constant", trueItems[0].IconAutomationText);
-                        Assert.AreEqual("Constant", falseItems[0].IconAutomationText);
-                    }
+                    Assert.AreEqual("Keyword", trueItems[0].IconAutomationText);
+                    Assert.AreEqual("Keyword", falseItems[0].IconAutomationText);
                     Assert.AreEqual("Keyword", noneItems[0].IconAutomationText);
                 }
             }

--- a/Python/Tests/PythonToolsMockTests/CompletionTests.cs
+++ b/Python/Tests/PythonToolsMockTests/CompletionTests.cs
@@ -212,10 +212,6 @@ l(42)
             foreach (var version in new[] { PythonLanguageVersion.V27, PythonLanguageVersion.V33 }) {
                 using (var view = new PythonEditor(version: version)) {
                     var completionList = view.GetCompletionList(0);
-                    for (int retries = 10; retries > 0 && !completionList.Any(); --retries) {
-                        completionList = view.GetCompletionList(0);
-                    }
-                    Assert.AreNotEqual(0, completionList.Count, $"No completions found for {view.Factory.Configuration.InterpreterPath}");
                     foreach (var c in completionList) {
                         Console.WriteLine(c.DisplayText);
                     }

--- a/Python/Tests/PythonToolsMockTests/PythonEditor.cs
+++ b/Python/Tests/PythonToolsMockTests/PythonEditor.cs
@@ -282,6 +282,23 @@ namespace PythonToolsMockTests {
             bool assertIfNoCompletions = true,
             ITextSnapshot snapshot = null
         ) {
+            for (int retries = 5; retries > 0; --retries) {
+                var completions = GetCompletionListNoRetry(index, false, snapshot);
+                if (completions.Any()) {
+                    return completions;
+                }
+            }
+            if (assertIfNoCompletions) {
+                Assert.Fail("No completions");
+            }
+            return new List<Completion>();
+        }
+
+        public List<Completion> GetCompletionListNoRetry(
+            int index,
+            bool assertIfNoCompletions = true,
+            ITextSnapshot snapshot = null
+        ) {
             snapshot = snapshot ?? CurrentSnapshot;
             if (index < 0) {
                 index += snapshot.Length + 1;


### PR DESCRIPTION
Fixes #3232 Classifications do not cover whole file
Moves in-proc tokenization into PythonTextBufferInfo
Switches some users of the classifier to the correct token source
Fixes line number management of token cache (i.e. don't trust the tokens)
Removes index comparisons from SourceLocation
Fixes explicit/incorrect uses of three argument SourceLocation constructor