### PR TITLE
Project system cut and paste fixes

### DIFF
--- a/Common/Product/SharedProject/ProjectNode.CopyPaste.cs
+++ b/Common/Product/SharedProject/ProjectNode.CopyPaste.cs
@@ -814,14 +814,6 @@ namespace Microsoft.VisualStudioTools.Project {
                                 //     add the parent to the project   
                                 ErrorHandler.ThrowOnFailure(sourceFolder.Parent.IncludeInProjectWithRefresh(false));
                             }
-
-                            if (DropEffect == DropEffect.Move) {
-                                Directory.Delete(SourceFolder);
-
-                                // we just handled the delete, the updated folder has the new filename,
-                                // and we don't want to delete where we just moved stuff...
-                                Project.ItemsDraggedOrCutOrCopied.Remove(sourceFolder);
-                            }
                         }
 
                         // Send OnItemRenamed for the folder now, after all of the children have been renamed

--- a/Common/Product/SharedProject/ProjectNode.CopyPaste.cs
+++ b/Common/Product/SharedProject/ProjectNode.CopyPaste.cs
@@ -330,7 +330,10 @@ namespace Microsoft.VisualStudioTools.Project {
             // they should always pass Move, and we'll know whether or not it's a cut from wasCut.
             // If they copied it from the project system wasCut will be false, and DropEffect
             // will still be Move, resulting in a copy.
-            if (wasCut != 0 && dropEffect == (uint)DropEffect.Move) {
+            // Speaking of other project systems... cut from Python and paste into C# results in
+            // wasCut==1 and dropEffect==Copy
+            // which makes no sense is hopefully harmless to support...
+            if (wasCut != 0 && (dropEffect == (uint)DropEffect.Move || dropEffect == (uint)DropEffect.Copy)) {
                 // If we just did a cut, then we need to free the data object. Otherwise, we leave it
                 // alone so that you can continue to paste the data in new locations.
                 CleanAndFlushClipboard();
@@ -495,6 +498,16 @@ namespace Microsoft.VisualStudioTools.Project {
                                 if (fileAddition.SourceMoniker.StartsWith(folder, StringComparison.OrdinalIgnoreCase)) {
                                     // this will be moved/copied by the folder, it doesn't need another move/copy
                                     add = false;
+
+                                    if (DropEffect == DropEffect.Move && Utilities.IsSameComObject(Project, fileAddition.SourceHierarchy)) {
+                                        var fileNode = Project.FindNodeByFullPath(fileAddition.SourceMoniker);
+                                        Debug.Assert(fileNode is FileNode, $"<{fileNode?.GetType().FullName ?? "null"}>");
+
+                                        if (fileNode != null) {
+                                            Project.ItemsDraggedOrCutOrCopied.Remove(fileNode); // we don't need to remove the file after Paste
+                                        }
+                                    }
+
                                     break;
                                 }
                             }
@@ -786,44 +799,50 @@ namespace Microsoft.VisualStudioTools.Project {
                     var sourceFolder = Project.FindNodeByFullPath(SourceFolder) as FolderNode;
                     if (sourceFolder == null || DropEffect != DropEffect.Move) {
                         newNode = Project.CreateFolderNodes(NewFolderPath);
+
+                        foreach (var addition in Additions) {
+                            addition.DoAddition(ref overwrite);
+                        }
+
+                        if (sourceFolder != null) {
+                            if (sourceFolder.IsNonMemberItem) {
+                                // copying or moving an existing excluded folder, new folder
+                                // is excluded too.
+                                ErrorHandler.ThrowOnFailure(newNode.ExcludeFromProjectWithRefresh());
+                            } else if (sourceFolder.Parent.IsNonMemberItem) {
+                                // We've moved an included folder to a show all files folder,
+                                //     add the parent to the project   
+                                ErrorHandler.ThrowOnFailure(sourceFolder.Parent.IncludeInProjectWithRefresh(false));
+                            }
+
+                            if (DropEffect == DropEffect.Move) {
+                                Directory.Delete(SourceFolder);
+
+                                // we just handled the delete, the updated folder has the new filename,
+                                // and we don't want to delete where we just moved stuff...
+                                Project.ItemsDraggedOrCutOrCopied.Remove(sourceFolder);
+                            }
+                        }
+
+                        // Send OnItemRenamed for the folder now, after all of the children have been renamed
+                        Project.Tracker.OnItemRenamed(SourceFolder, NewFolderPath, VSRENAMEFILEFLAGS.VSRENAMEFILEFLAGS_Directory);
                     } else {
                         // Rename the folder & reparent our existing FolderNode w/ potentially w/ a new ID,
-                        // but don't update the children as we'll handle that w/ our file additions...
                         wasExpanded = sourceFolder.GetIsExpanded();
 
+                        // Reparent takes care of renaming the folder on disk and sending rename notification(s)
                         var newFolderParent = Project.CreateFolderNodes(CommonUtils.GetParent(NewFolderPath));
                         sourceFolder.Reparent(newFolderParent);
 
                         sourceFolder.ExpandItem(wasExpanded ? EXPANDFLAGS.EXPF_ExpandFolder : EXPANDFLAGS.EXPF_CollapseFolder);
                         newNode = sourceFolder;
-                    }
-
-                    foreach (var addition in Additions) {
-                        addition.DoAddition(ref overwrite);
-                    }
-
-                    if (sourceFolder != null) {
-                        if (sourceFolder.IsNonMemberItem) {
-                            // copying or moving an existing excluded folder, new folder
-                            // is excluded too.
-                            ErrorHandler.ThrowOnFailure(newNode.ExcludeFromProjectWithRefresh());
-                        } else if (sourceFolder.Parent.IsNonMemberItem) {
-                            // We've moved an included folder to a show all files folder,
-                            //     add the parent to the project   
-                            ErrorHandler.ThrowOnFailure(sourceFolder.Parent.IncludeInProjectWithRefresh(false));
-                        }
 
                         if (DropEffect == DropEffect.Move) {
-                            Directory.Delete(SourceFolder);
-
                             // we just handled the delete, the updated folder has the new filename,
                             // and we don't want to delete where we just moved stuff...
                             Project.ItemsDraggedOrCutOrCopied.Remove(sourceFolder);
                         }
                     }
-
-                    // Send OnItemRenamed for the folder now, after all of the children have been renamed
-                    Project.Tracker.OnItemRenamed(SourceFolder, NewFolderPath, VSRENAMEFILEFLAGS.VSRENAMEFILEFLAGS_Directory);
 
                     if (sourceFolder != null && Project.ParentHierarchy != null) {
                         sourceFolder.ExpandItem(wasExpanded ? EXPANDFLAGS.EXPF_ExpandFolder : EXPANDFLAGS.EXPF_CollapseFolder);

--- a/Common/Tests/Utilities.UI/UI/SolutionExplorerTree.cs
+++ b/Common/Tests/Utilities.UI/UI/SolutionExplorerTree.cs
@@ -64,7 +64,7 @@ namespace TestUtilities.UI {
             for (int i = 1; i < path.Length; i++) {
                 basePath = Path.Combine(basePath, path[i]);
             }
-            Assert.IsTrue(Directory.Exists(basePath), "File doesn't exist: " + basePath);
+            Assert.IsTrue(Directory.Exists(basePath), "Folder doesn't exist: " + basePath);
         }
 
         public void AssertFolderDoesntExist(string projectLocation, params string[] path) {
@@ -74,7 +74,7 @@ namespace TestUtilities.UI {
             for (int i = 1; i < path.Length; i++) {
                 basePath = Path.Combine(basePath, path[i]);
             }
-            Assert.IsFalse(Directory.Exists(basePath), "File exists: " + basePath);
+            Assert.IsFalse(Directory.Exists(basePath), "Folder exists: " + basePath);
         }
 
         private void AssertItemExistsInTree(string[] path) {

--- a/Python/Tests/ProjectUITests/DragDropCopyCutPaste.cs
+++ b/Python/Tests/ProjectUITests/DragDropCopyCutPaste.cs
@@ -1397,6 +1397,35 @@ namespace ProjectUITests {
             }
         }
 
+        public void CopyFolderWithContents(VisualStudioApp app, ProjectGenerator pg) {
+            foreach (var projectType in pg.ProjectTypes) {
+                var testDef = new ProjectDefinition("FolderWithContentsProj",
+                    projectType,
+                    ProjectGenerator.ItemGroup(
+                        ProjectGenerator.Folder("A"),
+                        ProjectGenerator.Folder("A\\B"),
+                        ProjectGenerator.Content("A\\B\\File.txt", ""),
+                        ProjectGenerator.Folder("C")
+                    )
+                );
+
+                using (var solution = testDef.Generate().ToVs(app)) {
+                    CopyByKeyboard(
+                        solution,
+                        solution.FindItem("FolderWithContentsProj", "C"),
+                        solution.FindItem("FolderWithContentsProj", "A", "B")
+                    );
+
+                    solution.AssertFolderExists("FolderWithContentsProj", "A");
+                    solution.AssertFolderExists("FolderWithContentsProj", "A", "B");
+                    solution.AssertFileExists("FolderWithContentsProj", "A", "B", "File.txt");
+                    solution.AssertFolderExists("FolderWithContentsProj", "C");
+                    solution.AssertFolderExists("FolderWithContentsProj", "C", "B");
+                    solution.AssertFileExists("FolderWithContentsProj", "C", "B", "File.txt");
+                }
+            }
+        }
+
         public void MoveProjectToSolutionFolderKeyboard(VisualStudioApp app, ProjectGenerator pg) {
             MoveProjectToSolutionFolder(app, pg, MoveByKeyboard);
         }

--- a/Python/Tests/ProjectUITests/DragDropCopyCutPaste.cs
+++ b/Python/Tests/ProjectUITests/DragDropCopyCutPaste.cs
@@ -190,70 +190,25 @@ namespace ProjectUITests {
         }
 
         public void CopyFileToFolderTooLongKeyboard(VisualStudioApp app, ProjectGenerator pg) {
-            CopyFileToFolderTooLong(app, pg, CopyByKeyboard);
+            CutOrCopyFileToFolderTooLong(app, pg, CopyByKeyboard);
         }
 
         public void CopyFileToFolderTooLongMouse(VisualStudioApp app, ProjectGenerator pg) {
-            CopyFileToFolderTooLong(app, pg, CopyByMouse);
-        }
-
-        /// <summary>
-        /// Adds a new folder which fits exactly w/ no space left in the path name
-        /// </summary>
-        private void CopyFileToFolderTooLong(VisualStudioApp app, ProjectGenerator pg, MoveDelegate copier) {
-            foreach (var projectType in pg.ProjectTypes) {
-                var testDef = new ProjectDefinition("LFN",
-                    projectType,
-                    ProjectGenerator.ItemGroup(
-                        ProjectGenerator.Compile("server")
-                    )
-                );
-
-                using (var solution = SolutionFile.Generate("LongFileNames", 33, testDef).ToVs(app)) {
-                    // find server, send copy & paste, verify copy of file is there
-                    var projectNode = solution.WaitForItem("LFN");
-                    AutomationWrapper.Select(projectNode);
-
-                    solution.PressAndRelease(Key.F10, Key.LeftCtrl, Key.LeftShift);
-                    solution.PressAndRelease(Key.D);
-                    solution.PressAndRelease(Key.Right);
-                    solution.PressAndRelease(Key.D);
-                    solution.Type("01234567891");
-                    solution.PressAndRelease(Key.Enter);
-
-                    var folderNode = solution.WaitForItem("LFN", "01234567891");
-                    Assert.IsNotNull(folderNode);
-
-                    var serverNode = solution.WaitForItem("LFN", "server" + projectType.CodeExtension);
-                    AutomationWrapper.Select(serverNode);
-                    solution.ControlC();
-                    solution.ControlV();
-
-                    var serverCopy = solution.WaitForItem("LFN", "server - Copy" + projectType.CodeExtension);
-                    Assert.IsNotNull(serverCopy);
-
-                    copier(solution, folderNode, serverCopy);
-
-                    // Depending on VS version/update, the message may be:
-                    //  "The filename is too long."
-                    //  "The filename or extension is too long."
-                    solution.CheckMessageBox(" filename ", " is too long.");
-                }
-            }
+            CutOrCopyFileToFolderTooLong(app, pg, CopyByMouse);
         }
 
         public void CutFileToFolderTooLongKeyboard(VisualStudioApp app, ProjectGenerator pg) {
-            CutFileToFolderTooLong(app, pg, MoveByKeyboard);
+            CutOrCopyFileToFolderTooLong(app, pg, MoveByKeyboard);
         }
 
         public void CutFileToFolderTooLongMouse(VisualStudioApp app, ProjectGenerator pg) {
-            CutFileToFolderTooLong(app, pg, MoveByMouse);
+            CutOrCopyFileToFolderTooLong(app, pg, MoveByMouse);
         }
 
         /// <summary>
         /// Adds a new folder which fits exactly w/ no space left in the path name
         /// </summary>
-        private void CutFileToFolderTooLong(VisualStudioApp app, ProjectGenerator pg, MoveDelegate mover) {
+        private void CutOrCopyFileToFolderTooLong(VisualStudioApp app, ProjectGenerator pg, MoveDelegate mover) {
             foreach (var projectType in pg.ProjectTypes) {
                 var testDef = new ProjectDefinition("LFN",
                     projectType,
@@ -262,7 +217,7 @@ namespace ProjectUITests {
                     )
                 );
 
-                using (var solution = SolutionFile.Generate("LongFileNames", 33, testDef).ToVs(app)) {
+                using (var solution = SolutionFile.Generate("LongFileNames", 40, testDef).ToVs(app)) {
                     // find server, send copy & paste, verify copy of file is there
                     var projectNode = solution.WaitForItem("LFN");
                     AutomationWrapper.Select(projectNode);
@@ -271,13 +226,13 @@ namespace ProjectUITests {
                     solution.PressAndRelease(Key.D);
                     solution.PressAndRelease(Key.Right);
                     solution.PressAndRelease(Key.D);
-                    solution.Type("01234567891");
+                    solution.Type("012345678912345678");
                     solution.PressAndRelease(Key.Enter);
 
-                    var folderNode = solution.WaitForItem("LFN", "01234567891");
+                    var folderNode = solution.WaitForItem("LFN", "012345678912345678");
                     Assert.IsNotNull(folderNode);
 
-                    var serverNode = solution.FindItem("LFN", "server" + projectType.CodeExtension);
+                    var serverNode = solution.WaitForItem("LFN", "server" + projectType.CodeExtension);
                     AutomationWrapper.Select(serverNode);
                     solution.ControlC();
                     solution.ControlV();

--- a/Python/Tests/ProjectUITestsRunner/DragDropCopyCutPaste.cs
+++ b/Python/Tests/ProjectUITestsRunner/DragDropCopyCutPaste.cs
@@ -339,6 +339,12 @@ namespace ProjectUITestsRunner {
             _vs.RunTest(nameof(ProjectUITests.DragDropCopyCutPaste.MoveFolderWithContents));
         }
 
+        [TestMethod, Priority(2)]
+        [TestCategory("Installed")]
+        public void CopyFolderWithContents() {
+            _vs.RunTest(nameof(ProjectUITests.DragDropCopyCutPaste.CopyFolderWithContents));
+        }
+
         [TestMethod, Priority(0)]
         [TestCategory("Installed")]
         public void MoveProjectToSolutionFolderKeyboard() {

--- a/Python/Tests/ProjectUITestsRunner/DragDropCopyCutPaste.cs
+++ b/Python/Tests/ProjectUITestsRunner/DragDropCopyCutPaste.cs
@@ -69,7 +69,7 @@ namespace ProjectUITestsRunner {
             _vs.RunTest(nameof(ProjectUITests.DragDropCopyCutPaste.CutDeletePaste));
         }
 
-        [TestMethod, Priority(2)]
+        [TestMethod, Priority(0)]
         [TestCategory("Installed")]
         public void CopyFileToFolderTooLongKeyboard() {
             _vs.RunTest(nameof(ProjectUITests.DragDropCopyCutPaste.CopyFileToFolderTooLongKeyboard));
@@ -81,7 +81,7 @@ namespace ProjectUITestsRunner {
             _vs.RunTest(nameof(ProjectUITests.DragDropCopyCutPaste.CopyFileToFolderTooLongMouse));
         }
 
-        [TestMethod, Priority(2)]
+        [TestMethod, Priority(0)]
         [TestCategory("Installed")]
         public void CutFileToFolderTooLongKeyboard() {
             _vs.RunTest(nameof(ProjectUITests.DragDropCopyCutPaste.CutFileToFolderTooLongKeyboard));
@@ -141,7 +141,7 @@ namespace ProjectUITestsRunner {
             _vs.RunTest(nameof(ProjectUITests.DragDropCopyCutPaste.CutFileReplace));
         }
 
-        [TestMethod, Priority(2)]
+        [TestMethod, Priority(0)]
         [TestCategory("Installed")]
         public void CutFolderAndFile() {
             _vs.RunTest(nameof(ProjectUITests.DragDropCopyCutPaste.CutFolderAndFile));
@@ -219,7 +219,7 @@ namespace ProjectUITestsRunner {
             _vs.RunTest(nameof(ProjectUITests.DragDropCopyCutPaste.MoveCrossHierarchyMouse));
         }
 
-        [TestMethod, Priority(2)]
+        [TestMethod, Priority(0)]
         [TestCategory("Installed")]
         public void MoveReverseCrossHierarchyKeyboard() {
             _vs.RunTest(nameof(ProjectUITests.DragDropCopyCutPaste.MoveReverseCrossHierarchyKeyboard));
@@ -339,7 +339,7 @@ namespace ProjectUITestsRunner {
             _vs.RunTest(nameof(ProjectUITests.DragDropCopyCutPaste.MoveFolderWithContents));
         }
 
-        [TestMethod, Priority(2)]
+        [TestMethod, Priority(0)]
         [TestCategory("Installed")]
         public void CopyFolderWithContents() {
             _vs.RunTest(nameof(ProjectUITests.DragDropCopyCutPaste.CopyFolderWithContents));
@@ -381,7 +381,7 @@ namespace ProjectUITestsRunner {
             _vs.RunTest(nameof(ProjectUITests.DragDropCopyCutPaste.CopyFileFromFolderToLinkedFolderMouse));
         }
 
-        [TestMethod, Priority(2)]
+        [TestMethod, Priority(0)]
         [TestCategory("Installed")]
         public void CopyFileToFolderCrossProject() {
             _vs.RunTest(nameof(ProjectUITests.DragDropCopyCutPaste.CopyFileToFolderCrossProject));


### PR DESCRIPTION
Fix #3225 

Also fixes cut/paste from Python to C#, where the file wasn't deleted in source Python project after paste was done.

Adjustments to the long file name tests where msbuild was refusing to load the project due to the project file path being too long (so I've made it slightly shorter and increased the length of the files within the project to get the same result).

Both sets of drag & drop tests are all passing.