### PR TITLE
Fixes #3243 Mismatched line number assert while editing

### DIFF
--- a/Python/Product/PythonTools/PythonTools/TokenCache.cs
+++ b/Python/Product/PythonTools/PythonTools/TokenCache.cs
@@ -147,8 +147,6 @@ namespace Microsoft.PythonTools {
             // line is edited the span returned here may not be valid.
             var line = LineSpan.GetSpan(snapshot);
 
-            Debug.Assert(line.Start.GetContainingLine().LineNumber == LineNumber, "Mismatched line number");
-
             int startCol = Math.Min(LineToken.Column, line.Length);
             int endCol = Math.Min(LineToken.Column + LineToken.Length, line.Length);
 


### PR DESCRIPTION
Fixes #3243 Mismatched line number assert while editing
Removes assertion, as it is triggering when it should not.