### PR TITLE
Fixes #3099 Assert when starting VS with REPL visible

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Repl/InteractiveWindowProvider.cs
+++ b/Python/Product/PythonTools/PythonTools/Repl/InteractiveWindowProvider.cs
@@ -19,13 +19,15 @@ using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Diagnostics;
 using System.Linq;
-using Microsoft.VisualStudio.InteractiveWindow;
-using Microsoft.VisualStudio.InteractiveWindow.Shell;
+using System.Threading;
 using Microsoft.PythonTools.Interpreter;
 using Microsoft.VisualStudio.Imaging;
+using Microsoft.VisualStudio.InteractiveWindow;
+using Microsoft.VisualStudio.InteractiveWindow.Shell;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Utilities;
+using Microsoft.VisualStudioTools;
 
 namespace Microsoft.PythonTools.Repl {
     [Export(typeof(InteractiveWindowProvider))]
@@ -259,12 +261,13 @@ namespace Microsoft.PythonTools.Repl {
                 toolWindow.BitmapImageMoniker = KnownMonikers.PYInteractiveWindow;
             }
             replWindow.SetLanguage(GuidList.guidPythonLanguageServiceGuid, contentType);
-            replWindow.InteractiveWindow.InitializeAsync();
 
             var selectEval = evaluator as SelectableReplEvaluator;
             if (selectEval != null) {
                 selectEval.ProvideInteractiveWindowEvents(InteractiveWindowEvents.GetOrCreate(replWindow));
             }
+
+            _serviceProvider.GetUIThread().InvokeTaskSync(() => replWindow.InteractiveWindow.InitializeAsync(), CancellationToken.None);
 
             return replWindow;
         }

--- a/Python/Product/PythonTools/PythonToolsPackage.cs
+++ b/Python/Product/PythonTools/PythonToolsPackage.cs
@@ -217,6 +217,10 @@ namespace Microsoft.PythonTools {
                     replId = pyService.LoadString("Id", category);
                 } catch (Exception ex) when (!ex.IsCriticalException()) {
                     Debug.Fail("Could not load settings for interactive window.", ex.ToString());
+                    replId = null;
+                }
+
+                if (string.IsNullOrEmpty(replId)) {
                     pyService.DeleteCategory(category);
                     return VSConstants.S_OK;
                 }


### PR DESCRIPTION
Fixes #3099 Assert when starting VS with REPL visible
Filters out REPL settings that have not been saved correctly.