### PR TITLE
Fix debugger test failures

### DIFF
--- a/Python/Product/PythonTools/ptvsd_launcher.py
+++ b/Python/Product/PythonTools/ptvsd_launcher.py
@@ -80,7 +80,6 @@ filename = sys.argv[0]
 sys.path[0] = ''
 
 # exclude ourselves from being debugged
-vspd.PREFIXES.append(os.path.normcase(ptvs_lib_path))
 vspd.DONT_DEBUG.append(os.path.normcase(__file__))
 
 # remove all state we imported

--- a/Python/Tests/DebuggerTests/DebuggerTests.cs
+++ b/Python/Tests/DebuggerTests/DebuggerTests.cs
@@ -1972,8 +1972,10 @@ namespace DebuggerTests {
             var process = processRunInfo.Process;
 
             List<string> receivedFilenames = new List<string>();
+            List<string> receivedNames = new List<string>();
             process.ModuleLoaded += (sender, args) => {
                 receivedFilenames.Add(args.Module.Filename);
+                receivedNames.Add(args.Module.Name);
             };
 
             await StartAndWaitForExitAsync(processRunInfo);
@@ -1985,6 +1987,8 @@ namespace DebuggerTests {
             }
 
             AssertUtil.ContainsAtLeast(set, expectedModulesLoaded);
+
+            Assert.IsFalse(receivedNames.Any(n => n.StartsWith("ptvsd")), "ptvsd should not appear in loaded modules.");
         }
 
         #endregion


### PR DESCRIPTION
Don't add the ptvsd_launcher.py parent folder to the PREFIXES array of standard library folders. The ptvsd files are already in the DONT_DEBUG array of files to never debug.