### PR TITLE
Enables full line highlighting for breakpoints and call stack locations.

### DIFF
--- a/Python/Product/Analysis/Parsing/Ast/PythonAst.cs
+++ b/Python/Product/Analysis/Parsing/Ast/PythonAst.cs
@@ -109,11 +109,11 @@ namespace Microsoft.PythonTools.Parsing.Ast {
             }
         }
 
-        internal SourceLocation IndexToLocation(int index) {
+        public SourceLocation IndexToLocation(int index) {
             return NewLineLocation.IndexToLocation(_lineLocations, index);
         }
 
-        internal int LocationToIndex(SourceLocation location) {
+        public int LocationToIndex(SourceLocation location) {
             return NewLineLocation.LocationToIndex(_lineLocations, location);
         }
 

--- a/Python/Product/Analysis/Parsing/Tokenizer.cs
+++ b/Python/Product/Analysis/Parsing/Tokenizer.cs
@@ -2652,11 +2652,11 @@ namespace Microsoft.PythonTools.Parsing {
             if (line > 0) {
                 index = lineLocations[line - 1].EndIndex;
             }
-            index += location.Column - 1;
-            if (line < lineLocations.Length && index > lineLocations[line].EndIndex) {
-                index = lineLocations[line].EndIndex;
+
+            if (line < lineLocations.Length && location.Column >= (lineLocations[line].EndIndex - index)) {
+                return lineLocations[line].EndIndex;
             }
-            return index;
+            return checked(index + location.Column - 1);
         }
     }
 

--- a/Python/Product/Debugger/Debugger/DebugEngine/AD7MemoryAddress.cs
+++ b/Python/Product/Debugger/Debugger/DebugEngine/AD7MemoryAddress.cs
@@ -35,8 +35,11 @@ namespace Microsoft.PythonTools.Debugger.DebugEngine {
             _filename = filename;
             _frame = frame;
 
-            var pos = new TEXT_POSITION { dwLine = lineno, dwColumn = 0 };
-            _documentContext = new AD7DocumentContext(filename, pos, pos, this, frame != null ? frame.Kind : FrameKind.None);
+            var span = _engine.Process.GetStatementSpan(_filename, (int)_lineNo, 0);
+            var startPos = new TEXT_POSITION { dwLine = (uint)(span.Start.Line - 1), dwColumn = (uint)(span.Start.Column - 1) };
+            var endPos = new TEXT_POSITION { dwLine = (uint)(span.End.Line - 1), dwColumn = (uint)(span.End.Column - 1) };
+
+            _documentContext = new AD7DocumentContext(filename, startPos, endPos, this, frame != null ? frame.Kind : FrameKind.None);
         }
 
         public void SetDocumentContext(IDebugDocumentContext2 docContext) {

--- a/Python/Product/Debugger/Debugger/DebugEngine/AD7StackFrame.cs
+++ b/Python/Product/Debugger/Debugger/DebugEngine/AD7StackFrame.cs
@@ -268,13 +268,10 @@ namespace Microsoft.PythonTools.Debugger.DebugEngine {
         // and will use it to open the correct source document for this stack frame.
         int IDebugStackFrame2.GetDocumentContext(out IDebugDocumentContext2 docContext) {
             docContext = null;
-            // Assume all lines begin and end at the beginning of the line.
-            TEXT_POSITION begTp = new TEXT_POSITION();
-            begTp.dwColumn = 0;
-            begTp.dwLine = (uint)_stackFrame.LineNo - 1;
-            TEXT_POSITION endTp = new TEXT_POSITION();
-            endTp.dwColumn = 0;
-            endTp.dwLine = (uint)_stackFrame.LineNo - 1;
+
+            var span = _engine.Process.GetStatementSpan(StackFrame.FileName, _stackFrame.LineNo, 0);
+            var begTp = new TEXT_POSITION { dwLine = (uint)(span.Start.Line - 1), dwColumn = (uint)(span.Start.Column - 1) };
+            var endTp = new TEXT_POSITION { dwLine = (uint)(span.End.Line - 1), dwColumn = (uint)(span.End.Column - 1) };
 
             docContext = new AD7DocumentContext(_stackFrame.FileName, begTp, endTp, null, _stackFrame.Kind);
             return VSConstants.S_OK;

--- a/Python/Product/Debugger/Debugger/PythonProcess.cs
+++ b/Python/Product/Debugger/Debugger/PythonProcess.cs
@@ -490,9 +490,6 @@ namespace Microsoft.PythonTools.Debugger {
 
         internal SourceSpan GetStatementSpan(string filename, int line, int column = 0) {
             var ast = GetAst(filename);
-            if (ast == null) {
-                return new SourceSpan(new SourceLocation(line, 1), new SourceLocation(line, 1));
-            }
             int len = 0;
             if (ast != null) {
                 int start = ast.LocationToIndex(new SourceLocation(line, 1));
@@ -500,7 +497,7 @@ namespace Microsoft.PythonTools.Debugger {
                 len = end - start;
             }
 
-            return new SourceSpan(new SourceLocation(line, 1), new SourceLocation(line, Math.Max(0, len)));
+            return new SourceSpan(new SourceLocation(line, 1), new SourceLocation(line, Math.Max(0, len) + 1));
         }
 
         internal IList<Tuple<int, int, IList<string>>> GetHandledExceptionRanges(string filename) {

--- a/Python/Product/Debugger/Debugger/PythonProcess.cs
+++ b/Python/Product/Debugger/Debugger/PythonProcess.cs
@@ -488,6 +488,21 @@ namespace Microsoft.PythonTools.Debugger {
             return ast;
         }
 
+        internal SourceSpan GetStatementSpan(string filename, int line, int column = 0) {
+            var ast = GetAst(filename);
+            if (ast == null) {
+                return new SourceSpan(new SourceLocation(line, 1), new SourceLocation(line, 1));
+            }
+            int len = 0;
+            if (ast != null) {
+                int start = ast.LocationToIndex(new SourceLocation(line, 1));
+                int end = ast.LocationToIndex(new SourceLocation(line, int.MaxValue));
+                len = end - start;
+            }
+
+            return new SourceSpan(new SourceLocation(line, 1), new SourceLocation(line, Math.Max(0, len)));
+        }
+
         internal IList<Tuple<int, int, IList<string>>> GetHandledExceptionRanges(string filename) {
             PythonAst ast;
             TryHandlerWalker walker = new TryHandlerWalker();

--- a/Python/Product/PythonTools/PythonTools/Navigation/PythonLanguageInfo.cs
+++ b/Python/Product/PythonTools/PythonTools/Navigation/PythonLanguageInfo.cs
@@ -35,7 +35,7 @@ namespace Microsoft.PythonTools.Navigation {
     /// should be switched over to using our TextViewCreationListener instead).
     /// </summary>
     [Guid(GuidList.guidPythonLanguageService)]
-    internal sealed class PythonLanguageInfo : IVsLanguageInfo, IVsLanguageDebugInfo {
+    internal sealed class PythonLanguageInfo : IVsLanguageInfo, IVsLanguageDebugInfo, IVsLanguageDebugInfo2 {
         private readonly IServiceProvider _serviceProvider;
 
         public PythonLanguageInfo(IServiceProvider serviceProvider) {
@@ -145,28 +145,34 @@ namespace Microsoft.PythonTools.Navigation {
         }
 
         public int ValidateBreakpointLocation(IVsTextBuffer pBuffer, int iLine, int iCol, TextSpan[] pCodeSpan) {            
-            // per the docs, even if we don't indend to validate, we need to set the span info:
-            // http://msdn.microsoft.com/en-us/library/microsoft.visualstudio.textmanager.interop.ivslanguagedebuginfo.validatebreakpointlocation.aspx
-            // 
-            // Caution
-            // Even if you do not intend to support the ValidateBreakpointLocation method but your 
-            // language does support breakpoints, you must implement this method and return a span 
-            // that contains the specified line and column; otherwise, breakpoints cannot be set 
-            // anywhere except line 1. You can return E_NOTIMPL to indicate that you do not otherwise 
-            // support this method but the span must always be set. The example shows how this can be done.
-
-            // http://pytools.codeplex.com/workitem/787
-            // We were previously returning S_OK here indicating to VS that we have in fact validated
-            // the breakpoint.  Validating breakpoints actually interacts and effectively disables
-            // the "Highlight entire source line for breakpoints and current statement" option as instead
-            // VS highlights the validated region.  So we return E_NOTIMPL here to indicate that we have 
-            // not validated the breakpoint, and then VS will happily respect the option when we're in 
-            // design mode.
+            int len;
+            if (!ErrorHandler.Succeeded(pBuffer.GetLengthOfLine(iLine, out len))) {
+                len = iCol;
+            }
+            if (len <= 0) {
+                return VSConstants.S_FALSE;
+            }
             pCodeSpan[0].iStartLine = iLine;
             pCodeSpan[0].iEndLine = iLine;
+            pCodeSpan[0].iStartIndex = 0;
+            pCodeSpan[0].iEndIndex = len;
+            return VSConstants.S_OK;
+        }
+
+        public int QueryCommonLanguageBlock(IVsTextBuffer pBuffer, int iLine, int iCol, uint dwFlag, out int pfInBlock) {
+            pfInBlock = 0;
             return VSConstants.E_NOTIMPL;
         }
 
-#endregion
+        public int ValidateInstructionpointLocation(IVsTextBuffer pBuffer, int iLine, int iCol, TextSpan[] pCodeSpan) {
+            return ValidateBreakpointLocation(pBuffer, iLine, iCol, pCodeSpan);
+        }
+
+        public int QueryCatchLineSpan(IVsTextBuffer pBuffer, int iLine, int iCol, out int pfIsInCatch, TextSpan[] ptsCatchLine) {
+            pfIsInCatch = 0;
+            return VSConstants.E_NOTIMPL;
+        }
+
+        #endregion
     }
 }


### PR DESCRIPTION
Enables full line highlighting for breakpoints and call stack locations.
Prevents setting breakpoints on empty lines.
Make LocationToIndex and IndexToLocation functions public
Make LocationToIndex deliberately support columns well beyond the line length.

The LocationToIndex and IndexToLocation functions were always meant to become public - it's the only reliable way to translate between the two formats.