### PR TITLE
Ensure that exception type names don't have any pre/post whitespace.

### DIFF
--- a/Python/Product/Debugger/Debugger/PythonProcess.cs
+++ b/Python/Product/Debugger/Debugger/PythonProcess.cs
@@ -450,7 +450,7 @@ namespace Microsoft.PythonTools.Debugger {
                     member = (MemberExpression)member.Target;
                 }
                 if (member.Target is NameExpression) {
-                    return expr.ToCodeString(ast);
+                    return expr.ToCodeString(ast).Trim();
                 }
             } else if ((paren = expr as ParenthesisExpression) != null) {
                 return ToDottedNameString(paren.Expression, ast);


### PR DESCRIPTION
Fix https://github.com/Microsoft/PTVS/issues/3252
Fix https://github.com/Microsoft/PTVS/issues/3251 (not sure how, but I've gone back and forth several times and the bug no longer occurs with this fix)

Edit: For 3251 it's probably because of the following code where `os.error` ended up with a space:
```
def isdir(s):
    """Return true if the pathname refers to an existing directory."""
    try:
        st = os.stat(s)
    except os.error:
        return False
    return stat.S_ISDIR(st.st_mode)

```
