### PR TITLE
Fixes #3269 Changes in search paths are not automatically noticed by the analyzer

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Project/PythonProjectNode.cs
+++ b/Python/Product/PythonTools/PythonTools/Project/PythonProjectNode.cs
@@ -75,7 +75,7 @@ namespace Microsoft.PythonTools.Project {
         private VsProjectAnalyzer _analyzer;
         private readonly HashSet<AnalysisEntry> _warnOnLaunchFiles = new HashSet<AnalysisEntry>();
         private PythonDebugPropertyPage _debugPropPage;
-        internal readonly SearchPathManager _searchPaths = new SearchPathManager();
+        internal readonly SearchPathManager _searchPaths;
         private CommonSearchPathContainerNode _searchPathContainer;
         private InterpretersContainerNode _interpretersContainer;
         private readonly HashSet<string> _validFactories = new HashSet<string>();
@@ -89,6 +89,7 @@ namespace Microsoft.PythonTools.Project {
         private readonly SemaphoreSlim _recreatingAnalyzer = new SemaphoreSlim(1);
 
         public PythonProjectNode(IServiceProvider serviceProvider) : base(serviceProvider, null) {
+            _searchPaths = new SearchPathManager(serviceProvider);
             _searchPaths.Changed += SearchPaths_Changed;
 
             Type projectNodePropsType = typeof(PythonProjectNodeProperties);
@@ -1066,6 +1067,8 @@ namespace Microsoft.PythonTools.Project {
 
                 InterpreterOptions.DefaultInterpreterChanged -= GlobalDefaultInterpreterChanged;
                 InterpreterRegistry.InterpretersChanged -= OnInterpreterRegistryChanged;
+
+                _searchPaths.Dispose();
 
                 if (_interpretersContainer != null) {
                     _interpretersContainer.Dispose();

--- a/Python/Product/PythonTools/PythonTools/SearchPathManager.cs
+++ b/Python/Product/PythonTools/PythonTools/SearchPathManager.cs
@@ -17,13 +17,48 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using Microsoft.PythonTools.Infrastructure;
+using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.Shell.Interop;
 
 namespace Microsoft.PythonTools {
-    class SearchPathManager {
+    class SearchPathManager : IVsFileChangeEvents, IDisposable {
+        private readonly IVsFileChangeEx _changeService;
+        private readonly Timer _notifyChangeTimer;
         private readonly List<SearchPath> _paths = new List<SearchPath>();
 
         public SearchPathManager() { }
+
+        public SearchPathManager(IServiceProvider site) {
+            _changeService = site.GetService(typeof(SVsFileChangeEx)) as IVsFileChangeEx;
+            _notifyChangeTimer = new Timer(RaiseChanged, null, Timeout.Infinite, Timeout.Infinite);
+        }
+
+        public void Dispose() {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        ~SearchPathManager() {
+            Dispose(false);
+        }
+
+        protected void Dispose(bool disposing) {
+            if (disposing) {
+                lock (_paths) {
+                    foreach (var p in _paths) {
+                        Unwatch(p.Cookie);
+                    }
+                    _paths.Clear();
+                }
+
+                var timer = _notifyChangeTimer;
+                if (timer != null) {
+                    timer.Dispose();
+                }
+            }
+        }
 
         public event EventHandler Changed;
 
@@ -58,7 +93,7 @@ namespace Microsoft.PythonTools {
             }
 
             lock (_paths) {
-                _paths.Add(new SearchPath(absolutePath, persisted, moniker));
+                _paths.Add(new SearchPath(absolutePath, persisted, moniker, Watch(absolutePath)));
             }
             Changed?.Invoke(this, EventArgs.Empty);
         }
@@ -70,7 +105,7 @@ namespace Microsoft.PythonTools {
             }
 
             lock (_paths) {
-                _paths.Insert(index, new SearchPath(absolutePath, persisted, moniker));
+                _paths.Insert(index, new SearchPath(absolutePath, persisted, moniker, Watch(absolutePath)));
             }
             Changed?.Invoke(this, EventArgs.Empty);
         }
@@ -125,6 +160,7 @@ namespace Microsoft.PythonTools {
             lock (_paths) {
                 var toRemove = _paths.FirstOrDefault(p => p.Path.Equals(absolutePath, StringComparison.OrdinalIgnoreCase));
                 if (toRemove.Path != null && _paths.Remove(toRemove)) {
+                    Unwatch(toRemove.Cookie);
                     removed = true;
                 }
             }
@@ -153,13 +189,13 @@ namespace Microsoft.PythonTools {
                         any = true;
                         if (!p.Path.Equals(absolutePath, StringComparison.OrdinalIgnoreCase) ||
                             p.Persisted != isPersisted) {
-                            _paths[i] = new SearchPath(absolutePath, isPersisted, moniker);
+                            _paths[i] = new SearchPath(absolutePath, isPersisted, moniker, Watch(absolutePath));
                             changed = true;
                         }
                     }
                 }
                 if (!any) {
-                    _paths.Add(new SearchPath(absolutePath, isPersisted, moniker));
+                    _paths.Add(new SearchPath(absolutePath, isPersisted, moniker, Watch(absolutePath)));
                     changed = true;
                 }
             }
@@ -172,6 +208,11 @@ namespace Microsoft.PythonTools {
         public void RemoveByMoniker(object moniker) {
             bool any;
             lock (_paths) {
+                foreach (var p in _paths) {
+                    if (p.Moniker == moniker) {
+                        Unwatch(p.Cookie);
+                    }
+                }
                 any = _paths.RemoveAll(p => p.Moniker == moniker) > 0;
             }
 
@@ -189,14 +230,20 @@ namespace Microsoft.PythonTools {
                     }
 
                     if (string.IsNullOrEmpty(projectHome)) {
-                        newPaths.Add(new SearchPath(path, true, null));
+                        newPaths.Add(new SearchPath(path, true, null, Watch(path)));
                     } else {
-                        newPaths.Add(new SearchPath(PathUtils.GetAbsoluteFilePath(projectHome, path), true, null));
+                        var absolutePath = PathUtils.GetAbsoluteFilePath(projectHome, path);
+                        newPaths.Add(new SearchPath(absolutePath, true, null, Watch(absolutePath)));
                     }
                 }
             }
 
             lock (_paths) {
+                foreach (var p in _paths) {
+                    if (p.Moniker == null) {
+                        Unwatch(p.Cookie);
+                    }
+                }
                 _paths.RemoveAll(p => p.Moniker == null);
                 _paths.InsertRange(0, newPaths);
             }
@@ -227,12 +274,48 @@ namespace Microsoft.PythonTools {
             public string Path;
             public bool Persisted;
             public object Moniker;
+            public uint Cookie;
 
-            public SearchPath(string path, bool persisted, object moniker) {
+            public SearchPath(string path, bool persisted, object moniker, uint cookie) {
                 Path = path;
                 Persisted = persisted;
                 Moniker = moniker;
+                Cookie = cookie;
             }
+        }
+
+        private uint Watch(string path) {
+            if (_changeService == null) {
+                return 0;
+            }
+
+            uint cookie;
+            if (ErrorHandler.Succeeded(_changeService.AdviseDirChange(path, 1, this, out cookie))) {
+                return cookie;
+            }
+            return 0;
+        }
+
+        private void Unwatch(uint cookie) {
+            if (_changeService == null || cookie == 0) {
+                return;
+            }
+
+            ErrorHandler.ThrowOnFailure(_changeService.UnadviseDirChange(cookie));
+        }
+
+        private void RaiseChanged(object state) {
+            _notifyChangeTimer?.Change(Timeout.Infinite, Timeout.Infinite);
+            Changed?.Invoke(this, EventArgs.Empty);
+        }
+
+        int IVsFileChangeEvents.FilesChanged(uint cChanges, string[] rgpszFile, uint[] rggrfChange) {
+            return VSConstants.S_OK;
+        }
+
+        int IVsFileChangeEvents.DirectoryChanged(string pszDirectory) {
+            _notifyChangeTimer?.Change(500, Timeout.Infinite);
+            return VSConstants.S_OK;
         }
     }
 }

--- a/Python/Product/PythonTools/PythonTools/SearchPathManager.cs
+++ b/Python/Product/PythonTools/PythonTools/SearchPathManager.cs
@@ -44,7 +44,7 @@ namespace Microsoft.PythonTools {
             Dispose(false);
         }
 
-        protected void Dispose(bool disposing) {
+        protected virtual void Dispose(bool disposing) {
             if (disposing) {
                 lock (_paths) {
                     foreach (var p in _paths) {

--- a/Python/Tests/PythonToolsUITestsRunner/BasicProjectTests.cs
+++ b/Python/Tests/PythonToolsUITestsRunner/BasicProjectTests.cs
@@ -168,6 +168,12 @@ namespace PythonToolsUITestsRunner {
 
         [TestMethod, Priority(0)]
         [TestCategory("Installed")]
+        public void PythonSearchPaths() {
+            _vs.RunTest(nameof(PythonToolsUITests.BasicProjectTests.PythonSearchPaths));
+        }
+
+        [TestMethod, Priority(0)]
+        [TestCategory("Installed")]
         public void DotNetReferences() {
             _vs.RunTest(nameof(PythonToolsUITests.BasicProjectTests.DotNetReferences));
         }


### PR DESCRIPTION
Fixes #3269 Changes in search paths are not automatically noticed by the analyzer
Adds file watcher for search paths in the IDE. The notifications flow into the analyzer and cause it to rescan search paths as necessary.