### PR TITLE
Reduce the amount of text in test output

### DIFF
--- a/Python/Product/Debugger/Debugger/DebugConnectionListener.cs
+++ b/Python/Product/Debugger/Debugger/DebugConnectionListener.cs
@@ -54,6 +54,8 @@ namespace Microsoft.PythonTools.Debugger {
             }
         }
 
+        internal static TextWriter DebugLog { get; set; }
+
         private static void EnsureListenerSocket() {
             if (_listenerPort < 0) {
                 var socketSource = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.IP);
@@ -98,7 +100,7 @@ namespace Microsoft.PythonTools.Debugger {
                 try {
                     socket.Blocking = true;
 
-                    var debugConn = new DebugConnection(stream);
+                    var debugConn = new DebugConnection(stream, DebugLog);
                     try {
                         string debugId = string.Empty;
                         var result = ConnErrorMessages.None;

--- a/Python/Product/Debugger/Debugger/DebugEngine/AD7Engine.cs
+++ b/Python/Product/Debugger/Debugger/DebugEngine/AD7Engine.cs
@@ -345,7 +345,7 @@ namespace Microsoft.PythonTools.Debugger.DebugEngine {
                         query += "&" + DebugOptionsKey + "=" + _debugOptions;
                         uriBuilder.Query = query;
 
-                        _process = TaskHelpers.RunSynchronouslyOnUIThread(ct => PythonRemoteProcess.AttachAsync(uriBuilder.Uri, true, ct));
+                        _process = TaskHelpers.RunSynchronouslyOnUIThread(ct => PythonRemoteProcess.AttachAsync(uriBuilder.Uri, true, null, ct));
                     } else {
                         _process = PythonProcess.Attach(processId, _debugOptions);
                     }
@@ -743,7 +743,7 @@ namespace Microsoft.PythonTools.Debugger.DebugEngine {
                 _attached = true;
                 _pseudoAttach = true;
             } else {
-                _process = new PythonProcess(_languageVersion, exe, args, dir, env, _interpreterOptions, _debugOptions, _dirMapping);
+                _process = new PythonProcess(_languageVersion, exe, args, dir, env, _interpreterOptions, _debugOptions, dirMapping: _dirMapping);
             }
 
             if (!_debugOptions.HasFlag(PythonDebugOptions.AttachRunning)) {

--- a/Python/Product/Debugger/Debugger/DebugEngine/Remote/PythonRemoteDebugPort.cs
+++ b/Python/Product/Debugger/Debugger/DebugEngine/Remote/PythonRemoteDebugPort.cs
@@ -15,6 +15,8 @@
 // permissions and limitations under the License.
 
 using System;
+using System.IO;
+using Microsoft.PythonTools.Ipc.Json;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Debugger.Interop;
 
@@ -24,11 +26,13 @@ namespace Microsoft.PythonTools.Debugger.Remote {
         private readonly IDebugPortRequest2 _request;
         private readonly Guid _guid = Guid.NewGuid();
         private readonly Uri _uri;
+        private readonly TextWriter _debugLog;
 
-        public PythonRemoteDebugPort(PythonRemoteDebugPortSupplier supplier, IDebugPortRequest2 request, Uri uri) {
+        public PythonRemoteDebugPort(PythonRemoteDebugPortSupplier supplier, IDebugPortRequest2 request, Uri uri, TextWriter debugLog) {
             _supplier = supplier;
             _request = request;
             _uri = uri;
+            _debugLog = debugLog ?? new DebugTextWriter();
         }
 
         public Uri Uri {
@@ -36,7 +40,7 @@ namespace Microsoft.PythonTools.Debugger.Remote {
         }
 
         public int EnumProcesses(out IEnumDebugProcesses2 ppEnum) {
-            var process = TaskHelpers.RunSynchronouslyOnUIThread(ct => PythonRemoteDebugProcess.ConnectAsync(this, ct));
+            var process = TaskHelpers.RunSynchronouslyOnUIThread(ct => PythonRemoteDebugProcess.ConnectAsync(this, _debugLog, ct));
             if (process == null) {
                 ppEnum = null;
                 return VSConstants.E_FAIL;

--- a/Python/Product/Debugger/Debugger/DebugEngine/Remote/PythonRemoteDebugPortSupplier.cs
+++ b/Python/Product/Debugger/Debugger/DebugEngine/Remote/PythonRemoteDebugPortSupplier.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Runtime.InteropServices;
 using System.Windows.Forms;
 using Microsoft.PythonTools.Debugger.DebugEngine;
@@ -33,6 +34,8 @@ namespace Microsoft.PythonTools.Debugger.Remote {
         public const string PortSupplierId = "{FEB76325-D127-4E02-B59D-B16D93D46CF5}";
         public static readonly Guid PortSupplierGuid = new Guid(PortSupplierId);
         private readonly List<IDebugPort2> _ports = new List<IDebugPort2>();
+
+        internal static TextWriter DebugLog { get; set; }
 
         // Qualifier for our transport has one of the following formats:
         //
@@ -71,7 +74,7 @@ namespace Microsoft.PythonTools.Debugger.Remote {
                 return validationError.HResult;
             }
 
-            var port = new PythonRemoteDebugPort(this, pRequest, uri);
+            var port = new PythonRemoteDebugPort(this, pRequest, uri, DebugLog);
 
             // Validate connection early. Debugger automation (DTE) objects are not consistent in error checking from this
             // point on, so errors reported from EnumProcesses and further calls may be ignored and treated as successes

--- a/Python/Product/Debugger/Debugger/DebugEngine/Remote/PythonRemoteDebugProcess.cs
+++ b/Python/Product/Debugger/Debugger/DebugEngine/Remote/PythonRemoteDebugProcess.cs
@@ -158,7 +158,7 @@ namespace Microsoft.PythonTools.Debugger.Remote {
             get { return _version; }
         }
 
-        public static async Task<PythonRemoteDebugProcess> ConnectAsync(PythonRemoteDebugPort port, CancellationToken ct) {
+        public static async Task<PythonRemoteDebugProcess> ConnectAsync(PythonRemoteDebugPort port, TextWriter debugLog, CancellationToken ct) {
             PythonRemoteDebugProcess process = null;
 
             // Connect to the remote debugging server and obtain process information. If any errors occur, display an error dialog, and keep
@@ -168,7 +168,7 @@ namespace Microsoft.PythonTools.Debugger.Remote {
                 ConnectionException connEx = null;
                 try {
                     // Process information is not sensitive, so ignore any SSL certificate errors, rather than bugging the user with warning dialogs.
-                    debugConn = await PythonRemoteProcess.ConnectAsync(port.Uri, false, ct);
+                    debugConn = await PythonRemoteProcess.ConnectAsync(port.Uri, false, debugLog, ct);
                 } catch (ConnectionException ex) {
                     connEx = ex;
                 }

--- a/Python/Product/Debugger/Debugger/DebugEngine/Remote/PythonRemoteProcess.cs
+++ b/Python/Product/Debugger/Debugger/DebugEngine/Remote/PythonRemoteProcess.cs
@@ -34,8 +34,8 @@ namespace Microsoft.PythonTools.Debugger.Remote {
         public const string DebuggerSignature = "PTVSDBG";
         private const int ConnectTimeoutMs = 5000;
 
-        private PythonRemoteProcess(int pid, Uri uri, PythonLanguageVersion langVer)
-            : base(pid, langVer) {
+        private PythonRemoteProcess(int pid, Uri uri, PythonLanguageVersion langVer, TextWriter debugLog)
+            : base(pid, langVer, debugLog) {
             Uri = uri;
             ParseQueryString();
         }
@@ -62,7 +62,7 @@ namespace Microsoft.PythonTools.Debugger.Remote {
         /// Connects to and performs the initial handshake with the remote debugging server, verifying protocol signature and version number,
         /// and returns the opened stream in a state ready to receive further ptvsd commands (e.g. attach).
         /// </summary>
-        public static async Task<DebugConnection> ConnectAsync(Uri uri, bool warnAboutAuthenticationErrors, CancellationToken ct) {
+        public static async Task<DebugConnection> ConnectAsync(Uri uri, bool warnAboutAuthenticationErrors, TextWriter debugLog, CancellationToken ct) {
             var transport = DebuggerTransportFactory.Get(uri);
             if (transport == null) {
                 throw new ConnectionException(ConnErrorMessages.RemoteInvalidUri);
@@ -88,7 +88,7 @@ namespace Microsoft.PythonTools.Debugger.Remote {
                 }
             } while (stream == null);
 
-            var debugConn = new DebugConnection(stream);
+            var debugConn = new DebugConnection(stream, debugLog);
             bool connected = false;
             try {
                 string serverDebuggerName = string.Empty;
@@ -154,11 +154,11 @@ namespace Microsoft.PythonTools.Debugger.Remote {
         /// Same as the static version of this method, but uses the same <c>uri</c>
         /// that was originally used to create this instance of <see cref="PythonRemoteProcess"/>.
         /// </summary>
-        public async Task<DebugConnection> ConnectAsync(bool warnAboutAuthenticationErrors, CancellationToken ct) {
-            return await ConnectAsync(Uri, warnAboutAuthenticationErrors, ct);
+        public async Task<DebugConnection> ConnectAsync(bool warnAboutAuthenticationErrors, TextWriter debugLog, CancellationToken ct) {
+            return await ConnectAsync(Uri, warnAboutAuthenticationErrors, debugLog, ct);
         }
 
-        public static async Task<PythonProcess> AttachAsync(Uri uri, bool warnAboutAuthenticationErrors, CancellationToken ct) {
+        public static async Task<PythonProcess> AttachAsync(Uri uri, bool warnAboutAuthenticationErrors, TextWriter debugLog, CancellationToken ct) {
             string debugOptions = "";
             if (uri.Query != null) {
                 // It is possible to have more than one opt=... in the URI - the debug engine will always supply one based on
@@ -169,7 +169,7 @@ namespace Microsoft.PythonTools.Debugger.Remote {
                 debugOptions = queryParts[AD7Engine.DebugOptionsKey] ?? "";
             }
 
-            var debugConn = await ConnectAsync(uri, warnAboutAuthenticationErrors, ct);
+            var debugConn = await ConnectAsync(uri, warnAboutAuthenticationErrors, debugLog, ct);
             try {
                 var response = await debugConn.SendRequestAsync(new LDP.RemoteDebuggerAttachRequest() {
                     debugOptions = debugOptions,
@@ -184,7 +184,7 @@ namespace Microsoft.PythonTools.Debugger.Remote {
                     langVer = PythonLanguageVersion.None;
                 }
 
-                var process = new PythonRemoteProcess(response.processId, uri, langVer);
+                var process = new PythonRemoteProcess(response.processId, uri, langVer, debugLog);
                 process.Connect(debugConn);
                 debugConn = null;
                 return process;

--- a/Python/Product/Debugger/Debugger/PythonDebugger.cs
+++ b/Python/Product/Debugger/Debugger/PythonDebugger.cs
@@ -14,6 +14,7 @@
 // See the Apache Version 2.0 License for specific language governing
 // permissions and limitations under the License.
 
+using System.IO;
 using Microsoft.PythonTools.Parsing;
 
 namespace Microsoft.PythonTools.Debugger {
@@ -22,8 +23,8 @@ namespace Microsoft.PythonTools.Debugger {
         /// Creates a new PythonProcess object for debugging.  The process does not start until Start is called 
         /// on the returned PythonProcess object.
         /// </summary>
-        public PythonProcess CreateProcess(PythonLanguageVersion langVersion, string exe, string args, string dir, string env, string interpreterOptions = null, PythonDebugOptions debugOptions = PythonDebugOptions.None) {
-            return new PythonProcess(langVersion, exe, args, dir, env, interpreterOptions, debugOptions);
+        public PythonProcess CreateProcess(PythonLanguageVersion langVersion, string exe, string args, string dir, string env, string interpreterOptions = null, PythonDebugOptions debugOptions = PythonDebugOptions.None, TextWriter debugLog = null) {
+            return new PythonProcess(langVersion, exe, args, dir, env, interpreterOptions, debugOptions, debugLog);
         }
     }
 }

--- a/Python/Product/Ipc.Json/DebugTextWriter.cs
+++ b/Python/Product/Ipc.Json/DebugTextWriter.cs
@@ -14,48 +14,25 @@
 // See the Apache Version 2.0 License for specific language governing
 // permissions and limitations under the License.
 
-using System;
 using System.Diagnostics;
 using System.IO;
 using System.Text;
 
 namespace Microsoft.PythonTools.Ipc.Json {
-    public class DebugTextWriter : StreamWriter {
-        public DebugTextWriter() : base(new DebugStream(), Encoding.UTF8, 1024) {
-        }
-    }
-
-    class DebugStream : Stream {
-        public override bool CanRead => false;
-
-        public override bool CanSeek => false;
-
-        public override bool CanWrite => true;
-
-        public override long Length => throw new NotImplementedException();
-
-        public override long Position { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
-
-        public override void Flush() {
+    public class DebugTextWriter : TextWriter {
+        public override Encoding Encoding => Encoding.UTF8;
+        public override void Write(char value) {
+            // Technically this is the only Write/WriteLine overload we need to
+            // implement. We override the string versions for better performance.
+            Debug.Write(value);
         }
 
-        public override int Read(byte[] buffer, int offset, int count) {
-            throw new NotImplementedException();
+        public override void Write(string value) {
+            Debug.Write(value);
         }
 
-        public override long Seek(long offset, SeekOrigin origin) {
-            throw new NotImplementedException();
-        }
-
-        public override void SetLength(long value) {
-            throw new NotImplementedException();
-        }
-
-        public override void Write(byte[] buffer, int offset, int count) {
-#if DEBUG
-            var text = UTF8Encoding.UTF8.GetChars(buffer, offset, count);
-            Debug.Write(new string(text));
-#endif
+        public override void WriteLine(string value) {
+            Debug.WriteLine(value);
         }
     }
 }

--- a/Python/Product/Ipc.Json/DebugTextWriter.cs
+++ b/Python/Product/Ipc.Json/DebugTextWriter.cs
@@ -1,0 +1,61 @@
+﻿// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABLITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+
+namespace Microsoft.PythonTools.Ipc.Json {
+    public class DebugTextWriter : StreamWriter {
+        public DebugTextWriter() : base(new DebugStream(), Encoding.UTF8, 1024) {
+        }
+    }
+
+    class DebugStream : Stream {
+        public override bool CanRead => false;
+
+        public override bool CanSeek => false;
+
+        public override bool CanWrite => true;
+
+        public override long Length => throw new NotImplementedException();
+
+        public override long Position { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+
+        public override void Flush() {
+        }
+
+        public override int Read(byte[] buffer, int offset, int count) {
+            throw new NotImplementedException();
+        }
+
+        public override long Seek(long offset, SeekOrigin origin) {
+            throw new NotImplementedException();
+        }
+
+        public override void SetLength(long value) {
+            throw new NotImplementedException();
+        }
+
+        public override void Write(byte[] buffer, int offset, int count) {
+#if DEBUG
+            var text = UTF8Encoding.UTF8.GetChars(buffer, offset, count);
+            Debug.Write(new string(text));
+#endif
+        }
+    }
+}

--- a/Python/Product/Ipc.Json/Ipc.Json.csproj
+++ b/Python/Product/Ipc.Json/Ipc.Json.csproj
@@ -52,6 +52,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Connection.cs" />
+    <Compile Include="DebugTextWriter.cs" />
     <Compile Include="Event.cs" />
     <Compile Include="EventReceivedEventArgs.cs" />
     <Compile Include="FailedRequestException.cs" />

--- a/Python/Tests/Core/DebugReplEvaluatorTests.cs
+++ b/Python/Tests/Core/DebugReplEvaluatorTests.cs
@@ -369,7 +369,7 @@ NameError: name 'does_not_exist' is not defined
 
         private async Task AttachAsync(string filename, int lineNo) {
             var debugger = new PythonDebugger();
-            PythonProcess process = debugger.DebugProcess(Version, DebuggerTestPath + filename, async (newproc, newthread) => {
+            PythonProcess process = debugger.DebugProcess(Version, DebuggerTestPath + filename, null, async (newproc, newthread) => {
                 var breakPoint = newproc.AddBreakpointByFileExtension(lineNo, filename);
                 await breakPoint.AddAsync(TimeoutToken());
             });

--- a/Python/Tests/DebuggerTests/AttachTests.cs
+++ b/Python/Tests/DebuggerTests/AttachTests.cs
@@ -80,7 +80,7 @@ namespace DebuggerTests {
                         Assert.Fail("Process exited");
                     }
 
-                    var proc = PythonProcess.Attach(p.Id);
+                    var proc = PythonProcess.Attach(p.Id, debugLog: DebugLog);
                     try {
                         var attached = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
                         var readyToContinue = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -103,7 +103,7 @@ namespace DebuggerTests {
                         proc.BreakpointHit += async (sender, args) => {
                             if (args.Breakpoint.LineNo == 9) {
                                 // stop running the infinite loop
-                                Debug.WriteLine(String.Format("First BP hit {0}", args.Thread.Id));
+                                DebugLog?.WriteLine(String.Format("First BP hit {0}", args.Thread.Id));
                                 mainThread = args.Thread;
                                 await args.Thread.Frames[0].ExecuteTextAsync(
                                     "x = False",
@@ -111,12 +111,12 @@ namespace DebuggerTests {
                                     TimeoutToken());
                             } else if (args.Breakpoint.LineNo == 5) {
                                 // we hit the breakpoint on the new thread
-                                Debug.WriteLine(String.Format("Second BP hit {0}", args.Thread.Id));
+                                DebugLog?.WriteLine(String.Format("Second BP hit {0}", args.Thread.Id));
                                 bpThread = args.Thread;
                                 threadBreakpointHit.TrySetResult(true);
                                 await proc.ResumeAsync(TimeoutToken());
                             } else {
-                                Debug.WriteLine(String.Format("Hit breakpoint on wrong line number: {0}", args.Breakpoint.LineNo));
+                                DebugLog?.WriteLine(String.Format("Hit breakpoint on wrong line number: {0}", args.Breakpoint.LineNo));
                                 wrongLine = true;
                                 attached.TrySetResult(true);
                                 threadBreakpointHit.TrySetResult(true);
@@ -157,7 +157,7 @@ namespace DebuggerTests {
                         var attached = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
                         var detached = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
-                        var proc = PythonProcess.Attach(p.Id);
+                        var proc = PythonProcess.Attach(p.Id, debugLog: DebugLog);
 
                         proc.ProcessLoaded += (sender, args) => {
                             attached.SetResult(true);
@@ -202,7 +202,7 @@ namespace DebuggerTests {
 
                     var attached = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
-                    var proc = PythonProcess.Attach(p.Id);
+                    var proc = PythonProcess.Attach(p.Id, debugLog: DebugLog);
                     try {
                         proc.ProcessLoaded += (sender, args) => {
                             attached.SetResult(true);
@@ -211,7 +211,7 @@ namespace DebuggerTests {
 
                         await attached.Task.WithTimeout(10000, "Failed to attach within 10s");
                         await proc.ResumeAsync(TimeoutToken());
-                        Debug.WriteLine("Waiting for exit");
+                        DebugLog?.WriteLine("Waiting for exit");
                     } finally {
                         WaitForExit(proc);
                     }
@@ -237,7 +237,7 @@ namespace DebuggerTests {
 
                 var attached = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
-                var proc = PythonProcess.Attach(p.Id);
+                var proc = PythonProcess.Attach(p.Id, debugLog: DebugLog);
                 try {
                     proc.ProcessLoaded += (sender, args) => {
                         attached.SetResult(true);
@@ -247,7 +247,7 @@ namespace DebuggerTests {
                     using (var dumpWriter = new MiniDumpWriter(p)) {
                         await attached.Task.WithTimeout(10000, "Failed to attach within 10s");
                         await proc.ResumeAsync(TimeoutToken());
-                        Debug.WriteLine("Waiting for exit");
+                        DebugLog?.WriteLine("Waiting for exit");
                         dumpWriter.Cancel();
                     }
                 } finally {
@@ -272,7 +272,7 @@ namespace DebuggerTests {
                         var attached = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
                         var detached = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
-                        var proc = PythonProcess.Attach(p.Id);
+                        var proc = PythonProcess.Attach(p.Id, debugLog: DebugLog);
                         proc.ProcessLoaded += (sender, args) => {
                             attached.SetResult(true);
                         };
@@ -307,7 +307,7 @@ namespace DebuggerTests {
                         var attached = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
                         var detached = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
-                        var proc = PythonProcess.Attach(p.Id);
+                        var proc = PythonProcess.Attach(p.Id, debugLog: DebugLog);
                         proc.ProcessLoaded += (sender, args) => {
                             attached.SetResult(true);
                         };
@@ -462,7 +462,7 @@ void main()
                     var attached = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
                     var bpHit = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
-                    var proc = PythonProcess.Attach(p.Id);
+                    var proc = PythonProcess.Attach(p.Id, debugLog: DebugLog);
                     try {
                         proc.ProcessLoaded += (sender, args) => {
                             Console.WriteLine("Process loaded");
@@ -593,7 +593,7 @@ void main()
                     var attached = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
                     var bpHit = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
-                    var proc = PythonProcess.Attach(p.Id);
+                    var proc = PythonProcess.Attach(p.Id, debugLog: DebugLog);
                     try {
                         proc.ProcessLoaded += (sender, args) => {
                             Console.WriteLine("Process loaded");
@@ -690,7 +690,7 @@ int main(int argc, char* argv[]) {
                     // because StartListeningAsync waits until debuggee has connected
                     // back (which it won't do until handle is set).
                     var attachTask = Task.Run(async () => {
-                        var proc = PythonProcess.Attach(p.Id);
+                        var proc = PythonProcess.Attach(p.Id, debugLog: DebugLog);
                         try {
                             proc.ProcessLoaded += (sender, args) => {
                                 attachDone.SetResult(true);
@@ -713,7 +713,7 @@ int main(int argc, char* argv[]) {
                     dumpWriter.Cancel();
                 }
             } finally {
-                Debug.WriteLine(String.Format("Process output: {0}", outRecv.Output.ToString()));
+                DebugLog?.WriteLine(String.Format("Process output: {0}", outRecv.Output.ToString()));
                 DisposeProcess(p);
             }
         }
@@ -726,7 +726,7 @@ int main(int argc, char* argv[]) {
             try {
                 using (var dumpWriter = new MiniDumpWriter(p)) {
                     Thread.Sleep(1000);
-                    var proc = PythonProcess.Attach(p.Id);
+                    var proc = PythonProcess.Attach(p.Id, debugLog: DebugLog);
                     try {
                         var attached = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
                         proc.ProcessLoaded += async (sender, args) => {
@@ -786,7 +786,7 @@ int main(int argc, char* argv[]) {
                 }
 
                 using (var dumpWriter = new MiniDumpWriter(p)) {
-                    var proc = PythonProcess.Attach(p.Id, PythonDebugOptions.RedirectOutput);
+                    var proc = PythonProcess.Attach(p.Id, PythonDebugOptions.RedirectOutput, debugLog: DebugLog);
                     try {
                         var attached = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
                         proc.ProcessLoaded += (sender, args) => {
@@ -896,7 +896,7 @@ int main(int argc, char* argv[]) {
                     for (int i = 0; ; ++i) {
                         Thread.Sleep(1000);
                         try {
-                            proc = await PythonRemoteProcess.AttachAsync(uri, false, TimeoutToken());
+                            proc = await PythonRemoteProcess.AttachAsync(uri, false, DebugLog, TimeoutToken());
                             break;
                         } catch (SocketException) {
                             // Failed to connect - the process might have not started yet, so keep trying a few more times.

--- a/Python/Tests/DebuggerTests/DebugExtensions.cs
+++ b/Python/Tests/DebuggerTests/DebugExtensions.cs
@@ -23,7 +23,7 @@ using TestUtilities;
 
 namespace DebuggerTests {
     static class DebugExtensions {
-        internal static PythonProcess DebugProcess(this PythonDebugger debugger, PythonVersion version, string filename, Func<PythonProcess, PythonThread, Task> onLoaded = null, bool resumeOnProcessLoaded = true, string interpreterOptions = null, PythonDebugOptions debugOptions = PythonDebugOptions.RedirectOutput, string cwd = null, string arguments = "") {
+        internal static PythonProcess DebugProcess(this PythonDebugger debugger, PythonVersion version, string filename, TextWriter debugLog, Func<PythonProcess, PythonThread, Task> onLoaded = null, bool resumeOnProcessLoaded = true, string interpreterOptions = null, PythonDebugOptions debugOptions = PythonDebugOptions.RedirectOutput, string cwd = null, string arguments = "") {
             string fullPath = Path.GetFullPath(filename);
             string dir = cwd ?? Path.GetFullPath(Path.GetDirectoryName(filename));
             if (!String.IsNullOrEmpty(arguments)) {
@@ -31,7 +31,7 @@ namespace DebuggerTests {
             } else {
                 arguments = "\"" + fullPath + "\"";
             }
-            var process = debugger.CreateProcess(version.Version, version.InterpreterPath, arguments, dir, "", interpreterOptions, debugOptions);
+            var process = debugger.CreateProcess(version.Version, version.InterpreterPath, arguments, dir, "", interpreterOptions, debugOptions, debugLog);
             process.DebuggerOutput += (sender, args) => {
                 Console.WriteLine("{0}: {1}", args.Thread?.Id, args.Output);
             };

--- a/Python/Tests/DebuggerTests/DebuggerTests.cs
+++ b/Python/Tests/DebuggerTests/DebuggerTests.cs
@@ -479,13 +479,13 @@ namespace DebuggerTests {
                 for (int i = 0; i < 20; i++) {
                     Thread.Sleep(50);
 
-                    Debug.WriteLine(String.Format("Breaking {0}", i));
+                    DebugLog?.WriteLine(String.Format("Breaking {0}", i));
                     await process.BreakAsync(TimeoutToken());
                     if (!breakComplete.WaitOne(10000)) {
                         Console.WriteLine("Failed to break");
                     }
                     await process.ResumeAsync(TimeoutToken());
-                    Debug.WriteLine(String.Format("Resumed {0}", i));
+                    DebugLog?.WriteLine(String.Format("Resumed {0}", i));
                 }
             } finally {
                 TerminateProcess(process);
@@ -1044,7 +1044,8 @@ namespace DebuggerTests {
                     "\"" + fullPath + "\"",
                     DebuggerTestPath,
                     "",
-                    debugOptions: steppingStdLib ? (PythonDebugOptions.DebugStdLib | PythonDebugOptions.RedirectOutput) : PythonDebugOptions.RedirectOutput);
+                    debugOptions: steppingStdLib ? (PythonDebugOptions.DebugStdLib | PythonDebugOptions.RedirectOutput) : PythonDebugOptions.RedirectOutput,
+                    debugLog: DebugLog);
 
                 PythonThread thread = null;
                 process.ThreadCreated += (sender, args) => {
@@ -1089,7 +1090,7 @@ namespace DebuggerTests {
                     AssertWaited(processEvent);
                     Assert.IsTrue(stepComplete, "step was not completed");
 
-                    Debug.WriteLine(thread.Frames[thread.Frames.Count - 1].FileName);
+                    DebugLog?.WriteLine(thread.Frames[thread.Frames.Count - 1].FileName);
 
                     if (steppingStdLib) {
                         Assert.IsTrue(thread.Frames[0].FileName.EndsWith("\\os.py"), "did not break in os.py; instead, " + thread.Frames[0].FileName);
@@ -2087,7 +2088,7 @@ namespace DebuggerTests {
             string dir = cwd ?? Path.GetFullPath(Path.GetDirectoryName(filename));
 
             PythonProcessRunInfo processRunInfo = new PythonProcessRunInfo();
-            processRunInfo.Process = debugger.CreateProcess(Version.Version, pythonExe ?? Version.InterpreterPath, "\"" + fullPath + "\"", dir, "", interpreterOptions, debugOptions);
+            processRunInfo.Process = debugger.CreateProcess(Version.Version, pythonExe ?? Version.InterpreterPath, "\"" + fullPath + "\"", dir, "", interpreterOptions, debugOptions, DebugLog);
             processRunInfo.Process.ProcessLoaded += async (sender, args) => {
                 try {
                     if (onLoaded != null) {


### PR DESCRIPTION
Capture output and only print it if there's a test failure.

This eliminates most output from attach tests and debugger tests.

I can do something similar (separately) for analysis tests if this looks ok.