### PR TITLE
Fix a number of P0 issues

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Editor/PythonTextBufferInfo.cs
+++ b/Python/Product/PythonTools/PythonTools/Editor/PythonTextBufferInfo.cs
@@ -155,9 +155,11 @@ namespace Microsoft.PythonTools.Editor {
         }
 
         private string GetOrCreateFilename() {
-            var replEval = Buffer.GetInteractiveWindow()?.GetPythonEvaluator();
-            if (replEval != null) {
-                return replEval.AnalysisFilename;
+            var replEval = Buffer.GetInteractiveWindow()?.Evaluator;
+            if (replEval is PythonCommonInteractiveEvaluator pyEval) {
+                return pyEval.AnalysisFilename;
+            } else if (replEval is SelectableReplEvaluator selectEval) {
+                return selectEval.AnalysisFilename;
             }
 
             ITextDocument doc;

--- a/Python/Product/PythonTools/PythonTools/Intellisense/AnalysisEntryService.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/AnalysisEntryService.cs
@@ -234,7 +234,7 @@ namespace Microsoft.PythonTools.Intellisense {
             if ((evaluator = textBuffer.GetInteractiveWindow()?.Evaluator as IPythonInteractiveIntellisense) != null) {
                 analyzer = evaluator.Analyzer;
                 filename = evaluator.AnalysisFilename;
-                return true;
+                return analyzer != null;
             }
 
             // If we find an associated project, use its analyzer

--- a/Python/Product/PythonTools/PythonTools/Intellisense/CompletionAnalysis.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/CompletionAnalysis.cs
@@ -106,7 +106,6 @@ namespace Microsoft.PythonTools.Intellisense {
         internal AnalysisEntry GetAnalysisEntry() {
             var bi = PythonTextBufferInfo.TryGetForBuffer(TextBuffer);
             Debug.Assert(bi != null, "Getting completions from uninitialized buffer " + TextBuffer.ToString());
-            Debug.Assert(bi?.AnalysisEntry != null, "Failed to get project entry for buffer " + TextBuffer.ToString());
             return bi?.AnalysisEntry;
         }
 

--- a/Python/Product/PythonTools/PythonTools/Intellisense/IntellisenseController.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/IntellisenseController.cs
@@ -29,7 +29,6 @@ using Microsoft.PythonTools.Parsing;
 using Microsoft.PythonTools.Parsing.Ast;
 using Microsoft.PythonTools.Projects;
 using Microsoft.VisualStudio;
-using Microsoft.VisualStudio.Editor;
 using Microsoft.VisualStudio.InteractiveWindow;
 using Microsoft.VisualStudio.Language.Intellisense;
 using Microsoft.VisualStudio.Language.StandardClassification;
@@ -39,7 +38,6 @@ using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Text.IncrementalSearch;
 using Microsoft.VisualStudio.Text.Operations;
 using Microsoft.VisualStudio.TextManager.Interop;
-using IServiceProvider = System.IServiceProvider;
 using VSConstants = Microsoft.VisualStudio.VSConstants;
 
 namespace Microsoft.PythonTools.Intellisense {

--- a/Python/Product/PythonTools/PythonTools/Intellisense/NormalCompletionAnalysis.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/NormalCompletionAnalysis.cs
@@ -18,21 +18,17 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.PythonTools.Analysis;
 using Microsoft.PythonTools.Editor;
 using Microsoft.PythonTools.Infrastructure;
 using Microsoft.PythonTools.Interpreter;
 using Microsoft.PythonTools.Parsing;
-using Microsoft.PythonTools.Parsing.Ast;
 using Microsoft.PythonTools.Repl;
 using Microsoft.VisualStudio.InteractiveWindow;
 using Microsoft.VisualStudio.Language.Intellisense;
-using Microsoft.VisualStudio.Language.StandardClassification;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
-using Microsoft.VisualStudioTools;
 
 namespace Microsoft.PythonTools.Intellisense {
     internal class NormalCompletionAnalysis : CompletionAnalysis {
@@ -153,7 +149,7 @@ namespace Microsoft.PythonTools.Intellisense {
                     }
                 }
 
-                if (pyReplEval != null && pyReplEval.Analyzer.ShouldEvaluateForCompletion(text)) {
+                if (pyReplEval?.Analyzer != null && pyReplEval.Analyzer.ShouldEvaluateForCompletion(text)) {
                     replMembers = pyReplEval.GetMemberNames(text);
                 }
 

--- a/Python/Product/PythonTools/PythonTools/Intellisense/ProjectAnalyzer.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/ProjectAnalyzer.cs
@@ -2497,6 +2497,10 @@ namespace Microsoft.PythonTools.Intellisense {
 
         private static async Task<ExpressionAtPoint> GetExpressionAtPointAsync_BypassTelemetry(SnapshotPoint point, AP.ExpressionAtPointPurpose purpose, TimeSpan timeout) {
             var bi = PythonTextBufferInfo.TryGetForBuffer(point.Snapshot.TextBuffer);
+            if (bi == null) {
+                return null;
+            }
+
             var line = point.GetContainingLine();
 
             var sourceSpan = await GetExpressionSpanAtPointAsync_BypassTelemetry(
@@ -2525,6 +2529,10 @@ namespace Microsoft.PythonTools.Intellisense {
         }
 
         private static async Task<SourceSpan?> GetExpressionSpanAtPointAsync_BypassTelemetry(PythonTextBufferInfo buffer, SourceLocation point, AP.ExpressionAtPointPurpose purpose, TimeSpan timeout) {
+            if (buffer == null) {
+                throw new ArgumentNullException(nameof(buffer));
+            }
+
             if (buffer.AnalysisEntry == null) {
                 return null;
             }

--- a/Python/Product/PythonTools/PythonTools/Repl/PythonCommonInteractiveEvaluator.cs
+++ b/Python/Product/PythonTools/PythonTools/Repl/PythonCommonInteractiveEvaluator.cs
@@ -60,7 +60,7 @@ namespace Microsoft.PythonTools.Repl {
         private IInteractiveWindow _window;
         private PythonInteractiveOptions _options;
 
-        private VsProjectAnalyzer _analyzer;
+        protected VsProjectAnalyzer _analyzer;
         private readonly string _analysisFilename;
 
         private bool _enableMultipleScopes;
@@ -141,7 +141,7 @@ namespace Microsoft.PythonTools.Repl {
         }
 
 
-        public VsProjectAnalyzer Analyzer {
+        public virtual VsProjectAnalyzer Analyzer {
             get {
                 if (_analyzer != null) {
                     return _analyzer;
@@ -169,7 +169,7 @@ namespace Microsoft.PythonTools.Repl {
             }
         }
 
-        public string AnalysisFilename => _analysisFilename;
+        public virtual string AnalysisFilename => _analysisFilename;
 
         internal void WriteOutput(string text, bool addNewline = true) {
             var wnd = CurrentWindow;
@@ -351,6 +351,8 @@ namespace Microsoft.PythonTools.Repl {
             InterpreterConfiguration config,
             bool onlyIfExists = true
         ) {
+            provider.MustBeCalledFromUIThread();
+
             var root = provider.GetPythonToolsService().InteractiveOptions.Scripts;
 
             if (string.IsNullOrEmpty(root)) {

--- a/Python/Product/PythonTools/PythonTools/Repl/PythonDebugReplEvaluator.cs
+++ b/Python/Product/PythonTools/PythonTools/Repl/PythonDebugReplEvaluator.cs
@@ -47,7 +47,7 @@ namespace Microsoft.PythonTools.Repl {
         private readonly IServiceProvider _serviceProvider;
         private IInteractiveWindowCommands _commands;
 
-        // This filename is used 
+        // This filename is used for when we do not have a process
         private readonly string _analyzerFilename;
 
         private static readonly string currentPrefix = Strings.DebugReplCurrentIndicator;

--- a/Python/Product/PythonTools/PythonTools/Repl/PythonDebugReplEvaluator.cs
+++ b/Python/Product/PythonTools/PythonTools/Repl/PythonDebugReplEvaluator.cs
@@ -47,12 +47,16 @@ namespace Microsoft.PythonTools.Repl {
         private readonly IServiceProvider _serviceProvider;
         private IInteractiveWindowCommands _commands;
 
+        // This filename is used 
+        private readonly string _analyzerFilename;
+
         private static readonly string currentPrefix = Strings.DebugReplCurrentIndicator;
         private static readonly string notCurrentPrefix = Strings.DebugReplNotCurrentIndicator;
 
         public PythonDebugReplEvaluator(IServiceProvider serviceProvider) {
             _serviceProvider = serviceProvider;
             _pyService = serviceProvider.GetPythonToolsService();
+            _analyzerFilename = "{0}.py".FormatInvariant(Guid.NewGuid());
             AD7Engine.EngineAttached += new EventHandler<AD7EngineEventArgs>(OnEngineAttached);
             AD7Engine.EngineDetaching += new EventHandler<AD7EngineEventArgs>(OnEngineDetaching);
 
@@ -200,7 +204,7 @@ namespace Microsoft.PythonTools.Repl {
         public IInteractiveWindow CurrentWindow { get; set; }
 
         public VsProjectAnalyzer Analyzer => _activeEvaluator?.Analyzer;
-        public string AnalysisFilename => _activeEvaluator?.AnalysisFilename;
+        public string AnalysisFilename => _activeEvaluator?.AnalysisFilename ?? _analyzerFilename;
 
         public bool IsDisconnected => _activeEvaluator?.IsDisconnected ?? true;
 
@@ -312,7 +316,7 @@ namespace Microsoft.PythonTools.Repl {
             if (_evaluators.Keys.Contains(id)) {
                 SwitchProcess(_evaluators[id].Process, verbose);
             } else {
-                CurrentWindow.WriteError(Strings.DebugReplInvalidProcessId.FormatUI(id));
+                CurrentWindow.WriteErrorLine(Strings.DebugReplInvalidProcessId.FormatUI(id));
             }
         }
 
@@ -322,7 +326,7 @@ namespace Microsoft.PythonTools.Repl {
                 if (thread != null) {
                     _activeEvaluator.SwitchThread(thread, verbose);
                 } else {
-                    CurrentWindow.WriteError(Strings.DebugReplInvalidThreadId.FormatUI(id));
+                    CurrentWindow.WriteErrorLine(Strings.DebugReplInvalidThreadId.FormatUI(id));
                 }
             } else {
                 NoProcessError();
@@ -335,7 +339,7 @@ namespace Microsoft.PythonTools.Repl {
                 if (frame != null) {
                     _activeEvaluator.SwitchFrame(frame);
                 } else {
-                    CurrentWindow.WriteError(Strings.DebugReplInvalidFrameId.FormatUI(id));
+                    CurrentWindow.WriteErrorLine(Strings.DebugReplInvalidFrameId.FormatUI(id));
                 }
             } else {
                 NoProcessError();
@@ -495,11 +499,11 @@ namespace Microsoft.PythonTools.Repl {
         }
 
         private void NoProcessError() {
-            CurrentWindow.WriteError(Strings.DebugReplNoProcessError);
+            CurrentWindow.WriteErrorLine(Strings.DebugReplNoProcessError);
         }
 
         private void NoExecutionIfNotStoppedInDebuggerError() {
-            CurrentWindow.WriteError(Strings.DebugReplNoExecutionIfNotStoppedInDebuggerError);
+            CurrentWindow.WriteErrorLine(Strings.DebugReplNoExecutionIfNotStoppedInDebuggerError);
         }
 
         public Task<ExecutionResult> InitializeAsync() {

--- a/Python/Product/PythonTools/PythonTools/Repl/PythonReplEvaluatorProvider.cs
+++ b/Python/Product/PythonTools/PythonTools/Repl/PythonReplEvaluatorProvider.cs
@@ -70,6 +70,8 @@ namespace Microsoft.PythonTools.Repl {
         public event EventHandler EvaluatorsChanged;
 
         public IEnumerable<KeyValuePair<string, string>> GetEvaluators() {
+            _serviceProvider.MustBeCalledFromUIThread();
+
             foreach (var interpreter in _interpreterService.Configurations) {
                 yield return new KeyValuePair<string, string>(
                     interpreter.Description,
@@ -136,6 +138,8 @@ namespace Microsoft.PythonTools.Repl {
         }
 
         private IInteractiveEvaluator GetEnvironmentEvaluator(IReadOnlyList<string> args) {
+            _serviceProvider.MustBeCalledFromUIThread();
+
             var config = _interpreterService.FindConfiguration(args.ElementAtOrDefault(1));
 
             var eval = new PythonInteractiveEvaluator(_serviceProvider) {
@@ -149,6 +153,8 @@ namespace Microsoft.PythonTools.Repl {
         }
 
         private IInteractiveEvaluator GetProjectEvaluator(IReadOnlyList<string> args) {
+            _serviceProvider.MustBeCalledFromUIThread();
+
             var project = args.ElementAtOrDefault(1);
 
             var eval = new PythonInteractiveEvaluator(_serviceProvider) {

--- a/Python/Product/VSInterpreters/PythonRegistrySearch.cs
+++ b/Python/Product/VSInterpreters/PythonRegistrySearch.cs
@@ -71,7 +71,7 @@ namespace Microsoft.PythonTools.Interpreter {
             }
 
             var companies = GetSubkeys(root);
-            foreach (var company in companies) {
+            foreach (var company in companies.MaybeEnumerate()) {
                 if ("PyLauncher".Equals(company, StringComparison.OrdinalIgnoreCase)) {
                     continue;
                 }
@@ -93,7 +93,7 @@ namespace Microsoft.PythonTools.Interpreter {
                     }
 
                     var tags = GetSubkeys(companyKey);
-                    foreach (var tag in tags) {
+                    foreach (var tag in tags.MaybeEnumerate()) {
                         using (var tagKey = companyKey.OpenSubKey(tag))
                         using (var installKey = tagKey?.OpenSubKey("InstallPath")) {
                             var config = TryReadConfiguration(company, tag, tagKey, installKey, pythonCore, assumedArch);
@@ -234,6 +234,7 @@ namespace Microsoft.PythonTools.Interpreter {
 
         private static IList<string> GetSubkeys(RegistryKey key) {
             string[] subKeyNames = null;
+            int delay = 10;
             for (int retries = 5; subKeyNames == null && retries > 0; --retries) {
                 try {
                     subKeyNames = key.GetSubKeyNames();
@@ -242,7 +243,8 @@ namespace Microsoft.PythonTools.Interpreter {
                     // short period to settle down and try again.
                     // We are almost certainly being called from a background
                     // thread, so sleeping here is fine.
-                    Thread.Sleep(100);
+                    Thread.Sleep(delay);
+                    delay *= 5;
                 }
             }
             return subKeyNames;


### PR DESCRIPTION
Fixes #3264 NullReferenceException in GetExpressionSpanAtPointAsync_BypassTelemetry
Adds missing null check in caller.
Adds ArgumentNullException to callee.

Fixes #3250 Null reference in PythonRegistrySearch.Search
Checks for null results from GetSubKeys
Extends wait times between attempts to get subkeys
Ports fixes to cookiecutter

Fixes #3249 Threading issue in PythonCommonInteractiveEvaluator.GetScriptsPath
Ensures calls come from the UI thread.

Fixes #2065 Assert on completions when REPL env is unknown
Fixes #1788 Failed to get project entry for buffer error in debug repl
Ensures REPL properly handles the "no analyzer" case, which fixes multiple issues.
Fixes newlines in debug REPL errors

For #2953, enables returning locals