### PR TITLE
Prevent assertion dialogs from appearing during test runs

### DIFF
--- a/Python/Product/Analysis/Interpreter/PythonTypeDatabase.cs
+++ b/Python/Product/Analysis/Interpreter/PythonTypeDatabase.cs
@@ -434,7 +434,11 @@ namespace Microsoft.PythonTools.Interpreter {
             var glogPath = Path.Combine(CompletionDatabasePath, "AnalysisLog.txt");
 
             // Tests change Debug.Listeners so look for that to determine if we're running inside a test
+#if DEBUG
             var inTests = Debug.Listeners["Microsoft.PythonTools.AssertListener"] != null;
+#else
+            var inTests = false;
+#endif
 
             using (var output = ProcessOutput.RunHiddenAndCapture(
                 analyzerPath,

--- a/Python/Product/Analysis/Interpreter/PythonTypeDatabase.cs
+++ b/Python/Product/Analysis/Interpreter/PythonTypeDatabase.cs
@@ -433,6 +433,9 @@ namespace Microsoft.PythonTools.Interpreter {
             var logPath = Path.Combine(outPath, "AnalysisLog.txt");
             var glogPath = Path.Combine(CompletionDatabasePath, "AnalysisLog.txt");
 
+            // Tests change Debug.Listeners so look for that to determine if we're running inside a test
+            var inTests = Debug.Listeners["Microsoft.PythonTools.AssertListener"] != null;
+
             using (var output = ProcessOutput.RunHiddenAndCapture(
                 analyzerPath,
                 "/id", fact.Configuration.Id,
@@ -441,6 +444,7 @@ namespace Microsoft.PythonTools.Interpreter {
                 "/outdir", outPath,
                 "/basedb", baseDb,
                 (request.SkipUnchanged ? null : "/all"),  // null will be filtered out; empty strings are quoted
+                (inTests ? "/unittest" : null),
                 "/log", logPath,
                 "/glog", glogPath,
                 "/wait", (request.WaitFor != null ? AnalyzerStatusUpdater.GetIdentifier(request.WaitFor) : "")

--- a/Python/Product/Analyzer/PyLibAnalyzer.cs
+++ b/Python/Product/Analyzer/PyLibAnalyzer.cs
@@ -98,7 +98,9 @@ namespace Microsoft.PythonTools.Analysis {
             Console.WriteLine(" /wait       [identifier]       - wait for the specified analysis to complete.");
             Console.WriteLine(" /repeat     [count]            - repeat up to count times if needed (default 3).");
             Console.WriteLine(" /comment    [comment]          - provide descriptive text about why this analyzed was created");
+#if DEBUG
             Console.WriteLine(" /unittest                      - run from tests, Debug.Listeners will be replaced");
+#endif
         }
 
         private static IEnumerable<KeyValuePair<string, string>> ParseArguments(IEnumerable<string> args) {
@@ -329,9 +331,11 @@ namespace Microsoft.PythonTools.Analysis {
 
             var cwd = Environment.CurrentDirectory;
 
+#if DEBUG
             if (options.ContainsKey("unittest")) {
                 AssertListener.Initialize();
             }
+#endif
             if (options.ContainsKey("interactive")) {
                 interactive = true;
             }
@@ -1486,6 +1490,7 @@ namespace Microsoft.PythonTools.Analysis {
             TraceInformation(message, args);
         }
 
+#if DEBUG
         class AssertListener : TraceListener {
             private AssertListener() {
             }
@@ -1580,5 +1585,6 @@ namespace Microsoft.PythonTools.Analysis {
             public override void Write(string message) {
             }
         }
+#endif
     }
 }

--- a/Python/Tests/Analysis/CompletionDBTest.cs
+++ b/Python/Tests/Analysis/CompletionDBTest.cs
@@ -166,6 +166,7 @@ namespace PythonToolsTests {
                 "/version", "2.7",
                 "/outdir", outputPath,
                 "/indir", CompletionDB,
+                "/unittest",
                 "/log", "AnalysisLog.txt")) {
                 output.Wait();
                 Console.WriteLine("* Stdout *");
@@ -210,6 +211,7 @@ namespace PythonToolsTests {
                 "/version", "2.7",
                 "/outdir", outputPath,
                 "/indir", CompletionDB,
+                "/unittest",
                 "/log", "AnalysisLog.txt")) {
                 output.Wait();
                 Console.WriteLine("* Stdout *");


### PR DESCRIPTION
Copied parts of our existing AssertListener (test framework parts removed since we can't access them from here)
