### PR TITLE
Fixes nonlocal and global names not being resolved for refactor-rename.

### DIFF
--- a/Python/Product/Analysis/Parsing/Ast/GlobalStatement.cs
+++ b/Python/Product/Analysis/Parsing/Ast/GlobalStatement.cs
@@ -16,6 +16,7 @@
 
 using System.Collections.Generic;
 using System.Text;
+using Microsoft.PythonTools.Infrastructure;
 
 namespace Microsoft.PythonTools.Parsing.Ast {
     public class GlobalStatement : Statement {
@@ -31,15 +32,18 @@ namespace Microsoft.PythonTools.Parsing.Ast {
 
         public override void Walk(PythonWalker walker) {
             if (walker.Walk(this)) {
+                foreach (var n in _names.MaybeEnumerate()) {
+                    n?.Walk(walker);
+                }
             }
             walker.PostWalk(this);
         }
 
         internal override void AppendCodeStringStmt(StringBuilder res, PythonAst ast, CodeFormattingOptions format) {
-            var namesWhiteSpace = this.GetNamesWhiteSpace(ast);            
+            var namesWhiteSpace = this.GetNamesWhiteSpace(ast);
 
             if (namesWhiteSpace != null) {
-                ListExpression.AppendItems(res, ast, format, "global", "", this, Names.Count, (i, sb) => { 
+                ListExpression.AppendItems(res, ast, format, "global", "", this, Names.Count, (i, sb) => {
                     sb.Append(namesWhiteSpace[i]);
                     Names[i].AppendCodeString(res, ast, format);
                 });

--- a/Python/Product/Analysis/Parsing/Ast/NonlocalStatement.cs
+++ b/Python/Product/Analysis/Parsing/Ast/NonlocalStatement.cs
@@ -16,6 +16,7 @@
 
 using System.Collections.Generic;
 using System.Text;
+using Microsoft.PythonTools.Infrastructure;
 
 namespace Microsoft.PythonTools.Parsing.Ast {
 
@@ -32,6 +33,9 @@ namespace Microsoft.PythonTools.Parsing.Ast {
 
         public override void Walk(PythonWalker walker) {
             if (walker.Walk(this)) {
+                foreach (var n in _names.MaybeEnumerate()) {
+                    n?.Walk(walker);
+                }
             }
             walker.PostWalk(this);
         }

--- a/Python/Tests/Analysis/ExpressionFinderTests.cs
+++ b/Python/Tests/Analysis/ExpressionFinderTests.cs
@@ -147,6 +147,8 @@ C().fff", GetExpressionOptions.Evaluate);
         public void FindExpressionsForRename() {
             var code = Parse(@"class C(object):
     def f(a):
+        global a
+        nonlocal a
         return a
 
 b = C().f(1)
@@ -169,12 +171,20 @@ b = C().f(1)
             AssertExpr(code, 3, 16, "a");
             AssertExpr(code, 3, 17, "a");
 
-            AssertExpr(code, 5, 5, "C");
-            AssertExpr(code, 5, 6, "C");
-            AssertNoExpr(code, 5, 7);
-            AssertExpr(code, 5, 9, "f");
-            AssertExpr(code, 5, 10, "f");
-            AssertNoExpr(code, 5, 11);
+            AssertNoExpr(code, 4, 17);
+            AssertExpr(code, 4, 18, "a");
+            AssertExpr(code, 4, 19, "a");
+
+            AssertNoExpr(code, 5, 15);
+            AssertExpr(code, 5, 16, "a");
+            AssertExpr(code, 5, 17, "a");
+
+            AssertExpr(code, 7, 5, "C");
+            AssertExpr(code, 7, 6, "C");
+            AssertNoExpr(code, 7, 7);
+            AssertExpr(code, 7, 9, "f");
+            AssertExpr(code, 7, 10, "f");
+            AssertNoExpr(code, 7, 11);
         }
 
 


### PR DESCRIPTION
Spotted while reproing #378 