### PR TITLE
NRE in SendToReplCommand

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Commands/SendToReplCommand.cs
+++ b/Python/Product/PythonTools/PythonTools/Commands/SendToReplCommand.cs
@@ -151,7 +151,7 @@ namespace Microsoft.PythonTools.Commands {
 
         public override int? EditFilterQueryStatus(ref VisualStudio.OLE.Interop.OLECMD cmd, IntPtr pCmdText) {
             var activeView = CommonPackage.GetActiveTextView(_serviceProvider);
-            var empty = activeView.Selection.IsEmpty;
+            
             Intellisense.VsProjectAnalyzer analyzer;
             if (activeView != null && (analyzer = activeView.GetAnalyzerAtCaret(_serviceProvider)) != null) {
 


### PR DESCRIPTION
Fix #3331 : removing the line where the NRE occurred. The result of that check is never used.
Testing this process out with a NRE fix.