### PR TITLE
Fixes #499 Out of memory while editing

### DIFF
--- a/Python/Product/Analysis/AnalysisUnit.cs
+++ b/Python/Product/Analysis/AnalysisUnit.cs
@@ -51,7 +51,7 @@ namespace Microsoft.PythonTools.Analysis {
         internal static AnalysisUnit EvalUnit = new AnalysisUnit(null, null, null, true);
 
         internal AnalysisUnit(ScopeStatement ast, InterpreterScope scope)
-            : this(ast, (ast != null ? ast.GlobalParent : null), scope, false) {
+            : this(ast, ast?.GlobalParent, scope, false) {
         }
 
         internal AnalysisUnit(Node ast, PythonAst tree, InterpreterScope scope, bool forEval) {
@@ -356,6 +356,10 @@ namespace Microsoft.PythonTools.Analysis {
 
             return new LocationInfo(ProjectEntry.FilePath, span.Start.Line, span.Start.Column, span.End.Line, span.End.Column);
         }
+
+        internal virtual ILocationResolver AlternateResolver => null;
+
+        ILocationResolver ILocationResolver.GetAlternateResolver() => AlternateResolver;
     }
 
     /// <summary>

--- a/Python/Product/Analysis/Analyzer/FunctionAnalysisUnit.cs
+++ b/Python/Product/Analysis/Analyzer/FunctionAnalysisUnit.cs
@@ -215,11 +215,8 @@ namespace Microsoft.PythonTools.Analysis.Analyzer {
             Enqueue();
         }
 
-        public override IVersioned DependencyProject {
-            get {
-                return _agg;
-            }
-        }
+        public override IVersioned DependencyProject => _agg;
+        internal override ILocationResolver AlternateResolver => _originalUnit;
 
         internal override bool UpdateParameters(ArgumentSet callArgs, bool enqueue = true) {
             var defScope = _originalUnit.Scope;

--- a/Python/Product/Analysis/EncodedLocation.cs
+++ b/Python/Product/Analysis/EncodedLocation.cs
@@ -15,6 +15,7 @@
 // permissions and limitations under the License.
 
 using System;
+using System.Diagnostics;
 
 namespace Microsoft.PythonTools.Analysis {
     /// <summary>
@@ -42,6 +43,11 @@ namespace Microsoft.PythonTools.Analysis {
             if (resolver == null && !(location is LocationInfo)) {
                 throw new ArgumentNullException(nameof(resolver));
             }
+
+            for (var r = resolver; r != null; r = r.GetAlternateResolver()) {
+                resolver = r;
+            }
+            Debug.Assert(resolver != null);
 
             Resolver = resolver;
             Location = location;

--- a/Python/Product/Analysis/ILocationResolver.cs
+++ b/Python/Product/Analysis/ILocationResolver.cs
@@ -27,5 +27,11 @@ namespace Microsoft.PythonTools.Analysis {
     /// </summary>
     interface ILocationResolver {
         LocationInfo ResolveLocation(object location);
+
+        /// <summary>
+        /// Returns an alternate resolver, or <c>null</c> if this is the
+        /// best resolver to use.
+        /// </summary>
+        ILocationResolver GetAlternateResolver();
     }
 }

--- a/Python/Product/Analysis/LocationInfo.cs
+++ b/Python/Product/Analysis/LocationInfo.cs
@@ -90,6 +90,8 @@ namespace Microsoft.PythonTools.Analysis {
             return this;
         }
 
+        ILocationResolver ILocationResolver.GetAlternateResolver() => null;
+
         #endregion
     }
 }


### PR DESCRIPTION
Fixes #499 Out of memory while editing
Prevents CalledFunctionAnalysisUnit being used as location resolvers.