### PR TITLE
VirtualEnvUITests fixes

### DIFF
--- a/Python/Product/VSInterpreters/PipPackageManager.cs
+++ b/Python/Product/VSInterpreters/PipPackageManager.cs
@@ -184,8 +184,24 @@ namespace Microsoft.PythonTools.Interpreter {
                 )) {
                     try {
                         IsReady = (await proc == 0);
+#if DEBUG
+                        if (!IsReady) {
+                            Trace.WriteLine("import pip failed");
+                            Trace.WriteLine("stdout:");
+                            foreach (var line in proc.StandardOutputLines) {
+                                Trace.WriteLine(line);
+                            }
+                            Trace.WriteLine("stderr:");
+                            foreach (var line in proc.StandardErrorLines) {
+                                Trace.WriteLine(line);
+                            }
+                        }
+#endif
                     } catch (OperationCanceledException) {
                         IsReady = false;
+#if DEBUG
+                        Trace.WriteLine("import pip cancelled");
+#endif
                         return;
                     }
                 }

--- a/Python/Tests/Core.UI/VirtualEnvUITests.cs
+++ b/Python/Tests/Core.UI/VirtualEnvUITests.cs
@@ -115,8 +115,11 @@ namespace PythonToolsUITests {
                 var env = app.CreateVirtualEnvironment(project, out envName);
                 env.Select();
 
+                // CreateVirtualEnvironment only waits for the environment node.
+                // Give it time here to install the package(s).
                 app.SolutionExplorerTreeView.WaitForChildOfProject(
                     project,
+                    TimeSpan.FromSeconds(30),
                     Strings.Environments,
                     envName,
                     TestPackageDisplay


### PR DESCRIPTION
InstallUninstallPackage, InstallGenerateRequirementsTxt, CreateInstallRequirementsTxt have been failing consistently on the test machine, all in AbortIfNotReady like this:
```
Test method PythonToolsUITestsRunner.VirtualEnvUITests.CreateInstallRequirementsTxt threw exception: 
TestRunnerInterop.TestFailedException: AssertFailedException: Assert.Fail failed. Unhandled exception in Microsoft.PythonTools.Project.AddVirtualEnvironmentOperation.Run (E:\A\_work\15\s\Python\Product\PythonTools\PythonTools\Project\AddVirtualEnvironmentOperation.cs:113)
System.InvalidOperationException: Operation cannot be started because the environment is not configured.
at Microsoft.PythonTools.Interpreter.PipPackageManager.<AbortIfNotReady>d__24.MoveNext()
```

Not sure the additional logging will tell us anything we don't know, it will probably just print out the import error, but I don't have a better idea.

The other change, in CreateInstallRequirementsTxt, was needed for the test to pass locally.