### PR TITLE
Reducing memory leaks

### DIFF
--- a/Python/Product/Analysis/AnalysisUnit.cs
+++ b/Python/Product/Analysis/AnalysisUnit.cs
@@ -362,63 +362,14 @@ namespace Microsoft.PythonTools.Analysis {
         ILocationResolver ILocationResolver.GetAlternateResolver() => AlternateResolver;
     }
 
-    /// <summary>
-    /// Handles the re-evaluation of a base class when we have a deferred variable lookup.
-    /// 
-    /// For each base class which a class inherits from we create a new ClassBaseAnalysisUnit.  
-    /// 
-    /// We use this AnalysisUnit for the evaulation of the base class.  The ClassBaseAU is setup
-    /// to have the same set of scopes as the classes outer (defining) analysis unit.  We then
-    /// evaluate the base class inside of this unit.  If any of our dependencies change we will 
-    /// then re-evaluate our base class, and we will also re-evaluate our outer unit as well.
-    /// </summary>
-    class ClassBaseAnalysisUnit : AnalysisUnit {
-        private readonly Expression _baseClassNode;
-        private readonly AnalysisUnit _outerUnit;
-        private readonly int _indexInBasesList;
-
-        public ClassBaseAnalysisUnit(ClassDefinition node, InterpreterScope scope, int indexInBasesList, Expression baseClassNode, AnalysisUnit outerUnit)
-            : base(node, scope) {
-            _indexInBasesList = indexInBasesList;
-            _outerUnit = outerUnit;
-            _baseClassNode = baseClassNode;
-        }
-
-        internal override void AnalyzeWorker(DDG ddg, CancellationToken cancel) {
-            ddg.SetCurrentUnit(this);
-
-            InterpreterScope scope;
-            if (!ddg.Scope.TryGetNodeScope(Ast, out scope)) {
-                return;
-            }
-
-            var classInfo = ((ClassScope)scope).Class;
-            var bases = ClassAnalysisUnit.EvaluateBaseClass(
-                ddg,
-                classInfo,
-                _indexInBasesList,
-                _baseClassNode
-            );
-            classInfo.SetBase(_indexInBasesList, bases);
-
-            _outerUnit.Enqueue();
-        }
-    }
-
     class ClassAnalysisUnit : AnalysisUnit {
         private readonly AnalysisUnit _outerUnit;
-        private readonly ClassBaseAnalysisUnit[] _baseEvals;
 
         public ClassAnalysisUnit(ClassDefinition node, InterpreterScope declScope, AnalysisUnit outerUnit)
             : base(node, new ClassScope(new ClassInfo(node, outerUnit), node, declScope)) {
 
             ((ClassScope)Scope).Class.SetAnalysisUnit(this);
             _outerUnit = outerUnit;
-
-            _baseEvals = new ClassBaseAnalysisUnit[node.Bases.Count];
-            for (int i = 0; i < node.Bases.Count; i++) {
-                _baseEvals[i] = new ClassBaseAnalysisUnit(node, outerUnit.Scope, i, node.Bases[i].Expression, this);
-            }
 
             AnalysisLog.NewUnit(this);
         }
@@ -448,23 +399,17 @@ namespace Microsoft.PythonTools.Analysis {
                 for (int i = 0; i < Ast.Bases.Count; i++) {
                     var baseClassArg = Ast.Bases[i];
 
-                    ddg.SetCurrentUnit(_baseEvals[i]);
+                    if (baseClassArg.Name == null) {
+                        bases.Add(EvaluateBaseClass(ddg, classInfo, i, baseClassArg.Expression));
 
-                    if (baseClassArg.Name != null) {
-                        if (baseClassArg.Name == "metaclass") {
-                            var metaClass = baseClassArg.Expression;
-                            metaClass.Walk(ddg);
-                            var metaClassValue = ddg._eval.Evaluate(metaClass);
-                            if (metaClassValue.Count > 0) {
-                                classInfo.GetOrCreateMetaclassVariable().AddTypes(_outerUnit, metaClassValue);
-                            }
+                    } else if (baseClassArg.Name == "metaclass") {
+                        var metaClass = baseClassArg.Expression;
+                        metaClass.Walk(ddg);
+                        var metaClassValue = ddg._eval.Evaluate(metaClass);
+                        if (metaClassValue.Count > 0) {
+                            classInfo.GetOrCreateMetaclassVariable().AddTypes(_outerUnit, metaClassValue);
                         }
-                        continue;
                     }
-
-                    var baseExpr = baseClassArg.Expression;
-                    var baseSet = EvaluateBaseClass(ddg, classInfo, i, baseExpr);
-                    bases.Add(baseSet);
                 }
             }
 

--- a/Python/Product/Analysis/Analyzer/DependencyInfo.cs
+++ b/Python/Product/Analysis/Analyzer/DependencyInfo.cs
@@ -134,6 +134,10 @@ namespace Microsoft.PythonTools.Analysis.Analyzer {
         static bool TAKE_COPIES = false;
 
         public bool AddType(AnalysisValue ns) {
+            if (!ns.IsCurrent) {
+                return false;
+            }
+
             bool wasChanged;
             IAnalysisSet prev;
             if (TAKE_COPIES) {
@@ -141,7 +145,11 @@ namespace Microsoft.PythonTools.Analysis.Analyzer {
             } else {
                 prev = _types;
             }
-            _types = prev.Add(ns, out wasChanged);
+            if (prev.Any(av => !av.IsCurrent)) {
+                _types = AnalysisSet.Create(prev.Where(av => av.IsCurrent), prev.Comparer).Add(ns, out wasChanged);
+            } else {
+                _types = prev.Add(ns, out wasChanged);
+            }
 #if FULL_VALIDATION
             _changeCount += wasChanged ? 1 : 0;
             // The value doesn't mean anything, we just want to know if a variable is being

--- a/Python/Product/Analysis/Values/ClassInfo.cs
+++ b/Python/Product/Analysis/Values/ClassInfo.cs
@@ -839,6 +839,9 @@ namespace Microsoft.PythonTools.Analysis.Values {
         }
 
         public IAnalysisSet GetMemberNoReferences(Node node, AnalysisUnit unit, string name, bool addRef = true) {
+            if (addRef) {
+                AddDependency(unit);
+            }
             return GetMemberFromMroNoReferences(this, node, unit, name, addRef);
         }
 

--- a/Python/Product/Analysis/Values/FunctionInfo.cs
+++ b/Python/Product/Analysis/Values/FunctionInfo.cs
@@ -725,6 +725,15 @@ namespace Microsoft.PythonTools.Analysis.Values {
             return klass.Contains(ProjectState.ClassInfos[BuiltinTypeId.Function]);
         }
 
+        public override bool Equals(object obj) {
+            if (obj is FunctionInfo fi) {
+                return fi.FunctionDefinition == FunctionDefinition;
+            }
+            return false;
+        }
+
+        public override int GetHashCode() => FunctionDefinition.GetHashCode();
+
         internal override bool UnionEquals(AnalysisValue av, int strength) {
             if (strength >= MergeStrength.ToObject) {
                 return av is FunctionInfo || av is BuiltinFunctionInfo || av == ProjectState.ClassInfos[BuiltinTypeId.Function].Instance;

--- a/Python/Product/Analysis/Values/IteratorInfo.cs
+++ b/Python/Product/Analysis/Values/IteratorInfo.cs
@@ -117,11 +117,13 @@ namespace Microsoft.PythonTools.Analysis.Values {
     internal class SingleIteratorValue : BaseIteratorValue {
         internal readonly VariableDef _indexTypes;
         private readonly IPythonProjectEntry _declModule;
+        private readonly int _declVersion;
 
         public SingleIteratorValue(VariableDef indexTypes, BuiltinClassInfo iterType, IPythonProjectEntry declModule)
             : base(iterType) {
             _indexTypes = indexTypes;
             _declModule = declModule;
+            _declVersion = _declModule.AnalysisVersion;
         }
 
         public override IPythonProjectEntry DeclaringModule {
@@ -129,6 +131,8 @@ namespace Microsoft.PythonTools.Analysis.Values {
                 return _declModule;
             }
         }
+
+        public override int DeclaringVersion => _declVersion;
 
         protected override IAnalysisSet IteratorNext(Node node, Analysis.AnalysisUnit unit, IAnalysisSet[] args, NameExpression[] keywordArgNames) {
             return _indexTypes.GetTypesNoCopy(unit, DeclaringModule);

--- a/Python/Product/Analysis/Values/PartialFunctionInfo.cs
+++ b/Python/Product/Analysis/Values/PartialFunctionInfo.cs
@@ -26,21 +26,20 @@ namespace Microsoft.PythonTools.Analysis.Values {
         private readonly IAnalysisSet[] _args;
         private readonly NameExpression[] _keywordArgNames;
         private readonly IPythonProjectEntry _declProjEntry;
+        private readonly int _declVersion;
         private IAnalysisSet _argsTuple;
         private IAnalysisSet _keywordsDict;
 
         public PartialFunctionInfo(ProjectEntry declProjEntry, IAnalysisSet function, IAnalysisSet[] args, NameExpression[] keywordArgNames) {
             _declProjEntry = declProjEntry;
+            _declVersion = _declProjEntry.AnalysisVersion;
             _function = function;
             _args = args;
             _keywordArgNames = keywordArgNames;
         }
 
-        public override IPythonProjectEntry DeclaringModule {
-            get {
-                return _declProjEntry;
-            }
-        }
+        public override IPythonProjectEntry DeclaringModule => _declProjEntry;
+        public override int DeclaringVersion => _declVersion;
 
         public override IAnalysisSet Call(Node node, AnalysisUnit unit, IAnalysisSet[] args, NameExpression[] keywordArgNames) {
             var newArgs = _args.Take(_args.Length - _keywordArgNames.Length)

--- a/Python/Product/Analysis/Values/SuperInfo.cs
+++ b/Python/Product/Analysis/Values/SuperInfo.cs
@@ -85,6 +85,8 @@ namespace Microsoft.PythonTools.Analysis.Values {
                 return AnalysisSet.Empty;
             }
 
+            mro.AddDependency(unit);
+
             // First item in MRO list is always the class itself.
             var member = Values.Mro.GetMemberFromMroNoReferences(mro.Skip(1), node, unit, name, addRef: true);
             if (member == null) {

--- a/Python/Tests/Analysis/AnalysisTest.cs
+++ b/Python/Tests/Analysis/AnalysisTest.cs
@@ -6680,6 +6680,23 @@ def h(x): return g(x)";
             Assert.AreEqual(1, g.References.Count());
         }
 
+        [TestMethod, Priority(0)]
+        public void CrossModuleBaseClasses() {
+            var analyzer = CreateAnalyzer();
+            var entryA = analyzer.AddModule("A", @"class ClsA(object): pass");
+            var entryB = analyzer.AddModule("B", @"from A import ClsA
+class ClsB(ClsA): pass
+
+x = ClsB.x");
+            analyzer.WaitForAnalysis();
+            analyzer.AssertIsInstance(entryB, "x");
+
+            entryA.Parse(entryA.Tree.LanguageVersion, @"class ClsA(object): x = 123");
+            entryA.Analyze(CancellationToken.None, true);
+            analyzer.WaitForAnalysis();
+            analyzer.AssertIsInstance(entryB, "x", BuiltinTypeId.Int);
+        }
+
         #endregion
 
         #region Helpers


### PR DESCRIPTION
Work towards #3298
Improves memory usage by better clearing out old values.
Fixes some values that were not managing their version properly.
Ensures correct MRO references are created.

This is certainly not all of the leakage we can see in #3298, but it looks like a lot of it. I'll leave that bug open as we continue working through reductions.