### PR TITLE
Experimental conda support

### DIFF
--- a/Python/Product/Analysis/Interpreter/IPackageManager.cs
+++ b/Python/Product/Analysis/Interpreter/IPackageManager.cs
@@ -52,19 +52,19 @@ namespace Microsoft.PythonTools.Interpreter {
         event EventHandler IsReadyChanged;
 
         /// <summary>
-        /// Name to display for the extension in the environments window.
+        /// Localized name to display for the extension in the environments window.
         /// Example: 'Packages (PyPI)'
         /// </summary>
         string ExtensionDisplayName { get; }
 
         /// <summary>
-        /// Name of the index where packages are fetched from.
+        /// Localized name of the index where packages are fetched from.
         /// Example: 'PyPI'
         /// </summary>
         string IndexDisplayName { get; }
 
         /// <summary>
-        /// Watermark for the search query text box.
+        /// Localized watermark text for the search query text box.
         /// Example: 'Search PyPI and installed packages'
         /// </summary>
         string SearchHelpText { get; }
@@ -78,7 +78,7 @@ namespace Microsoft.PythonTools.Interpreter {
         /// <summary>
         /// Returns if the specified package is allowed to be uninstalled.
         /// </summary>
-        bool CanBeUninstalled(PackageSpec package);
+        bool CanUninstall(PackageSpec package);
 
         /// <summary>
         /// Prepares the package manager for use. This only needs to be called

--- a/Python/Product/Analysis/Interpreter/IPackageManager.cs
+++ b/Python/Product/Analysis/Interpreter/IPackageManager.cs
@@ -52,6 +52,35 @@ namespace Microsoft.PythonTools.Interpreter {
         event EventHandler IsReadyChanged;
 
         /// <summary>
+        /// Name to display for the extension in the environments window.
+        /// Example: 'Packages (PyPI)'
+        /// </summary>
+        string ExtensionDisplayName { get; }
+
+        /// <summary>
+        /// Name of the index where packages are fetched from.
+        /// Example: 'PyPI'
+        /// </summary>
+        string IndexDisplayName { get; }
+
+        /// <summary>
+        /// Watermark for the search query text box.
+        /// Example: 'Search PyPI and installed packages'
+        /// </summary>
+        string SearchHelpText { get; }
+
+        /// <summary>
+        /// Returns a description for the command that appears in search result.
+        /// Example: 'pip install mypackage from PyPI'
+        /// </summary>
+        string GetInstallCommandDisplayName(string searchQuery);
+
+        /// <summary>
+        /// Returns if the specified package is allowed to be uninstalled.
+        /// </summary>
+        bool CanBeUninstalled(PackageSpec package);
+
+        /// <summary>
         /// Prepares the package manager for use. This only needs to be called
         /// if <see cref="IsReady"/> is false. After successful completion,
         /// <see cref="IsReady"/> should be true.

--- a/Python/Product/Analysis/Interpreter/NoPackageManager.cs
+++ b/Python/Product/Analysis/Interpreter/NoPackageManager.cs
@@ -28,10 +28,20 @@ namespace Microsoft.PythonTools.Interpreter {
         public bool IsReady => true;
         public IPythonInterpreterFactory Factory => null;
 
+        public string ExtensionDisplayName => string.Empty;
+
+        public string IndexDisplayName => string.Empty;
+
+        public string SearchHelpText => throw new NotImplementedException();
+
         public event EventHandler InstalledFilesChanged { add { } remove { } }
         public event EventHandler InstalledPackagesChanged { add { } remove { } }
 
         public event EventHandler IsReadyChanged { add { } remove { } }
+
+        public bool CanBeUninstalled(PackageSpec package) {
+            return true;
+        }
 
         public Task<PackageSpec> GetInstalledPackageAsync(string name, CancellationToken cancellationToken) {
             return Task.FromResult(new PackageSpec());
@@ -79,6 +89,10 @@ namespace Microsoft.PythonTools.Interpreter {
 
         public Task<PackageSpec> GetInstallablePackageAsync(PackageSpec package, CancellationToken cancellationToken) {
             return Task.FromResult(new PackageSpec());
+        }
+
+        public string GetInstallCommandDisplayName(string searchQuery) {
+            throw new NotImplementedException();
         }
     }
 }

--- a/Python/Product/Analysis/Interpreter/NoPackageManager.cs
+++ b/Python/Product/Analysis/Interpreter/NoPackageManager.cs
@@ -39,7 +39,7 @@ namespace Microsoft.PythonTools.Interpreter {
 
         public event EventHandler IsReadyChanged { add { } remove { } }
 
-        public bool CanBeUninstalled(PackageSpec package) {
+        public bool CanUninstall(PackageSpec package) {
             return true;
         }
 
@@ -92,7 +92,7 @@ namespace Microsoft.PythonTools.Interpreter {
         }
 
         public string GetInstallCommandDisplayName(string searchQuery) {
-            throw new NotImplementedException();
+            return string.Empty;
         }
     }
 }

--- a/Python/Product/Common/Strings.Designer.cs
+++ b/Python/Product/Common/Strings.Designer.cs
@@ -702,16 +702,7 @@ namespace Microsoft.PythonTools {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &quot;conda install {0}&quot;.
-        /// </summary>
-        public static string CondaExtensionCondaInstall {
-            get {
-                return ResourceManager.GetString("CondaExtensionCondaInstall", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to  from {0}.
+        ///   Looks up a localized string similar to conda install {0} from Conda.
         /// </summary>
         public static string CondaExtensionCondaInstallFrom {
             get {
@@ -3637,16 +3628,7 @@ namespace Microsoft.PythonTools {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &quot;pip install {0}&quot;.
-        /// </summary>
-        public static string PipExtensionPipInstall {
-            get {
-                return ResourceManager.GetString("PipExtensionPipInstall", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to  from {0}.
+        ///   Looks up a localized string similar to pip install {0} from PyPI.
         /// </summary>
         public static string PipExtensionPipInstallFrom {
             get {

--- a/Python/Product/Common/Strings.Designer.cs
+++ b/Python/Product/Common/Strings.Designer.cs
@@ -693,6 +693,51 @@ namespace Microsoft.PythonTools {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Conda.
+        /// </summary>
+        public static string CondaDefaultIndexName {
+            get {
+                return ResourceManager.GetString("CondaDefaultIndexName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &quot;conda install {0}&quot;.
+        /// </summary>
+        public static string CondaExtensionCondaInstall {
+            get {
+                return ResourceManager.GetString("CondaExtensionCondaInstall", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to  from {0}.
+        /// </summary>
+        public static string CondaExtensionCondaInstallFrom {
+            get {
+                return ResourceManager.GetString("CondaExtensionCondaInstallFrom", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Packages (Conda).
+        /// </summary>
+        public static string CondaExtensionDisplayName {
+            get {
+                return ResourceManager.GetString("CondaExtensionDisplayName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Search Conda and installed packages.
+        /// </summary>
+        public static string CondaExtensionSearchCondaLabel {
+            get {
+                return ResourceManager.GetString("CondaExtensionSearchCondaLabel", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Cannot create thread in debuggee process.
         /// </summary>
         public static string ConnErrorMessages_CannotInjectThread {
@@ -3570,6 +3615,51 @@ namespace Microsoft.PythonTools {
         public static string ParameterClassificationType {
             get {
                 return ResourceManager.GetString("ParameterClassificationType", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to PyPI.
+        /// </summary>
+        public static string PipDefaultIndexName {
+            get {
+                return ResourceManager.GetString("PipDefaultIndexName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Packages (PyPI).
+        /// </summary>
+        public static string PipExtensionDisplayName {
+            get {
+                return ResourceManager.GetString("PipExtensionDisplayName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &quot;pip install {0}&quot;.
+        /// </summary>
+        public static string PipExtensionPipInstall {
+            get {
+                return ResourceManager.GetString("PipExtensionPipInstall", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to  from {0}.
+        /// </summary>
+        public static string PipExtensionPipInstallFrom {
+            get {
+                return ResourceManager.GetString("PipExtensionPipInstallFrom", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Search PyPI and installed packages.
+        /// </summary>
+        public static string PipExtensionSearchPyPILabel {
+            get {
+                return ResourceManager.GetString("PipExtensionSearchPyPILabel", resourceCulture);
             }
         }
         

--- a/Python/Product/Common/Strings.resx
+++ b/Python/Product/Common/Strings.resx
@@ -2128,38 +2128,34 @@ Expand selection to the full expression?</value>
   </data>
   <data name="PipDefaultIndexName" xml:space="preserve">
     <value>PyPI</value>
+    <comment>Do not translate</comment>
   </data>
   <data name="PipExtensionDisplayName" xml:space="preserve">
     <value>Packages (PyPI)</value>
+    <comment>Do not translate 'PyPI'</comment>
   </data>
   <data name="CondaDefaultIndexName" xml:space="preserve">
     <value>Conda</value>
+    <comment>Do not translate</comment>
   </data>
   <data name="CondaExtensionDisplayName" xml:space="preserve">
     <value>Packages (Conda)</value>
-  </data>
-  <data name="PipExtensionPipInstall" xml:space="preserve">
-    <value>"pip install {0}"</value>
-    <comment>Do not translate.
-{0} is the search query</comment>
+    <comment>Do not translate 'Conda'</comment>
   </data>
   <data name="PipExtensionPipInstallFrom" xml:space="preserve">
-    <value> from {0}</value>
-    <comment>{0} is name of package index. This string is appended to the string resource PipExtensionPipInstall</comment>
+    <value>pip install {0} from PyPI</value>
+    <comment>'pip install {0}' is a command-line that should not be translated. Do not translate 'PyPI'</comment>
   </data>
   <data name="PipExtensionSearchPyPILabel" xml:space="preserve">
     <value>Search PyPI and installed packages</value>
-  </data>
-  <data name="CondaExtensionCondaInstall" xml:space="preserve">
-    <value>"conda install {0}"</value>
-    <comment>Do not translate.
-{0} is the search query</comment>
+    <comment>Do not translate 'PyPI'</comment>
   </data>
   <data name="CondaExtensionCondaInstallFrom" xml:space="preserve">
-    <value> from {0}</value>
-    <comment>{0} is name of package index. This string is appended to the string resource CondaExtensionCondaInstall</comment>
+    <value>conda install {0} from Conda</value>
+    <comment>'conda install {0}' is a command-line that should not be translated. Do not translate 'Conda'</comment>
   </data>
     <data name="CondaExtensionSearchCondaLabel" xml:space="preserve">
     <value>Search Conda and installed packages</value>
+    <comment>Do not translate 'Conda'</comment>
   </data>
 </root>

--- a/Python/Product/Common/Strings.resx
+++ b/Python/Product/Common/Strings.resx
@@ -2126,4 +2126,40 @@ Expand selection to the full expression?</value>
   <data name="RegularExpressionClassificationType" xml:space="preserve">
     <value>Python Regular Expression</value>
   </data>
+  <data name="PipDefaultIndexName" xml:space="preserve">
+    <value>PyPI</value>
+  </data>
+  <data name="PipExtensionDisplayName" xml:space="preserve">
+    <value>Packages (PyPI)</value>
+  </data>
+  <data name="CondaDefaultIndexName" xml:space="preserve">
+    <value>Conda</value>
+  </data>
+  <data name="CondaExtensionDisplayName" xml:space="preserve">
+    <value>Packages (Conda)</value>
+  </data>
+  <data name="PipExtensionPipInstall" xml:space="preserve">
+    <value>"pip install {0}"</value>
+    <comment>Do not translate.
+{0} is the search query</comment>
+  </data>
+  <data name="PipExtensionPipInstallFrom" xml:space="preserve">
+    <value> from {0}</value>
+    <comment>{0} is name of package index. This string is appended to the string resource PipExtensionPipInstall</comment>
+  </data>
+  <data name="PipExtensionSearchPyPILabel" xml:space="preserve">
+    <value>Search PyPI and installed packages</value>
+  </data>
+  <data name="CondaExtensionCondaInstall" xml:space="preserve">
+    <value>"conda install {0}"</value>
+    <comment>Do not translate.
+{0} is the search query</comment>
+  </data>
+  <data name="CondaExtensionCondaInstallFrom" xml:space="preserve">
+    <value> from {0}</value>
+    <comment>{0} is name of package index. This string is appended to the string resource CondaExtensionCondaInstall</comment>
+  </data>
+    <data name="CondaExtensionSearchCondaLabel" xml:space="preserve">
+    <value>Search Conda and installed packages</value>
+  </data>
 </root>

--- a/Python/Product/EnvironmentsList/PipExtension.xaml
+++ b/Python/Product/EnvironmentsList/PipExtension.xaml
@@ -123,11 +123,7 @@
                                 Command="{x:Static l:PipExtension.InstallPackage}"
                                 CommandParameter="{Binding View.SearchQuery,Mode=OneWay}"
                                 Margin="3">
-                            <TextBlock>
-                                <!-- TODO: Localization - make this a single string if possible -->
-                                <Run Text="{Binding View.SearchQuery,Mode=OneWay,StringFormat={x:Static l:Resources.PipExtensionPipInstall}}" />
-                                <Run Text="{Binding IndexName,Mode=OneWay,StringFormat={x:Static l:Resources.PipExtensionPipInstallFrom}}" />
-                            </TextBlock>
+                            <TextBlock Text="{Binding View.InstallPackageText,Mode=OneWay}"/>
                         </Button>
                         <DataTemplate.Triggers>
                             <Trigger SourceName="InstallButton" Property="IsEnabled" Value="False">
@@ -196,7 +192,7 @@
                 <Setter Property="Padding" Value="2" />
                 <Setter Property="IsEnabled" Value="{Binding IsPipInstalled,Mode=OneWay}" />
                 <Setter Property="Text" Value="{Binding SearchQuery,UpdateSourceTrigger=PropertyChanged}" />
-                <Setter Property="AutomationProperties.Name" Value="{x:Static l:Resources.PipExtensionSearchPyPILabel}" />
+                <Setter Property="AutomationProperties.Name" Value="{Binding SearchWatermark,Mode=OneWay}" />
                 <Setter Property="Template">
                     <Setter.Value>
                         <ControlTemplate>
@@ -218,7 +214,7 @@
                                                     Command="{x:Static l:PipExtension.InstallPackage}"
                                                     CommandParameter="{Binding Text,RelativeSource={RelativeSource TemplatedParent}}" />
                                     </Grid.InputBindings>
-                                    
+
                                     <ScrollViewer Name="PART_ContentHost"
                                                   HorizontalScrollBarVisibility="Hidden"
                                                   VerticalScrollBarVisibility="Hidden" />
@@ -249,7 +245,7 @@
                                                Margin="8 2"
                                                IsHitTestVisible="False"
                                                Foreground="{DynamicResource {x:Static wpf:Controls.GrayTextKey}}"
-                                               Text="{x:Static l:Resources.PipExtensionSearchPyPILabel}">
+                                               Text="{Binding SearchWatermark,Mode=OneWay}">
                                         <TextBlock.Visibility>
                                             <MultiBinding Converter="{StaticResource VisibilityIfAll}">
                                                 <Binding Path="IsPipInstalled" Mode="OneWay"  />

--- a/Python/Product/EnvironmentsList/PipExtension.xaml.cs
+++ b/Python/Product/EnvironmentsList/PipExtension.xaml.cs
@@ -81,7 +81,7 @@ namespace Microsoft.PythonTools.EnvironmentsList {
 
         private void UninstallPackage_CanExecute(object sender, CanExecuteRoutedEventArgs e) {
             var view = e.Parameter as PipPackageView;
-            e.CanExecute = _provider.CanExecute && view != null && _provider._packageManager.CanBeUninstalled(view.Package);
+            e.CanExecute = _provider.CanExecute && view != null && _provider._packageManager.CanUninstall(view.Package);
             e.Handled = true;
         }
 

--- a/Python/Product/EnvironmentsList/PipExtensionProvider.cs
+++ b/Python/Product/EnvironmentsList/PipExtensionProvider.cs
@@ -26,11 +26,7 @@ namespace Microsoft.PythonTools.EnvironmentsList {
     public sealed class PipExtensionProvider : IEnvironmentViewExtension, IPackageManagerUI, IDisposable {
         private readonly IPythonInterpreterFactory _factory;
         internal readonly IPackageManager _packageManager;
-        private readonly Uri _index;
-        private readonly string _indexName;
         private FrameworkElement _wpfObject;
-
-        private PipPackageCache _cache;
 
         private readonly CancellationTokenSource _cancelAll = new CancellationTokenSource();
 
@@ -51,20 +47,13 @@ namespace Microsoft.PythonTools.EnvironmentsList {
         /// Display name of the index. Defaults to PyPI.
         /// </param>
         public PipExtensionProvider(
-            IPythonInterpreterFactory factory,
-            string index = null,
-            string indexName = null
+            IPythonInterpreterFactory factory
         ) {
             _factory = factory;
             _packageManager = _factory?.PackageManager;
             if (_packageManager == null) {
                 throw new NotSupportedException();
             }
-
-            if (!string.IsNullOrEmpty(index) && Uri.TryCreate(index, UriKind.Absolute, out _index)) {
-                _indexName = string.IsNullOrEmpty(indexName) ? _index.Host : indexName;
-            }
-            _cache = PipPackageCache.GetCache(_index, _indexName);
         }
 
         public void Dispose() {
@@ -77,11 +66,11 @@ namespace Microsoft.PythonTools.EnvironmentsList {
         }
 
         public string LocalizedDisplayName {
-            get { return _indexName ?? Resources.PipExtensionDisplayName; }
+            get { return _packageManager.ExtensionDisplayName; }
         }
 
         public string IndexName {
-            get { return _indexName ?? Resources.PipDefaultIndexName; }
+            get { return _packageManager.IndexDisplayName; }
         }
 
         public object HelpContent {
@@ -117,7 +106,7 @@ namespace Microsoft.PythonTools.EnvironmentsList {
                 return Array.Empty<PipPackageView>();
             }
 
-            return (await _cache.GetAllPackagesAsync(_cancelAll.Token))
+            return (await _packageManager.GetInstallablePackagesAsync(_cancelAll.Token))
                 .Where(p => p.IsValid)
                 .Select(p => new PipPackageView(_packageManager, p, false))
                 .ToArray();

--- a/Python/Product/EnvironmentsList/Resources.Designer.cs
+++ b/Python/Product/EnvironmentsList/Resources.Designer.cs
@@ -823,29 +823,11 @@ namespace Microsoft.PythonTools.EnvironmentsList {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to PyPI.
-        /// </summary>
-        public static string PipDefaultIndexName {
-            get {
-                return ResourceManager.GetString("PipDefaultIndexName", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Clear search filter.
         /// </summary>
         public static string PipExtensionClearSearchToolTip {
             get {
                 return ResourceManager.GetString("PipExtensionClearSearchToolTip", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Packages.
-        /// </summary>
-        public static string PipExtensionDisplayName {
-            get {
-                return ResourceManager.GetString("PipExtensionDisplayName", resourceCulture);
             }
         }
         
@@ -882,33 +864,6 @@ namespace Microsoft.PythonTools.EnvironmentsList {
         public static string PipExtensionInstallPipToolTip {
             get {
                 return ResourceManager.GetString("PipExtensionInstallPipToolTip", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to &quot;pip install {0}&quot;.
-        /// </summary>
-        public static string PipExtensionPipInstall {
-            get {
-                return ResourceManager.GetString("PipExtensionPipInstall", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to  from {0}.
-        /// </summary>
-        public static string PipExtensionPipInstallFrom {
-            get {
-                return ResourceManager.GetString("PipExtensionPipInstallFrom", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Search PyPI and installed packages.
-        /// </summary>
-        public static string PipExtensionSearchPyPILabel {
-            get {
-                return ResourceManager.GetString("PipExtensionSearchPyPILabel", resourceCulture);
             }
         }
         

--- a/Python/Product/EnvironmentsList/Resources.resx
+++ b/Python/Product/EnvironmentsList/Resources.resx
@@ -199,12 +199,6 @@
   <data name="NoDescription" xml:space="preserve">
     <value>(No description)</value>
   </data>
-  <data name="PipDefaultIndexName" xml:space="preserve">
-    <value>PyPI</value>
-  </data>
-  <data name="PipExtensionDisplayName" xml:space="preserve">
-    <value>Packages</value>
-  </data>
   <data name="PipExtensionHelpContent" xml:space="preserve">
     <value>These packages can be managed using your environment's package manager. Type in the search box to install new packages, or use the buttons on existing packages to update or remove them.</value>
   </data>
@@ -377,9 +371,6 @@
   <data name="PipExtensionClearSearchToolTip" xml:space="preserve">
     <value>Clear search filter</value>
   </data>
-  <data name="PipExtensionSearchPyPILabel" xml:space="preserve">
-    <value>Search PyPI and installed packages</value>
-  </data>
   <data name="PipExtensionInstallPipToolTip" xml:space="preserve">
     <value>Install the setuptools and pip packages from PyPI. These packages are required to use this panel.</value>
   </data>
@@ -389,15 +380,6 @@
   <data name="PipExtensionInstallLabel" xml:space="preserve">
     <value>Install {0}</value>
     <comment>{0} is package display name</comment>
-  </data>
-  <data name="PipExtensionPipInstall" xml:space="preserve">
-    <value>"pip install {0}"</value>
-    <comment>Do not translate.
-{0} is the search query</comment>
-  </data>
-  <data name="PipExtensionPipInstallFrom" xml:space="preserve">
-    <value> from {0}</value>
-    <comment>{0} is name of package index. This string is appended to the string resource PipExtensionPipInstall</comment>
   </data>
   <data name="PipPackageUnknownPackageSpec" xml:space="preserve">
     <value>(unknown)</value>

--- a/Python/Product/PythonTools/PythonTools/Options/ExperimentalOptions.cs
+++ b/Python/Product/PythonTools/PythonTools/Options/ExperimentalOptions.cs
@@ -25,16 +25,22 @@ namespace Microsoft.PythonTools.Options {
 
         public void Load() {
             NoDatabaseFactory = EO.GetNoDatabaseFactory();
+            AutoDetectCondaEnvironments = EO.GetAutoDetectCondaEnvironments();
+            UseCondaPackageManager = EO.GetUseCondaPackageManager();
             Changed?.Invoke(this, EventArgs.Empty);
         }
 
         public void Save() {
             EO.NoDatabaseFactory = NoDatabaseFactory;
+            EO.AutoDetectCondaEnvironments = AutoDetectCondaEnvironments;
+            EO.UseCondaPackageManager = UseCondaPackageManager;
             Changed?.Invoke(this, EventArgs.Empty);
         }
 
         public void Reset() {
             NoDatabaseFactory = false;
+            AutoDetectCondaEnvironments = false;
+            UseCondaPackageManager = false;
             Changed?.Invoke(this, EventArgs.Empty);
         }
 
@@ -45,5 +51,15 @@ namespace Microsoft.PythonTools.Options {
         /// without old-style completion databases.
         /// </summary>
         public bool NoDatabaseFactory { get; set; }
+
+        /// <summary>
+        /// True to auto detect all non-root conda environments on the machine.
+        /// </summary>
+        public bool AutoDetectCondaEnvironments { get; set; }
+
+        /// <summary>
+        /// True to use conda for package management when available.
+        /// </summary>
+        public bool UseCondaPackageManager { get; set; }
     }
 }

--- a/Python/Product/PythonTools/PythonTools/Options/PythonExperimentalOptionsControl.Designer.cs
+++ b/Python/Product/PythonTools/PythonTools/Options/PythonExperimentalOptionsControl.Designer.cs
@@ -27,6 +27,8 @@ namespace Microsoft.PythonTools.Options {
             this._noDatabaseFactory = new System.Windows.Forms.CheckBox();
             this.tableLayoutPanel2 = new System.Windows.Forms.TableLayoutPanel();
             this._mustRestartLabel = new System.Windows.Forms.Label();
+            this._condaPackageManager = new System.Windows.Forms.CheckBox();
+            this._condaEnvironments = new System.Windows.Forms.CheckBox();
             this.tableLayoutPanel2.SuspendLayout();
             this.SuspendLayout();
             // 
@@ -40,14 +42,28 @@ namespace Microsoft.PythonTools.Options {
             // tableLayoutPanel2
             // 
             resources.ApplyResources(this.tableLayoutPanel2, "tableLayoutPanel2");
+            this.tableLayoutPanel2.Controls.Add(this._condaEnvironments, 0, 1);
+            this.tableLayoutPanel2.Controls.Add(this._condaPackageManager, 0, 2);
             this.tableLayoutPanel2.Controls.Add(this._noDatabaseFactory, 0, 0);
-            this.tableLayoutPanel2.Controls.Add(this._mustRestartLabel, 0, 2);
+            this.tableLayoutPanel2.Controls.Add(this._mustRestartLabel, 0, 4);
             this.tableLayoutPanel2.Name = "tableLayoutPanel2";
             // 
             // _mustRestartLabel
             // 
             resources.ApplyResources(this._mustRestartLabel, "_mustRestartLabel");
             this._mustRestartLabel.Name = "_mustRestartLabel";
+            // 
+            // _condaPackageManager
+            // 
+            resources.ApplyResources(this._condaPackageManager, "_condaPackageManager");
+            this._condaPackageManager.Name = "_condaPackageManager";
+            this._condaPackageManager.UseVisualStyleBackColor = true;
+            // 
+            // _condaEnvironments
+            // 
+            resources.ApplyResources(this._condaEnvironments, "_condaEnvironments");
+            this._condaEnvironments.Name = "_condaEnvironments";
+            this._condaEnvironments.UseVisualStyleBackColor = true;
             // 
             // PythonExperimentalOptionsControl
             // 
@@ -67,5 +83,7 @@ namespace Microsoft.PythonTools.Options {
         private System.Windows.Forms.CheckBox _noDatabaseFactory;
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel2;
         private System.Windows.Forms.Label _mustRestartLabel;
+        private System.Windows.Forms.CheckBox _condaEnvironments;
+        private System.Windows.Forms.CheckBox _condaPackageManager;
     }
 }

--- a/Python/Product/PythonTools/PythonTools/Options/PythonExperimentalOptionsControl.cs
+++ b/Python/Product/PythonTools/PythonTools/Options/PythonExperimentalOptionsControl.cs
@@ -24,11 +24,15 @@ namespace Microsoft.PythonTools.Options {
         }
 
         internal void SyncControlWithPageSettings(PythonToolsService pyService) {
-            _noDatabaseFactory.Checked = pyService.ExperimentalOptions.NoDatabaseFactory; ;
+            _noDatabaseFactory.Checked = pyService.ExperimentalOptions.NoDatabaseFactory;
+            _condaEnvironments.Checked = pyService.ExperimentalOptions.AutoDetectCondaEnvironments;
+            _condaPackageManager.Checked = pyService.ExperimentalOptions.UseCondaPackageManager;
         }
 
         internal void SyncPageWithControlSettings(PythonToolsService pyService) {
             pyService.ExperimentalOptions.NoDatabaseFactory = _noDatabaseFactory.Checked;
+            pyService.ExperimentalOptions.AutoDetectCondaEnvironments = _condaEnvironments.Checked;
+            pyService.ExperimentalOptions.UseCondaPackageManager = _condaPackageManager.Checked;
         }
     }
 }

--- a/Python/Product/PythonTools/PythonTools/Options/PythonExperimentalOptionsControl.resx
+++ b/Python/Product/PythonTools/PythonTools/Options/PythonExperimentalOptionsControl.resx
@@ -151,7 +151,7 @@
     <value>tableLayoutPanel2</value>
   </data>
   <data name="&gt;&gt;_noDatabaseFactory.ZOrder" xml:space="preserve">
-    <value>0</value>
+    <value>2</value>
   </data>
   <data name="tableLayoutPanel2.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -160,6 +160,78 @@
     <value>GrowAndShrink</value>
   </data>
   <data name="tableLayoutPanel2.ColumnCount" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="_condaEnvironments.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Left</value>
+  </data>
+  <data name="_condaEnvironments.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="_condaEnvironments.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="_condaEnvironments.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 26</value>
+  </data>
+  <data name="_condaEnvironments.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>6, 3, 6, 3</value>
+  </data>
+  <data name="_condaEnvironments.Size" type="System.Drawing.Size, System.Drawing">
+    <value>221, 17</value>
+  </data>
+  <data name="_condaEnvironments.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="_condaEnvironments.Text" xml:space="preserve">
+    <value>Automatically detect Conda &amp;environments</value>
+  </data>
+  <data name="&gt;&gt;_condaEnvironments.Name" xml:space="preserve">
+    <value>_condaEnvironments</value>
+  </data>
+  <data name="&gt;&gt;_condaEnvironments.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;_condaEnvironments.Parent" xml:space="preserve">
+    <value>tableLayoutPanel2</value>
+  </data>
+  <data name="&gt;&gt;_condaEnvironments.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="_condaPackageManager.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Left</value>
+  </data>
+  <data name="_condaPackageManager.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="_condaPackageManager.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="_condaPackageManager.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 49</value>
+  </data>
+  <data name="_condaPackageManager.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>6, 3, 6, 3</value>
+  </data>
+  <data name="_condaPackageManager.Size" type="System.Drawing.Size, System.Drawing">
+    <value>315, 17</value>
+  </data>
+  <data name="_condaPackageManager.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="_condaPackageManager.Text" xml:space="preserve">
+    <value>Use Conda &amp;package manager when available (instead of Pip)</value>
+  </data>
+  <data name="&gt;&gt;_condaPackageManager.Name" xml:space="preserve">
+    <value>_condaPackageManager</value>
+  </data>
+  <data name="&gt;&gt;_condaPackageManager.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;_condaPackageManager.Parent" xml:space="preserve">
+    <value>tableLayoutPanel2</value>
+  </data>
+  <data name="&gt;&gt;_condaPackageManager.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
   <data name="_mustRestartLabel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
@@ -193,7 +265,7 @@
     <value>tableLayoutPanel2</value>
   </data>
   <data name="&gt;&gt;_mustRestartLabel.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>3</value>
   </data>
   <data name="tableLayoutPanel2.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
@@ -202,7 +274,7 @@
     <value>0, 0</value>
   </data>
   <data name="tableLayoutPanel2.RowCount" type="System.Int32, mscorlib">
-    <value>3</value>
+    <value>5</value>
   </data>
   <data name="tableLayoutPanel2.Size" type="System.Drawing.Size, System.Drawing">
     <value>381, 290</value>
@@ -223,7 +295,7 @@
     <value>0</value>
   </data>
   <data name="tableLayoutPanel2.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="_noDatabaseFactory" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_mustRestartLabel" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,Percent,100,AutoSize,20,Absolute,20,Absolute,20,Absolute,20,Absolute,20,Absolute,20" /&gt;&lt;/TableLayoutSettings&gt;</value>
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="_condaEnvironments" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_condaPackageManager" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_noDatabaseFactory" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_mustRestartLabel" Row="4" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,Percent,100,AutoSize,0,Absolute,20" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>

--- a/Python/Product/VSInterpreters/CondaEnvironmentFactoryConstants.cs
+++ b/Python/Product/VSInterpreters/CondaEnvironmentFactoryConstants.cs
@@ -1,0 +1,62 @@
+// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABLITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System;
+using System.Reflection;
+using System.Text.RegularExpressions;
+
+namespace Microsoft.PythonTools.Interpreter {
+    /// <summary>
+    /// Provides constants used to identify interpreters that are detected from
+    /// globally registered conda environments.
+    /// </summary>
+    public static class CondaEnvironmentFactoryConstants {
+        public const string ConsoleExecutable = "python.exe";
+        public const string WindowsExecutable = "pythonw.exe";
+        public const string LibrarySubPath = "lib";
+        public const string PathEnvironmentVariableName = "PYTHONPATH";
+
+        private static readonly Regex IdParser = new Regex(
+            "^(?<provider>.+?)\\|(?<company>.+?)\\|(?<tag>.+?)$",
+            RegexOptions.None,
+            TimeSpan.FromSeconds(1)
+        );
+
+        public static string GetInterpreterId(string company, string tag) {
+            return String.Join(
+                "|", 
+                CondaEnvironmentFactoryProvider.FactoryProviderName,
+                company,
+                tag
+            );
+        }
+
+        public static bool TryParseInterpreterId(string id, out string company, out string env) {
+            company = env = null;
+            try {
+                var m = IdParser.Match(id);
+                if (m.Success && m.Groups["provider"].Value == CondaEnvironmentFactoryProvider.FactoryProviderName) {
+                    company = m.Groups["company"].Value;
+                    env = m.Groups["env"].Value;
+                    return true;
+                }
+                return false;
+            } catch (RegexMatchTimeoutException) {
+                return false;
+            }
+        }
+    }
+}

--- a/Python/Product/VSInterpreters/CondaEnvironmentFactoryProvider.cs
+++ b/Python/Product/VSInterpreters/CondaEnvironmentFactoryProvider.cs
@@ -1,0 +1,372 @@
+// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABLITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using Microsoft.PythonTools.Infrastructure;
+using Newtonsoft.Json;
+
+namespace Microsoft.PythonTools.Interpreter {
+    /// <summary>
+    /// Detects interpreters in user-created conda environments.
+    /// </summary>
+    /// <remarks>
+    /// Uses %HOMEPATH%/.conda/environments.txt and `conda info --envs`.
+    /// </remarks>
+    [InterpreterFactoryId(FactoryProviderName)]
+    [Export(typeof(IPythonInterpreterFactoryProvider))]
+    [Export(typeof(CondaEnvironmentFactoryProvider))]
+    [PartCreationPolicy(CreationPolicy.Shared)]
+    class CondaEnvironmentFactoryProvider : IPythonInterpreterFactoryProvider {
+        private readonly Dictionary<string, PythonInterpreterInformation> _factories = new Dictionary<string, PythonInterpreterInformation>();
+        internal const string FactoryProviderName = "CondaEnv";
+        internal const string EnvironmentCompanyName = "CondaEnv";
+        private int _ignoreNotifications;
+        private bool _initialized;
+        private readonly CPythonInterpreterFactoryProvider _globalProvider;
+        private readonly bool _watchFileSystem;
+        private FileSystemWatcher _envsTxtWatcher;
+        private Timer _envsTxtWatcherTimer;
+        private string _environmentsTxtPath;
+
+        [ImportingConstructor]
+        public CondaEnvironmentFactoryProvider(
+            [Import] CPythonInterpreterFactoryProvider globalProvider,
+            [Import("Microsoft.VisualStudioTools.MockVsTests.IsMockVs", AllowDefault = true)] object isMockVs = null
+        ) {
+            _watchFileSystem = isMockVs == null;
+            _globalProvider = globalProvider;
+        }
+
+        private void EnsureInitialized() {
+            lock (this) {
+                if (!_initialized) {
+                    _initialized = true;
+                    _environmentsTxtPath = Path.Combine(
+                        Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+                        ".conda",
+                        "environments.txt"
+                    );
+
+                    DiscoverInterpreterFactories();
+
+                    if (_watchFileSystem) {
+                        // Watch the file %HOMEPATH%/.conda/Environments.txt which
+                        // is updated by conda after a new environment is created.
+                        var watchedPath = Path.GetDirectoryName(_environmentsTxtPath);
+                        if (Directory.Exists(watchedPath)) {
+                            try {
+                                _envsTxtWatcher = new FileSystemWatcher(watchedPath, "*.txt");
+                                _envsTxtWatcher.Changed += _envsTxtWatcher_Changed;
+                                _envsTxtWatcher.Created += _envsTxtWatcher_Changed;
+                                _envsTxtWatcher.EnableRaisingEvents = true;
+                                _envsTxtWatcherTimer = new Timer(_envsTxtWatcherTimer_Elapsed);
+                            } catch (ArgumentException) {
+                            } catch (IOException) {
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        private async void _envsTxtWatcherTimer_Elapsed(object state) {
+            try {
+                _envsTxtWatcherTimer.Change(Timeout.Infinite, Timeout.Infinite);
+            } catch (ObjectDisposedException) {
+            }
+
+            DiscoverInterpreterFactories();
+        }
+
+        private void _envsTxtWatcher_Changed(object sender, FileSystemEventArgs e) {
+            if (PathUtils.IsSamePath(e.FullPath, _environmentsTxtPath)) {
+                try {
+                    _envsTxtWatcherTimer.Change(1000, Timeout.Infinite);
+                } catch (ObjectDisposedException) {
+                }
+            }
+        }
+
+        private void DiscoverInterpreterFactories() {
+            if (Volatile.Read(ref _ignoreNotifications) > 0) {
+                return;
+            }
+
+            // Discover the available interpreters...
+            bool anyChanged = false;
+
+            List<PythonInterpreterInformation> found = null;
+
+            try {
+                string mainCondaExePath = GetMainCondaExecutablePath();
+                if (mainCondaExePath != null) {
+                    found = FindCondaEnvironments(mainCondaExePath).ToList();
+                }
+            } catch (ObjectDisposedException) {
+                // We are aborting, so silently return with no results.
+                return;
+            }
+
+            var uniqueIds = new HashSet<string>(found.Select(i => i.Configuration.Id));
+
+            // Then update our cached state with the lock held.
+            lock (this) {
+                foreach (var info in found.MaybeEnumerate()) {
+                    PythonInterpreterInformation existingInfo;
+                    if (!_factories.TryGetValue(info.Configuration.Id, out existingInfo) ||
+                        info.Configuration != existingInfo.Configuration) {
+                        _factories[info.Configuration.Id] = info;
+                        anyChanged = true;
+                    }
+                }
+
+                // Remove any factories we had before and no longer see...
+                foreach (var unregistered in _factories.Keys.Except(uniqueIds).ToArray()) {
+                    _factories.Remove(unregistered);
+                    anyChanged = true;
+                }
+            }
+
+            if (anyChanged) {
+                OnInterpreterFactoriesChanged();
+            }
+        }
+
+        private string GetMainCondaExecutablePath() {
+            // Try to find an existing root conda installation
+            // If the future we may decide to install a private installation of conda/miniconda
+            string mainCondaExePath = null;
+            var globalFactories = _globalProvider.GetInterpreterFactories().ToList();
+            foreach (var factory in globalFactories) {
+                var condaPath = CondaUtils.GetCondaExecutablePath(factory.Configuration.PrefixPath, allowBatch: false);
+                if (!string.IsNullOrEmpty(condaPath)) {
+                    // TODO: check executable version, we want to use the latest
+                    // because older ones may not be able to detect environments
+                    // created by a later conda.
+                    mainCondaExePath = condaPath;
+                    break;
+                }
+            }
+
+            return mainCondaExePath;
+        }
+
+        private static CondaInfoResult ExecuteCondaInfo(string condaPath) {
+            using (var output = ProcessOutput.RunHiddenAndCapture(condaPath, "info", "--json")) {
+                output.Wait();
+                if (output.ExitCode == 0) {
+                    var json = string.Join(Environment.NewLine, output.StandardOutputLines);
+                    try {
+                        return JsonConvert.DeserializeObject<CondaInfoResult>(json);
+                    } catch (JsonException ex) {
+                        Debug.WriteLine("Failed to parse: {0}".FormatInvariant(ex.Message));
+                        Debug.WriteLine(json);
+                        return null;
+                    }
+                }
+                return null;
+            }
+        }
+
+        class CondaInfoResult {
+            [JsonProperty("envs")]
+            public string[] EnvironmentFolders = null;
+
+            [JsonProperty("envs_dirs")]
+            public string[] EnvironmentRootFolders = null;
+        }
+
+        private List<PythonInterpreterInformation> FindCondaEnvironments(string condaPath) {
+            var found = new List<PythonInterpreterInformation>();
+            var watchFolders = new HashSet<string>();
+
+            // Find environments that were created with "conda create -n <name>"
+            var condaInfoResult = ExecuteCondaInfo(condaPath);
+            if (condaInfoResult != null) {
+                foreach (var folder in condaInfoResult.EnvironmentFolders) {
+                    if (!Directory.Exists(folder)) {
+                        continue;
+                    }
+
+                    PythonInterpreterInformation env = CreateEnvironmentInfo(folder);
+                    if (env != null) {
+                        found.Add(env);
+                    }
+                }
+            }
+
+            // Find environments that were created with "conda create -p <folder>"
+            // Note that this may have a bunch of entries that no longer exist
+            // as well as duplicates that were returned by conda info.
+            if (File.Exists(_environmentsTxtPath)) {
+                try {
+                    var folders = File.ReadAllLines(_environmentsTxtPath);
+                    foreach (var folder in folders) {
+                        if (!Directory.Exists(folder)) {
+                            continue;
+                        }
+
+                        if (found.FirstOrDefault(pii => PathUtils.IsSameDirectory(pii.Configuration.PrefixPath, folder)) != null) {
+                            continue;
+                        }
+
+                        PythonInterpreterInformation env = CreateEnvironmentInfo(folder);
+                        if (env != null) {
+                            found.Add(env);
+                        }
+                    }
+                } catch (IOException) {
+                } catch (UnauthorizedAccessException) {
+                }
+            }
+
+            return found;
+        }
+
+        private static PythonInterpreterInformation CreateEnvironmentInfo(string prefixPath) {
+            var name = Path.GetFileName(prefixPath);
+            var description = name;
+            var vendor = string.Empty;
+            var vendorUrl = string.Empty;
+            var supportUrl = string.Empty;
+            var interpreterPath = Path.Combine(prefixPath, CondaEnvironmentFactoryConstants.ConsoleExecutable);
+            var windowsInterpreterPath = Path.Combine(prefixPath, CondaEnvironmentFactoryConstants.WindowsExecutable);
+
+            InterpreterArchitecture arch = InterpreterArchitecture.Unknown;
+            Version version = null;
+
+            if (File.Exists(interpreterPath)) {
+                using (var output = ProcessOutput.RunHiddenAndCapture(
+                    interpreterPath, "-c", "import sys; print('%s.%s' % (sys.version_info[0], sys.version_info[1]))"
+                )) {
+                    output.Wait();
+                    if (output.ExitCode == 0) {
+                        var versionName = output.StandardOutputLines.FirstOrDefault() ?? "";
+                        if (!Version.TryParse(versionName, out version)) {
+                            version = null;
+                        }
+                    }
+                }
+
+                arch = InterpreterArchitecture.FromExe(interpreterPath);
+            } else {
+                return null;
+            }
+
+            var config = new InterpreterConfiguration(
+                CondaEnvironmentFactoryConstants.GetInterpreterId(CondaEnvironmentFactoryProvider.EnvironmentCompanyName, name),
+                description,
+                prefixPath,
+                interpreterPath,
+                windowsInterpreterPath,
+                CondaEnvironmentFactoryConstants.PathEnvironmentVariableName,
+                arch,
+                version
+            );
+
+            var unique = new PythonInterpreterInformation(
+                config,
+                vendor,
+                vendorUrl,
+                supportUrl
+            );
+            return unique;
+        }
+
+        #region IPythonInterpreterProvider Members
+
+        public IEnumerable<InterpreterConfiguration> GetInterpreterConfigurations() {
+            if (!ExperimentalOptions.AutoDetectCondaEnvironments) {
+                return Enumerable.Empty<InterpreterConfiguration>();
+            }
+
+            EnsureInitialized();
+
+            lock (_factories) {
+                return _factories.Values.Select(x => x.Configuration).ToArray();
+            }
+        }
+
+        public IPythonInterpreterFactory GetInterpreterFactory(string id) {
+            if (!ExperimentalOptions.AutoDetectCondaEnvironments) {
+                return null;
+            }
+
+            EnsureInitialized();
+
+            PythonInterpreterInformation info;
+            lock (_factories) {
+                _factories.TryGetValue(id, out info);
+            }
+
+            return info?.EnsureFactory();
+        }
+
+        private EventHandler _interpFactoriesChanged;
+        public event EventHandler InterpreterFactoriesChanged {
+            add {
+                if (ExperimentalOptions.AutoDetectCondaEnvironments) {
+                    EnsureInitialized();
+                }
+                _interpFactoriesChanged += value;
+            }
+            remove {
+                _interpFactoriesChanged -= value;
+            }
+        }
+
+        private void OnInterpreterFactoriesChanged() {
+            _interpFactoriesChanged?.Invoke(this, EventArgs.Empty);
+        }
+
+        public object GetProperty(string id, string propName) {
+            if (!ExperimentalOptions.AutoDetectCondaEnvironments) {
+                return null;
+            }
+
+            PythonInterpreterInformation info;
+
+            switch (propName) {
+                case PythonRegistrySearch.CompanyPropertyKey:
+                    lock (_factories) {
+                        if (_factories.TryGetValue(id, out info)) {
+                            return info.Vendor;
+                        }
+                    }
+                    break;
+                case PythonRegistrySearch.SupportUrlPropertyKey:
+                    lock (_factories) {
+                        if (_factories.TryGetValue(id, out info)) {
+                            return info.SupportUrl;
+                        }
+                    }
+                    break;
+                case "PersistInteractive":
+                    return true;
+            }
+
+            return null;
+        }
+
+        #endregion
+    }
+}

--- a/Python/Product/VSInterpreters/CondaPackageManager.cs
+++ b/Python/Product/VSInterpreters/CondaPackageManager.cs
@@ -1,0 +1,680 @@
+﻿// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABLITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.PythonTools.Infrastructure;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.PythonTools.Interpreter {
+    class CondaPackageManager : IPackageManager, IDisposable {
+        private IPythonInterpreterFactory _factory;
+        private string _condaPath;
+        private FileSystemWatcher _historyWatcher;
+        private Timer _historyWatcherTimer;
+        private string _historyPath;
+        private readonly List<PackageSpec> _installedPackages;
+        private readonly List<PackageSpec> _availablePackages;
+        private CancellationTokenSource _currentRefresh;
+        private bool _isReady, _everCached, _everCachedInstallable;
+
+        internal readonly SemaphoreSlim _working = new SemaphoreSlim(1);
+
+        private int _suppressCount;
+        private bool _isDisposed;
+
+        // Prevent too many concurrent executions to avoid exhausting disk IO
+        private static readonly SemaphoreSlim _concurrencyLock = new SemaphoreSlim(4);
+
+        private static readonly KeyValuePair<string, string>[] UnbufferedEnv = new[] {
+            new KeyValuePair<string, string>("PYTHONUNBUFFERED", "1")
+        };
+
+        public CondaPackageManager(
+            bool allowFileSystemWatchers = true
+        ) {
+            _installedPackages = new List<PackageSpec>();
+            _availablePackages = new List<PackageSpec>();
+
+            if (allowFileSystemWatchers) {
+                _historyWatcher = new FileSystemWatcher();
+                _historyWatcher.Changed += _historyWatcher_Changed;
+                _historyWatcher.Created += _historyWatcher_Changed;
+                _historyWatcherTimer = new Timer(_historyWatcherTimer_Elapsed);
+            }
+        }
+
+        private async void _historyWatcherTimer_Elapsed(object state) {
+            try {
+                _historyWatcherTimer.Change(Timeout.Infinite, Timeout.Infinite);
+            } catch (ObjectDisposedException) {
+            }
+
+            OnHistoryFileChanged(this, EventArgs.Empty);
+        }
+
+        private void _historyWatcher_Changed(object sender, FileSystemEventArgs e) {
+            if (PathUtils.IsSamePath(e.FullPath, _historyPath)) {
+                try {
+                    _historyWatcherTimer.Change(1000, Timeout.Infinite);
+                } catch (ObjectDisposedException) {
+                }
+            }
+        }
+
+        public void SetInterpreterFactory(IPythonInterpreterFactory factory) {
+            if (factory == null) {
+                throw new ArgumentNullException(nameof(factory));
+            }
+            if (!File.Exists(factory.Configuration?.InterpreterPath)) {
+                throw new NotSupportedException();
+            }
+
+            _factory = factory;
+            _condaPath = CondaUtils.GetCondaExecutablePath(factory.Configuration.PrefixPath);
+            _historyPath = Path.Combine(_factory.Configuration.PrefixPath, "conda-meta", "history");
+
+            if (_historyWatcher != null) {
+                // Watch the conda-meta/history file, which is updated after 
+                // a package is installed or uninstalled successfully.
+                // Note: conda packages don't all install under lib/site-packages.
+                try {
+                    _historyWatcher.Path = Path.GetDirectoryName(_historyPath);
+                    _historyWatcher.EnableRaisingEvents = true;
+                } catch (ArgumentException) {
+                } catch (IOException) {
+                }
+            }
+
+            Task.Delay(100).ContinueWith(async t => {
+                try {
+                    await UpdateIsReadyAsync(false, CancellationToken.None);
+                } catch (Exception ex) when (!ex.IsCriticalException()) {
+                    Debug.Fail(ex.ToUnhandledExceptionMessage(GetType()));
+                }
+            }).DoNotWait();
+        }
+
+        public IPythonInterpreterFactory Factory => _factory;
+
+        public void Dispose() {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        ~CondaPackageManager() {
+            Dispose(false);
+        }
+
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2213:DisposableFieldsShouldBeDisposed", MessageId = "_refreshIsCurrentTrigger")]
+        protected void Dispose(bool disposing) {
+            if (_isDisposed) {
+                return;
+            }
+            _isDisposed = true;
+
+            if (disposing) {
+                if (_historyWatcher != null) {
+                    _historyWatcher.Changed -= _historyWatcher_Changed;
+                    _historyWatcher.Created -= _historyWatcher_Changed;
+                    _historyWatcher.Dispose();
+                }
+
+                if (_historyWatcherTimer != null) {
+                    _historyWatcherTimer.Dispose();
+                }
+
+                _working.Dispose();
+            }
+        }
+
+        private void AbortOnInvalidConfiguration() {
+            if (_factory == null || _factory.Configuration == null ||
+                string.IsNullOrEmpty(_factory.Configuration.InterpreterPath)) {
+                throw new InvalidOperationException(Strings.MisconfiguredEnvironment);
+            }
+        }
+
+        private async Task AbortIfNotReady(CancellationToken cancellationToken) {
+            if (!IsReady) {
+                await UpdateIsReadyAsync(false, cancellationToken);
+                if (!IsReady) {
+                    throw new InvalidOperationException(Strings.MisconfiguredEnvironment);
+                }
+            }
+        }
+
+        private Task<bool> ShouldElevate(IPackageManagerUI ui, string operation) {
+            // Global installation in C:\ProgramData\<prefix>
+            // requires elevation to modify existing files, but our
+            // elevation detection logic in package manager UI only
+            // tries to create a file (which succeeds) so it thinks we
+            // do not need to elevate.
+            //
+            // Conda itself checks for permission against the first file that matches:
+            // - ./conda-meta/history
+            // - ./conda-meta/conda*.json
+            // - ./conda-meta/*.json
+            // - ./python.exe
+            // It tries to open the file with append mode, if that fails => CondaIOError
+
+            // TODO: we need to apply the same logic so the user gets prompted for elevation
+            return ui == null ? Task.FromResult(false) : ui.ShouldElevateAsync(this, operation);
+        }
+
+        public bool IsReady {
+            get {
+                return _isReady;
+            }
+            private set {
+                if (_isReady != value) {
+                    _isReady = value;
+                    IsReadyChanged?.Invoke(this, EventArgs.Empty);
+                }
+            }
+        }
+        public event EventHandler IsReadyChanged;
+
+        private async Task UpdateIsReadyAsync(bool alreadyHasLock, CancellationToken cancellationToken) {
+            var args = new [] { "-h" };
+            var workingLock = alreadyHasLock ? null : await _working.LockAsync(cancellationToken);
+            try {
+                using (var proc = ProcessOutput.Run(
+                    _condaPath,
+                    args,
+                    _factory.Configuration.PrefixPath,
+                    UnbufferedEnv,
+                    false,
+                    null
+                )) {
+                    try {
+                        IsReady = (await proc == 0);
+                    } catch (OperationCanceledException) {
+                        IsReady = false;
+                        return;
+                    }
+                }
+            } finally {
+                workingLock?.Dispose();
+            }
+        }
+
+        public async Task PrepareAsync(IPackageManagerUI ui, CancellationToken cancellationToken) {
+            if (IsReady) {
+                return;
+            }
+
+            AbortOnInvalidConfiguration();
+
+            await UpdateIsReadyAsync(false, cancellationToken);
+            if (IsReady) {
+                return;
+            }
+        }
+
+        public async Task<bool> ExecuteAsync(string arguments, IPackageManagerUI ui, CancellationToken cancellationToken) {
+            AbortOnInvalidConfiguration();
+            await AbortIfNotReady(cancellationToken);
+            return false;
+        }
+
+        public async Task<bool> InstallAsync(PackageSpec package, IPackageManagerUI ui, CancellationToken cancellationToken) {
+            AbortOnInvalidConfiguration();
+            await AbortIfNotReady(cancellationToken);
+
+            bool success = false;
+            var args = new List<string>();
+            args.Add("install");
+            args.Add("-p");
+            args.Add(ProcessOutput.QuoteSingleArgument(_factory.Configuration.PrefixPath));
+            args.Add("-y");
+
+            args.Add(package.FullSpec);
+            var name = string.IsNullOrEmpty(package.Name) ? package.FullSpec : package.Name;
+            var operation = string.Join(" ", args);
+
+            using (await _working.LockAsync(cancellationToken)) {
+                ui?.OnOperationStarted(this, operation);
+                ui?.OnOutputTextReceived(this, Strings.InstallingPackageStarted.FormatUI(name));
+
+                try {
+                    using (var output = ProcessOutput.Run(
+                        _condaPath,
+                        args,
+                        _factory.Configuration.PrefixPath,
+                        UnbufferedEnv,
+                        false,
+                        PackageManagerUIRedirector.Get(this, ui),
+                        quoteArgs: false,
+                        elevate: await ShouldElevate(ui, operation)
+                    )) {
+                        if (!output.IsStarted) {
+                            return false;
+                        }
+                        var exitCode = await output;
+                        success = exitCode == 0;
+                    }
+                    return success;
+                } catch (IOException) {
+                    return false;
+                } finally {
+                    if (!success) {
+                        // Check whether we failed because conda is missing
+                        UpdateIsReadyAsync(true, CancellationToken.None).DoNotWait();
+                    }
+
+                    var msg = success ? Strings.InstallingPackageSuccess : Strings.InstallingPackageFailed;
+                    ui?.OnOutputTextReceived(this, msg.FormatUI(name));
+                    ui?.OnOperationFinished(this, operation, success);
+                    await CacheInstalledPackagesAsync(true, false, cancellationToken);
+                }
+            }
+        }
+
+        public async Task<bool> UninstallAsync(PackageSpec package, IPackageManagerUI ui, CancellationToken cancellationToken) {
+            AbortOnInvalidConfiguration();
+            await AbortIfNotReady(cancellationToken);
+
+            bool success = false;
+            var args = new List<string>();
+            args.Add("uninstall");
+            args.Add("-p");
+            args.Add(ProcessOutput.QuoteSingleArgument(_factory.Configuration.PrefixPath));
+            args.Add("-y");
+
+            args.Add(package.Name);
+            var name = string.IsNullOrEmpty(package.Name) ? package.FullSpec : package.Name;
+            var operation = string.Join(" ", args);
+
+            try {
+                using (await _working.LockAsync(cancellationToken)) {
+                    ui?.OnOperationStarted(this, operation);
+                    ui?.OnOutputTextReceived(this, Strings.UninstallingPackageStarted.FormatUI(name));
+
+                    using (var output = ProcessOutput.Run(
+                        _condaPath,
+                        args,
+                        _factory.Configuration.PrefixPath,
+                        UnbufferedEnv,
+                        false,
+                        PackageManagerUIRedirector.Get(this, ui),
+                        elevate: await ShouldElevate(ui, operation)
+                    )) {
+                        if (!output.IsStarted) {
+                            // The finally block handles output
+                            return false;
+                        }
+                        var exitCode = await output;
+                        success = exitCode == 0;
+                    }
+                    return success;
+                }
+            } catch (IOException) {
+                return false;
+            } finally {
+                if (!success) {
+                    // Check whether we failed because conda is missing
+                    UpdateIsReadyAsync(false, CancellationToken.None).DoNotWait();
+                }
+
+                if (IsReady) {
+                    await CacheInstalledPackagesAsync(false, false, cancellationToken);
+                    if (!success) {
+                        // Double check whether the package has actually
+                        // been uninstalled, to avoid reporting errors 
+                        // where, for all practical purposes, there is no
+                        // error.
+                        if (!(await GetInstalledPackageAsync(package, cancellationToken)).IsValid) {
+                            success = true;
+                        }
+                    }
+                }
+
+                var msg = success ? Strings.UninstallingPackageSuccess : Strings.UninstallingPackageFailed;
+                ui?.OnOutputTextReceived(this, msg.FormatUI(name));
+                ui?.OnOperationFinished(this, operation, success);
+            }
+        }
+
+        public event EventHandler InstalledPackagesChanged;
+        public event EventHandler InstalledFilesChanged;
+
+        private string EnvironmentName => Path.GetFileName(_factory.Configuration.PrefixPath);
+
+        public string ExtensionDisplayName => Strings.CondaExtensionDisplayName;
+
+        public string IndexDisplayName => Strings.CondaDefaultIndexName;
+
+        public string SearchHelpText => Strings.CondaExtensionSearchCondaLabel;
+
+        public string GetInstallCommandDisplayName(string searchQuery) {
+            if (string.IsNullOrEmpty(searchQuery)) {
+                return string.Empty;
+            }
+
+            return Strings.CondaExtensionCondaInstall.FormatUI(searchQuery) + Strings.CondaExtensionCondaInstallFrom.FormatUI(IndexDisplayName);
+        }
+
+        public bool CanBeUninstalled(PackageSpec package) {
+            // Don't make it easy for the users to get themselves in trouble.
+            // If they really need to uninstall these packages, they can fall
+            // back to command line.
+            return package.Name != "python";
+        }
+
+        private async Task CacheInstalledPackagesAsync(
+            bool alreadyHasLock,
+            bool alreadyHasConcurrencyLock,
+            CancellationToken cancellationToken
+        ) {
+            if (!IsReady) {
+                await UpdateIsReadyAsync(alreadyHasLock, cancellationToken);
+                if (!IsReady) {
+                    return;
+                }
+            }
+
+            List<PackageSpec> packages = null;
+
+            var workingLock = alreadyHasLock ? null : await _working.LockAsync(cancellationToken);
+            try {
+                var args = new List<string>();
+                args.Add("list");
+                args.Add("-p");
+                args.Add(ProcessOutput.QuoteSingleArgument(_factory.Configuration.PrefixPath));
+                args.Add("--json");
+
+                var concurrencyLock = alreadyHasConcurrencyLock ? null : await _concurrencyLock.LockAsync(cancellationToken);
+                try {
+                    using (var proc = ProcessOutput.Run(
+                        _condaPath,
+                        args,
+                        _factory.Configuration.PrefixPath,
+                        UnbufferedEnv,
+                        false,
+                        null
+                    )) {
+                        try {
+                            if ((await proc) == 0) {
+                                var json = string.Join(Environment.NewLine, proc.StandardOutputLines);
+                                try {
+                                    var data = JArray.Parse(json);
+                                    packages = data
+                                        .Select(j => new PackageSpec(j.Value<string>("name"), j.Value<string>("version")))
+                                        .Where(p => p.IsValid)
+                                        .OrderBy(p => p.Name)
+                                        .ToList();
+                                } catch (Newtonsoft.Json.JsonException ex) {
+                                    Debug.WriteLine("Failed to parse: {0}".FormatInvariant(ex.Message));
+                                    Debug.WriteLine(json);
+                                }
+                            }
+                        } catch (OperationCanceledException) {
+                            // Process failed to run
+                            Debug.WriteLine("Failed to run conda to collect installed packages");
+                            foreach (var line in proc.StandardOutputLines) {
+                                Debug.WriteLine(line);
+                            }
+                        }
+                    }
+                } finally {
+                    concurrencyLock?.Dispose();
+                }
+
+                // Outside of concurrency lock, still in working lock
+
+                _installedPackages.Clear();
+                if (packages != null) {
+                    _installedPackages.AddRange(packages);
+                }
+                _everCached = true;
+            } finally {
+                workingLock?.Dispose();
+            }
+
+            InstalledPackagesChanged?.Invoke(this, EventArgs.Empty);
+        }
+
+        private async Task CacheInstallablePackagesAsync(
+            bool alreadyHasLock,
+            bool alreadyHasConcurrencyLock,
+            CancellationToken cancellationToken
+        ) {
+            if (!IsReady) {
+                await UpdateIsReadyAsync(alreadyHasLock, cancellationToken);
+                if (!IsReady) {
+                    return;
+                }
+            }
+
+            List<PackageSpec> packages = null;
+
+            var workingLock = alreadyHasLock ? null : await _working.LockAsync(cancellationToken);
+            try {
+                var concurrencyLock = alreadyHasConcurrencyLock ? null : await _concurrencyLock.LockAsync(cancellationToken);
+                try {
+                    packages = await ExecuteCondaSearch();
+                } finally {
+                    concurrencyLock?.Dispose();
+                }
+
+                // Outside of concurrency lock, still in working lock
+
+                _availablePackages.Clear();
+                _availablePackages.AddRange(packages);
+                _everCachedInstallable = true;
+            } finally {
+                workingLock?.Dispose();
+            }
+        }
+
+        private async Task<List<PackageSpec>> ExecuteCondaSearch() {
+            var packages = new List<PackageSpec>();
+
+            // TODO: Find a way to obtain package descriptions
+            //       When a package is downloaded, often this file exists:
+            //       %LOCALAPPDATA%/conda/conda/pkgs/requests-2.14.2-py36_0/info/about.json
+            //       There are "summary" and "description" fields
+            //       Latest news:
+            //       Conda developer says they are working on a better API for this
+            //       (which will get us descriptions), they will let us know when ready.
+
+            // TODO: Use a global cache that can be reused by multiple conda envs (may need one per platform)
+            // TODO: need to check if conda uses the platform of specified environment
+            // or the platform of the conda.exe (does it always match?).
+            // If the latter, we may need to pass in:
+            // --platform win-32
+            // --platform win-64
+            var args = new List<string>();
+            args.Add("search");
+            args.Add("-p");
+            args.Add(ProcessOutput.QuoteSingleArgument(_factory.Configuration.PrefixPath));
+            args.Add("--json");
+
+            using (var proc = ProcessOutput.Run(
+                _condaPath,
+                args,
+                _factory.Configuration.PrefixPath,
+                UnbufferedEnv,
+                false,
+                null
+            )) {
+                try {
+                    if ((await proc) == 0) {
+                        var json = string.Join(Environment.NewLine, proc.StandardOutputLines);
+                        try {
+                            // This json can be large, and has a lot of fields
+                            // that we don't care about. For this json, DeserializeObject
+                            // is much faster than JObject.Parse by about 4x-5x.
+
+                            // TODO: find how to do this with a reader
+                            var data = JsonConvert.DeserializeObject<Dictionary<string, CondaPackage[]>>(json);
+                            packages = data.Values.Select(LastPackageSpec)
+                                .Where(p => p.IsValid)
+                                .OrderBy(p => p.Name)
+                                .ToList();
+                        } catch (JsonException ex) {
+                            Debug.WriteLine("Failed to parse: {0}".FormatInvariant(ex.Message));
+                            Debug.WriteLine(json);
+                        }
+                    }
+                } catch (OperationCanceledException) {
+                    // Process failed to run
+                    Debug.WriteLine("Failed to run conda to collect installable packages");
+                    foreach (var line in proc.StandardOutputLines) {
+                        Debug.WriteLine(line);
+                    }
+                }
+            }
+
+            return packages;
+        }
+
+        class CondaPackage {
+            [JsonProperty("name")]
+            public string Name = null;
+
+            [JsonProperty("version")]
+            public string VersionText = null;
+        }
+
+        private PackageSpec LastPackageSpec(CondaPackage[] pkgs) {
+            // TODO: the last package may not be compatible?
+            var last = pkgs.LastOrDefault();
+            return last != null ? new PackageSpec(last.Name, last.VersionText) : new PackageSpec();
+         }
+
+        public async Task<IList<PackageSpec>> GetInstalledPackagesAsync(CancellationToken cancellationToken) {
+            using (await _working.LockAsync(cancellationToken)) {
+                if (!_everCached) {
+                    await CacheInstalledPackagesAsync(true, false, cancellationToken);
+                }
+                return _installedPackages.ToArray();
+            }
+        }
+
+        public async Task<PackageSpec> GetInstalledPackageAsync(PackageSpec package, CancellationToken cancellationToken) {
+            if (!package.IsValid) {
+                return package;
+            }
+            using (await _working.LockAsync(cancellationToken)) {
+                if (!_everCached) {
+                    await CacheInstalledPackagesAsync(true, false, cancellationToken);
+                }
+                return _installedPackages.FirstOrDefault(p => p.Name == package.Name) ?? new PackageSpec(null);
+            }
+        }
+
+        public async Task<IList<PackageSpec>> GetInstallablePackagesAsync(CancellationToken cancellationToken) {
+            using (await _working.LockAsync(cancellationToken)) {
+                if (!_everCachedInstallable) {
+                    await CacheInstallablePackagesAsync(true, false, cancellationToken);
+                }
+                return _availablePackages.ToArray();
+            }
+        }
+
+        public async Task<PackageSpec> GetInstallablePackageAsync(PackageSpec package, CancellationToken cancellationToken) {
+            if (!package.IsValid) {
+                return package;
+            }
+            using (await _working.LockAsync(cancellationToken)) {
+                if (!_everCachedInstallable) {
+                    await CacheInstallablePackagesAsync(true, false, cancellationToken);
+                }
+                return _availablePackages.FirstOrDefault(p => p.Name == package.Name) ?? new PackageSpec(null);
+            }
+        }
+
+        private bool WatchingLibrary {
+            get {
+                if (_historyWatcher == null) {
+                    return false;
+                }
+
+                return _historyWatcher.EnableRaisingEvents;
+            }
+            set {
+                if (_historyWatcher == null) {
+                    return;
+                }
+
+                if (_historyWatcher.EnableRaisingEvents != value) {
+                    try {
+                        _historyWatcher.EnableRaisingEvents = value;
+                    } catch (ArgumentException) {
+                    } catch (IOException) {
+                    } catch (ObjectDisposedException) {
+                    }
+                }
+            }
+        }
+
+        private sealed class Suppressed : IDisposable {
+            private readonly CondaPackageManager _manager;
+
+            public Suppressed(CondaPackageManager manager) {
+                _manager = manager;
+            }
+
+            public void Dispose() {
+                if (Interlocked.Decrement(ref _manager._suppressCount) == 0) {
+                    _manager.WatchingLibrary = true;
+                }
+            }
+        }
+
+        public IDisposable SuppressNotifications() {
+            WatchingLibrary = false;
+            Interlocked.Increment(ref _suppressCount);
+            return new Suppressed(this);
+        }
+
+        public void NotifyPackagesChanged() {
+            OnHistoryFileChanged(this, EventArgs.Empty);
+        }
+
+        private async void OnHistoryFileChanged(object sender, EventArgs e) {
+            if (_isDisposed) {
+                return;
+            }
+
+            InstalledFilesChanged?.Invoke(this, EventArgs.Empty);
+
+            var cts = new CancellationTokenSource();
+            var cancellationToken = cts.Token;
+            var oldCts = Interlocked.Exchange(ref _currentRefresh, cts);
+            try {
+                oldCts?.Cancel();
+                oldCts?.Dispose();
+            } catch (ObjectDisposedException) {
+            }
+
+            try {
+                await CacheInstalledPackagesAsync(false, false, cancellationToken);
+            } catch (OperationCanceledException) {
+            } catch (Exception ex) when (!ex.IsCriticalException()) {
+                Debug.Fail(ex.ToUnhandledExceptionMessage(GetType()));
+            }
+        }
+    }
+}

--- a/Python/Product/VSInterpreters/CondaPackageManager.cs
+++ b/Python/Product/VSInterpreters/CondaPackageManager.cs
@@ -371,10 +371,10 @@ namespace Microsoft.PythonTools.Interpreter {
                 return string.Empty;
             }
 
-            return Strings.CondaExtensionCondaInstall.FormatUI(searchQuery) + Strings.CondaExtensionCondaInstallFrom.FormatUI(IndexDisplayName);
+            return Strings.CondaExtensionCondaInstallFrom.FormatUI(searchQuery);
         }
 
-        public bool CanBeUninstalled(PackageSpec package) {
+        public bool CanUninstall(PackageSpec package) {
             // Don't make it easy for the users to get themselves in trouble.
             // If they really need to uninstall these packages, they can fall
             // back to command line.

--- a/Python/Product/VSInterpreters/CondaUtils.cs
+++ b/Python/Product/VSInterpreters/CondaUtils.cs
@@ -1,0 +1,41 @@
+// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABLITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System.IO;
+
+namespace Microsoft.PythonTools.Interpreter {
+    static class CondaUtils {
+        internal static string GetCondaExecutablePath(string prefixPath, bool allowBatch = true) {
+            if (!Directory.Exists(prefixPath)) {
+                return null;
+            }
+
+            var condaExePath = Path.Combine(prefixPath, "scripts", "conda.exe");
+            if (File.Exists(condaExePath)) {
+                return condaExePath;
+            }
+
+            if (allowBatch) {
+                var condaBatPath = Path.Combine(prefixPath, "scripts", "conda.bat");
+                if (File.Exists(condaBatPath)) {
+                    return condaBatPath;
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/Python/Product/VSInterpreters/ExperimentalOptions.cs
+++ b/Python/Product/VSInterpreters/ExperimentalOptions.cs
@@ -21,15 +21,21 @@ namespace Microsoft.PythonTools.Interpreter {
     public static class ExperimentalOptions {
         private const string ExperimentSubkey = @"Software\Microsoft\PythonTools\Experimental";
         internal const string NoDatabaseFactoryKey = "NoDatabaseFactory";
+        internal const string AutoDetectCondaEnvironmentsKey = "AutoDetectCondaEnvironments";
+        internal const string UseCondaPackageManagerKey = "UseCondaPackageManager";
         internal static readonly Lazy<bool> _noDatabaseFactory = new Lazy<bool>(GetNoDatabaseFactory);
+        internal static readonly Lazy<bool> _autoDetectCondaEnvironments = new Lazy<bool>(GetAutoDetectCondaEnvironments);
+        internal static readonly Lazy<bool> _useCondaPackageManager = new Lazy<bool>(GetUseCondaPackageManager);
 
-        public static bool GetNoDatabaseFactory() => GetBooleanFactoryFlag(NoDatabaseFactoryKey);
+        public static bool GetNoDatabaseFactory() => GetBooleanFlag(NoDatabaseFactoryKey, defaultVal: true);
+        public static bool GetAutoDetectCondaEnvironments() => GetBooleanFlag(AutoDetectCondaEnvironmentsKey, defaultVal: false);
+        public static bool GetUseCondaPackageManager() => GetBooleanFlag(UseCondaPackageManagerKey, defaultVal: false);
 
-        private static bool GetBooleanFactoryFlag(string keyName) {
+        private static bool GetBooleanFlag(string keyName, bool defaultVal) {
             using (var root = Registry.CurrentUser.OpenSubKey(ExperimentSubkey, false)) {
-                var value = root?.GetValue(NoDatabaseFactoryKey);
+                var value = root?.GetValue(keyName);
                 if (value == null) {
-                    return true;
+                    return defaultVal;
                 }
                 int? asInt = value as int?;
                 if (asInt.HasValue) {
@@ -45,7 +51,7 @@ namespace Microsoft.PythonTools.Interpreter {
             return true;
         }
 
-        private static void SetBooleanFactoryFlag(string keyName, bool value) {
+        private static void SetBooleanFlag(string keyName, bool value) {
             using (var root = Registry.CurrentUser.CreateSubKey(ExperimentSubkey, true)) {
                 if (root == null) {
                     throw new UnauthorizedAccessException();
@@ -70,7 +76,25 @@ namespace Microsoft.PythonTools.Interpreter {
                 return _noDatabaseFactory.Value;
             }
             set {
-                SetBooleanFactoryFlag(NoDatabaseFactoryKey, value);
+                SetBooleanFlag(NoDatabaseFactoryKey, value);
+            }
+        }
+
+        public static bool AutoDetectCondaEnvironments {
+            get {
+                return _autoDetectCondaEnvironments.Value;
+            }
+            set {
+                SetBooleanFlag(AutoDetectCondaEnvironmentsKey, value);
+            }
+        }
+
+        public static bool UseCondaPackageManager {
+            get {
+                return _useCondaPackageManager.Value;
+            }
+            set {
+                SetBooleanFlag(UseCondaPackageManagerKey, value);
             }
         }
     }

--- a/Python/Product/VSInterpreters/PipPackageManager.cs
+++ b/Python/Product/VSInterpreters/PipPackageManager.cs
@@ -435,10 +435,10 @@ namespace Microsoft.PythonTools.Interpreter {
                 return string.Empty;
             }
 
-            return Strings.PipExtensionPipInstall.FormatUI(searchQuery) + Strings.PipExtensionPipInstallFrom.FormatUI(IndexDisplayName);
+            return Strings.PipExtensionPipInstallFrom.FormatUI(searchQuery);
         }
 
-        public bool CanBeUninstalled(PackageSpec package) {
+        public bool CanUninstall(PackageSpec package) {
             return true;
         }
 

--- a/Python/Product/VSInterpreters/PipPackageManager.cs
+++ b/Python/Product/VSInterpreters/PipPackageManager.cs
@@ -424,6 +424,24 @@ namespace Microsoft.PythonTools.Interpreter {
 
         private bool SupportsDashMPip => _factory.Configuration.Version > new Version(2, 7);
 
+        public string ExtensionDisplayName => Strings.PipExtensionDisplayName;
+
+        public string IndexDisplayName => Strings.PipDefaultIndexName;
+
+        public string SearchHelpText => Strings.PipExtensionSearchPyPILabel;
+
+        public string GetInstallCommandDisplayName(string searchQuery) {
+            if (string.IsNullOrEmpty(searchQuery)) {
+                return string.Empty;
+            }
+
+            return Strings.PipExtensionPipInstall.FormatUI(searchQuery) + Strings.PipExtensionPipInstallFrom.FormatUI(IndexDisplayName);
+        }
+
+        public bool CanBeUninstalled(PackageSpec package) {
+            return true;
+        }
+
         private async Task CacheInstalledPackagesAsync(
             bool alreadyHasLock,
             bool alreadyHasConcurrencyLock,

--- a/Python/Product/VSInterpreters/PythonInterpreterInformation.cs
+++ b/Python/Product/VSInterpreters/PythonInterpreterInformation.cs
@@ -41,7 +41,7 @@ namespace Microsoft.PythonTools.Interpreter {
                         Factory = InterpreterFactoryCreator.CreateInterpreterFactory(
                             Configuration,
                             new InterpreterFactoryCreationOptions {
-                                PackageManager = new PipPackageManager(),
+                                PackageManager = CreatePackageManager(),
                                 WatchFileSystem = true,
                                 NoDatabase = ExperimentalOptions.NoDatabaseFactory
                             }
@@ -50,6 +50,14 @@ namespace Microsoft.PythonTools.Interpreter {
                 }
             }
             return Factory;
+        }
+
+        private IPackageManager CreatePackageManager() {
+            if (ExperimentalOptions.UseCondaPackageManager && !string.IsNullOrEmpty(CondaUtils.GetCondaExecutablePath(Configuration.PrefixPath))) {
+                return new CondaPackageManager();
+            } else {
+                return new PipPackageManager();
+            }
         }
     }
 }

--- a/Python/Product/VSInterpreters/VSInterpreters.csproj
+++ b/Python/Product/VSInterpreters/VSInterpreters.csproj
@@ -76,6 +76,10 @@
   <ItemGroup>
     <Compile Include="AssemblyInfo.cs" />
     <Compile Include="BuiltInPackageManagers.cs" />
+    <Compile Include="CondaEnvironmentFactoryConstants.cs" />
+    <Compile Include="CondaUtils.cs" />
+    <Compile Include="CondaEnvironmentFactoryProvider.cs" />
+    <Compile Include="CondaPackageManager.cs" />
     <Compile Include="CPythonInterpreterFactoryConstants.cs" />
     <Compile Include="CPythonInterpreterFactoryProvider.cs" />
     <Compile Include="ExperimentalOptions.cs" />

--- a/Python/Tests/Utilities.Python.Analysis/PythonPaths.cs
+++ b/Python/Tests/Utilities.Python.Analysis/PythonPaths.cs
@@ -196,6 +196,15 @@ namespace TestUtilities {
             return null;
         }
 
+        public static IEnumerable<PythonVersion> AnacondaVersions {
+            get {
+                if (Anaconda36 != null) yield return Anaconda36;
+                if (Anaconda36_x64 != null) yield return Anaconda36_x64;
+                if (Anaconda27 != null) yield return Anaconda27;
+                if (Anaconda27_x64 != null) yield return Anaconda27_x64;
+            }
+        }
+
         public static IEnumerable<PythonVersion> Versions {
             get {
                 if (Python26 != null) yield return Python26;

--- a/Python/Tests/Utilities.Python/MockPackageManager.cs
+++ b/Python/Tests/Utilities.Python/MockPackageManager.cs
@@ -26,9 +26,15 @@ namespace TestUtilities.Python {
 
         public string SearchHelpText => string.Empty;
 
-        public string GetInstallCommandDisplayName(string searchQuery) => string.Empty;
+        public string GetInstallCommandDisplayName(string searchQuery) {
+            if (string.IsNullOrEmpty(searchQuery)) {
+                return string.Empty;
+            }
 
-        public bool CanBeUninstalled(PackageSpec package) => true;
+            return string.Format("pip install {0} from PyPI", searchQuery);
+        }
+
+        public bool CanUninstall(PackageSpec package) => true;
 
         public void SetInterpreterFactory(IPythonInterpreterFactory factory) {
             Factory = factory;

--- a/Python/Tests/Utilities.Python/MockPackageManager.cs
+++ b/Python/Tests/Utilities.Python/MockPackageManager.cs
@@ -20,6 +20,16 @@ namespace TestUtilities.Python {
         public event EventHandler InstalledPackagesChanged;
         public event EventHandler IsReadyChanged { add { throw new NotImplementedException(); } remove { } }
 
+        public string ExtensionDisplayName => string.Empty;
+
+        public string IndexDisplayName => string.Empty;
+
+        public string SearchHelpText => string.Empty;
+
+        public string GetInstallCommandDisplayName(string searchQuery) => string.Empty;
+
+        public bool CanBeUninstalled(PackageSpec package) => true;
+
         public void SetInterpreterFactory(IPythonInterpreterFactory factory) {
             Factory = factory;
         }


### PR DESCRIPTION
I broke out of bug jail for a few hours to bring this up to date and have it disabled by default using experimental options registry keys.

- If a global Anaconda installation is found, it uses it to automatically detect Conda environments.
- When conda is available for an environment, it uses it as the package manager.

There are some TODOs that explain what remains to be done, as well as potential upcoming changes to conda that will require some work on our part (our contact will let us know about them when ready).

I had to make some changes to the package manager interfaces and UI in order to make it more generic (remove any reference to PyPI). Hopefully they don't break anything, since that's not behind the experimental flags.

I hadn't gotten to this yet, but I wanted to make it so that an environment can have multiple package managers, so that the UI can display all of them (pip, conda). This is part of the reason I made the experimental options for env detection and conda package manager separate for now (so you can still use pip if you want or if our conda package manager causes issues).

FYI my first attempt at implementing this had the discovery of root and user-created conda environments in the same factory. It was a much more complicated change, which required refactoring a bunch of code in the existing 'regular' factory for reuse. It introduced ambiguity between environments detected by our 'regular' factory and 'conda' factory, which I was partially able to resolve by introducing priorities (but not completely solve - add custom environment was still broken at that point). I realized that our MEF architecture for plugin discoverers is working well for adding environments from different sources, but having multiple factories try to discover from the same source just to be able to provide a different package manager doesn't work out.

We can wait as long as we want to merge this, I was just tired of having it sit in a branch and not be visible.