### PR TITLE
Fixes #1645 Cannot parse trailing commas in function definitions

### DIFF
--- a/Python/Product/Analysis/Analyzer/FunctionScope.cs
+++ b/Python/Product/Analysis/Analyzer/FunctionScope.cs
@@ -61,12 +61,13 @@ namespace Microsoft.PythonTools.Analysis.Analyzer {
             for (int i = 0; i < astParams.Count; ++i) {
                 VariableDef param;
                 if (!TryGetVariable(astParams[i].Name, out param)) {
+                    var n = (Node)astParams[i].NameExpression ?? astParams[i];
                     if (astParams[i].Kind == ParameterKind.List) {
-                        param = _seqParameters = _seqParameters ?? new ListParameterVariableDef(unit, astParams[i]);
+                        param = _seqParameters = _seqParameters ?? new ListParameterVariableDef(unit, n);
                     } else if (astParams[i].Kind == ParameterKind.Dictionary) {
-                        param = _dictParameters = _dictParameters ?? new DictParameterVariableDef(unit, astParams[i]);
+                        param = _dictParameters = _dictParameters ?? new DictParameterVariableDef(unit, n);
                     } else {
-                        param = new LocatedVariableDef(unit.ProjectEntry, astParams[i]);
+                        param = new LocatedVariableDef(unit.ProjectEntry, n);
                     }
                     AddVariable(astParams[i].Name, param);
                 }

--- a/Python/Product/Analysis/Parsing/Ast/ErrorParameter.cs
+++ b/Python/Product/Analysis/Parsing/Ast/ErrorParameter.cs
@@ -18,46 +18,17 @@ using System.Text;
 
 namespace Microsoft.PythonTools.Parsing.Ast {
     class ErrorParameter : Parameter {
-        private readonly ErrorExpression _error;
+        private readonly Expression _error;
         
-        public ErrorParameter(ErrorExpression errorValue)
-            : base("", ParameterKind.Normal) {
+        public ErrorParameter(Expression errorValue, ParameterKind kind)
+            : base(null, kind) {
                 _error = errorValue;
         }
 
-        public ErrorExpression Error {
-            get {
-                return _error;
-            }
-        }
+        public Expression Error => _error;
 
-        internal override void AppendCodeString(StringBuilder res, PythonAst ast, CodeFormattingOptions format, string leadingWhiteSpace) {
-            string kwOnlyText = this.GetExtraVerbatimText(ast);
-            if (kwOnlyText != null) {
-                if (leadingWhiteSpace != null) {
-                    res.Append(leadingWhiteSpace);
-                    res.Append(kwOnlyText.TrimStart());
-                    leadingWhiteSpace = null;
-                } else {
-                    res.Append(kwOnlyText);
-                }
-            }
-            bool isAltForm = this.IsAltForm(ast);
-            if (isAltForm) {
-                res.Append(leadingWhiteSpace ?? this.GetPreceedingWhiteSpace(ast));
-                res.Append('(');
-                leadingWhiteSpace = null;
-            }
-            _error.AppendCodeString(res, ast, format, leadingWhiteSpace);
-            if (this.DefaultValue != null) {
-                res.Append(this.GetSecondWhiteSpace(ast));
-                res.Append('=');
-                this.DefaultValue.AppendCodeString(res, ast, format);
-            }
-            if (isAltForm && !this.IsMissingCloseGrouping(ast)) {
-                res.Append(this.GetSecondWhiteSpace(ast));
-                res.Append(')');
-            }
+        internal override void AppendParameterName(StringBuilder res, PythonAst ast, CodeFormattingOptions format, string leadingWhiteSpace) {
+            _error?.AppendCodeString(res, ast, format, leadingWhiteSpace);
         }
     }
 }

--- a/Python/Product/Analysis/Parsing/Ast/Parameter.cs
+++ b/Python/Product/Analysis/Parsing/Ast/Parameter.cs
@@ -25,14 +25,14 @@ namespace Microsoft.PythonTools.Parsing.Ast {
         /// <summary>
         /// Position of the parameter: 0-based index
         /// </summary>
-        private readonly string/*!*/ _name;
+        private readonly NameExpression _name;
         internal readonly ParameterKind _kind;
         internal Expression _defaultValue, _annotation;
 
         internal static readonly object WhitespacePrecedingAssign = new object();
 
-        public Parameter(string name, ParameterKind kind) {
-            _name = name ?? "";
+        public Parameter(NameExpression name, ParameterKind kind) {
+            _name = name;
             _kind = kind;
         }
 
@@ -45,9 +45,10 @@ namespace Microsoft.PythonTools.Parsing.Ast {
         /// <summary>
         /// Parameter name
         /// </summary>
-        public string/*!*/ Name {
-            get { return _name; }
-        }
+        public virtual string/*!*/ Name => _name?.Name ?? "";
+
+        public NameExpression NameExpression => _name;
+        internal IndexSpan NameSpan => _name?.IndexSpan ?? IndexSpan;
 
         public Expression DefaultValue {
             get { return _defaultValue; }
@@ -115,6 +116,10 @@ namespace Microsoft.PythonTools.Parsing.Ast {
             AppendCodeString(res, ast, format, null);
         }
 
+        internal virtual void AppendParameterName(StringBuilder res, PythonAst ast, CodeFormattingOptions format, string leadingWhiteSpace) {
+            _name?.AppendCodeString(res, ast, format, leadingWhiteSpace);
+        }
+
         internal override void AppendCodeString(StringBuilder res, PythonAst ast, CodeFormattingOptions format, string leadingWhiteSpace) {
             string kwOnlyText = this.GetExtraVerbatimText(ast);
             if (kwOnlyText != null) {
@@ -126,43 +131,45 @@ namespace Microsoft.PythonTools.Parsing.Ast {
                     res.Append(kwOnlyText);
                 }
             }
+
+            bool writeName = true;
             switch (Kind) {
                 case ParameterKind.Dictionary:
-                    res.Append(leadingWhiteSpace ?? this.GetPreceedingWhiteSpace(ast));
+                    res.Append(leadingWhiteSpace ?? this.GetPreceedingWhiteSpaceDefaultNull(ast) ?? "");
+                    leadingWhiteSpace = null;
                     res.Append("**");
-                    res.Append(this.GetSecondWhiteSpace(ast));
-                    res.Append(this.GetVerbatimImage(ast) ?? _name);
-                    AppendAnnotation(res, ast, format);
                     break;
                 case ParameterKind.List:
-                    res.Append(leadingWhiteSpace ?? this.GetPreceedingWhiteSpace(ast));
+                    res.Append(leadingWhiteSpace ?? this.GetPreceedingWhiteSpaceDefaultNull(ast) ?? "");
+                    leadingWhiteSpace = null;
                     res.Append('*');
-                    res.Append(this.GetSecondWhiteSpace(ast));
-                    res.Append(this.GetVerbatimImage(ast) ?? _name);
-                    AppendAnnotation(res, ast, format);
                     break;
                 case ParameterKind.Normal:
                     if (this.IsAltForm(ast)) {
-                        res.Append(leadingWhiteSpace ?? this.GetPreceedingWhiteSpace(ast));
+                        res.Append(leadingWhiteSpace ?? this.GetPreceedingWhiteSpaceDefaultNull(ast) ?? "");
+                        leadingWhiteSpace = null;
                         res.Append('(');
-                        res.Append(this.GetThirdWhiteSpace(ast));
-                        res.Append(this.GetVerbatimImage(ast) ?? _name);
+                        AppendParameterName(res, ast, format, leadingWhiteSpace);
                         if (!this.IsMissingCloseGrouping(ast)) {
                             res.Append(this.GetSecondWhiteSpace(ast));
                             res.Append(')');
                         }
-                    } else {
-                        res.Append(leadingWhiteSpace ?? this.GetPreceedingWhiteSpaceDefaultNull(ast));
-                        res.Append(this.GetVerbatimImage(ast) ?? _name);
-                        AppendAnnotation(res, ast, format);
+                        writeName = false;
                     }
                     break;
                 case ParameterKind.KeywordOnly:
-                    res.Append(leadingWhiteSpace ?? this.GetPreceedingWhiteSpace(ast));
-                    res.Append(this.GetVerbatimImage(ast) ?? _name);
-                    AppendAnnotation(res, ast, format);
                     break;
                 default: throw new InvalidOperationException();
+            }
+
+            if (writeName) {
+                AppendParameterName(res, ast, format, leadingWhiteSpace);
+            }
+
+            if (_annotation != null) {
+                res.Append(this.GetThirdWhiteSpaceDefaultNull(ast) ?? "");
+                res.Append(':');
+                _annotation.AppendCodeString(res, ast, format);
             }
 
             if (_defaultValue != null) {
@@ -180,14 +187,6 @@ namespace Microsoft.PythonTools.Parsing.Ast {
                 } else {
                     _defaultValue.AppendCodeString(res, ast, format);
                 }
-            }
-        }
-
-        private void AppendAnnotation(StringBuilder res, PythonAst ast, CodeFormattingOptions format) {
-            if (_annotation != null) {
-                res.Append(this.GetThirdWhiteSpace(ast));
-                res.Append(':');
-                _annotation.AppendCodeString(res, ast, format);
             }
         }
     }

--- a/Python/Product/Analysis/Parsing/Ast/SublistParameter.cs
+++ b/Python/Product/Analysis/Parsing/Ast/SublistParameter.cs
@@ -19,15 +19,17 @@ using System.Text;
 namespace Microsoft.PythonTools.Parsing.Ast {
     public class SublistParameter : Parameter {
         private readonly TupleExpression _tuple;
+        private readonly int _position;
 
         public SublistParameter(int position, TupleExpression tuple)
-            : base("." + position, ParameterKind.Normal) {
+            : base(null, ParameterKind.Normal) {
+            _position = position;
             _tuple = tuple;
         }
 
-        public TupleExpression Tuple {
-            get { return _tuple; }
-        }
+        public override string Name => $".{_position}";
+
+        public TupleExpression Tuple => _tuple;
 
         public override void Walk(PythonWalker walker) {
             if (walker.Walk(this)) {
@@ -52,26 +54,20 @@ namespace Microsoft.PythonTools.Parsing.Ast {
                     res.Append(kwOnlyText);
                 }
             }
-            res.Append(leadingWhiteSpace ?? this.GetPreceedingWhiteSpace(ast));
-            res.Append('(');
-            Tuple.AppendCodeString(res, ast, format);
-            if (!this.IsMissingCloseGrouping(ast)) {
-                res.Append(this.GetSecondWhiteSpaceDefaultNull(ast) ?? "");
-                res.Append(')');
-                if (_defaultValue != null) {
-                    format.Append(
-                        res,
-                        format.SpaceAroundDefaultValueEquals,
-                        " ",
-                        "",
-                        NodeAttributes.GetWhiteSpace(this, ast, WhitespacePrecedingAssign)
-                    );
-                    res.Append('=');
-                    if (format.SpaceAroundDefaultValueEquals != null) {
-                        _defaultValue.AppendCodeString(res, ast, format, format.SpaceAroundDefaultValueEquals.Value ? " " : "");
-                    } else {
-                        _defaultValue.AppendCodeString(res, ast, format);
-                    }
+            Tuple.AppendCodeString(res, ast, format, leadingWhiteSpace);
+            if (_defaultValue != null) {
+                format.Append(
+                    res,
+                    format.SpaceAroundDefaultValueEquals,
+                    " ",
+                    "",
+                    NodeAttributes.GetWhiteSpace(this, ast, WhitespacePrecedingAssign)
+                );
+                res.Append('=');
+                if (format.SpaceAroundDefaultValueEquals != null) {
+                    _defaultValue.AppendCodeString(res, ast, format, format.SpaceAroundDefaultValueEquals.Value ? " " : "");
+                } else {
+                    _defaultValue.AppendCodeString(res, ast, format);
                 }
             }
         }

--- a/Python/Product/Analysis/Parsing/Parser.cs
+++ b/Python/Product/Analysis/Parsing/Parser.cs
@@ -2196,65 +2196,6 @@ namespace Microsoft.PythonTools.Parsing {
             }
         }
 
-        //private Expression LEGACY_ParseSublistParameter(HashSet<string> names) {
-        //    Token t = NextToken();
-        //    Expression ret = null;
-        //    switch (t.Kind) {
-        //        case TokenKind.LeftParenthesis: // sublist
-        //            string parenWhiteSpace = _tokenWhiteSpace;
-        //            ret = ParseSublist(names, false);
-        //            Eat(TokenKind.RightParenthesis);
-        //            if (_verbatim && ret is TupleExpression) {
-        //                AddPreceedingWhiteSpace(ret, parenWhiteSpace);
-        //                AddSecondPreceedingWhiteSpace(ret, _tokenWhiteSpace);
-        //            }
-        //            break;
-        //        case TokenKind.Name:  // identifier
-        //            string name = FixName((string)t.Value);
-        //            NameExpression ne = MakeName(TokenToName(t));
-        //            if (_verbatim) {
-        //                AddPreceedingWhiteSpace(ne, _tokenWhiteSpace);
-        //            }
-        //            CompleteParameterName(ne, name, names, GetStart());
-        //            return ne;
-        //        default:
-        //            ReportSyntaxError(_token);
-        //            ret = Error(_verbatim ? (_tokenWhiteSpace + _token.Token.VerbatimImage) : null);
-        //            break;
-        //    }
-        //    return ret;
-        //}
-
-        //  sublist ::=
-        //      parameter ("," parameter)* [","]
-        //private Expression ParseSublist(HashSet<string> names, bool parenFreeTuple) {
-        //    bool trailingComma;
-        //    List<Expression> list = new List<Expression>();
-        //    List<string> itemWhiteSpace = MakeWhiteSpaceList();
-        //    for (; ; ) {
-        //        trailingComma = false;
-        //        list.Add(ParseSublistParameter(names));
-        //        if (MaybeEat(TokenKind.Comma)) {
-        //            if (itemWhiteSpace != null) {
-        //                itemWhiteSpace.Add(_tokenWhiteSpace);
-        //            }
-        //            trailingComma = true;
-        //            switch (PeekToken().Kind) {
-        //                case TokenKind.LeftParenthesis:
-        //                case TokenKind.Name:
-        //                    continue;
-        //                default:
-        //                    break;
-        //            }
-        //            break;
-        //        } else {
-        //            trailingComma = false;
-        //            break;
-        //        }
-        //    }
-        //    return MakeTupleOrExpr(list, itemWhiteSpace, trailingComma, parenFreeTuple);
-        //}
-
         //Python2.5 -> old_lambdef: 'lambda' [varargslist] ':' old_expression
         private Expression FinishOldLambdef() {
             string whitespace = _tokenWhiteSpace;

--- a/Python/Product/Analysis/Parsing/Tokenizer.cs
+++ b/Python/Product/Analysis/Parsing/Tokenizer.cs
@@ -1689,7 +1689,7 @@ namespace Microsoft.PythonTools.Parsing {
                 case '-':
                     if (NextChar('=')) {
                         return Tokens.SubtractEqualToken;
-                    } else if (_langVersion.Is3x() && NextChar('>')) {
+                    } else if (NextChar('>')) {
                         return Tokens.ArrowToken;
                     }
                     return Tokens.SubtractToken;
@@ -2717,7 +2717,7 @@ namespace Microsoft.PythonTools.Parsing {
                 index = lineLocations[line - 1].EndIndex;
             }
 
-            if (line < lineLocations.Length && location.Column >= (lineLocations[line].EndIndex - index)) {
+            if (line < lineLocations.Length && location.Column > (lineLocations[line].EndIndex - index)) {
                 return lineLocations[line].EndIndex;
             }
 

--- a/Python/Product/Analyzer/Intellisense/ExtractedMethodCreator.cs
+++ b/Python/Product/Analyzer/Intellisense/ExtractedMethodCreator.cs
@@ -57,7 +57,7 @@ namespace Microsoft.PythonTools.Intellisense {
         public ExtractMethodResult GetExtractionResult() {
             bool isStaticMethod = false, isClassMethod = false;
             var parameters = new List<Parameter>();
-            string selfParam = null;
+            NameExpression selfParam = null;
             if (_targetScope is ClassDefinition) {
                 var fromScope = _scopes[_scopes.Length - 1] as FunctionDefinition;
                 Debug.Assert(fromScope != null);  // we don't allow extracting from classes, so we have to be coming from a function
@@ -77,7 +77,7 @@ namespace Microsoft.PythonTools.Intellisense {
 
                     if (!isStaticMethod) {
                         if (fromScope.Parameters.Count > 0) {
-                            selfParam = fromScope.Parameters[0].Name;
+                            selfParam = fromScope.Parameters[0].NameExpression;
                             parameters.Add(new Parameter(selfParam, ParameterKind.Normal));
                         }
                     }
@@ -85,10 +85,11 @@ namespace Microsoft.PythonTools.Intellisense {
             }
 
             foreach (var param in _parameters) {
-                var newParam = new Parameter(param, ParameterKind.Normal);
+                var paramName = new NameExpression(param);
                 if (parameters.Count > 0) {
-                    newParam.AddPreceedingWhiteSpace(_ast, " ");
+                    paramName.AddPreceedingWhiteSpace(_ast, " ");
                 }
+                var newParam = new Parameter(paramName, ParameterKind.Normal);
                 parameters.Add(newParam);
             }
 
@@ -102,12 +103,13 @@ namespace Microsoft.PythonTools.Intellisense {
                     parentScope = parentScope.Parent;
                 }
 
-                if (parentScope == null && input.Name != selfParam) {
+                if (parentScope == null && input.Name != selfParam.Name) {
                     // we can either close over or pass these in as parameters, add them to the list
-                    var newParam = new Parameter(input.Name, ParameterKind.Normal);
+                    var paramName = new NameExpression(input.Name);
                     if (parameters.Count > 0) {
-                        newParam.AddPreceedingWhiteSpace(_ast, " ");
+                        paramName.AddPreceedingWhiteSpace(_ast, " ");
                     }
+                    var newParam = new Parameter(paramName, ParameterKind.Normal);
                     parameters.Add(newParam);
                 }
             }
@@ -251,7 +253,7 @@ namespace Microsoft.PythonTools.Intellisense {
 
             comma = "";
             foreach (var param in parameters) {
-                if (param.Name != selfParam) {
+                if (param.Name != selfParam.Name) {
                     newCall.Append(comma);
                     newCall.Append(param.Name);
                     comma = ", ";

--- a/Python/Product/Analyzer/Intellisense/OutOfProcProjectAnalyzer.cs
+++ b/Python/Product/Analyzer/Intellisense/OutOfProcProjectAnalyzer.cs
@@ -324,7 +324,8 @@ namespace Microsoft.PythonTools.Intellisense {
                     await _pyAnalyzer.ReloadModulesAsync();
                     interpreter.ModuleNamesChanged += OnModulesChanged;
                 }
-            } catch (Exception ex) when (!ex.IsCriticalException()) {
+            } catch (Exception ex) {
+                // Even "critical" exceptions we want to return here
                 error = ex.ToString();
             }
 

--- a/Python/Product/Common/Strings.Designer.cs
+++ b/Python/Product/Common/Strings.Designer.cs
@@ -4281,6 +4281,15 @@ namespace Microsoft.PythonTools {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Unable to get analysis for the selected expression..
+        /// </summary>
+        public static string RenameVariable_UnableGetExpressionAnalysis {
+            get {
+                return ResourceManager.GetString("RenameVariable_UnableGetExpressionAnalysis", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Unable to read file &apos;{0}&apos;.
         /// </summary>
         public static string ReplCannotReadFile {

--- a/Python/Product/Common/Strings.resx
+++ b/Python/Product/Common/Strings.resx
@@ -2126,4 +2126,7 @@ Expand selection to the full expression?</value>
   <data name="RegularExpressionClassificationType" xml:space="preserve">
     <value>Python Regular Expression</value>
   </data>
+  <data name="RenameVariable_UnableGetExpressionAnalysis" xml:space="preserve">
+    <value>Unable to get analysis for the selected expression.</value>
+  </data>
 </root>

--- a/Python/Product/PythonTools/PythonTools/Intellisense/ProjectAnalyzer.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/ProjectAnalyzer.cs
@@ -1788,10 +1788,13 @@ namespace Microsoft.PythonTools.Intellisense {
             try {
                 res = await conn.SendRequestAsync(request, cancel).ConfigureAwait(false);
             } catch (OperationCanceledException) {
+                Debug.WriteLine($"Request cancelled");
                 _logger?.LogEvent(Logging.PythonLogEvent.AnalysisOperationCancelled, null);
-            } catch (IOException) {
+            } catch (IOException e) {
+                Debug.WriteLine($"Request failed: {e}");
                 _logger?.LogEvent(Logging.PythonLogEvent.AnalysisOperationCancelled, null);
             } catch (FailedRequestException e) {
+                Debug.WriteLine($"Request failed: {e}");
                 _logger?.LogEvent(Logging.PythonLogEvent.AnalysisOperationFailed, e.Message);
             } catch (ObjectDisposedException) {
                 _logger?.LogEvent(Logging.PythonLogEvent.AnalysisOperationCancelled, null);

--- a/Python/Tests/Analysis/AnalysisTest.cs
+++ b/Python/Tests/Analysis/AnalysisTest.cs
@@ -2813,6 +2813,49 @@ def f(a):
 
 
         [TestMethod, Priority(0)]
+        public void ListDictArgReferences() {
+            var text = @"
+def f(*a, **k):
+    x = a[1]
+    y = k['a']
+
+#out
+a = 1
+k = 2
+";
+            var entry = ProcessText(text);
+            entry.AssertReferences("a", text.IndexOf("a["),
+                new VariableLocation(2, 8, VariableType.Definition),
+                new VariableLocation(3, 9, VariableType.Reference)
+            );
+            entry.AssertReferences("k", text.IndexOf("k["),
+                new VariableLocation(2, 12, VariableType.Definition),
+                new VariableLocation(4, 9, VariableType.Reference)
+            );
+            entry.AssertReferences("a", text.IndexOf("#out"),
+                new VariableLocation(7, 1, VariableType.Definition)
+            );
+            entry.AssertReferences("k", text.IndexOf("#out"),
+                new VariableLocation(8, 1, VariableType.Definition)
+            );
+        }
+
+        [TestMethod, Priority(0)]
+        public void KeywordArgReferences() {
+            var text = @"
+def f(a):
+    pass
+
+f(a=1)
+";
+            var entry = ProcessText(text);
+            entry.AssertReferences("a", text.IndexOf("a"),
+                new VariableLocation(2, 7, VariableType.Definition),
+                new VariableLocation(5, 3, VariableType.Reference)
+            );
+        }
+
+        [TestMethod, Priority(0)]
         public void ReferencesCrossModule() {
             var fobText = @"
 from oar import abc

--- a/Python/Tests/Analysis/ExpressionFinderTests.cs
+++ b/Python/Tests/Analysis/ExpressionFinderTests.cs
@@ -146,7 +146,7 @@ C().fff", GetExpressionOptions.Evaluate);
         [TestMethod]
         public void FindExpressionsForRename() {
             var code = Parse(@"class C(object):
-    def f(a):
+    def f(a, *b, **c = True):
         global a
         nonlocal a
         return a
@@ -166,6 +166,11 @@ b = C().f(1)
             AssertNoExpr(code, 2, 5);
             AssertExpr(code, 2, 9, 2, 10, "f");
             AssertExpr(code, 2, 11, "a");
+            AssertNoExpr(code, 2, 14);
+            AssertExpr(code, 2, 15, "b");
+            AssertNoExpr(code, 2, 19);
+            AssertExpr(code, 2, 20, "c");
+            AssertNoExpr(code, 2, 22);
 
             AssertNoExpr(code, 3, 15);
             AssertExpr(code, 3, 16, "a");
@@ -214,7 +219,10 @@ b = C().f(1)
             int start = ast.LocationToIndex(new SourceLocation(startLine, 1));
             int end = ast.LocationToIndex(new SourceLocation(endLine + 1, 1));
             var fullLine = code.Substring(start);
-            fullLine = fullLine.Remove("\r\n".Select(c => fullLine.LastIndexOf(c, end - start - 1)).Where(i => i > 0).Min());
+            int lastNewline = "\r\n".Select(c => fullLine.LastIndexOf(c, end - start - 1)).Where(i => i > 0).DefaultIfEmpty(-1).Min();
+            if (lastNewline > 0) {
+                fullLine = fullLine.Remove(lastNewline);
+            }
 
             var finder = new ExpressionFinder(ast, options);
             var range = new SourceSpan(new SourceLocation(startLine, startColumn), new SourceLocation(endLine, endColumn));
@@ -241,7 +249,10 @@ b = C().f(1)
             int start = ast.LocationToIndex(new SourceLocation(startLine, 1));
             int end = ast.LocationToIndex(new SourceLocation(endLine + 1, 1));
             var fullLine = code.Substring(start);
-            fullLine = fullLine.Remove("\r\n".Select(c => fullLine.LastIndexOf(c, end - start - 1)).Where(i => i > 0).Min());
+            int lastNewline = "\r\n".Select(c => fullLine.LastIndexOf(c, end - start - 1)).Where(i => i > 0).DefaultIfEmpty(-1).Min();
+            if (lastNewline > 0) {
+                fullLine = fullLine.Remove(lastNewline);
+            }
 
             var finder = new ExpressionFinder(ast, options);
             var range = new SourceSpan(new SourceLocation(startLine, startColumn), new SourceLocation(endLine, endColumn));

--- a/Python/Tests/Analysis/ParserTests.cs
+++ b/Python/Tests/Analysis/ParserTests.cs
@@ -182,8 +182,8 @@ namespace AnalysisTests {
                 new ErrorInfo("only one ** allowed", 162, 10, 11, 165, 10, 14),
                 new ErrorInfo("keywords must come before ** args", 180, 11, 13, 186, 11, 19),
                 new ErrorInfo("unexpected token 'pass'", 197, 14, 1, 201, 14, 5),
-                new ErrorInfo("unexpected token '42'", 217, 17, 11, 219, 17, 13),
-                new ErrorInfo("unexpected token '42'", 251, 20, 10, 253, 20, 12),
+                new ErrorInfo("invalid sublist parameter", 217, 17, 11, 219, 17, 13),
+                new ErrorInfo("invalid parameter", 251, 20, 10, 253, 20, 12),
                 new ErrorInfo("'break' outside loop", 278, 25, 1, 283, 25, 6),
                 new ErrorInfo("'continue' not properly in loop", 285, 26, 1, 293, 26, 9),
                 new ErrorInfo("print statement expected expression to be printed", 297, 28, 1, 311, 28, 15),
@@ -211,16 +211,16 @@ namespace AnalysisTests {
                 new ErrorInfo("unexpected token 'blazzz'", 797, 82, 10, 803, 82, 16),
                 new ErrorInfo("invalid syntax, from cause not allowed in 2.x.", 837, 87, 11, 845, 87, 19),
                 new ErrorInfo("invalid syntax, class decorators require 2.6 or later.", 861, 93, 1, 866, 93, 6),
-                new ErrorInfo("invalid syntax, parameter annotations require 3.x", 890, 96, 8, 894, 96, 12),
+                new ErrorInfo("invalid syntax, parameter annotations require 3.x", 889, 96, 7, 894, 96, 12),
                 new ErrorInfo("default value must be specified here", 924, 99, 15, 925, 99, 16),
                 new ErrorInfo("positional parameter after * args not allowed", 953, 102, 13, 959, 102, 19),
-                new ErrorInfo("duplicate * args arguments", 987, 105, 13, 988, 105, 14),
-                new ErrorInfo("duplicate * args arguments", 1017, 108, 13, 1018, 108, 14),
-                new ErrorInfo("unexpected token ','", 1045, 111, 11, 1046, 111, 12),
-                new ErrorInfo("unexpected token '42'", 1107, 117, 11, 1109, 117, 13),
+                new ErrorInfo("duplicate * args arguments", 987, 105, 13, 989, 105, 15),
+                new ErrorInfo("duplicate * args arguments", 1017, 108, 13, 1019, 108, 15),
+                new ErrorInfo("invalid syntax", 1044, 111, 10, 1045, 111, 11),
+                new ErrorInfo("invalid sublist parameter", 1107, 117, 11, 1109, 117, 13),
                 new ErrorInfo("duplicate argument 'abc' in function definition", 1143, 120, 12, 1146, 120, 15),
                 new ErrorInfo("duplicate argument 'abc' in function definition", 1177, 123, 16, 1180, 123, 19),
-                new ErrorInfo("unexpected token '42'", 1208, 127, 7, 1210, 127, 9),
+                new ErrorInfo("invalid parameter", 1208, 127, 7, 1210, 127, 9),
                 new ErrorInfo("default 'except' must be last", 1242, 132, 1, 1249, 132, 8),
                 new ErrorInfo("'as' requires Python 2.6 or later", 1328, 139, 18, 1330, 139, 20),
                 new ErrorInfo("invalid syntax", 1398, 147, 2, 1403, 147, 7),
@@ -232,7 +232,7 @@ namespace AnalysisTests {
                 new ErrorInfo("invalid syntax", 1442, 150, 8, 1444, 150, 10),
                 new ErrorInfo("invalid syntax", 1451, 152, 4, 1453, 152, 6),
                 new ErrorInfo("expected name", 1459, 154, 3, 1461, 154, 5),
-                new ErrorInfo("unexpected token '42'", 1476, 156, 7, 1478, 156, 9),
+                new ErrorInfo("invalid parameter", 1476, 156, 7, 1482, 156, 13),
                 new ErrorInfo("invalid syntax, set literals require Python 2.7 or later.", 1511, 160, 12, 1512, 160, 13),
                 new ErrorInfo("invalid syntax, set literals require Python 2.7 or later.", 1521, 161, 7, 1522, 161, 8)
             );
@@ -249,8 +249,8 @@ namespace AnalysisTests {
                 new ErrorInfo("only one ** allowed", 162, 10, 11, 165, 10, 14),
                 new ErrorInfo("keywords must come before ** args", 180, 11, 13, 186, 11, 19),
                 new ErrorInfo("unexpected token 'pass'", 197, 14, 1, 201, 14, 5),
-                new ErrorInfo("unexpected token '42'", 217, 17, 11, 219, 17, 13),
-                new ErrorInfo("unexpected token '42'", 251, 20, 10, 253, 20, 12),
+                new ErrorInfo("invalid sublist parameter", 217, 17, 11, 219, 17, 13),
+                new ErrorInfo("invalid parameter", 251, 20, 10, 253, 20, 12),
                 new ErrorInfo("'break' outside loop", 278, 25, 1, 283, 25, 6),
                 new ErrorInfo("'continue' not properly in loop", 285, 26, 1, 293, 26, 9),
                 new ErrorInfo("print statement expected expression to be printed", 297, 28, 1, 311, 28, 15),
@@ -278,16 +278,16 @@ namespace AnalysisTests {
                 new ErrorInfo("unexpected token 'blazzz'", 797, 82, 10, 803, 82, 16),
                 new ErrorInfo("invalid syntax, from cause not allowed in 2.x.", 837, 87, 11, 845, 87, 19),
                 new ErrorInfo("invalid syntax, class decorators require 2.6 or later.", 861, 93, 1, 866, 93, 6),
-                new ErrorInfo("invalid syntax, parameter annotations require 3.x", 890, 96, 8, 894, 96, 12),
+                new ErrorInfo("invalid syntax, parameter annotations require 3.x", 889, 96, 7, 894, 96, 12),
                 new ErrorInfo("default value must be specified here", 924, 99, 15, 925, 99, 16),
                 new ErrorInfo("positional parameter after * args not allowed", 953, 102, 13, 959, 102, 19),
-                new ErrorInfo("duplicate * args arguments", 987, 105, 13, 988, 105, 14),
-                new ErrorInfo("duplicate * args arguments", 1017, 108, 13, 1018, 108, 14),
-                new ErrorInfo("unexpected token ','", 1045, 111, 11, 1046, 111, 12),
-                new ErrorInfo("unexpected token '42'", 1107, 117, 11, 1109, 117, 13),
+                new ErrorInfo("duplicate * args arguments", 987, 105, 13, 989, 105, 15),
+                new ErrorInfo("duplicate * args arguments", 1017, 108, 13, 1019, 108, 15),
+                new ErrorInfo("invalid syntax", 1044, 111, 10, 1045, 111, 11),
+                new ErrorInfo("invalid sublist parameter", 1107, 117, 11, 1109, 117, 13),
                 new ErrorInfo("duplicate argument 'abc' in function definition", 1143, 120, 12, 1146, 120, 15),
                 new ErrorInfo("duplicate argument 'abc' in function definition", 1177, 123, 16, 1180, 123, 19),
-                new ErrorInfo("unexpected token '42'", 1208, 127, 7, 1210, 127, 9),
+                new ErrorInfo("invalid parameter", 1208, 127, 7, 1210, 127, 9),
                 new ErrorInfo("default 'except' must be last", 1242, 132, 1, 1249, 132, 8),
                 new ErrorInfo("'as' requires Python 2.6 or later", 1328, 139, 18, 1330, 139, 20),
                 new ErrorInfo("invalid syntax", 1398, 147, 2, 1403, 147, 7),
@@ -299,7 +299,7 @@ namespace AnalysisTests {
                 new ErrorInfo("invalid syntax", 1442, 150, 8, 1444, 150, 10),
                 new ErrorInfo("invalid syntax", 1451, 152, 4, 1453, 152, 6),
                 new ErrorInfo("expected name", 1459, 154, 3, 1461, 154, 5),
-                new ErrorInfo("unexpected token '42'", 1476, 156, 7, 1478, 156, 9),
+                new ErrorInfo("invalid parameter", 1476, 156, 7, 1482, 156, 13),
                 new ErrorInfo("invalid syntax, set literals require Python 2.7 or later.", 1511, 160, 12, 1512, 160, 13),
                 new ErrorInfo("invalid syntax, set literals require Python 2.7 or later.", 1521, 161, 7, 1522, 161, 8)
             );
@@ -316,8 +316,8 @@ namespace AnalysisTests {
                 new ErrorInfo("only one ** allowed", 162, 10, 11, 165, 10, 14),
                 new ErrorInfo("keywords must come before ** args", 180, 11, 13, 186, 11, 19),
                 new ErrorInfo("unexpected token 'pass'", 197, 14, 1, 201, 14, 5),
-                new ErrorInfo("unexpected token '42'", 217, 17, 11, 219, 17, 13),
-                new ErrorInfo("unexpected token '42'", 251, 20, 10, 253, 20, 12),
+                new ErrorInfo("invalid sublist parameter", 217, 17, 11, 219, 17, 13),
+                new ErrorInfo("invalid parameter", 251, 20, 10, 253, 20, 12),
                 new ErrorInfo("'break' outside loop", 278, 25, 1, 283, 25, 6),
                 new ErrorInfo("'continue' not properly in loop", 285, 26, 1, 293, 26, 9),
                 new ErrorInfo("print statement expected expression to be printed", 297, 28, 1, 311, 28, 15),
@@ -344,16 +344,16 @@ namespace AnalysisTests {
                 new ErrorInfo("from __future__ imports must occur at the beginning of the file", 749, 78, 1, 780, 78, 32),
                 new ErrorInfo("unexpected token 'blazzz'", 797, 82, 10, 803, 82, 16),
                 new ErrorInfo("invalid syntax, from cause not allowed in 2.x.", 837, 87, 11, 845, 87, 19),
-                new ErrorInfo("invalid syntax, parameter annotations require 3.x", 890, 96, 8, 894, 96, 12),
+                new ErrorInfo("invalid syntax, parameter annotations require 3.x", 889, 96, 7, 894, 96, 12),
                 new ErrorInfo("default value must be specified here", 924, 99, 15, 925, 99, 16),
                 new ErrorInfo("positional parameter after * args not allowed", 953, 102, 13, 959, 102, 19),
-                new ErrorInfo("duplicate * args arguments", 987, 105, 13, 988, 105, 14),
-                new ErrorInfo("duplicate * args arguments", 1017, 108, 13, 1018, 108, 14),
-                new ErrorInfo("unexpected token ','", 1045, 111, 11, 1046, 111, 12),
-                new ErrorInfo("unexpected token '42'", 1107, 117, 11, 1109, 117, 13),
+                new ErrorInfo("duplicate * args arguments", 987, 105, 13, 989, 105, 15),
+                new ErrorInfo("duplicate * args arguments", 1017, 108, 13, 1019, 108, 15),
+                new ErrorInfo("invalid syntax", 1044, 111, 10, 1045, 111, 11),
+                new ErrorInfo("invalid sublist parameter", 1107, 117, 11, 1109, 117, 13),
                 new ErrorInfo("duplicate argument 'abc' in function definition", 1143, 120, 12, 1146, 120, 15),
                 new ErrorInfo("duplicate argument 'abc' in function definition", 1177, 123, 16, 1180, 123, 19),
-                new ErrorInfo("unexpected token '42'", 1208, 127, 7, 1210, 127, 9),
+                new ErrorInfo("invalid parameter", 1208, 127, 7, 1210, 127, 9),
                 new ErrorInfo("default 'except' must be last", 1242, 132, 1, 1249, 132, 8),
                 new ErrorInfo("invalid syntax", 1431, 149, 7, 1433, 149, 9),
                 new ErrorInfo("invalid syntax", 1431, 149, 7, 1433, 149, 9),
@@ -361,7 +361,7 @@ namespace AnalysisTests {
                 new ErrorInfo("invalid syntax", 1442, 150, 8, 1444, 150, 10),
                 new ErrorInfo("invalid syntax", 1451, 152, 4, 1453, 152, 6),
                 new ErrorInfo("expected name", 1459, 154, 3, 1461, 154, 5),
-                new ErrorInfo("unexpected token '42'", 1476, 156, 7, 1478, 156, 9),
+                new ErrorInfo("invalid parameter", 1476, 156, 7, 1482, 156, 13),
                 new ErrorInfo("invalid syntax, set literals require Python 2.7 or later.", 1511, 160, 12, 1512, 160, 13),
                 new ErrorInfo("invalid syntax, set literals require Python 2.7 or later.", 1521, 161, 7, 1522, 161, 8)
             );
@@ -378,8 +378,8 @@ namespace AnalysisTests {
                 new ErrorInfo("only one ** allowed", 162, 10, 11, 165, 10, 14),
                 new ErrorInfo("keywords must come before ** args", 180, 11, 13, 186, 11, 19),
                 new ErrorInfo("unexpected token 'pass'", 197, 14, 1, 201, 14, 5),
-                new ErrorInfo("unexpected token '42'", 217, 17, 11, 219, 17, 13),
-                new ErrorInfo("unexpected token '42'", 251, 20, 10, 253, 20, 12),
+                new ErrorInfo("invalid sublist parameter", 217, 17, 11, 219, 17, 13),
+                new ErrorInfo("invalid parameter", 251, 20, 10, 253, 20, 12),
                 new ErrorInfo("'break' outside loop", 278, 25, 1, 283, 25, 6),
                 new ErrorInfo("'continue' not properly in loop", 285, 26, 1, 293, 26, 9),
                 new ErrorInfo("print statement expected expression to be printed", 297, 28, 1, 311, 28, 15),
@@ -406,16 +406,16 @@ namespace AnalysisTests {
                 new ErrorInfo("from __future__ imports must occur at the beginning of the file", 749, 78, 1, 780, 78, 32),
                 new ErrorInfo("unexpected token 'blazzz'", 797, 82, 10, 803, 82, 16),
                 new ErrorInfo("invalid syntax, from cause not allowed in 2.x.", 837, 87, 11, 845, 87, 19),
-                new ErrorInfo("invalid syntax, parameter annotations require 3.x", 890, 96, 8, 894, 96, 12),
+                new ErrorInfo("invalid syntax, parameter annotations require 3.x", 889, 96, 7, 894, 96, 12),
                 new ErrorInfo("default value must be specified here", 924, 99, 15, 925, 99, 16),
                 new ErrorInfo("positional parameter after * args not allowed", 953, 102, 13, 959, 102, 19),
-                new ErrorInfo("duplicate * args arguments", 987, 105, 13, 988, 105, 14),
-                new ErrorInfo("duplicate * args arguments", 1017, 108, 13, 1018, 108, 14),
-                new ErrorInfo("unexpected token ','", 1045, 111, 11, 1046, 111, 12),
-                new ErrorInfo("unexpected token '42'", 1107, 117, 11, 1109, 117, 13),
+                new ErrorInfo("duplicate * args arguments", 987, 105, 13, 989, 105, 15),
+                new ErrorInfo("duplicate * args arguments", 1017, 108, 13, 1019, 108, 15),
+                new ErrorInfo("invalid syntax", 1044, 111, 10, 1045, 111, 11),
+                new ErrorInfo("invalid sublist parameter", 1107, 117, 11, 1109, 117, 13),
                 new ErrorInfo("duplicate argument 'abc' in function definition", 1143, 120, 12, 1146, 120, 15),
                 new ErrorInfo("duplicate argument 'abc' in function definition", 1177, 123, 16, 1180, 123, 19),
-                new ErrorInfo("unexpected token '42'", 1208, 127, 7, 1210, 127, 9),
+                new ErrorInfo("invalid parameter", 1208, 127, 7, 1210, 127, 9),
                 new ErrorInfo("default 'except' must be last", 1242, 132, 1, 1249, 132, 8),
                 new ErrorInfo("invalid syntax", 1431, 149, 7, 1433, 149, 9),
                 new ErrorInfo("invalid syntax", 1431, 149, 7, 1433, 149, 9),
@@ -423,7 +423,7 @@ namespace AnalysisTests {
                 new ErrorInfo("invalid syntax", 1442, 150, 8, 1444, 150, 10),
                 new ErrorInfo("invalid syntax", 1451, 152, 4, 1453, 152, 6),
                 new ErrorInfo("expected name", 1459, 154, 3, 1461, 154, 5),
-                new ErrorInfo("unexpected token '42'", 1476, 156, 7, 1478, 156, 9),
+                new ErrorInfo("invalid parameter", 1476, 156, 7, 1482, 156, 13),
                 new ErrorInfo("invalid syntax", 1511, 160, 12, 1512, 160, 13),
                 new ErrorInfo("invalid syntax", 1524, 161, 10, 1527, 161, 13)
             );
@@ -441,9 +441,8 @@ namespace AnalysisTests {
                     new ErrorInfo("only one ** allowed", 162, 10, 11, 165, 10, 14),
                     new ErrorInfo("keywords must come before ** args", 180, 11, 13, 186, 11, 19),
                     new ErrorInfo("unexpected token 'pass'", 197, 14, 1, 201, 14, 5),
-                    new ErrorInfo("unexpected token '42'", 217, 17, 11, 219, 17, 13),
-                    new ErrorInfo("sublist parameters are not supported in 3.x", 216, 17, 10, 222, 17, 16),
-                    new ErrorInfo("unexpected token '42'", 251, 20, 10, 253, 20, 12),
+                    new ErrorInfo("sublist parameters are not supported in 3.x", 216, 17, 10, 223, 17, 17),
+                    new ErrorInfo("invalid parameter", 251, 20, 10, 253, 20, 12),
                     new ErrorInfo("'break' outside loop", 278, 25, 1, 283, 25, 6),
                     new ErrorInfo("'continue' not properly in loop", 285, 26, 1, 293, 26, 9),
                     new ErrorInfo("'continue' not supported inside 'finally' clause", 374, 34, 9, 382, 34, 17),
@@ -470,16 +469,14 @@ namespace AnalysisTests {
                     new ErrorInfo("nonlocal declaration not allowed at module level", 788, 82, 1, 796, 82, 9),
                     new ErrorInfo("invalid syntax, only exception value is allowed in 3.x.", 814, 83, 10, 819, 83, 15),
                     new ErrorInfo("default value must be specified here", 924, 99, 15, 925, 99, 16),
-                    new ErrorInfo("duplicate * args arguments", 987, 105, 13, 988, 105, 14),
-                    new ErrorInfo("duplicate * args arguments", 1017, 108, 13, 1018, 108, 14),
-                    new ErrorInfo("named arguments must follow bare *", 1044, 111, 10, 1048, 111, 14),
-                    new ErrorInfo("sublist parameters are not supported in 3.x", 1072, 114, 10, 1077, 114, 15),
-                    new ErrorInfo("unexpected token '42'", 1107, 117, 11, 1109, 117, 13),
-                    new ErrorInfo("sublist parameters are not supported in 3.x", 1106, 117, 10, 1112, 117, 16),
+                    new ErrorInfo("duplicate * args arguments", 987, 105, 13, 989, 105, 15),
+                    new ErrorInfo("duplicate * args arguments", 1017, 108, 13, 1019, 108, 15),
+                    new ErrorInfo("named arguments must follow bare *", 1044, 111, 10, 1045, 111, 11),
+                    new ErrorInfo("sublist parameters are not supported in 3.x", 1072, 114, 10, 1078, 114, 16),
+                    new ErrorInfo("sublist parameters are not supported in 3.x", 1106, 117, 10, 1113, 117, 17),
                     new ErrorInfo("duplicate argument 'abc' in function definition", 1143, 120, 12, 1146, 120, 15),
-                    new ErrorInfo("duplicate argument 'abc' in function definition", 1177, 123, 16, 1180, 123, 19),
-                    new ErrorInfo("sublist parameters are not supported in 3.x", 1171, 123, 10, 1180, 123, 19),
-                    new ErrorInfo("unexpected token '42'", 1208, 127, 7, 1210, 127, 9),
+                    new ErrorInfo("sublist parameters are not supported in 3.x", 1171, 123, 10, 1181, 123, 20),
+                    new ErrorInfo("invalid parameter", 1208, 127, 7, 1210, 127, 9),
                     new ErrorInfo("\", variable\" not allowed in 3.x - use \"as variable\" instead.", 1277, 134, 17, 1280, 134, 20),
                     new ErrorInfo("default 'except' must be last", 1242, 132, 1, 1249, 132, 8),
                     new ErrorInfo("\", variable\" not allowed in 3.x - use \"as variable\" instead.", 1379, 144, 17, 1382, 144, 20),
@@ -491,7 +488,7 @@ namespace AnalysisTests {
                     new ErrorInfo("invalid syntax", 1442, 150, 8, 1444, 150, 10),
                     new ErrorInfo("invalid syntax", 1451, 152, 4, 1453, 152, 6),
                     new ErrorInfo("expected name", 1459, 154, 3, 1461, 154, 5),
-                    new ErrorInfo("unexpected token '42'", 1476, 156, 7, 1478, 156, 9),
+                    new ErrorInfo("invalid parameter", 1476, 156, 7, 1482, 156, 13),
                     new ErrorInfo("invalid syntax", 1511, 160, 12, 1512, 160, 13),
                     new ErrorInfo("invalid syntax", 1524, 161, 10, 1527, 161, 13)
                 );
@@ -510,9 +507,8 @@ namespace AnalysisTests {
                     new ErrorInfo("only one ** allowed", 162, 10, 11, 165, 10, 14),
                     new ErrorInfo("keywords must come before ** args", 180, 11, 13, 186, 11, 19),
                     new ErrorInfo("unexpected token 'pass'", 197, 14, 1, 201, 14, 5),
-                    new ErrorInfo("unexpected token '42'", 217, 17, 11, 219, 17, 13),
-                    new ErrorInfo("sublist parameters are not supported in 3.x", 216, 17, 10, 222, 17, 16),
-                    new ErrorInfo("unexpected token '42'", 251, 20, 10, 253, 20, 12),
+                    new ErrorInfo("sublist parameters are not supported in 3.x", 216, 17, 10, 223, 17, 17),
+                    new ErrorInfo("invalid parameter", 251, 20, 10, 253, 20, 12),
                     new ErrorInfo("'break' outside loop", 278, 25, 1, 283, 25, 6),
                     new ErrorInfo("'continue' not properly in loop", 285, 26, 1, 293, 26, 9),
                     new ErrorInfo("'continue' not supported inside 'finally' clause", 374, 34, 9, 382, 34, 17),
@@ -536,16 +532,14 @@ namespace AnalysisTests {
                     new ErrorInfo("nonlocal declaration not allowed at module level", 788, 82, 1, 796, 82, 9),
                     new ErrorInfo("invalid syntax, only exception value is allowed in 3.x.", 814, 83, 10, 819, 83, 15),
                     new ErrorInfo("default value must be specified here", 924, 99, 15, 925, 99, 16),
-                    new ErrorInfo("duplicate * args arguments", 987, 105, 13, 988, 105, 14),
-                    new ErrorInfo("duplicate * args arguments", 1017, 108, 13, 1018, 108, 14),
-                    new ErrorInfo("named arguments must follow bare *", 1044, 111, 10, 1048, 111, 14),
-                    new ErrorInfo("sublist parameters are not supported in 3.x", 1072, 114, 10, 1077, 114, 15),
-                    new ErrorInfo("unexpected token '42'", 1107, 117, 11, 1109, 117, 13),
-                    new ErrorInfo("sublist parameters are not supported in 3.x", 1106, 117, 10, 1112, 117, 16),
+                    new ErrorInfo("duplicate * args arguments", 987, 105, 13, 989, 105, 15),
+                    new ErrorInfo("duplicate * args arguments", 1017, 108, 13, 1019, 108, 15),
+                    new ErrorInfo("named arguments must follow bare *", 1044, 111, 10, 1045, 111, 11),
+                    new ErrorInfo("sublist parameters are not supported in 3.x", 1072, 114, 10, 1078, 114, 16),
+                    new ErrorInfo("sublist parameters are not supported in 3.x", 1106, 117, 10, 1113, 117, 17),
                     new ErrorInfo("duplicate argument 'abc' in function definition", 1143, 120, 12, 1146, 120, 15),
-                    new ErrorInfo("duplicate argument 'abc' in function definition", 1177, 123, 16, 1180, 123, 19),
-                    new ErrorInfo("sublist parameters are not supported in 3.x", 1171, 123, 10, 1180, 123, 19),
-                    new ErrorInfo("unexpected token '42'", 1208, 127, 7, 1210, 127, 9),
+                    new ErrorInfo("sublist parameters are not supported in 3.x", 1171, 123, 10, 1181, 123, 20),
+                    new ErrorInfo("invalid parameter", 1208, 127, 7, 1210, 127, 9),
                     new ErrorInfo("\", variable\" not allowed in 3.x - use \"as variable\" instead.", 1277, 134, 17, 1280, 134, 20),
                     new ErrorInfo("default 'except' must be last", 1242, 132, 1, 1249, 132, 8),
                     new ErrorInfo("\", variable\" not allowed in 3.x - use \"as variable\" instead.", 1379, 144, 17, 1382, 144, 20),
@@ -557,14 +551,15 @@ namespace AnalysisTests {
                     new ErrorInfo("invalid syntax", 1442, 150, 8, 1444, 150, 10),
                     new ErrorInfo("invalid syntax", 1451, 152, 4, 1453, 152, 6),
                     new ErrorInfo("expected name", 1459, 154, 3, 1461, 154, 5),
-                    new ErrorInfo("unexpected token '42'", 1476, 156, 7, 1478, 156, 9),
+                    new ErrorInfo("invalid parameter", 1476, 156, 7, 1482, 156, 13),
                     new ErrorInfo("invalid syntax", 1511, 160, 12, 1512, 160, 13),
                     new ErrorInfo("invalid syntax", 1524, 161, 10, 1527, 161, 13)
                 );
             }
 
-            ParseErrors("AllErrors.py",
-                    PythonLanguageVersion.V35,
+            foreach (var version in V35AndUp) {
+                ParseErrors("AllErrors.py",
+                    version,
                     new ErrorInfo("future statement does not support import *", 0, 1, 1, 24, 1, 25),
                     new ErrorInfo("future feature is not defined: *", 0, 1, 1, 24, 1, 25),
                     new ErrorInfo("not a chance", 26, 2, 1, 55, 2, 30),
@@ -572,9 +567,8 @@ namespace AnalysisTests {
                     new ErrorInfo("default value must be specified here", 106, 5, 16, 107, 5, 17),
                     new ErrorInfo("positional argument follows keyword argument", 134, 8, 12, 135, 8, 13),
                     new ErrorInfo("unexpected token 'pass'", 197, 14, 1, 201, 14, 5),
-                    new ErrorInfo("unexpected token '42'", 217, 17, 11, 219, 17, 13),
-                    new ErrorInfo("sublist parameters are not supported in 3.x", 216, 17, 10, 222, 17, 16),
-                    new ErrorInfo("unexpected token '42'", 251, 20, 10, 253, 20, 12),
+                    new ErrorInfo("sublist parameters are not supported in 3.x", 216, 17, 10, 223, 17, 17),
+                    new ErrorInfo("invalid parameter", 251, 20, 10, 253, 20, 12),
                     new ErrorInfo("'break' outside loop", 278, 25, 1, 283, 25, 6),
                     new ErrorInfo("'continue' not properly in loop", 285, 26, 1, 293, 26, 9),
                     new ErrorInfo("'continue' not supported inside 'finally' clause", 374, 34, 9, 382, 34, 17),
@@ -598,16 +592,14 @@ namespace AnalysisTests {
                     new ErrorInfo("nonlocal declaration not allowed at module level", 788, 82, 1, 796, 82, 9),
                     new ErrorInfo("invalid syntax, only exception value is allowed in 3.x.", 814, 83, 10, 819, 83, 15),
                     new ErrorInfo("default value must be specified here", 924, 99, 15, 925, 99, 16),
-                    new ErrorInfo("duplicate * args arguments", 987, 105, 13, 988, 105, 14),
-                    new ErrorInfo("duplicate * args arguments", 1017, 108, 13, 1018, 108, 14),
-                    new ErrorInfo("named arguments must follow bare *", 1044, 111, 10, 1048, 111, 14),
-                    new ErrorInfo("sublist parameters are not supported in 3.x", 1072, 114, 10, 1077, 114, 15),
-                    new ErrorInfo("unexpected token '42'", 1107, 117, 11, 1109, 117, 13),
-                    new ErrorInfo("sublist parameters are not supported in 3.x", 1106, 117, 10, 1112, 117, 16),
+                    new ErrorInfo("duplicate * args arguments", 987, 105, 13, 989, 105, 15),
+                    new ErrorInfo("duplicate * args arguments", 1017, 108, 13, 1019, 108, 15),
+                    new ErrorInfo("named arguments must follow bare *", 1044, 111, 10, 1045, 111, 11),
+                    new ErrorInfo("sublist parameters are not supported in 3.x", 1072, 114, 10, 1078, 114, 16),
+                    new ErrorInfo("sublist parameters are not supported in 3.x", 1106, 117, 10, 1113, 117, 17),
                     new ErrorInfo("duplicate argument 'abc' in function definition", 1143, 120, 12, 1146, 120, 15),
-                    new ErrorInfo("duplicate argument 'abc' in function definition", 1177, 123, 16, 1180, 123, 19),
-                    new ErrorInfo("sublist parameters are not supported in 3.x", 1171, 123, 10, 1180, 123, 19),
-                    new ErrorInfo("unexpected token '42'", 1208, 127, 7, 1210, 127, 9),
+                    new ErrorInfo("sublist parameters are not supported in 3.x", 1171, 123, 10, 1181, 123, 20),
+                    new ErrorInfo("invalid parameter", 1208, 127, 7, 1210, 127, 9),
                     new ErrorInfo("\", variable\" not allowed in 3.x - use \"as variable\" instead.", 1277, 134, 17, 1280, 134, 20),
                     new ErrorInfo("default 'except' must be last", 1242, 132, 1, 1249, 132, 8),
                     new ErrorInfo("\", variable\" not allowed in 3.x - use \"as variable\" instead.", 1379, 144, 17, 1382, 144, 20),
@@ -619,10 +611,11 @@ namespace AnalysisTests {
                     new ErrorInfo("invalid syntax", 1442, 150, 8, 1444, 150, 10),
                     new ErrorInfo("invalid syntax", 1451, 152, 4, 1453, 152, 6),
                     new ErrorInfo("expected name", 1459, 154, 3, 1461, 154, 5),
-                    new ErrorInfo("unexpected token '42'", 1476, 156, 7, 1478, 156, 9),
+                    new ErrorInfo("invalid parameter", 1476, 156, 7, 1482, 156, 13),
                     new ErrorInfo("invalid syntax", 1511, 160, 12, 1512, 160, 13),
                     new ErrorInfo("invalid syntax", 1524, 161, 10, 1527, 161, 13)
                 );
+            }
         }
 
         [TestMethod, Priority(0)]
@@ -2190,7 +2183,7 @@ namespace AnalysisTests {
         public void FuncDefV2() {
             foreach (var version in V2Versions) {
                 CheckAst(
-                    ParseFile("FuncDefV2.py", ErrorSink.Null, version),
+                    ParseFileNoErrors("FuncDefV2.py", version),
                     CheckSuite(
                         CheckFuncDef("f", new[] { CheckParameter("a"), CheckSublistParameter("b", "c"), CheckParameter("d") }, CheckSuite(Pass))
                     )
@@ -2199,7 +2192,7 @@ namespace AnalysisTests {
 
             foreach (var version in V3Versions) {
                 ParseErrors("FuncDefV2.py", version,
-                    new ErrorInfo("sublist parameters are not supported in 3.x", 9, 1, 10, 14, 1, 15)
+                    new ErrorInfo("sublist parameters are not supported in 3.x", 9, 1, 10, 15, 1, 16)
                 );
             }
         }
@@ -2208,7 +2201,7 @@ namespace AnalysisTests {
         public void FuncDefV3() {
             foreach (var version in V3Versions) {
                 CheckAst(
-                    ParseFile("FuncDefV3.py", ErrorSink.Null, version),
+                    ParseFileNoErrors("FuncDefV3.py", version),
                     CheckSuite(
                         CheckFuncDef("f", new[] { CheckParameter("a", ParameterKind.List), CheckParameter("x", ParameterKind.KeywordOnly) }, CheckSuite(Pass)),
                         CheckFuncDef("f", new[] { CheckParameter("a", ParameterKind.List), CheckParameter("x", ParameterKind.KeywordOnly, defaultValue: One) }, CheckSuite(Pass)),
@@ -2223,7 +2216,7 @@ namespace AnalysisTests {
                         CheckFuncDef("f", new[] { CheckParameter("a", annotation: One) }, CheckSuite(Pass), returnAnnotation: One),
 
                         CheckFuncDef("f", new[] { CheckParameter("a", defaultValue: Two, annotation: One) }, CheckSuite(Pass)),
-                        CheckFuncDef("f", new[] { CheckParameter("a", ParameterKind.KeywordOnly) }, CheckSuite(Pass))
+                        CheckFuncDef("f", new[] { CheckParameter(null, ParameterKind.List), CheckParameter("a", ParameterKind.KeywordOnly) }, CheckSuite(Pass))
 
                     )
                 );
@@ -2233,27 +2226,17 @@ namespace AnalysisTests {
                 ParseErrors("FuncDefV3.py", version,
                     new ErrorInfo("positional parameter after * args not allowed", 10, 1, 11, 11, 1, 12),
                     new ErrorInfo("positional parameter after * args not allowed", 30, 2, 11, 35, 2, 16),
-                    new ErrorInfo("invalid syntax, parameter annotations require 3.x", 53, 4, 8, 56, 4, 11),
-                    new ErrorInfo("invalid syntax, parameter annotations require 3.x", 72, 5, 8, 74, 5, 10),
-                    new ErrorInfo("invalid syntax, parameter annotations require 3.x", 93, 6, 9, 95, 6, 11),
-                    new ErrorInfo("invalid syntax, parameter annotations require 3.x", 113, 7, 8, 116, 7, 11),
-                    new ErrorInfo("invalid syntax, parameter annotations require 3.x", 119, 7, 14, 121, 7, 16),
-                    new ErrorInfo("invalid syntax, parameter annotations require 3.x", 127, 7, 22, 129, 7, 24),
-                    new ErrorInfo("unexpected token '-'", 151, 9, 9, 152, 9, 10),
-                    new ErrorInfo("unexpected token '>'", 152, 9, 10, 153, 9, 11),
-                    new ErrorInfo("invalid syntax", 154, 9, 12, 155, 9, 13),
-                    new ErrorInfo("unexpected token ':'", 155, 9, 13, 156, 9, 14),
-                    new ErrorInfo("invalid syntax, parameter annotations require 3.x", 172, 11, 8, 175, 11, 11),
-                    new ErrorInfo("unexpected token '-'", 177, 11, 13, 178, 11, 14),
-                    new ErrorInfo("unexpected token '>'", 178, 11, 14, 179, 11, 15),
-                    new ErrorInfo("invalid syntax", 180, 11, 16, 181, 11, 17),
-                    new ErrorInfo("unexpected token ':'", 181, 11, 17, 182, 11, 18),
-                    new ErrorInfo("invalid syntax, parameter annotations require 3.x", 198, 13, 8, 201, 13, 11),
-                    new ErrorInfo("unexpected token ','", 223, 15, 8, 224, 15, 9),
-                    new ErrorInfo("unexpected token 'a'", 225, 15, 10, 226, 15, 11),
-                    new ErrorInfo("unexpected token 'a'", 225, 15, 10, 226, 15, 11),
-                    new ErrorInfo("unexpected token ')'", 226, 15, 11, 227, 15, 12),
-                    new ErrorInfo("unexpected token ':'", 227, 15, 12, 228, 15, 13)
+                    new ErrorInfo("invalid syntax, parameter annotations require 3.x", 52, 4, 7, 56, 4, 11),
+                    new ErrorInfo("invalid syntax, parameter annotations require 3.x", 71, 5, 7, 76, 5, 12),
+                    new ErrorInfo("invalid syntax, parameter annotations require 3.x", 91, 6, 7, 97, 6, 13),
+                    new ErrorInfo("invalid syntax, parameter annotations require 3.x", 112, 7, 7, 116, 7, 11),
+                    new ErrorInfo("invalid syntax, parameter annotations require 3.x", 118, 7, 13, 123, 7, 18),
+                    new ErrorInfo("invalid syntax, parameter annotations require 3.x", 125, 7, 20, 131, 7, 26),
+                    new ErrorInfo("invalid syntax, return annotations require 3.x", 151, 9, 9, 155, 9, 13),
+                    new ErrorInfo("invalid syntax, parameter annotations require 3.x", 171, 11, 7, 175, 11, 11),
+                    new ErrorInfo("invalid syntax, return annotations require 3.x", 177, 11, 13, 181, 11, 17),
+                    new ErrorInfo("invalid syntax, parameter annotations require 3.x", 197, 13, 7, 205, 13, 15),
+                    new ErrorInfo("invalid syntax", 222, 15, 7, 223, 15, 8)
                 );
             }
         }
@@ -2262,9 +2245,24 @@ namespace AnalysisTests {
         public void FuncDefV3Illegal() {
             foreach (var version in V3Versions) {
                 ParseErrors("FuncDefV3Illegal.py", version,
-                    new ErrorInfo("unexpected token ')'", 7, 1, 8, 8, 1, 9),
-                    new ErrorInfo("unexpected token ':'", 8, 1, 9, 9, 1, 10),
-                    new ErrorInfo("named arguments must follow bare *", 22, 2, 7, 26, 2, 11)
+                    new ErrorInfo("named arguments must follow bare *", 6, 1, 7, 7, 1, 8),
+                    new ErrorInfo("named arguments must follow bare *", 22, 2, 7, 23, 2, 8)
+                );
+            }
+        }
+
+        [TestMethod, Priority(0)]
+        public void FuncDefTrailingComma() {
+            foreach (var version in AllVersions) {
+                CheckAst(
+                    ParseFileNoErrors("FuncDefTrailingComma.py", version),
+                    CheckSuite(
+                        CheckFuncDef("f", new[] { CheckParameter("a") }, CheckSuite(Pass)),
+                        CheckFuncDef("f", new[] { CheckParameter("a"), CheckParameter("b", ParameterKind.List) }, CheckSuite(Pass)),
+                        CheckFuncDef("f", new[] { CheckParameter("a"), CheckParameter("b", ParameterKind.List), CheckParameter("c", ParameterKind.Dictionary) }, CheckSuite(Pass)),
+                        CheckFuncDef("f", new[] { CheckParameter("a", ParameterKind.List) }, CheckSuite(Pass)),
+                        CheckFuncDef("f", new[] { CheckParameter("a", ParameterKind.Dictionary) }, CheckSuite(Pass))
+                    )
                 );
             }
         }
@@ -2861,9 +2859,7 @@ namespace AnalysisTests {
                 switch (curVersion.Version) {
                     case PythonLanguageVersion.V36:
                         if (// https://github.com/Microsoft/PTVS/issues/1637
-                            filename.Equals("test_unicode_identifiers.py", StringComparison.OrdinalIgnoreCase) ||
-                            // https://github.com/Microsoft/PTVS/issues/1645
-                            filename.Equals("test_grammar.py", StringComparison.OrdinalIgnoreCase)
+                            filename.Equals("test_unicode_identifiers.py", StringComparison.OrdinalIgnoreCase)
                             ) {
                             continue;
                         }
@@ -3383,7 +3379,7 @@ namespace AnalysisTests {
 
         private static Action<Parameter> CheckParameter(string name, ParameterKind kind = ParameterKind.Normal, Action<Expression> defaultValue = null, Action<Expression> annotation = null) {
             return param => {
-                Assert.AreEqual(name, param.Name);
+                Assert.AreEqual(name ?? "", param.Name ?? "");
                 Assert.AreEqual(kind, param.Kind);
 
                 if (defaultValue != null) {

--- a/Python/Tests/PythonToolsMockTests/RefactorRenameTests.cs
+++ b/Python/Tests/PythonToolsMockTests/RefactorRenameTests.cs
@@ -2514,7 +2514,7 @@ def g(a, b, c):
             }
 
             public RenameVariableRequest GetRenameInfo(string originalName, PythonLanguageVersion languageVersion) {
-                Assert.IsTrue(_originalName.StartsWith(originalName), $"Selected text {originalName} did not match {_originalName}");
+                Assert.IsTrue(_originalName.StartsWith(originalName) || originalName.StartsWith("__") && _originalName.EndsWith(originalName), $"Selected text {originalName} did not match {_originalName}");
 
                 var requestView = new RenameVariableRequestView(originalName, languageVersion);
                 requestView.Name = _name;

--- a/Python/Tests/TestData/Grammar/FuncDefTrailingComma.py
+++ b/Python/Tests/TestData/Grammar/FuncDefTrailingComma.py
@@ -1,0 +1,14 @@
+def f(a,):
+    pass
+
+def f(a, *b,):
+    pass
+
+def f(a, *b, **c, ):
+    pass
+
+def f(*a,):
+    pass
+
+def f(**a, ):
+    pass


### PR DESCRIPTION
Fixes #1645 Cannot parse trailing commas in function definitions
Rewrites function definition parser to be more reliable. We now parse all syntax valid in any version and then raise errors later.
Fixes formatting/round-trip of parameters.
Fixes finding variables to rename.
Ensures more error messages are returned from analyzer initialization.