### PR TITLE
Remove peek definition workaround

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Navigation/Peek/PythonPeekResultSource.cs
+++ b/Python/Product/PythonTools/PythonTools/Navigation/Peek/PythonPeekResultSource.cs
@@ -86,8 +86,7 @@ namespace Microsoft.PythonTools.Navigation.Peek {
                 location.Column - 1,
                 location.Line - 1,
                 location.Column - 1,
-                isReadOnly: false,
-                editorDestination: new Guid(PythonConstants.EditorFactoryGuid)
+                isReadOnly: false
             );
         }
     }


### PR DESCRIPTION
Remove peek definition workaround that was put in place so that promote to document functionality opens with the Python editor. No longer needed now that we register the Python editor/file extension for peek (Steve added the registration in a PR last week).