### PR TITLE
Update executable name for IronPython 2.7.8 and above.

### DIFF
--- a/Python/Product/IronPython/Interpreter/IronPythonInterpreterFactory.cs
+++ b/Python/Product/IronPython/Interpreter/IronPythonInterpreterFactory.cs
@@ -43,12 +43,20 @@ namespace Microsoft.IronPythonTools.Interpreter {
                 return null;
             }
 
+            // IronPython 2.7.8 changed the executable names for 64-bit vs 32-bit
+            var ipyExe = arch == InterpreterArchitecture.x64 ? "ipy64.exe" : "ipy.exe";
+            var ipywExec = arch == InterpreterArchitecture.x64 ? "ipyw64.exe" : "ipyw.exe";
+            if (File.Exists(Path.Combine(prefixPath, "ipy32.exe"))) {
+                ipyExe = arch == InterpreterArchitecture.x64 ? "ipy.exe" : "ipy32.exe";
+                ipywExec = arch == InterpreterArchitecture.x64 ? "ipyw.exe" : "ipyw32.exe";
+            }
+
             return new InterpreterConfiguration(
                 GetInterpreterId(arch),
                 string.Format("IronPython 2.7{0: ()}", arch),
                 prefixPath,
-                Path.Combine(prefixPath, arch == InterpreterArchitecture.x64 ? "ipy64.exe" : "ipy.exe"),
-                Path.Combine(prefixPath, arch == InterpreterArchitecture.x64 ? "ipyw64.exe" : "ipyw.exe"),
+                Path.Combine(prefixPath, ipyExe),
+                Path.Combine(prefixPath, ipywExe),
                 "IRONPYTHONPATH",
                 arch,
                 new Version(2, 7),

--- a/Python/Tests/Utilities.Python.Analysis/PythonPaths.cs
+++ b/Python/Tests/Utilities.Python.Analysis/PythonPaths.cs
@@ -71,6 +71,11 @@ namespace TestUtilities {
                                 var res = installPath.GetValue("") as string;
                                 if (res != null) {
                                     return new PythonVersion(
+                                        // IronPython changed to Any CPU for ipy.exe and ipy32.exe for 32-bit in 2.7.8
+                                        if (File.Exists(Path.Combine(res, "ipy32.exe"))) {
+                                            exeName = x64 ? "ipy.exe" : "ipy32.exe";
+                                        }
+
                                         new InterpreterConfiguration(
                                             x64 ? "IronPython|2.7-64" : "IronPython|2.7-32",
                                             string.Format("IronPython {0} 2.7", x64 ? "64-bit" : "32-bit"),


### PR DESCRIPTION
In IronPython 2.7.8, we will be changing the file names for the 32-bit specific and Any CPU executables. ipy.exe will now be Any CPU and ipy32.exe will be the 32-bit (x86) executable. This is to make the Any CPU the default build.