### PR TITLE
Fixes correction of source location for getting completions.

### DIFF
--- a/Common/Tests/MockVsTests/MockVs.cs
+++ b/Common/Tests/MockVsTests/MockVs.cs
@@ -491,7 +491,8 @@ namespace Microsoft.VisualStudioTools.MockVsTests {
                 var _excludedAssemblies = new HashSet<string>(new string[] {
                     "Microsoft.VisualStudio.Text.Internal.dll",
                     "Microsoft.VisualStudio.Utilities.dll",
-                    "Microsoft.VisualStudio.Workspace.dll"
+                    "Microsoft.VisualStudio.Workspace.dll",
+                    "Microsoft.VisualStudio.Debugger.Interop.VSCodeDebuggerHost.dll"
                 }, StringComparer.OrdinalIgnoreCase);
 
                 foreach (var file in Directory.GetFiles(runningLoc, "*.dll")) {

--- a/Common/Tests/MockVsTests/MockVsTestExtensions.cs
+++ b/Common/Tests/MockVsTests/MockVsTestExtensions.cs
@@ -14,6 +14,7 @@
 // See the Apache Version 2.0 License for specific language governing
 // permissions and limitations under the License.
 
+using System;
 using Microsoft.VisualStudio;
 using TestUtilities;
 using TestUtilities.SharedProject;
@@ -22,7 +23,14 @@ namespace Microsoft.VisualStudioTools.MockVsTests {
     public static class MockVsTestExtensions {
         public static IVisualStudioInstance ToMockVs(this SolutionFile self) {
             MockVs vs = new MockVs();
-            vs.Invoke(() => ErrorHandler.ThrowOnFailure(vs.Solution.OpenSolutionFile(0, self.Filename)));
+            vs.Invoke(() => {
+                // HACK: The default targets files require a function that we don't provide
+                // The tests are mostly still broken, but they get further now. We should probably
+                // move them into UI tests, as we can't emulate the MSBuild environment well enough
+                // to open projects from here.
+                Microsoft.Build.Evaluation.ProjectCollection.GlobalProjectCollection.SetGlobalProperty("NugetRestoreTargets", "false");
+                ErrorHandler.ThrowOnFailure(vs.Solution.OpenSolutionFile(0, self.Filename));
+            });
             return vs;
         }
 

--- a/Python/Product/Analysis/Interpreter/Ast/AstPythonMultipleMembers.cs
+++ b/Python/Product/Analysis/Interpreter/Ast/AstPythonMultipleMembers.cs
@@ -1,6 +1,21 @@
-﻿using System;
+﻿// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABLITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 
 namespace Microsoft.PythonTools.Interpreter.Ast {
@@ -51,6 +66,12 @@ namespace Microsoft.PythonTools.Interpreter.Ast {
         }
 
         public void AddMember(IMember member) {
+            if (member == this) {
+                return;
+            } else if (member is IPythonMultipleMembers mm) {
+                AddMembers(mm.Members);
+                return;
+            }
             var old = _members;
             if (!old.Contains(member)) {
                 _members = old.Concat(Enumerable.Repeat(member, 1)).ToArray();
@@ -64,10 +85,10 @@ namespace Microsoft.PythonTools.Interpreter.Ast {
         public void AddMembers(IEnumerable<IMember> members) {
             var old = _members;
             if (old.Any()) {
-                _members = old.Union(members).ToArray();
+                _members = old.Union(members.Where(m => m != this)).ToArray();
                 _checkForLazy = true;
             } else {
-                _members = members.ToArray();
+                _members = members.Where(m => m != this).ToArray();
                 _checkForLazy = true;
             }
         }
@@ -76,7 +97,7 @@ namespace Microsoft.PythonTools.Interpreter.Ast {
         public IList<IMember> Members {
             get {
                 if (_checkForLazy) {
-                    _members = _members.Select(m => (m as ILazyMember)?.Get() ?? m).ToArray();
+                    _members = _members.Select(m => (m as ILazyMember)?.Get() ?? m).Where(m => m != this).ToArray();
                     _checkForLazy = false;
                 }
                 return _members;

--- a/Python/Product/Analysis/Interpreter/PythonMemberType.cs
+++ b/Python/Product/Analysis/Interpreter/PythonMemberType.cs
@@ -96,6 +96,11 @@ namespace Microsoft.PythonTools.Interpreter {
         /// <summary>
         /// The member represents a code snippet
         /// </summary>
-        CodeSnippet
+        CodeSnippet,
+
+        /// <summary>
+        /// The member represents a named argument
+        /// </summary>
+        NamedArgument
     }
 }

--- a/Python/Product/Analysis/Parsing/Ast/FunctionDefinition.cs
+++ b/Python/Product/Analysis/Parsing/Ast/FunctionDefinition.cs
@@ -319,19 +319,20 @@ namespace Microsoft.PythonTools.Parsing.Ast {
                         res.Append(namedOnly);
                     }
 
-                    if (!this.IsMissingCloseGrouping(ast)) {                        
-                        format.Append(
-                            res,
-                            Parameters.Count != 0 ? 
-                                format.SpaceWithinFunctionDeclarationParens :
-                                format.SpaceWithinEmptyParameterList,
-                            " ",
-                            "",
-                            this.GetFourthWhiteSpaceDefaultNull(ast)
-                        ); 
-                        
+                    format.Append(
+                        res,
+                        Parameters.Count != 0 ? 
+                            format.SpaceWithinFunctionDeclarationParens :
+                            format.SpaceWithinEmptyParameterList,
+                        " ",
+                        "",
+                        this.GetFourthWhiteSpaceDefaultNull(ast)
+                    ); 
+
+                    if (!this.IsMissingCloseGrouping(ast)) {
                         res.Append(')');
                     }
+
                     if (ReturnAnnotation != null) {
                         format.Append(
                             res,

--- a/Python/Product/Analysis/Parsing/Ast/LambdaExpression.cs
+++ b/Python/Product/Analysis/Parsing/Ast/LambdaExpression.cs
@@ -48,8 +48,8 @@ namespace Microsoft.PythonTools.Parsing.Ast {
             if (namedOnlyText != null) {
                 res.Append(namedOnlyText);
             }
+            res.Append(this.GetSecondWhiteSpace(ast));
             if (!this.IsIncompleteNode(ast)) {
-                res.Append(this.GetSecondWhiteSpace(ast));
                 res.Append(":");
                 if (_function.Body is ReturnStatement) {
                     ((ReturnStatement)_function.Body).Expression.AppendCodeString(res, ast, format);

--- a/Python/Product/Analysis/Parsing/Parser.cs
+++ b/Python/Product/Analysis/Parsing/Parser.cs
@@ -1913,7 +1913,7 @@ namespace Microsoft.PythonTools.Parsing {
             List<string> commaWhiteSpace = null;
             bool ateTerminator = false;
             var parameters = ateLeftParen ? ParseVarArgsList(TokenKind.RightParenthesis, true, out commaWhiteSpace, out ateTerminator) : null;
-            string closeParenWhiteSpace = _tokenWhiteSpace;
+            string closeParenWhiteSpace = ateTerminator || PeekToken(TokenKind.EndOfFile) ? _tokenWhiteSpace : null;
             FunctionDefinition ret;
             if (parameters == null) {
                 // error in parameters
@@ -1941,7 +1941,7 @@ namespace Microsoft.PythonTools.Parsing {
 
             string arrowWhiteSpace = null;
             Expression returnAnnotation = null;
-            if (MaybeEat(TokenKind.Arrow)) {
+            if (ateTerminator && MaybeEat(TokenKind.Arrow)) {
                 arrowWhiteSpace = _tokenWhiteSpace;
                 var arrStart = GetStart();
                 returnAnnotation = ParseExpression();
@@ -2202,7 +2202,7 @@ namespace Microsoft.PythonTools.Parsing {
             List<string> commaWhiteSpace;
             bool ateTerminator;
             FunctionDefinition func = ParseLambdaHelperStart(out commaWhiteSpace, out ateTerminator);
-            string colonWhiteSpace = _tokenWhiteSpace;
+            string colonWhiteSpace = ateTerminator || PeekToken(TokenKind.EndOfFile) ? _tokenWhiteSpace : null;
 
             Expression expr = ateTerminator ? ParseOldExpression() : Error("");
             return ParseLambdaHelperEnd(func, expr, whitespace, colonWhiteSpace, commaWhiteSpace, ateTerminator);
@@ -2214,7 +2214,7 @@ namespace Microsoft.PythonTools.Parsing {
             List<string> commaWhiteSpace;
             bool ateTerminator;
             FunctionDefinition func = ParseLambdaHelperStart(out commaWhiteSpace, out ateTerminator);
-            string colonWhiteSpace = _tokenWhiteSpace;
+            string colonWhiteSpace = ateTerminator || PeekToken(TokenKind.EndOfFile) ? _tokenWhiteSpace : null;
 
             Expression expr = ateTerminator ? ParseExpression() : Error("");
             return ParseLambdaHelperEnd(func, expr, whitespace, colonWhiteSpace, commaWhiteSpace, ateTerminator);

--- a/Python/Product/Analysis/Values/InstanceInfo.cs
+++ b/Python/Product/Analysis/Values/InstanceInfo.cs
@@ -392,42 +392,16 @@ namespace Microsoft.PythonTools.Analysis.Values {
             return base.GetAsyncEnumeratorTypes(node, unit);
         }
 
-        public override IPythonProjectEntry DeclaringModule {
-            get {
-                return _classInfo.DeclaringModule;
-            }
-        }
+        public ClassInfo ClassInfo => _classInfo;
 
-        public override int DeclaringVersion {
-            get {
-                return _classInfo.DeclaringVersion;
-            }
-        }
-
-        public override string Description {
-            get {
-                return ClassInfo.ClassDefinition.Name + " instance";
-            }
-        }
-
-        public override string Documentation {
-            get {
-                return ClassInfo.Documentation;
-            }
-        }
-
-        public override PythonMemberType MemberType {
-            get {
-                return PythonMemberType.Instance;
-            }
-        }
+        public override IPythonProjectEntry DeclaringModule => ClassInfo.DeclaringModule;
+        public override int DeclaringVersion => ClassInfo.DeclaringVersion;
+        public override string Description => ClassInfo.Name;
+        public override string Documentation => ClassInfo.Documentation;
+        public override PythonMemberType MemberType => PythonMemberType.Instance;
 
         internal override bool IsOfType(IAnalysisSet klass) {
             return klass.Contains(ClassInfo) || klass.Contains(ProjectState.ClassInfos[BuiltinTypeId.Object]);
-        }
-
-        public ClassInfo ClassInfo {
-            get { return _classInfo; }
         }
 
         public override string ToString() {

--- a/Python/Product/PythonTools/PythonTools/Extensions.cs
+++ b/Python/Product/PythonTools/PythonTools/Extensions.cs
@@ -88,6 +88,7 @@ namespace Microsoft.PythonTools {
                 case PythonMemberType.Event: group = StandardGlyphGroup.GlyphGroupEvent; break;
                 case PythonMemberType.Keyword: group = StandardGlyphGroup.GlyphKeyword; break;
                 case PythonMemberType.CodeSnippet: group = StandardGlyphGroup.GlyphCSharpExpansion; break;
+                case PythonMemberType.NamedArgument: group = StandardGlyphGroup.GlyphGroupMapItem; break;
                 case PythonMemberType.Function:
                 case PythonMemberType.Method:
                 default:

--- a/Python/Product/PythonTools/PythonTools/Intellisense/BufferParser.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/BufferParser.cs
@@ -317,16 +317,23 @@ namespace Microsoft.PythonTools.Intellisense {
             Debug.WriteLine("Changes for version {0}", curVersion.VersionNumber);
             var changes = new List<AP.ChangeInfo>();
             if (curVersion.Changes != null) {
+                AP.ChangeInfo prev = null;
                 foreach (var change in curVersion.Changes) {
                     Debug.WriteLine("Changes for version {0} {1} {2}", change.OldPosition, change.OldLength, change.NewText);
 
-                    changes.Add(
-                        new AP.ChangeInfo() {
-                            start = change.OldPosition,
-                            length = change.OldLength,
-                            newText = change.NewText
-                        }
-                    );
+                    if (prev != null && !string.IsNullOrEmpty(prev.newText) &&
+                        change.OldLength == 0 && prev.length == 0 && prev.start + prev.newText.Length == change.OldPosition) {
+                        // we can merge the two changes together
+                        prev.newText += change.NewText;
+                        continue;
+                    }
+
+                    prev = new AP.ChangeInfo() {
+                        start = change.OldPosition,
+                        length = change.OldLength,
+                        newText = change.NewText
+                    };
+                    changes.Add(prev);
                 }
             }
             return changes.ToArray();

--- a/Python/Product/PythonTools/PythonTools/Intellisense/CompletionAnalysis.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/CompletionAnalysis.cs
@@ -103,10 +103,14 @@ namespace Microsoft.PythonTools.Intellisense {
             return result;
         }
 
-        internal AnalysisEntry GetAnalysisEntry() {
+        internal PythonTextBufferInfo GetBufferInfo() {
             var bi = PythonTextBufferInfo.TryGetForBuffer(TextBuffer);
             Debug.Assert(bi != null, "Getting completions from uninitialized buffer " + TextBuffer.ToString());
-            return bi?.AnalysisEntry;
+            return bi;
+        }
+
+        internal AnalysisEntry GetAnalysisEntry() {
+            return GetBufferInfo()?.AnalysisEntry;
         }
 
         private static Stopwatch MakeStopWatch() {

--- a/Python/Product/PythonTools/PythonTools/Intellisense/ProjectAnalyzer.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/ProjectAnalyzer.cs
@@ -1229,8 +1229,10 @@ namespace Microsoft.PythonTools.Intellisense {
 
                 var fromPoint = new SnapshotPoint(fromSnapshot, index);
                 var toPoint = fromPoint.TranslateTo(analysisSnapshot, PointTrackingMode.Negative);
-
-                return toPoint.ToSourceLocation();
+                return new SourceLocation(
+                    toPoint.GetContainingLine().LineNumber + 1,
+                    (fromPoint - fromPoint.GetContainingLine().Start) + 1
+                );
             } else if (fromSnapshot != null) {
                 return new SnapshotPoint(fromSnapshot, index).ToSourceLocation();
             } else {

--- a/Python/Product/PythonTools/PythonTools/PythonAnalysisClassifier.cs
+++ b/Python/Product/PythonTools/PythonTools/PythonAnalysisClassifier.cs
@@ -153,24 +153,12 @@ namespace Microsoft.PythonTools {
                 if (_provider._colorNames) {
                     var bi = PythonTextBufferInfo.TryGetForBuffer(snapshot.TextBuffer);
                     if (bi?.AnalysisEntry != null && bi.AnalysisEntry.IsAnalyzed) {
-                        lock (_spanCacheLock) {
-                            spans = _spanCache;
-                            spanTranslator = _spanTranslator;
-                            if (spans == null) {
-                                // Put something in the cache so we don't retrigger too often
-                                _spanCache = new AP.AnalysisClassification[0];
-                            }
-                        }
-                        if (spans == null) {
-                            // Trigger the request so we get info on first open
-                            OnNewAnalysisAsync(bi, bi.AnalysisEntry).HandleAllExceptions(bi.Services.Site, GetType()).DoNotWait();
-                        }
+                        // Trigger the request so we get info on first open
+                        OnNewAnalysisAsync(bi, bi.AnalysisEntry).HandleAllExceptions(bi.Services.Site, GetType()).DoNotWait();
                     }
                 }
 
-                if (spans == null || spanTranslator == null) {
-                    return classifications;
-                }
+                return classifications;
             }
 
             // find where in the spans we should start scanning from (they're sorted by

--- a/Python/Product/VSInterpreters/PackageManager/PipPackageCache.cs
+++ b/Python/Product/VSInterpreters/PackageManager/PipPackageCache.cs
@@ -530,6 +530,7 @@ namespace Microsoft.PythonTools.Interpreter {
                 using (var resp = req.GetResponse()) {
                     return new Uri(resp.Headers.Get("Location") ?? uri);
                 }
+            } catch (WebException) {
             } catch (Exception ex) when (!ex.IsCriticalException()) {
                 Debug.Fail(ex.ToString());
                 // Nowhere else to report this error, so just swallow it

--- a/Python/Tests/Analysis/AnalysisSaveTest.cs
+++ b/Python/Tests/Analysis/AnalysisSaveTest.cs
@@ -173,7 +173,7 @@ Overloaded = test.Overloaded
 
                 var allMembers = newMod.Analysis.GetAllAvailableMembersByIndex(pos, GetMemberOptions.None);
 
-                Assert.AreEqual("class test.Aliased\r\nclass doc\r\n\r\nfunction Aliased(fob)\r\nfunction doc", allMembers.First(x => x.Name == "Aliased").Documentation);
+                Assert.AreEqual("class test.Aliased or function Aliased(fob)\r\n\r\nclass test.Aliased: class doc\r\n\r\nfunction Aliased(fob): function doc", allMembers.First(x => x.Name == "Aliased").Documentation);
                 newPs.Analyzer.AssertHasParameters("FunctionNoRetType", "value");
 
                 //var doc = newMod.Analysis.GetMembersByIndex("test", pos).Where(x => x.Name == "Overloaded").First();
@@ -402,7 +402,7 @@ def m(x = math.atan2(1, 0)): pass
                 new { FuncName = "j", ParamName="x", DefaultValue="[...]" },
                 new { FuncName = "k", ParamName="x", DefaultValue = "()" },
                 new { FuncName = "l", ParamName="x", DefaultValue = "(...)" },
-                new { FuncName = "m", ParamName="x", DefaultValue = "math.atan2(1,0)" },
+                new { FuncName = "m", ParamName="x", DefaultValue = "math.atan2(1, 0)" },
             };
 
             using (var newPs = SaveLoad(PythonLanguageVersion.V27, new AnalysisModule("test", "test.py", code))) {

--- a/Python/Tests/Analysis/AnalysisTest.cs
+++ b/Python/Tests/Analysis/AnalysisTest.cs
@@ -1855,7 +1855,7 @@ a = C()
 a.count";
             var entry = ProcessTextV2(text);
 
-            AssertUtil.ContainsExactly(entry.GetShortDescriptions("a", text.IndexOf("a =")), "C instance");
+            entry.AssertIsInstance("a", text.IndexOf("a ="), "C");
             var result = entry.GetSignatures("a.count");
             Assert.AreEqual(1, result.Length);
             Assert.AreEqual(1, result[0].Parameters.Length);
@@ -2028,7 +2028,7 @@ def g():
             var entry = ProcessTextV2(text);
 
             AssertUtil.ContainsExactly(entry.GetTypes("e1", text.IndexOf(", e1")), entry.GetBuiltin("TypeError"));
-            entry.AssertDescription("e2", text.IndexOf(", e2"), "MyException instance");
+            entry.AssertIsInstance("e2", text.IndexOf(", e2"), "MyException");
         }
 
         [TestMethod, Priority(0)]
@@ -2224,8 +2224,8 @@ b = {1}{1}C()
                 Console.WriteLine(test.Operator);
                 var entry = ProcessText(String.Format(text, test.Method, test.Operator));
 
-                AssertUtil.ContainsExactly(entry.GetShortDescriptions("a", text.IndexOf("a =")), "Result instance");
-                AssertUtil.ContainsExactly(entry.GetShortDescriptions("b", text.IndexOf("b =")), "Result instance");
+                entry.AssertIsInstance("a", text.IndexOf("a ="), "Result");
+                entry.AssertIsInstance("b", text.IndexOf("b ="), "Result");
             }
         }
 
@@ -2303,20 +2303,20 @@ m {1}= m
                     code = code.Replace("42L", "42");
                 }
                 using (var state = ProcessText(code, test.Version)) {
-                    AssertUtil.ContainsExactly(state.GetShortDescriptions("a", text.IndexOf("a =")), "ForwardResult instance");
-                    AssertUtil.ContainsExactly(state.GetShortDescriptions("b", text.IndexOf("b =")), "ReverseResult instance");
-                    AssertUtil.ContainsExactly(state.GetShortDescriptions("c", text.IndexOf("c =")), "ReverseResult instance");
-                    AssertUtil.ContainsExactly(state.GetShortDescriptions("d", text.IndexOf("d =")), "ForwardResult instance");
-                    AssertUtil.ContainsExactly(state.GetShortDescriptions("e", text.IndexOf("e =")), "ReverseResult instance");
-                    AssertUtil.ContainsExactly(state.GetShortDescriptions("f", text.IndexOf("f =")), "ForwardResult instance");
-                    AssertUtil.ContainsExactly(state.GetShortDescriptions("g", text.IndexOf("g =")), "ForwardResult instance");
-                    AssertUtil.ContainsExactly(state.GetShortDescriptions("h", text.IndexOf("h =")), "ReverseResult instance");
-                    AssertUtil.ContainsExactly(state.GetShortDescriptions("i", text.IndexOf("i =")), "ForwardResult instance");
-                    AssertUtil.ContainsExactly(state.GetShortDescriptions("j", text.IndexOf("j =")), "ReverseResult instance");
-                    AssertUtil.ContainsExactly(state.GetShortDescriptions("k", text.IndexOf("k =")), "ForwardResult instance");
-                    AssertUtil.ContainsExactly(state.GetShortDescriptions("l", text.IndexOf("l =")), "ReverseResult instance");
+                    state.AssertIsInstance("a", text.IndexOf("a ="), "ForwardResult");
+                    state.AssertIsInstance("b", text.IndexOf("b ="), "ReverseResult");
+                    state.AssertIsInstance("c", text.IndexOf("c ="), "ReverseResult");
+                    state.AssertIsInstance("d", text.IndexOf("d ="), "ForwardResult");
+                    state.AssertIsInstance("e", text.IndexOf("e ="), "ReverseResult");
+                    state.AssertIsInstance("f", text.IndexOf("f ="), "ForwardResult");
+                    state.AssertIsInstance("g", text.IndexOf("g ="), "ForwardResult");
+                    state.AssertIsInstance("h", text.IndexOf("h ="), "ReverseResult");
+                    state.AssertIsInstance("i", text.IndexOf("i ="), "ForwardResult");
+                    state.AssertIsInstance("j", text.IndexOf("j ="), "ReverseResult");
+                    state.AssertIsInstance("k", text.IndexOf("k ="), "ForwardResult");
+                    state.AssertIsInstance("l", text.IndexOf("l ="), "ReverseResult");
                     // We assume that augmented assignments keep their type
-                    AssertUtil.ContainsExactly(state.GetShortDescriptions("m", code.IndexOf("m " + test.Operator)), "C instance");
+                    state.AssertIsInstance("m", code.IndexOf("m " + test.Operator), "C");
                 }
             }
         }
@@ -3129,8 +3129,8 @@ mod1.l.append(a)
                 mod2.Analyze(CancellationToken.None, true);
                 state.WaitForAnalysis();
 
-                state.AssertDescription("l", "list of C instance");
-                state.AssertDescription("l[0]", "C instance");
+                state.AssertDescription("l", "list of C");
+                state.AssertIsInstance("l[0]", "C");
             }
         }
 
@@ -4116,7 +4116,7 @@ val = next(it)
             // Ensure the returned generators are distinct
             var entry = ProcessText(text);
             entry.AssertIsInstance("it", BuiltinTypeId.Generator);
-            entry.AssertDescription("val", "S0 instance");
+            entry.AssertIsInstance("val", "S0");
         }
 
         [TestMethod, Priority(0)]
@@ -4510,7 +4510,7 @@ oar = C().x
             entry.AssertIsInstance("C.x", BuiltinTypeId.Int);
 
             entry.AssertIsInstance("ctx", text.IndexOf("return"), BuiltinTypeId.Type);
-            AssertUtil.ContainsExactly(entry.GetShortDescriptions("inst", text.IndexOf("return 42")), "None", "C instance");
+            entry.AssertIsInstance("inst", text.IndexOf("return 42"), "None", "C");
 
             text = @"
 class mydesc(object):
@@ -4526,7 +4526,7 @@ oar = C().x
 ";
 
             entry = ProcessText(text);
-            entry.AssertDescription("inst", text.IndexOf("return 42"), "C instance");
+            entry.AssertIsInstance("inst", text.IndexOf("return 42"), "C");
             entry.AssertHasAttr("inst", text.IndexOf("return 42"), "instfunc");
         }
 
@@ -5233,8 +5233,8 @@ a = X(2)
             var entry = ProcessText(text);
             entry.AssertDescription("cls", text.IndexOf("= value"), "X");
             entry.AssertIsInstance("value", text.IndexOf("res.value = "), BuiltinTypeId.Int);
-            entry.AssertDescription("res", text.IndexOf("res.value = "), "X instance");
-            entry.AssertDescription("a", text.IndexOf("a = "), "X instance");
+            entry.AssertIsInstance("res", text.IndexOf("res.value = "), "X");
+            entry.AssertIsInstance("a", text.IndexOf("a = "), "X");
             entry.AssertIsInstance("a.value", BuiltinTypeId.Int);
         }
 
@@ -5500,7 +5500,7 @@ def f(a):
 ";
 
             var entry = ProcessText(text);
-            entry.AssertDescription("a", text.IndexOf("print(a)"), "C instance");
+            entry.AssertIsInstance("a", text.IndexOf("print(a)"), "C");
         }
 
         [TestMethod, Priority(0)]
@@ -5721,7 +5721,7 @@ def with_params_default_starargs(*args, **kwargs):
 ";
             var entry = ProcessTextV2(text);
 
-            entry.AssertDescription("fob()", "fob instance");
+            entry.AssertIsInstance("fob()", "fob");
             entry.AssertDescription("int()", "int");
             entry.AssertDescription("a", "float");
             entry.AssertDescription("a", "float");
@@ -5734,7 +5734,7 @@ def with_params_default_starargs(*args, **kwargs):
             entry.AssertDescription("list.append", "built-in method list.append(item)\r\nappend(self: list, item: object)");
             entry.AssertIsInstance("\"abc\".Length");
             entry.AssertIsInstance("c.Length");
-            entry.AssertDescription("d", "fob instance");
+            entry.AssertIsInstance("d", "fob");
             entry.AssertDescription("sys", "built-in module sys");
             entry.AssertDescription("f", "def test-module.f() -> str");
             entry.AssertDescription("fob.f", "def test-module.fob.f(self)\r\ndeclared in fob");
@@ -5791,7 +5791,7 @@ def g():
 ";
             var entry = ProcessText(text);
 
-            AssertUtil.Contains(entry.GetCompletionDocumentation("f", "func_name", 1).First(), "of type str");
+            AssertUtil.Contains(entry.GetCompletionDocumentation("", "d", 1).First(), "instance of fob");
             AssertUtil.Contains(entry.GetCompletionDocumentation("", "int", 1).First(), "integer");
             AssertUtil.Contains(entry.GetCompletionDocumentation("", "min", 1).First(), "min(");
         }
@@ -5990,8 +5990,8 @@ abc = f(())
 class Fob(object):
     def oar(self, a):
         pass
-        
-        
+
+
     def fob(self): 
         pass
 
@@ -6000,8 +6000,29 @@ x.oar(100)
 ";
 
             var entry = ProcessText(text);
+            var mod = entry.Modules[entry.DefaultModule].Analysis;
 
-            entry.AssertIsInstance("a", text.IndexOf("pass") + 14, BuiltinTypeId.Int);
+            AssertUtil.ContainsAtLeast(mod.GetAllAvailableMembers(new SourceLocation(6, 9)).Select(mr => mr.Name), "a");
+        }
+
+        [TestMethod, Priority(0)]
+        public void TypeAtEndOfIncompleteMethod() {
+            string text = @"
+class Fob(object):
+    def oar(self, a):
+
+
+
+
+
+x = Fob()
+x.oar(100)
+";
+
+            var entry = ProcessText(text, allowParseErrors: true);
+            var mod = entry.Modules[entry.DefaultModule].Analysis;
+
+            AssertUtil.ContainsAtLeast(mod.GetAllAvailableMembers(new SourceLocation(6, 9)).Select(mr => mr.Name), "a");
         }
 
         [TestMethod, Priority(0)]

--- a/Python/Tests/Analysis/ParserRoundTripTest.cs
+++ b/Python/Tests/Analysis/ParserRoundTripTest.cs
@@ -871,6 +871,7 @@ import fob");
             // Lambda Expression
 
             TestOneString(PythonLanguageVersion.V27, "lambda");
+            TestOneString(PythonLanguageVersion.V27, "lambda ");
             TestOneString(PythonLanguageVersion.V27, "lambda :");
             TestOneString(PythonLanguageVersion.V27, "lambda pass");
             TestOneString(PythonLanguageVersion.V27, "lambda : pass"); 
@@ -1521,6 +1522,8 @@ def f(): pass");
             TestOneString(PythonLanguageVersion.V35, "@fob\r\n\r\nasync def f(): pass");
             TestOneString(PythonLanguageVersion.V35, "@fob(2)\r\nasync \\\r\ndef f(): pass");
 
+            TestOneString(PythonLanguageVersion.V35, "def f(a, ");
+
             // Variable annotations
             TestOneString(PythonLanguageVersion.V36, "a:b");
             TestOneString(PythonLanguageVersion.V36, "a:b = 1");
@@ -1544,6 +1547,11 @@ def f(): pass");
             TestOneString(PythonLanguageVersion.V27, "exec(f, g, h) in i, j");
             TestOneString(PythonLanguageVersion.V27, "exec f in g");
             TestOneString(PythonLanguageVersion.V27, "exec(f,g)");
+        }
+
+        [TestMethod, Priority(0)]
+        public void RoundTripErrorParameter() {
+            TestOneString(PythonLanguageVersion.V35, "def inner(_it, _timer{init}): pass");
         }
 
 

--- a/Python/Tests/PythonToolsMockTests/CompletionTests.cs
+++ b/Python/Tests/PythonToolsMockTests/CompletionTests.cs
@@ -829,8 +829,8 @@ class Baz(Fob, Oar):
                     view3.GetCompletionListAfter("def ").Select(x => x.InsertionText),
                 @"capitalize(self):
         return super().capitalize()",
-                @"index(self, v):
-        return super().index(v)"
+                @"index(self, sub, start, end):
+        return super().index(sub, start, end)"
                 );
 
                 view2.Text = view3.Text = @"class Fob(str, list):
@@ -844,8 +844,8 @@ class Baz(Fob, Oar):
                 );
                 AssertUtil.Contains(
                     view3.GetCompletionListAfter("def ").Select(c => c.InsertionText),
-                    @"index(self, v):
-        return super().index(v)"
+                    @"index(self, sub, start, end):
+        return super().index(sub, start, end)"
                 );
 
                 view2.Text = view3.Text = @"class Fob(list, str):
@@ -858,8 +858,8 @@ class Baz(Fob, Oar):
                 );
                 AssertUtil.Contains(
                     view3.GetCompletionListAfter("def ").Select(c => c.InsertionText),
-                    @"index(self, v):
-        return super().index(v)"
+                    @"index(self, item, start, stop):
+        return super().index(item, start, stop)"
                 );
             }
         }
@@ -1047,7 +1047,7 @@ x = f(";
 
             using (var view = new PythonEditor(code)) {
                 view.Text = view.Text;
-                AssertUtil.ContainsAtLeast(view.GetCompletions(-1), "param1", "param2");
+                AssertUtil.ContainsAtLeast(view.GetCompletions(-1), "param1=", "param2=");
                 AssertUtil.DoesntContain(view.GetCompletions(0), "param1");
             }
         }
@@ -1071,8 +1071,8 @@ x = m.f(";
                     Console.WriteLine("Retry {0}", retries);
                     view.Text = view.Text;
                 }
-                AssertUtil.ContainsAtLeast(view.GetCompletions(-1), "param1", "param2");
-                AssertUtil.DoesntContain(view.GetCompletions(0), "param1");
+                AssertUtil.ContainsAtLeast(view.GetCompletions(-1), "param1=", "param2=");
+                AssertUtil.DoesntContain(view.GetCompletions(0), "param1=");
             }
         }
 

--- a/Python/Tests/PythonToolsMockTests/NavigableTests.cs
+++ b/Python/Tests/PythonToolsMockTests/NavigableTests.cs
@@ -229,7 +229,7 @@ res = my_var * 10
             private readonly PythonEditor _view;
 
             public NavigableHelper(string code, PythonVersion version) {
-                var factory = InterpreterFactoryCreator.CreateInterpreterFactory(version.Configuration, new InterpreterFactoryCreationOptions() { WatchFileSystem = false });
+                var factory = InterpreterFactoryCreator.CreateInterpreterFactory(version.Configuration, new InterpreterFactoryCreationOptions() { WatchFileSystem = false, NoDatabase = true });
                 _view = new PythonEditor("", version.Version, factory: factory);
                 _view.Text = code;
             }

--- a/Python/Tests/Utilities.Python.Analysis/PythonAnalysis.cs
+++ b/Python/Tests/Utilities.Python.Analysis/PythonAnalysis.cs
@@ -425,6 +425,22 @@ namespace TestUtilities.Python {
             AssertUtil.AreEqual(module.Analysis.GetSignaturesByIndex(expr, index).Single().Parameters.Select(p => p.Name), paramNames);
         }
 
+        public void AssertIsInstance(string expr) {
+            AssertIsInstance(expr, 0);
+        }
+
+        public void AssertIsInstance(string expr, int index) {
+            AssertIsInstance(_entries[DefaultModule], expr, index);
+        }
+
+        public void AssertIsInstance(IPythonProjectEntry module, string expr) {
+            AssertIsInstance(module, expr, 0);
+        }
+
+        public void AssertIsInstance(IPythonProjectEntry module, string expr, int index) {
+            AssertIsInstance(module, expr, index, Array.Empty<BuiltinTypeId>());
+        }
+
         public void AssertIsInstance(string expr, params BuiltinTypeId[] types) {
             AssertIsInstance(_entries[DefaultModule], expr, 0, types);
         }
@@ -449,6 +465,23 @@ namespace TestUtilities.Python {
             AssertUtil.ContainsExactly(GetTypeIds(module, expr, index), fixedTypes);
         }
 
+        public void AssertIsInstance(string expr, params string[] className) {
+            AssertIsInstance(_entries[DefaultModule], expr, 0, className);
+        }
+
+        public void AssertIsInstance(string expr, int index, params string[] className) {
+            AssertIsInstance(_entries[DefaultModule], expr, index, className);
+        }
+
+        public void AssertIsInstance(IPythonProjectEntry module, string expr, params string[] className) {
+            AssertIsInstance(module, expr, 0, className);
+        }
+
+        public void AssertIsInstance(IPythonProjectEntry module, string expr, int index, params string[] className) {
+            var vars = GetValues(module, expr, index);
+            AssertUtil.ContainsAtLeast(vars.Select(v => v.MemberType), PythonMemberType.Instance);
+            AssertUtil.ContainsExactly(vars.Select(v => v.ShortDescription), className);
+        }
         public void AssertAttrIsType(string variable, string memberName, params PythonMemberType[] types) {
             AssertAttrIsType(_entries[DefaultModule], variable, memberName, 0, types);
         }


### PR DESCRIPTION
Fixes #3421 Analysis can't keep up
Fixes correction of source location for getting completions.

Fixes #679 Named arguments in completion list should be visually different from other items
Adds trailing '=' to parameter name completions.

Fixes a few test failures and round-trip problems.