### PR TITLE
Fix cookiecutter add to solution failure

### DIFF
--- a/Python/Product/Cookiecutter/ViewModel/CookiecutterViewModel.cs
+++ b/Python/Product/Cookiecutter/ViewModel/CookiecutterViewModel.cs
@@ -1119,7 +1119,7 @@ namespace Microsoft.CookiecutterTools.ViewModel {
                 var openProjCmd = _postCommands?.FirstOrDefault(cmd => cmd.Name == "File.OpenProject");
                 if (openProjCmd != null) {
                     if (_solutionLoaded) {
-                        _projectSystemClient.AddToSolution(openProjCmd.Args);
+                        _projectSystemClient.AddToSolution(openProjCmd.Args.Trim('"'));
                     } else {
                         _executeCommand(openProjCmd.Name, openProjCmd.Args);
                     }


### PR DESCRIPTION
Fix #3431
Trim the quotes from the File.OpenProject command arguments before passing it to an API that expects a file path.