### PR TITLE
Fix launch when startup file is missing or not set

### DIFF
--- a/Common/Tests/Utilities.UI/UI/VisualStudioApp.cs
+++ b/Common/Tests/Utilities.UI/UI/VisualStudioApp.cs
@@ -566,6 +566,13 @@ namespace TestUtilities.UI {
             }
         }
 
+        /// <summary>
+        /// Checks the text of a dialog and dismisses it.
+        /// </summary>
+        /// <remarks>
+        /// Task dialog will be dismissed only if it was created with
+        /// AllowCancellation=true (ensures window pattern close is enabled).
+        /// </remarks>
         public void CheckMessageBox(params string[] text) {
             CheckMessageBox(MessageBoxButton.Close, text);
         }

--- a/Python/Product/Common/Strings.Designer.cs
+++ b/Python/Product/Common/Strings.Designer.cs
@@ -1237,6 +1237,15 @@ namespace Microsoft.PythonTools {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The project cannot be launched because the startup file &apos;{0}&apos; was not found..
+        /// </summary>
+        public static string DebugLaunchScriptNameDoesntExist {
+            get {
+                return ResourceManager.GetString("DebugLaunchScriptNameDoesntExist", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The project cannot be launched because the startup file is not specified..
         /// </summary>
         public static string DebugLaunchScriptNameMissing {

--- a/Python/Product/Common/Strings.resx
+++ b/Python/Product/Common/Strings.resx
@@ -1385,6 +1385,9 @@ modified from these scripts.</value>
   <data name="DebugLaunchScriptNameMissing" xml:space="preserve">
     <value>The project cannot be launched because the startup file is not specified.</value>
   </data>
+  <data name="DebugLaunchScriptNameDoesntExist" xml:space="preserve">
+    <value>The project cannot be launched because the startup file '{0}' was not found.</value>
+  </data>
   <data name="PublishToAzure30" xml:space="preserve">
     <value>Publishing Python projects has recently changed.</value>
   </data>

--- a/Python/Product/IronPython/Debugger/IronPythonLauncher.cs
+++ b/Python/Product/IronPython/Debugger/IronPythonLauncher.cs
@@ -75,6 +75,7 @@ namespace Microsoft.IronPythonTools.Debugger {
         }
 
         private int Launch(LaunchConfiguration config, bool debug) {
+            DebugLaunchHelper.RequireStartupFile(config);
 
             //if (factory.Id == _cpyInterpreterGuid || factory.Id == _cpy64InterpreterGuid) {
             //    MessageBox.Show(

--- a/Python/Product/PythonTools/PythonTools.csproj
+++ b/Python/Product/PythonTools/PythonTools.csproj
@@ -265,6 +265,7 @@
     <Compile Include="PythonTools\Commands\DiagnosticsCommand.cs" />
     <Compile Include="PythonTools\Commands\ImportCoverageCommand.cs" />
     <Compile Include="PythonTools\Commands\OpenWebUrlCommand.cs" />
+    <Compile Include="PythonTools\Debugger\NoStartupFileException.cs" />
     <Compile Include="PythonTools\Debugger\DebugLaunchHelper.cs" />
     <Compile Include="PythonTools\Debugger\ProvideDebugAdapterAttrributes.cs" />
     <Compile Include="PythonTools\Editor\IPythonTextBufferInfoEventSink.cs" />

--- a/Python/Product/PythonTools/PythonTools/Debugger/DebugLaunchHelper.cs
+++ b/Python/Product/PythonTools/PythonTools/Debugger/DebugLaunchHelper.cs
@@ -138,6 +138,16 @@ namespace Microsoft.PythonTools.Debugger {
             return jsonObj.ToString();
         }
 
+        public static void RequireStartupFile(LaunchConfiguration config) {
+            if (string.IsNullOrEmpty(config.ScriptName)) {
+                throw new NoStartupFileException(Strings.DebugLaunchScriptNameMissing);
+            }
+
+            if (!File.Exists(config.ScriptName)) {
+                throw new NoStartupFileException(Strings.DebugLaunchScriptNameDoesntExist.FormatUI(config.ScriptName));
+            }
+        }
+
         public static unsafe DebugTargetInfo CreateDebugTargetInfo(IServiceProvider provider, LaunchConfiguration config) {
             if (config.Interpreter.Version < new Version(2, 6)) {
                 // We don't support Python 2.5 now that our debugger needs the json module

--- a/Python/Product/PythonTools/PythonTools/Debugger/NoStartupFileException.cs
+++ b/Python/Product/PythonTools/PythonTools/Debugger/NoStartupFileException.cs
@@ -1,0 +1,32 @@
+// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABLITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System;
+using System.Runtime.Serialization;
+
+namespace Microsoft.PythonTools.Debugger {
+    [Serializable]
+    public class NoStartupFileException : Exception {
+        public NoStartupFileException() : base() { }
+        public NoStartupFileException(string msg) : base(msg) { }
+        public NoStartupFileException(string message, Exception innerException)
+            : base(message, innerException) {
+        }
+
+        protected NoStartupFileException(SerializationInfo info, StreamingContext context)
+            : base(info, context) { }
+    }
+}

--- a/Python/Product/PythonTools/PythonTools/Project/DefaultPythonLauncher.cs
+++ b/Python/Product/PythonTools/PythonTools/Project/DefaultPythonLauncher.cs
@@ -47,12 +47,7 @@ namespace Microsoft.PythonTools.Project {
         }
 
         private int Launch(LaunchConfiguration config, bool debug) {
-            // Most configuration is validated or inferred later, but while the
-            // helper class supports launching without a script, this launcher
-            // does not. So we validate script name now.
-            if (!File.Exists(config.ScriptName)) {
-                throw new ArgumentException(Strings.DebugLaunchScriptNameMissing);
-            }
+            DebugLaunchHelper.RequireStartupFile(config);
 
             if (debug) {
                 StartWithDebugger(config);

--- a/Python/Product/PythonTools/PythonTools/Project/PythonProjectConfig.cs
+++ b/Python/Product/PythonTools/PythonTools/Project/PythonProjectConfig.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Windows.Forms;
+using Microsoft.PythonTools.Debugger;
 using Microsoft.PythonTools.Infrastructure;
 using Microsoft.PythonTools.Interpreter;
 using Microsoft.VisualStudio;
@@ -65,7 +66,11 @@ namespace Microsoft.PythonTools.Project {
                 }
             } catch (NoInterpretersException ex) {
                 PythonToolsPackage.OpenNoInterpretersHelpPage(ProjectMgr.Site, ex.HelpPage);
+            } catch (NoStartupFileException ex) {
+                errorMessage = ex.Message;
             } catch (ArgumentException ex) {
+                // Previously used to handle "No startup file" which now has its own exception.
+                // Keeping it in case some launchers started relying on us catching this.
                 errorMessage = ex.Message;
             }
 

--- a/Python/Product/PythonTools/PythonTools/Project/PythonProjectConfig.cs
+++ b/Python/Product/PythonTools/PythonTools/Project/PythonProjectConfig.cs
@@ -78,7 +78,8 @@ namespace Microsoft.PythonTools.Project {
                 var td = new TaskDialog(ProjectMgr.Site) {
                     Title = Strings.ProductTitle,
                     MainInstruction = Strings.FailedToLaunchDebugger,
-                    Content = errorMessage
+                    Content = errorMessage,
+                    AllowCancellation = true
                 };
                 td.Buttons.Add(TaskDialogButton.Close);
                 td.ShowModal();

--- a/Python/Product/PythonTools/PythonTools/WebProject/PythonWebLauncher.cs
+++ b/Python/Product/PythonTools/PythonTools/WebProject/PythonWebLauncher.cs
@@ -79,6 +79,8 @@ namespace Microsoft.PythonTools.Project.Web {
         public int LaunchProject(bool debug) {
             var config = debug ? _debugConfig : _runConfig;
 
+            DebugLaunchHelper.RequireStartupFile(config);
+
             Uri url;
             int port;
             GetFullUrl(_serviceProvider, config, out url, out port);

--- a/Python/Product/Wsl/Debugger/WslLauncher.cs
+++ b/Python/Product/Wsl/Debugger/WslLauncher.cs
@@ -22,6 +22,7 @@ using System.Linq;
 using System.Net.NetworkInformation;
 using System.Runtime.InteropServices;
 using System.Text;
+using Microsoft.PythonTools.Debugger;
 using Microsoft.PythonTools.Debugger.Remote;
 using Microsoft.PythonTools.Infrastructure;
 using Microsoft.PythonTools.Interpreter;
@@ -67,6 +68,8 @@ namespace Microsoft.PythonTools.Wsl.Debugger {
         }
 
         private int Launch(LaunchConfiguration config, bool debug) {
+            DebugLaunchHelper.RequireStartupFile(config);
+
             if (debug) {
                 StartWithDebugger(config);
             } else {
@@ -139,10 +142,6 @@ namespace Microsoft.PythonTools.Wsl.Debugger {
         }
 
         private void StartWithDebugger(LaunchConfiguration config) {
-            if (string.IsNullOrEmpty(config.ScriptName)) {
-                throw new ArgumentException("script name");
-            }
-
             int port = Enumerable.Range(new Random().Next(49152, 65536), 60000)
                 .Except(IPGlobalProperties.GetIPGlobalProperties().GetActiveTcpConnections().Select(c => c.LocalEndPoint.Port))
                 .First();

--- a/Python/Tests/DebuggerUITests/DebugProjectUITests.cs
+++ b/Python/Tests/DebuggerUITests/DebugProjectUITests.cs
@@ -715,6 +715,20 @@ namespace DebuggerUITests {
             }
         }
 
+        public void WebProjectLauncherNoStartupFile(VisualStudioApp app, DotNotWaitOnNormalExit optionSetter) {
+            var project = app.CreateProject(
+                PythonVisualStudioApp.TemplateLanguageName,
+                PythonVisualStudioApp.EmptyWebProjectTemplate,
+                TestData.GetTempPath(),
+                "NewWebProject"
+            );
+
+            foreach (var cmd in new[] { "Debug.Start", "Debug.StartWithoutDebugging" }) {
+                app.Dte.ExecuteCommand(cmd);
+                app.CheckMessageBox("The project cannot be launched because the startup file is not specified.");
+            }
+        }
+
         #endregion
 
         #region Helpers

--- a/Python/Tests/DebuggerUITestsRunner/DebugProjectUITests.cs
+++ b/Python/Tests/DebuggerUITestsRunner/DebugProjectUITests.cs
@@ -236,5 +236,11 @@ namespace DebuggerUITestsRunner {
         public void StartWithoutDebuggingNoScript() {
             _vs.RunTest(nameof(DebuggerUITests.DebugProjectUITests.StartWithoutDebuggingNoScript));
         }
+
+        [TestMethod, Priority(0)]
+        [TestCategory("Installed")]
+        public void WebProjectLauncherNoStartupFile() {
+            _vs.RunTest(nameof(DebuggerUITests.DebugProjectUITests.WebProjectLauncherNoStartupFile));
+        }
     }
 }


### PR DESCRIPTION
Fix #3434 

I had previously fixed this but only for the default launcher and didn't realize that some of the others, like web launcher, were still broken.

Slightly improve the error message when the startup file is set but the file doesn't exist.