### PR TITLE
Fixes #3338 Tokenizer mishandles grouping recovery

### DIFF
--- a/Python/Product/Analysis/Parsing/Tokenizer.cs
+++ b/Python/Product/Analysis/Parsing/Tokenizer.cs
@@ -51,7 +51,7 @@ namespace Microsoft.PythonTools.Parsing {
 
         private const int EOF = -1;
         private const int MaxIndent = 80;
-        private const int DefaultBufferCapacity = 1024;
+        internal const int DefaultBufferCapacity = 1024;
 
         private Dictionary<object, NameToken> _names;
         private static object _currentName = new object();
@@ -346,6 +346,10 @@ namespace Microsoft.PythonTools.Parsing {
                 (_options & TokenizerOptions.GroupingRecovery) != 0 &&
                 _state.GroupingRecovery != null &&
                 _state.GroupingRecovery.TokenStart == _tokenStartIndex) {
+
+                // Pre-validate so that we have the current values on entry
+                Debug.Assert(_start - (_tokenStartIndex - _state.GroupingRecovery.NewlineStart) >= 0,
+                    $"Recovery failed with _start={_start}, _tokenStartIndex={_tokenStartIndex}, NewLineStart={_state.GroupingRecovery.NewlineStart}");
 
                 _state.ParenLevel = _state.BraceLevel = _state.BracketLevel = 0;
 
@@ -2586,12 +2590,14 @@ namespace Microsoft.PythonTools.Parsing {
 
         private void RefillBuffer() {
             if (_end == _buffer.Length) {
-                int new_size = System.Math.Max(System.Math.Max((_end - _start) * 2, _buffer.Length), _position);
-                ResizeInternal(ref _buffer, new_size, _start, _end - _start);
-                _end -= _start;
-                _position -= _start;
+                int ws_start = _tokenStartIndex - _state.GroupingRecovery?.NewlineStart ?? 0;
+                int new_start = _start - ws_start;    // move the buffer to the start of the current whitespace
+                int new_size = Math.Max(Math.Max((_end - new_start) * 2, _buffer.Length), _position);
+                ResizeInternal(ref _buffer, new_size, new_start, _end - new_start);
+                _end -= new_start;
+                _position -= new_start;
                 _tokenEnd = -1;
-                _start = 0;
+                _start = ws_start;   // start this many characters into the buffer
                 _bufferResized = true;
             }
 

--- a/Python/Tests/Analysis/ParserTests.cs
+++ b/Python/Tests/Analysis/ParserTests.cs
@@ -39,6 +39,11 @@ namespace AnalysisTests {
             AssertListener.Initialize();
         }
 
+        [TestCleanup]
+        public void TestCleanup() {
+            AssertListener.ThrowUnhandled();
+        }
+
         internal static readonly PythonLanguageVersion[] AllVersions = new[] { PythonLanguageVersion.V26, PythonLanguageVersion.V27, PythonLanguageVersion.V30, PythonLanguageVersion.V31, PythonLanguageVersion.V32, PythonLanguageVersion.V33, PythonLanguageVersion.V34, PythonLanguageVersion.V35, PythonLanguageVersion.V36, PythonLanguageVersion.V37 };
         internal static readonly PythonLanguageVersion[] V26AndUp = AllVersions.Where(v => v >= PythonLanguageVersion.V26).ToArray();
         internal static readonly PythonLanguageVersion[] V27AndUp = AllVersions.Where(v => v >= PythonLanguageVersion.V27).ToArray();
@@ -1083,6 +1088,17 @@ namespace AnalysisTests {
                     )
                 );
             }
+        }
+
+        [TestMethod, Priority(0)]
+        public void GroupingRecoveryFailure() {
+            // Align the "pass" keyword on a buffer border to ensure we restore the whitespace
+            ParseString(new string(' ', Tokenizer.DefaultBufferCapacity - 9) + "{\r\n    pass", ErrorSink.Null, PythonLanguageVersion.V36);
+            AssertListener.ThrowUnhandled();
+
+            // Ensure we can restore whitespace that crosses buffer borders
+            ParseString("{\r\n" + new string(' ', Tokenizer.DefaultBufferCapacity * 2 - 9) + "    pass", ErrorSink.Null, PythonLanguageVersion.V36);
+            AssertListener.ThrowUnhandled();
         }
 
         [TestMethod, Priority(0)]
@@ -2978,6 +2994,13 @@ namespace AnalysisTests {
         private static PythonAst ParseFile(string filename, ErrorSink errorSink, PythonLanguageVersion version, Severity indentationInconsistencySeverity = Severity.Ignore) {
             var src = TestData.GetPath("TestData", "Grammar", filename);
             using (var reader = new StreamReader(src, true)) {
+                var parser = Parser.CreateParser(reader, version, new ParserOptions() { ErrorSink = errorSink, IndentationInconsistencySeverity = indentationInconsistencySeverity });
+                return parser.ParseFile();
+            }
+        }
+
+        private static PythonAst ParseString(string content, ErrorSink errorSink, PythonLanguageVersion version, Severity indentationInconsistencySeverity = Severity.Ignore) {
+            using (var reader = new StringReader(content)) {
                 var parser = Parser.CreateParser(reader, version, new ParserOptions() { ErrorSink = errorSink, IndentationInconsistencySeverity = indentationInconsistencySeverity });
                 return parser.ParseFile();
             }


### PR DESCRIPTION
Fixes #3338 Tokenizer mishandles grouping recovery
Ensures leading whitespace is restored when recovering from an invalid grouping.