### PR TITLE
Signature help improvements

### DIFF
--- a/Python/Product/Analysis/MemberResult.cs
+++ b/Python/Product/Analysis/MemberResult.cs
@@ -146,10 +146,8 @@ namespace Microsoft.PythonTools.Analysis {
 
                     string typeDisplay = "unknown type";
                     var types = docType.Value.OrderBy(s => s).ToList();
-                    if (types.Count == 0) {
+                    if (types.Count <= 1) {
                         typeDisplay = "";
-                    } else if (types.Count == 1) {
-                        typeDisplay = types[0] + ": ";
                     } else {
                         var orStr = types.Count == 2 ? " or " : ", or ";
                         typeDisplay = string.Join(", ", types.Take(types.Count - 1)) + orStr + types.Last() + ": ";

--- a/Python/Product/Analysis/Values/BoundMethodInfo.cs
+++ b/Python/Product/Analysis/Values/BoundMethodInfo.cs
@@ -100,22 +100,9 @@ namespace Microsoft.PythonTools.Analysis.Values {
 
         public override IEnumerable<OverloadResult> Overloads {
             get {
-                var p = _function.FunctionDefinition.Parameters;
-
-                var pp = p.Count == 0 ? new ParameterResult[0] : new ParameterResult[p.Count - 1];
-                for (int i = 1; i < p.Count; i++) {
-                    pp[i - 1] = new ParameterResult(
-                        FunctionInfo.MakeParameterName(p[i]),
-                        string.Empty,
-                        "object",
-                        false,
-                        null,
-                        FunctionInfo.GetDefaultValue(_function.ProjectState, p[i], DeclaringModule.Tree)
-                    );
+                foreach (var p in _function.Overloads) {
+                    yield return p.Parameters.Length > 0 ? p.WithNewParameters(p.Parameters.Skip(1).ToArray()) : p;
                 }
-                string doc = _function.Documentation;
-
-                yield return new SimpleOverloadResult(pp, _function.FunctionDefinition.Name, doc);
             }
         }
 

--- a/Python/Product/Analysis/Values/FunctionInfo.cs
+++ b/Python/Product/Analysis/Values/FunctionInfo.cs
@@ -468,18 +468,24 @@ namespace Microsoft.PythonTools.Analysis.Values {
 
                 foreach (var keyValue in references) {
                     yield return new SimpleOverloadResult(
-                        FunctionDefinition.Parameters.Select((p, i) => {
-                            var name = MakeParameterName(p);
-                            var defaultValue = GetDefaultValue(ProjectState, p, DeclaringModule.Tree);
-                            var type = keyValue.Key[i];
-                            var refs = keyValue.Value[i];
-                            return new ParameterResult(name, string.Empty, type, false, refs, defaultValue);
-                        }).ToArray(),
+                        FunctionDefinition.Parameters.Select((p, i) => ToParameterResult(p, keyValue.Key[i], keyValue.Value[i], ProjectState, DeclaringModule.Tree)).ToArray(),
                         FunctionDefinition.Name,
                         Documentation
                     );
                 }
             }
+        }
+
+        internal static ParameterResult ToParameterResult(Parameter p, string type, IEnumerable<AnalysisVariable> refs, PythonAnalyzer state, PythonAst tree) {
+            if (p.IsDictionary) {
+                return new ParameterResult("**" + p.Name ?? "", null, null, false, refs, null);
+            } else if (p.IsList) {
+                return new ParameterResult("*" + p.Name ?? "", null, null, false, refs, null);
+            }
+
+            var name = p.Name ?? "";
+            var defaultValue = GetDefaultValue(state, p, tree);
+            return new ParameterResult(name, null, type, false, refs, defaultValue);
         }
 
         internal static string MakeParameterName(Parameter curParam) {

--- a/Python/Product/Common/Infrastructure/EnumerableExtensions.cs
+++ b/Python/Product/Common/Infrastructure/EnumerableExtensions.cs
@@ -90,5 +90,33 @@ namespace Microsoft.PythonTools.Infrastructure {
             }
             return Enumerable.Empty<T>();
         }
+
+        public static int IndexOf<T>(this IEnumerable<T> source, T value) where T : IEquatable<T> {
+            return source.IndexOf(value, EqualityComparer<T>.Default);
+        }
+
+        public static int IndexOf<T>(this IEnumerable<T> source, T value, IEqualityComparer<T> comparer) {
+            int index = 0;
+            foreach (var v in source) {
+                if (comparer.Equals(value, v)) {
+                    return index;
+                }
+                index += 1;
+            }
+
+            return -1;
+        }
+
+        public static int IndexOf<T>(this IEnumerable<T> source, Func<T, bool> predicate) {
+            int index = 0;
+            foreach (var v in source) {
+                if (predicate(v)) {
+                    return index;
+                }
+                index += 1;
+            }
+
+            return -1;
+        }
     }
 }

--- a/Python/Product/PythonTools/PythonTools/Intellisense/IntellisenseController.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/IntellisenseController.cs
@@ -821,33 +821,23 @@ namespace Microsoft.PythonTools.Intellisense {
             // pick the best signature when the signature includes types.
             var bestSig = sigHelpSession.SelectedSignature as PythonSignature;
             if (bestSig != null) {
-                for (int i = 0; i < bestSig.Parameters.Count; ++i) {
-                    if (bestSig.Parameters[i].Name == lastKeywordArg ||
-                        lastKeywordArg == null && (i == curParam || PythonSignature.IsParamArray(bestSig.Parameters[i].Name))
-                    ) {
-                        bestSig.SetCurrentParameter(bestSig.Parameters[i]);
-                        sigHelpSession.SelectedSignature = bestSig;
-                        return;
-                    }
+                if (bestSig.SelectBestParameter(curParam, lastKeywordArg) >= 0) {
+                    sigHelpSession.SelectedSignature = bestSig;
+                    return;
                 }
             }
 
             PythonSignature fallback = null;
             foreach (var sig in sigHelpSession.Signatures.OfType<PythonSignature>().OrderBy(s => s.Parameters.Count)) {
                 fallback = sig;
-                for (int i = 0; i < sig.Parameters.Count; ++i) {
-                    if (sig.Parameters[i].Name == lastKeywordArg ||
-                        lastKeywordArg == null && (i == curParam || PythonSignature.IsParamArray(sig.Parameters[i].Name))
-                    ) {
-                        sig.SetCurrentParameter(sig.Parameters[i]);
-                        sigHelpSession.SelectedSignature = sig;
-                        return;
-                    }
+                if (sig.SelectBestParameter(curParam, lastKeywordArg) >= 0) {
+                    sigHelpSession.SelectedSignature = sig;
+                    return;
                 }
             }
 
             if (fallback != null) {
-                fallback.SetCurrentParameter(null);
+                fallback.ClearParameter();
                 sigHelpSession.SelectedSignature = fallback;
             } else {
                 sigHelpSession.Dismiss();
@@ -911,11 +901,6 @@ namespace Microsoft.PythonTools.Intellisense {
                 ISignature sig;
                 if (sigHelpSession.Properties.TryGetProperty(typeof(PythonSignature), out sig)) {
                     sigHelpSession.SelectedSignature = sig;
-
-                    IParameter param;
-                    if (sigHelpSession.Properties.TryGetProperty(typeof(PythonParameter), out param)) {
-                        ((PythonSignature)sig).SetCurrentParameter(param);
-                    }
                 }
 
                 _sigHelpSession = sigHelpSession;


### PR DESCRIPTION
Fixes #3456 Parameter info does not include types
Improves generation of bound method signatures to preserve information from the underlying function.

Fixes #3453 Duplication in help strings when documentation string is present
Skips adding additional type label when only one value is present.

Also improves selection of signature parameter.