### PR TITLE
Fixes #3467 Incorrectly exported TemplateTextViewConnectionListener

### DIFF
--- a/Python/Product/Django/Intellisense/TemplateTextViewConnectionListener.cs
+++ b/Python/Product/Django/Intellisense/TemplateTextViewConnectionListener.cs
@@ -15,6 +15,7 @@
 // permissions and limitations under the License.
 
 using System.ComponentModel.Composition;
+using System.Linq;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Utilities;
@@ -22,15 +23,19 @@ using Microsoft.Web.Editor.ContainedLanguage;
 using Microsoft.Web.Editor.Controller;
 using Microsoft.Web.Editor.Host;
 using Microsoft.Web.Editor.Services;
+using ITextViewCreationListener = Microsoft.VisualStudio.Text.Editor.ITextViewCreationListener;
 
 namespace Microsoft.PythonTools.Django.Intellisense {
-    [Export(typeof(IWpfTextViewConnectionListener))]
-    [Export(typeof(IWpfTextViewCreationListener))]
+    [Export(typeof(ITextViewConnectionListener))]
+    [Export(typeof(ITextViewCreationListener))]
     [ContentType(TemplateTagContentType.ContentTypeName)]
     [TextViewRole(PredefinedTextViewRoles.Editable)]
     [Name("Django Template Text View Connection Listener")]
     [Order(Before = "default")]
-    internal class TemplateTextViewConnectionListener : TextViewConnectionListener {
+    internal class TemplateTextViewConnectionListener : TextViewConnectionListener,
+        ITextViewConnectionListener,
+        ITextViewCreationListener
+    {
         protected override void OnTextViewConnected(ITextView textView, ITextBuffer textBuffer) {
             var mainController = ServiceManager.GetService<TemplateMainController>(textView) ??
                 new TemplateMainController(textView, textBuffer);
@@ -55,6 +60,18 @@ namespace Microsoft.PythonTools.Django.Intellisense {
             }
 
             base.OnTextViewDisconnected(textView, textBuffer);
+        }
+
+        void ITextViewConnectionListener.SubjectBuffersConnected(ITextView textView, ConnectionReason reason, System.Collections.Generic.IReadOnlyCollection<ITextBuffer> subjectBuffers) {
+            SubjectBuffersConnected((IWpfTextView)textView, reason, new System.Collections.ObjectModel.Collection<ITextBuffer>(subjectBuffers.ToArray()));
+        }
+
+        void ITextViewConnectionListener.SubjectBuffersDisconnected(ITextView textView, ConnectionReason reason, System.Collections.Generic.IReadOnlyCollection<ITextBuffer> subjectBuffers) {
+            SubjectBuffersDisconnected((IWpfTextView)textView, reason, new System.Collections.ObjectModel.Collection<ITextBuffer>(subjectBuffers.ToArray()));
+        }
+
+        void ITextViewCreationListener.TextViewCreated(ITextView textView) {
+            TextViewCreated((IWpfTextView)textView);
         }
     }
 }


### PR DESCRIPTION
Fixes #3467 Incorrectly exported TemplateTextViewConnectionListener
Updates exports for text view connection listener.
As a transitional step, explicitly implements the interfaces to ensure correct behaviour on current builds.