### PR TITLE
Fix typo and tab order in Python general options page

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Options/PythonGeneralOptionsControl.Designer.cs
+++ b/Python/Product/PythonTools/PythonTools/Options/PythonGeneralOptionsControl.Designer.cs
@@ -44,15 +44,15 @@ namespace Microsoft.PythonTools.Options {
             resources.ApplyResources(this.tableLayoutPanel3, "tableLayoutPanel3");
             this.tableLayoutPanel3.Controls.Add(this._showOutputWindowForVirtualEnvCreate, 0, 0);
             this.tableLayoutPanel3.Controls.Add(this._showOutputWindowForPackageInstallation, 0, 1);
+            this.tableLayoutPanel3.Controls.Add(this._elevatePip, 0, 2);
             this.tableLayoutPanel3.Controls.Add(this._autoAnalysis, 0, 3);
+            this.tableLayoutPanel3.Controls.Add(this._clearGlobalPythonPath, 0, 4);
             this.tableLayoutPanel3.Controls.Add(this._updateSearchPathsForLinkedFiles, 0, 5);
+            this.tableLayoutPanel3.Controls.Add(this._unresolvedImportWarning, 0, 6);
+            this.tableLayoutPanel3.Controls.Add(this._invalidEncodingWarning, 0, 7);
             this.tableLayoutPanel3.Controls.Add(this._indentationInconsistentLabel, 0, 8);
             this.tableLayoutPanel3.Controls.Add(this._indentationInconsistentCombo, 1, 8);
-            this.tableLayoutPanel3.Controls.Add(this._elevatePip, 0, 2);
-            this.tableLayoutPanel3.Controls.Add(this._unresolvedImportWarning, 0, 6);
-            this.tableLayoutPanel3.Controls.Add(this._clearGlobalPythonPath, 0, 4);
             this.tableLayoutPanel3.Controls.Add(this._resetSuppressDialog, 0, 10);
-            this.tableLayoutPanel3.Controls.Add(this._invalidEncodingWarning, 0, 7);
             this.tableLayoutPanel3.Name = "tableLayoutPanel3";
             // 
             // _showOutputWindowForVirtualEnvCreate

--- a/Python/Product/PythonTools/PythonTools/Options/PythonGeneralOptionsControl.resx
+++ b/Python/Product/PythonTools/PythonTools/Options/PythonGeneralOptionsControl.resx
@@ -475,13 +475,13 @@
     <value>6, 3, 6, 3</value>
   </data>
   <data name="_invalidEncodingWarning.Size" type="System.Drawing.Size, System.Drawing">
-    <value>279, 17</value>
+    <value>297, 17</value>
   </data>
   <data name="_invalidEncodingWarning.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
   </data>
   <data name="_invalidEncodingWarning.Text" xml:space="preserve">
-    <value>Warn when file &amp;encoding does match magic comment</value>
+    <value>Warn when file &amp;encoding does not match magic comment</value>
   </data>
   <data name="&gt;&gt;_invalidEncodingWarning.Name" xml:space="preserve">
     <value>_invalidEncodingWarning</value>


### PR DESCRIPTION
Fix #3477 