### PR TITLE
Cookiecutter virtual environment creation fixes

### DIFF
--- a/Python/Product/Cookiecutter/Cookiecutter.csproj
+++ b/Python/Product/Cookiecutter/Cookiecutter.csproj
@@ -323,6 +323,12 @@
       <IncludeInVSIX>true</IncludeInVSIX>
       <VSIXSubPath>.</VSIXSubPath>
     </Content>
+    <Content Include="..\PythonTools\pip_downloader.py">
+      <Link>pip_downloader.py</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <IncludeInVSIX>true</IncludeInVSIX>
+      <VSIXSubPath>.</VSIXSubPath>
+    </Content>
     <Content Include="cookiecutter_render.py">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <IncludeInVSIX>true</IncludeInVSIX>

--- a/Python/Product/Cookiecutter/Model/CookiecutterClient.cs
+++ b/Python/Product/Cookiecutter/Model/CookiecutterClient.cs
@@ -71,15 +71,73 @@ namespace Microsoft.CookiecutterTools.Model {
 
         public async Task CreateCookiecutterEnv() {
             // Create a virtual environment using the global interpreter
-            var interpreterPath = _interpreter.InterpreterExecutablePath;
-            var output = ProcessOutput.RunHiddenAndCapture(interpreterPath, "-m", "venv", _envFolderPath);
+            try {
+                await CreateVenv();
+            } catch (ProcessException ex) when (ex.Result.ExitCode == 1) {
+                // Create fails on some Anaconda due to venv failing to install pip.
+                // Try again by installing pip ourselves.
+                await CreateVenvWithoutPipThenInstallPip();
+            }
+        }
 
-            await WaitForOutput(interpreterPath, output);
+        private async Task CreateVenv() {
+            if (Directory.Exists(_envFolderPath)) {
+                _redirector.WriteLine(Strings.InstallingCookiecutterDeleteEnv.FormatUI(_envFolderPath));
+                Directory.Delete(_envFolderPath, true);
+            }
+
+            _redirector.WriteLine(Strings.InstallingCookiecutterCreateEnv.FormatUI(_envFolderPath));
+            var output = ProcessOutput.Run(
+                _interpreter.InterpreterExecutablePath,
+                new[] { "-m", "venv", _envFolderPath },
+                null,
+                null,
+                false,
+                _redirector
+            );
+            await WaitForOutput(_interpreter.InterpreterExecutablePath, output);
+        }
+
+        private async Task CreateVenvWithoutPipThenInstallPip() {
+            if (Directory.Exists(_envFolderPath)) {
+                _redirector.WriteLine(Strings.InstallingCookiecutterDeleteEnv.FormatUI(_envFolderPath));
+                Directory.Delete(_envFolderPath, true);
+            }
+
+            _redirector.WriteLine(Strings.InstallingCookiecutterCreateEnvWithoutPip.FormatUI(_envFolderPath));
+            var output = ProcessOutput.Run(
+                _interpreter.InterpreterExecutablePath,
+                new[] { "-m", "venv", _envFolderPath, "--without-pip" },
+                null,
+                null,
+                false,
+                _redirector
+            );
+            await WaitForOutput(_interpreter.InterpreterExecutablePath, output);
+
+            _redirector.WriteLine(Strings.InstallingCookiecutterInstallPip.FormatUI(_envFolderPath));
+            var pipScriptPath = PythonToolsInstallPath.GetFile("pip_downloader.py");
+            output = ProcessOutput.Run(
+                _envInterpreterPath,
+                new[] { pipScriptPath },
+                _interpreter.PrefixPath,
+                null,
+                false,
+                _redirector
+            );
+            await WaitForOutput(_interpreter.InterpreterExecutablePath, output);
         }
 
         public async Task InstallPackage() {
-            // Install the package into the virtual environment
-            var output = ProcessOutput.RunHiddenAndCapture(_envInterpreterPath, "-m", "pip", "install", "cookiecutter<1.5");
+            _redirector.WriteLine(Strings.InstallingCookiecutterInstallPackages.FormatUI(_envFolderPath));
+            var output = ProcessOutput.Run(
+                _envInterpreterPath,
+                new[] { "-m", "pip", "install", "cookiecutter<1.5" },
+                null,
+                null,
+                false,
+                _redirector
+            );
 
             await WaitForOutput(_envInterpreterPath, output);
         }

--- a/Python/Product/Cookiecutter/Model/CookiecutterClient.cs
+++ b/Python/Product/Cookiecutter/Model/CookiecutterClient.cs
@@ -81,10 +81,7 @@ namespace Microsoft.CookiecutterTools.Model {
         }
 
         private async Task CreateVenv() {
-            if (Directory.Exists(_envFolderPath)) {
-                _redirector.WriteLine(Strings.InstallingCookiecutterDeleteEnv.FormatUI(_envFolderPath));
-                Directory.Delete(_envFolderPath, true);
-            }
+            RemoveExistingVenv();
 
             _redirector.WriteLine(Strings.InstallingCookiecutterCreateEnv.FormatUI(_envFolderPath));
             var output = ProcessOutput.Run(
@@ -99,10 +96,7 @@ namespace Microsoft.CookiecutterTools.Model {
         }
 
         private async Task CreateVenvWithoutPipThenInstallPip() {
-            if (Directory.Exists(_envFolderPath)) {
-                _redirector.WriteLine(Strings.InstallingCookiecutterDeleteEnv.FormatUI(_envFolderPath));
-                Directory.Delete(_envFolderPath, true);
-            }
+            RemoveExistingVenv();
 
             _redirector.WriteLine(Strings.InstallingCookiecutterCreateEnvWithoutPip.FormatUI(_envFolderPath));
             var output = ProcessOutput.Run(
@@ -126,6 +120,16 @@ namespace Microsoft.CookiecutterTools.Model {
                 _redirector
             );
             await WaitForOutput(_interpreter.InterpreterExecutablePath, output);
+        }
+
+        private void RemoveExistingVenv() {
+            if (Directory.Exists(_envFolderPath)) {
+                _redirector.WriteLine(Strings.InstallingCookiecutterDeleteEnv.FormatUI(_envFolderPath));
+                try {
+                    Directory.Delete(_envFolderPath, true);
+                } catch (DirectoryNotFoundException) {
+                }
+            }
         }
 
         public async Task InstallPackage() {

--- a/Python/Product/Cookiecutter/Model/CookiecutterClientProvider.cs
+++ b/Python/Product/Cookiecutter/Model/CookiecutterClientProvider.cs
@@ -41,12 +41,13 @@ namespace Microsoft.CookiecutterTools.Model {
             var all = interpreters
                 .Where(x => File.Exists(x.Configuration.InterpreterPath))
                 .Where(x => x.Configuration.Version >= new Version(3, 3))
-                .OrderByDescending(x => x.Configuration.Version);
+                .OrderByDescending(x => x.Configuration.Version)
+                .ToArray();
 
             // Prefer a CPython installation if there is one because
             // some Anaconda installs have trouble creating a venv.
             var cpython = all
-                .Where(x => x.Vendor.IndexOf("Python Software Foundation", StringComparison.InvariantCultureIgnoreCase) == 0);
+                .Where(x => x.Vendor.IndexOf("Python Software Foundation", StringComparison.OrdinalIgnoreCase) == 0);
             var best = cpython.FirstOrDefault() ?? all.FirstOrDefault();
 
             return best != null ? new CookiecutterPythonInterpreter(

--- a/Python/Product/Cookiecutter/Model/CookiecutterClientProvider.cs
+++ b/Python/Product/Cookiecutter/Model/CookiecutterClientProvider.cs
@@ -38,11 +38,21 @@ namespace Microsoft.CookiecutterTools.Model {
 
         private static CookiecutterPythonInterpreter FindCompatibleInterpreter() {
             var interpreters = PythonRegistrySearch.PerformDefaultSearch();
-            var compatible = interpreters
+            var all = interpreters
                 .Where(x => File.Exists(x.Configuration.InterpreterPath))
-                .OrderByDescending(x => x.Configuration.Version)
-                .FirstOrDefault(x => x.Configuration.Version >= new Version(3, 3));
-            return compatible != null ? new CookiecutterPythonInterpreter(compatible.Configuration.InterpreterPath) : null;
+                .Where(x => x.Configuration.Version >= new Version(3, 3))
+                .OrderByDescending(x => x.Configuration.Version);
+
+            // Prefer a CPython installation if there is one because
+            // some Anaconda installs have trouble creating a venv.
+            var cpython = all
+                .Where(x => x.Vendor.IndexOf("Python Software Foundation", StringComparison.InvariantCultureIgnoreCase) == 0);
+            var best = cpython.FirstOrDefault() ?? all.FirstOrDefault();
+
+            return best != null ? new CookiecutterPythonInterpreter(
+                best.Configuration.PrefixPath,
+                best.Configuration.InterpreterPath
+            ) : null;
         }
     }
 }

--- a/Python/Product/Cookiecutter/Model/CookiecutterPythonInterpreter.cs
+++ b/Python/Product/Cookiecutter/Model/CookiecutterPythonInterpreter.cs
@@ -16,9 +16,11 @@
 
 namespace Microsoft.CookiecutterTools.Model {
     class CookiecutterPythonInterpreter {
+        public string PrefixPath { get; }
         public string InterpreterExecutablePath { get; }
 
-        public CookiecutterPythonInterpreter(string interpreterExecutablePath) {
+        public CookiecutterPythonInterpreter(string prefixPath, string interpreterExecutablePath) {
+            PrefixPath = prefixPath;
             InterpreterExecutablePath = interpreterExecutablePath;
         }
     }

--- a/Python/Product/Cookiecutter/Strings.Designer.cs
+++ b/Python/Product/Cookiecutter/Strings.Designer.cs
@@ -335,11 +335,56 @@ namespace Microsoft.CookiecutterTools {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Creating virtual environment at &apos;{0}&apos;.
+        /// </summary>
+        public static string InstallingCookiecutterCreateEnv {
+            get {
+                return ResourceManager.GetString("InstallingCookiecutterCreateEnv", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Creating virtual environment without pip at &apos;{0}&apos;.
+        /// </summary>
+        public static string InstallingCookiecutterCreateEnvWithoutPip {
+            get {
+                return ResourceManager.GetString("InstallingCookiecutterCreateEnvWithoutPip", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Deleting previous environment at &apos;{0}&apos;.
+        /// </summary>
+        public static string InstallingCookiecutterDeleteEnv {
+            get {
+                return ResourceManager.GetString("InstallingCookiecutterDeleteEnv", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to ----- Failed to install cookiecutter -----.
         /// </summary>
         public static string InstallingCookiecutterFailed {
             get {
                 return ResourceManager.GetString("InstallingCookiecutterFailed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Installing packages into virtual environment at &apos;{0}&apos;.
+        /// </summary>
+        public static string InstallingCookiecutterInstallPackages {
+            get {
+                return ResourceManager.GetString("InstallingCookiecutterInstallPackages", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Installing pip into virtual environment at &apos;{0}&apos;.
+        /// </summary>
+        public static string InstallingCookiecutterInstallPip {
+            get {
+                return ResourceManager.GetString("InstallingCookiecutterInstallPip", resourceCulture);
             }
         }
         

--- a/Python/Product/Cookiecutter/Strings.resx
+++ b/Python/Product/Cookiecutter/Strings.resx
@@ -176,6 +176,26 @@ Please delete the installed template and try again.</value>
   <data name="InstallingCookiecutterFailed" xml:space="preserve">
     <value>----- Failed to install cookiecutter -----</value>
   </data>
+  <data name="InstallingCookiecutterCreateEnv" xml:space="preserve">
+    <value>Creating virtual environment at '{0}'</value>
+    <comment>{0} is a folder path</comment>
+  </data>
+  <data name="InstallingCookiecutterCreateEnvWithoutPip" xml:space="preserve">
+    <value>Creating virtual environment without pip at '{0}'</value>
+    <comment>{0} is a folder path</comment>
+  </data>
+  <data name="InstallingCookiecutterDeleteEnv" xml:space="preserve">
+    <value>Deleting previous environment at '{0}'</value>
+    <comment>{0} is a folder path</comment>
+  </data>
+  <data name="InstallingCookiecutterInstallPip" xml:space="preserve">
+    <value>Installing pip into virtual environment at '{0}'</value>
+    <comment>{0} is a folder path</comment>
+  </data>
+  <data name="InstallingCookiecutterInstallPackages" xml:space="preserve">
+    <value>Installing packages into virtual environment at '{0}'</value>
+    <comment>{0} is a folder path</comment>
+  </data>
   <data name="CloningTemplateStarted" xml:space="preserve">
     <value>----- Cloning template '{0}' -----</value>
     <comment>{0} is a template name</comment>

--- a/Python/Tests/CookiecutterTests/CookiecutterIntegrationTests.cs
+++ b/Python/Tests/CookiecutterTests/CookiecutterIntegrationTests.cs
@@ -135,7 +135,7 @@ namespace CookiecutterTests {
             Assert.AreEqual(6, _vm.Recommended.Templates.Count);
 
             // For GitHub results, check for a range since the exact count is bit inconsistent.
-            Assert.IsTrue(_vm.GitHub.Templates.Count > 25 && _vm.GitHub.Templates.Count < 32);
+            Assert.IsTrue(_vm.GitHub.Templates.Count > 20 && _vm.GitHub.Templates.Count < 32);
             Assert.AreEqual(_vm.GitHub.Templates.Count - 1, _vm.GitHub.Templates.OfType<TemplateViewModel>().Count());
             Assert.AreEqual(1, _vm.GitHub.Templates.OfType<ContinuationViewModel>().Count());
 
@@ -144,7 +144,7 @@ namespace CookiecutterTests {
             Assert.IsFalse(string.IsNullOrEmpty(continuationVM.ContinuationToken));
 
             await _vm.LoadMoreTemplatesAsync(continuationVM.ContinuationToken);
-            Assert.IsTrue(_vm.GitHub.Templates.Count > 50 && _vm.GitHub.Templates.Count < 64);
+            Assert.IsTrue(_vm.GitHub.Templates.Count > 40 && _vm.GitHub.Templates.Count < 64);
             Assert.AreEqual(_vm.GitHub.Templates.Count - 1, _vm.GitHub.Templates.OfType<TemplateViewModel>().Count());
             Assert.AreEqual(1, _vm.GitHub.Templates.OfType<ContinuationViewModel>().Count());
 


### PR DESCRIPTION
Fix #3485 

When selecting a Python interpreter for use with cookiecutter, prefer CPython over others.

When creating a virtual environment fails, try again using --without-pip option (workaround for Anaconda), then install pip.

Delete the virtual environment folder before creating a new one, to ensure that broken virtual environments are repaired (such as when the base environment was removed/moved).

Also, send all output from environment creation and installation of packages to output window to help diagnose future issues.