### PR TITLE
Fix quoting of arguments for pip install

### DIFF
--- a/Python/Product/IronPython/IronPythonPipPackageManagerProvider.cs
+++ b/Python/Product/IronPython/IronPythonPipPackageManagerProvider.cs
@@ -24,7 +24,7 @@ namespace Microsoft.IronPythonTools.Interpreter {
     [Export(typeof(IPackageManagerProvider))]
     sealed class IronPythonPipPackageManagerProvider : IPackageManagerProvider {
         class IPyPipCommands : PipPackageManagerCommands {
-            public override IEnumerable<string> Base() => new[] { "-X:Frames", "-c", "import pip; pip.main()" };
+            public override IEnumerable<string> Base() => new[] { "-X:Frames", "-c", ProcessOutput.QuoteSingleArgument("import pip; pip.main()") };
             public override IEnumerable<string> CheckIsReady() => new[] { "-X:Frames", "-c", "import pip" };
             public override IEnumerable<string> Prepare() => new[] { "-X:Frames", PythonToolsInstallPath.GetFile("pip_downloader.py", typeof(PipPackageManager).Assembly) };
         }

--- a/Python/Product/VSInterpreters/PackageManager/CPythonPipPackageManagerProvider.cs
+++ b/Python/Product/VSInterpreters/PackageManager/CPythonPipPackageManagerProvider.cs
@@ -23,7 +23,7 @@ namespace Microsoft.PythonTools.Interpreter {
     [Export(typeof(IPackageManagerProvider))]
     sealed class CPythonPipPackageManagerProvider : IPackageManagerProvider {
         class PipCommandsV2 : PipPackageManagerCommands {
-            public override IEnumerable<string> Base() => new[] { "-c", "import pip; pip.main()" };
+            public override IEnumerable<string> Base() => new[] { "-c", ProcessOutput.QuoteSingleArgument("import pip; pip.main()") };
             public override IEnumerable<string> Prepare() => new[] { PythonToolsInstallPath.GetFile("pip_downloader.py", typeof(PipPackageManager).Assembly) };
         }
 

--- a/Python/Product/VSInterpreters/PackageManager/PipPackageManager.cs
+++ b/Python/Product/VSInterpreters/PackageManager/PipPackageManager.cs
@@ -263,6 +263,7 @@ namespace Microsoft.PythonTools.Interpreter {
                         UnbufferedEnv,
                         false,
                         PackageManagerUIRedirector.Get(this, ui),
+                        quoteArgs: false,
                         elevate: await ShouldElevate(ui, operation)
                     )) {
                         if (!output.IsStarted) {


### PR DESCRIPTION
Fix #3555 

Reverts to the old logic prior to package manager refactor.

Install from requirements sends a PackageSpec with FullSpec set to `-r requirements.txt`, which produced a full arguments list:
`-m pip install -U "-r requirements.txt"`

instead of the expected:
`-m pip install -U -r requirements.txt`.