### PR TITLE
Fixes #3570 Buffer mismatches

### DIFF
--- a/Python/Product/Analysis/LanguageServer/ParseQueue.cs
+++ b/Python/Product/Analysis/LanguageServer/ParseQueue.cs
@@ -32,13 +32,12 @@ namespace Microsoft.PythonTools.Analysis.LanguageServer {
         public const string PythonParserSource = "Python";
         private const string TaskCommentSource = "Task comment";
 
-        private readonly ConcurrentDictionary<IDocument, Task<IAnalysisCookie>> _parsing;
-
+        private readonly ConcurrentDictionary<IDocument, ParseTask> _parsing;
         private readonly VolatileCounter _parsingInProgress;
 
-        public ParseQueue() {
+        public ParseQueue(Action<string> logError) {
             _parsingInProgress = new VolatileCounter();
-            _parsing = new ConcurrentDictionary<IDocument, Task<IAnalysisCookie>>();
+            _parsing = new ConcurrentDictionary<IDocument, ParseTask>();
         }
 
         public int Count => _parsingInProgress.Count;
@@ -59,154 +58,199 @@ namespace Microsoft.PythonTools.Analysis.LanguageServer {
                 throw new ArgumentNullException(nameof(doc));
             }
 
-            (doc as IPythonProjectEntry)?.BeginParsingTree();
-            _parsingInProgress.Increment();
-
-            Task<IAnalysisCookie> result = null;
+            var task = new ParseTask(this, doc, languageVersion);
             try {
-                result = _parsing.AddOrUpdate(doc,
-                    _ => ParseAndClearEntry(doc, languageVersion, null),
-                    (_, prev) => ParseAndClearEntry(doc, languageVersion, prev)
-                );
-                return result;
+                var c = _parsing.AddOrUpdate(doc, task, (d, prev) => prev?.ContinueWith(task) ?? task);
+                if (c == task) {
+                    task.Start();
+                }
+                return task.Task;
             } finally {
-                if (result == null) {
-                    AbortParsingTree(doc as IPythonProjectEntry);
-                    _parsingInProgress.Decrement();
-                }
+                task.DisposeIfNotStarted();
             }
-        }
-
-        private Task<IAnalysisCookie> ParseAndClearEntry(IDocument doc, PythonLanguageVersion languageVersion, Task<IAnalysisCookie> previousTask) {
-            var task = Parse(doc, languageVersion, previousTask);
-            task.ContinueWith(_ => _parsing.TryUpdate(doc, null, task));
-            return task;
-        }
-
-        private async Task<IAnalysisCookie> Parse(IDocument doc, PythonLanguageVersion languageVersion, Task<IAnalysisCookie> previousTask) {
-            if (previousTask != null) {
-                try {
-                    await previousTask.ConfigureAwait(false);
-                } catch {
-                    // Don't care about any errors in the previous task.
-                    // We just do not want to start until it is finished.
-                }
-            }
-
-            return await Task.Factory.StartNew(
-                () => ParseWorker(doc, languageVersion),
-                TaskCreationOptions.RunContinuationsAsynchronously
-            ).ConfigureAwait(false);
         }
 
         private IAnalysisCookie ParseWorker(IDocument doc, PythonLanguageVersion languageVersion) {
             IAnalysisCookie result = null;
 
-            try {
-                if (doc is IExternalProjectEntry externalEntry) {
-                    using (var r = doc.ReadDocument(0, out var version)) {
-                        if (r == null) {
-                            throw new FileNotFoundException("failed to parse file", externalEntry.FilePath);
-                        }
-                        result = new VersionCookie(version);
-                        externalEntry.ParseContent(r, result);
+            if (doc is IExternalProjectEntry externalEntry) {
+                using (var r = doc.ReadDocument(0, out var version)) {
+                    if (r == null) {
+                        throw new FileNotFoundException("failed to parse file", externalEntry.FilePath);
                     }
-                } else if (doc is IPythonProjectEntry pyEntry) {
-                    bool complete = false;
-                    pyEntry.GetTreeAndCookie(out _, out var lastCookie);
-                    var lastVc = lastCookie as VersionCookie;
-                    try {
-                        var buffers = new SortedDictionary<int, BufferVersion>();
-                        foreach (var part in doc.DocumentParts.Reverse()) {
-                            using (var r = doc.ReadDocumentBytes(part, out var version)) {
-                                if (r == null) {
-                                    continue;
-                                }
-                                if (version >= 0 && lastVc != null && lastVc.Versions.TryGetValue(part, out var lastParse) && lastParse.Version >= version) {
-                                    buffers[part] = lastParse;
-                                    continue;
-                                }
-                                ParsePython(r, pyEntry, languageVersion, out var tree, out List<Diagnostic> diags);
-                                buffers[part] = new BufferVersion(
-                                    version,
-                                    tree,
-                                    diags.MaybeEnumerate()
-                                );
-                            }
-                        }
-                        if (!buffers.Any()) {
-                            throw new FileNotFoundException($"failed to parse file {pyEntry.DocumentUri.AbsoluteUri}", pyEntry.FilePath);
-                        }
-                        complete = true;
-                        result = UpdateTree(pyEntry, buffers);
-                    } finally {
-                        if (!complete) {
-                            AbortParsingTree(pyEntry);
-                        }
-                    }
-                } else {
-                    Debug.Fail($"Don't know how to parse {doc.GetType().FullName}");
+                    result = new VersionCookie(version);
+                    externalEntry.ParseContent(r, result);
                 }
-            } finally {
-                _parsingInProgress.Decrement();
+            } else if (doc is IPythonProjectEntry pyEntry) {
+                pyEntry.GetTreeAndCookie(out _, out var lastCookie);
+                var lastVc = lastCookie as VersionCookie;
+                result = ParsePythonEntry(pyEntry, languageVersion, lastCookie as VersionCookie);
+            } else {
+                Debug.Fail($"Don't know how to parse {doc.GetType().FullName}");
             }
             return result;
         }
 
-        private IAnalysisCookie UpdateTree(IPythonProjectEntry entry, SortedDictionary<int, BufferVersion> buffers) {
-            bool needAbort = true;
-            try {
-                var cookie = new VersionCookie(buffers);
+        private IAnalysisCookie ParsePythonEntry(IPythonProjectEntry entry, PythonLanguageVersion languageVersion, VersionCookie lastParseCookie) {
+            PythonAst tree;
+            var doc = (IDocument)entry;
+            var buffers = new SortedDictionary<int, BufferVersion>();
+            foreach (var part in doc.DocumentParts.Reverse()) {
+                using (var r = doc.ReadDocumentBytes(part, out int version)) {
+                    if (r == null) {
+                        continue;
+                    }
 
-                if (buffers.Count == 1) {
-                    entry.UpdateTree(buffers.First().Value.Ast, cookie);
-                    needAbort = false;
-                    return cookie;
-                }
+                    if (version >= 0 && lastParseCookie != null && lastParseCookie.Versions.TryGetValue(part, out var lastParse) && lastParse.Version >= version) {
+                        buffers[part] = lastParse;
+                        continue;
+                    }
 
-                var tree = new PythonAst(buffers.Values.Select(v => v.Ast));
-                entry.UpdateTree(tree, cookie);
-                needAbort = false;
-                return cookie;
-            } finally {
-                if (needAbort) {
-                    AbortParsingTree(entry);
+                    buffers[part] = ParsePython(r, entry, languageVersion, version);
                 }
             }
+
+            if (!buffers.Any()) {
+                throw new FileNotFoundException($"failed to parse file {entry.DocumentUri.AbsoluteUri}", entry.FilePath);
+            }
+
+            var cookie = new VersionCookie(buffers);
+
+            if (buffers.Count == 1) {
+                tree = buffers.First().Value.Ast;
+            } else {
+                tree = new PythonAst(buffers.Values.Select(v => v.Ast));
+            }
+
+            entry.UpdateTree(tree, cookie);
+            return cookie;
         }
 
         public Dictionary<string, DiagnosticSeverity> TaskCommentMap { get; set; }
 
         public DiagnosticSeverity InconsistentIndentation { get; set; }
 
-        private void ParsePython(
+        sealed class ParseTask {
+            private readonly ParseQueue _queue;
+            private readonly IDocument _document;
+            private readonly PythonLanguageVersion _languageVersion;
+
+            private readonly TaskCompletionSource<IAnalysisCookie> _tcs;
+            private ParseTask _next;
+
+            // State transitions:
+            //  UNSTARTED -> QUEUED     when passed to ContinueWith
+            //  UNSTARTED -> DISPOSED   when DisposeIfNotStarted() is called
+            //  UNSTARTED -> STARTED    when Start() is called
+            //  QUEUED    -> STARTED    when Start(QUEUED) is called
+            //  STARTED   -> DISPOSED   when task completes
+            // Note that calling Dispose() only has an effect on a task that
+            // has not been started or queued.
+            private const int UNSTARTED = 0;
+            private const int QUEUED = 1;
+            private const int STARTED = 2;
+            private const int DISPOSED = 3;
+            private int _state = UNSTARTED;
+
+            public ParseTask(ParseQueue queue, IDocument document, PythonLanguageVersion languageVersion) {
+                _queue = queue;
+                _document = document;
+                _languageVersion = languageVersion;
+
+                _queue._parsingInProgress.Increment();
+                (_document as IPythonProjectEntry)?.BeginParsingTree();
+
+                _tcs = new TaskCompletionSource<IAnalysisCookie>();
+            }
+
+            public Task<IAnalysisCookie> Task => _tcs.Task;
+
+            public void DisposeIfNotStarted() {
+                if (Interlocked.CompareExchange(ref _state, DISPOSED, UNSTARTED) == UNSTARTED) {
+                    DisposeWorker();
+                }
+            }
+
+            private void DisposeWorker() {
+                Debug.Assert(Volatile.Read(ref _state) == DISPOSED);
+
+                var next = Interlocked.Exchange(ref _next, null);
+                _queue._parsingInProgress.Decrement();
+                _queue._parsing.TryUpdate(_document, next, this);
+                next?.Start(QUEUED);
+            }
+
+            public ParseTask ContinueWith(ParseTask nextTask) {
+                // Set our subsequent task
+                var actualNext = Interlocked.CompareExchange(ref _next, nextTask, null);
+                if (actualNext != null) {
+                    // Already set, so pass the new task along
+                    return actualNext.ContinueWith(nextTask);
+                }
+
+                // Set the subsequent to QUEUED
+                if (Interlocked.CompareExchange(ref nextTask._state, QUEUED, UNSTARTED) != UNSTARTED) {
+                    Interlocked.Exchange(ref _next, null);
+                    throw new InvalidOperationException("cannot queue task that has been started");
+                }
+
+                // We were complete, or completed while adding the task,
+                // so make sure it runs
+                if (Volatile.Read(ref _state) == DISPOSED) {
+                    actualNext = Interlocked.Exchange(ref _next, null);
+                    if (actualNext != null) {
+                        return actualNext;
+                    }
+                }
+                return this;
+            }
+
+            public void Start() => Start(UNSTARTED);
+
+            private void Start(int expectedState) {
+                if (Interlocked.CompareExchange(ref _state, STARTED, expectedState) != expectedState) {
+                    throw new InvalidOperationException("cannot start parsing");
+                }
+
+                try {
+                    _tcs.SetResult(_queue.ParseWorker(_document, _languageVersion));
+                } catch (Exception ex) {
+                    _tcs.SetException(ex);
+                } finally {
+                    if (Interlocked.CompareExchange(ref _state, DISPOSED, STARTED) == STARTED) {
+                        DisposeWorker();
+                    }
+                }
+            }
+        }
+
+
+        private BufferVersion ParsePython(
             Stream stream,
             IPythonProjectEntry entry,
-            PythonLanguageVersion version,
-            out PythonAst tree,
-            out List<Diagnostic> diagnostics
+            PythonLanguageVersion languageVersion,
+            int version
         ) {
             var opts = new ParserOptions {
                 BindReferences = true,
                 IndentationInconsistencySeverity = DiagnosticsErrorSink.GetSeverity(InconsistentIndentation)
             };
 
-            var u = entry.DocumentUri;
-            if (u != null) {
-                var diags = new List<Diagnostic>();
-                diagnostics = diags;
+            List<Diagnostic> diags = null;
+
+            if (entry.DocumentUri != null) {
+                diags = new List<Diagnostic>();
                 opts.ErrorSink = new DiagnosticsErrorSink(PythonParserSource, d => { lock (diags) diags.Add(d); });
                 var tcm = TaskCommentMap;
                 if (tcm != null && tcm.Any()) {
                     opts.ProcessComment += new DiagnosticsErrorSink(TaskCommentSource, d => { lock (diags) diags.Add(d); }, tcm).ProcessTaskComment;
                 }
-            } else {
-                diagnostics = null;
             }
 
-            var parser = Parser.CreateParser(stream, version, opts);
+            var parser = Parser.CreateParser(stream, languageVersion, opts);
+            var tree = parser.ParseFile();
 
-            tree = parser.ParseFile();
+            return new BufferVersion(version, tree, diags.MaybeEnumerate());
         }
     }
 }

--- a/Python/Product/Analysis/LanguageServer/ParseQueue.cs
+++ b/Python/Product/Analysis/LanguageServer/ParseQueue.cs
@@ -181,11 +181,8 @@ namespace Microsoft.PythonTools.Analysis.LanguageServer {
                 // If we were pending, calling start ensures we are queued
                 var previous = Interlocked.Exchange(ref _previous, null);
                 if (previous != null) {
-                    try {
-                        previous.ContinueWith(StartAfterTask);
-                        return Task;
-                    } catch (ObjectDisposedException) {
-                    }
+                    previous.ContinueWith(StartAfterTask);
+                    return Task;
                 }
 
                 ThreadPool.QueueUserWorkItem(StartWork);

--- a/Python/Product/Analysis/LanguageServer/ParseQueue.cs
+++ b/Python/Product/Analysis/LanguageServer/ParseQueue.cs
@@ -35,7 +35,7 @@ namespace Microsoft.PythonTools.Analysis.LanguageServer {
         private readonly ConcurrentDictionary<IDocument, ParseTask> _parsing;
         private readonly VolatileCounter _parsingInProgress;
 
-        public ParseQueue(Action<string> logError) {
+        public ParseQueue() {
             _parsingInProgress = new VolatileCounter();
             _parsing = new ConcurrentDictionary<IDocument, ParseTask>();
         }

--- a/Python/Product/Analysis/Parsing/Tokenizer.cs
+++ b/Python/Product/Analysis/Parsing/Tokenizer.cs
@@ -2702,6 +2702,13 @@ namespace Microsoft.PythonTools.Parsing {
                 match = ~match - 1;
             }
 
+            while (match >= 0 && index == lineLocations[match].EndIndex && lineLocations[match].Kind == NewLineKind.None) {
+                match -= 1;
+            }
+            if (match < 0) {
+                return new SourceLocation(index, 1, checked(index + 1));
+            }
+
             int line = match + 2;
             int col = index - lineLocations[match].EndIndex + 1;
             return new SourceLocation(index, line, col);

--- a/Python/Product/Analysis/ProjectEntry.cs
+++ b/Python/Product/Analysis/ProjectEntry.cs
@@ -143,7 +143,9 @@ namespace Microsoft.PythonTools.Analysis {
         }
 
         public IPythonParse WaitForCurrentParse(int timeout = -1) {
-            _pendingParse.Wait(timeout);
+            if (!_pendingParse.Wait(timeout)) {
+                return null;
+            }
             return GetCurrentParse();
         }
 

--- a/Python/Product/Analysis/ProjectEntry.cs
+++ b/Python/Product/Analysis/ProjectEntry.cs
@@ -41,8 +41,6 @@ namespace Microsoft.PythonTools.Analysis {
         Justification = "Unclear ownership makes it unlikely this object will be disposed correctly")]
     internal sealed class ProjectEntry : IPythonProjectEntry, IAggregateableProjectEntry, IDocument {
         private AnalysisUnit _unit;
-        private ManualResetEventSlim _curWaiter;
-        private int _updatesPending, _waiters;
         private readonly SortedDictionary<int, DocumentBuffer> _buffers;
         internal readonly HashSet<AggregateProjectEntry> _aggregates = new HashSet<AggregateProjectEntry>();
 
@@ -84,86 +82,74 @@ namespace Microsoft.PythonTools.Analysis {
         public event EventHandler<EventArgs> OnNewParseTree;
         public event EventHandler<EventArgs> OnNewAnalysis;
 
-        public void UpdateTree(PythonAst newAst, IAnalysisCookie newCookie) {
-            lock (this) {
-                if (_updatesPending > 0) {
-                    _updatesPending--;
-                }
-                if (newAst == null) {
-                    // there was an error in parsing, just let the waiter go...
-                    if (_curWaiter != null) {
-                        _curWaiter.Set();
-                    }
-                    Tree = null;
+        private readonly ManualResetEventSlim _pendingParse = new ManualResetEventSlim(true);
+        private long _expectedParse;
+
+        private class ActivePythonParse : IPythonParse {
+            private readonly ProjectEntry _entry;
+            private readonly long _expected;
+            private bool _completed;
+
+            public ActivePythonParse(ProjectEntry entry, long expected) {
+                _entry = entry;
+                _expected = expected;
+            }
+
+            public PythonAst Tree { get; set; }
+            public IAnalysisCookie Cookie { get; set; }
+
+            public void Dispose() {
+                if (_completed) {
                     return;
                 }
-
-                Tree = newAst;
-                Cookie = newCookie;
-
-                if (_curWaiter != null) {
-                    _curWaiter.Set();
+                lock (_entry) {
+                    if (_entry._expectedParse == _expected) {
+                        _entry._pendingParse.Set();
+                    }
                 }
             }
 
+            public void Complete() {
+                _completed = true;
+                lock (_entry) {
+                    if (_entry._expectedParse == _expected) {
+                        _entry.SetCurrentParse(Tree, Cookie);
+                        _entry._pendingParse.Set();
+                    }
+                }
+            }
+        }
+
+        public IPythonParse BeginParse() {
+            _pendingParse.Reset();
+            lock (this) {
+                _expectedParse += 1;
+                return new ActivePythonParse(this, _expectedParse);
+            }
+        }
+
+        public IPythonParse GetCurrentParse() {
+            lock (this) {
+                return new StaticPythonParse(Tree, Cookie);
+            }
+        }
+
+        public void SetCurrentParse(PythonAst tree, IAnalysisCookie cookie) {
+            lock (this) {
+                Tree = tree;
+                Cookie = cookie;
+            }
             OnNewParseTree?.Invoke(this, EventArgs.Empty);
         }
 
+        public IPythonParse WaitForCurrentParse(int timeout = -1) {
+            _pendingParse.Wait(timeout);
+            return GetCurrentParse();
+        }
+
+
         internal bool IsVisible(ProjectEntry assigningScope) {
             return true;
-        }
-
-        public void GetTreeAndCookie(out PythonAst tree, out IAnalysisCookie cookie) {
-            lock (this) {
-                tree = Tree;
-                cookie = Cookie;
-            }
-        }
-
-        public void BeginParsingTree() {
-            lock (this) {
-                _updatesPending++;
-            }
-        }
-
-        public PythonAst WaitForCurrentTree(int timeout = -1) => WaitForCurrentTree(timeout, out _);
-
-        public PythonAst WaitForCurrentTree(int timeout, out IAnalysisCookie cookie) {
-            lock (this) {
-                if (_updatesPending == 0) {
-                    cookie = Cookie;
-                    return Tree;
-                }
-
-                _waiters++;
-                if (_curWaiter == null) {
-                    _curWaiter = Interlocked.Exchange(ref _sharedWaitEvent, null);
-                    if (_curWaiter == null) {
-                        _curWaiter = new ManualResetEventSlim(false);
-                    } else {
-                        _curWaiter.Reset();
-                    }
-                }
-            }
-
-            bool gotNewTree = _curWaiter.Wait(timeout);
-
-            lock (this) {
-                _waiters--;
-                if (_waiters == 0 &&
-                    Interlocked.CompareExchange(ref _sharedWaitEvent, _curWaiter, null) != null) {
-                    _curWaiter.Dispose();
-                }
-                _curWaiter = null;
-
-                if (gotNewTree) {
-                    cookie = Cookie;
-                    return Tree;
-                }
-            }
-
-            cookie = null;
-            return null;
         }
 
         public void Analyze(CancellationToken cancel) {
@@ -199,9 +185,9 @@ namespace Microsoft.PythonTools.Analysis {
         public bool IsAnalyzed => Analysis != null;
 
         private void Parse(bool enqueueOnly, CancellationToken cancel) {
-            PythonAst tree;
-            IAnalysisCookie cookie;
-            GetTreeAndCookie(out tree, out cookie);
+            var parse = GetCurrentParse();
+            var tree = parse?.Tree;
+            var cookie = parse?.Cookie;
             if (tree == null) {
                 return;
             }
@@ -534,15 +520,11 @@ namespace Microsoft.PythonTools.Analysis {
         /// <summary>
         /// Returns the last parsed AST.
         /// </summary>
-        PythonAst Tree {
-            get;
-        }
+        PythonAst Tree { get; }
 
         string ModuleName { get; }
 
-        ModuleAnalysis Analysis {
-            get;
-        }
+        ModuleAnalysis Analysis { get; }
 
         event EventHandler<EventArgs> OnNewParseTree;
         event EventHandler<EventArgs> OnNewAnalysis;
@@ -552,21 +534,35 @@ namespace Microsoft.PythonTools.Analysis {
         /// a call to UpdateTree.  Calling this method will cause WaitForCurrentTree to block until
         /// UpdateTree has been called.
         /// 
-        /// Calls to BeginParsingTree should be balanced with calls to UpdateTree.
-        /// 
-        /// This method is thread safe.
+        /// To complete the parse, call either Complete or Cancel on the returned object.
         /// </summary>
-        void BeginParsingTree();
+        IPythonParse BeginParse();
 
-        void UpdateTree(PythonAst ast, IAnalysisCookie fileCookie);
-        void GetTreeAndCookie(out PythonAst ast, out IAnalysisCookie cookie);
+        IPythonParse GetCurrentParse();
 
         /// <summary>
         /// Returns the current tree if no parsing is currently pending, otherwise waits for the 
         /// current parse to finish and returns the up-to-date tree.
         /// </summary>
-        PythonAst WaitForCurrentTree(int timeout = -1);
-
-        PythonAst WaitForCurrentTree(int timeout, out IAnalysisCookie cookie);
+        IPythonParse WaitForCurrentParse(int timeout = -1);
     }
+
+    public interface IPythonParse : IDisposable {
+        PythonAst Tree { get; set; }
+        IAnalysisCookie Cookie { get; set; }
+        void Complete();
+    }
+
+    sealed class StaticPythonParse : IPythonParse {
+        public StaticPythonParse(PythonAst tree, IAnalysisCookie cookie) {
+            Tree = tree;
+            Cookie = cookie;
+        }
+
+        public PythonAst Tree { get; set; }
+        public IAnalysisCookie Cookie { get; set; }
+        public void Dispose() { }
+        public void Complete() => throw new NotSupportedException();
+    }
+
 }

--- a/Python/Product/Analyzer/Intellisense/OutOfProcProjectAnalyzer.cs
+++ b/Python/Product/Analyzer/Intellisense/OutOfProcProjectAnalyzer.cs
@@ -88,6 +88,9 @@ namespace Microsoft.PythonTools.Intellisense {
                 "Analyzer"
             );
             _connection.EventReceived += ConectionReceivedEvent;
+            if (!string.IsNullOrEmpty(_connection.LogFilename)) {
+                _log?.Invoke($"Connection log: {_connection.LogFilename}");
+            }
         }
 
         private void Server_OnLogMessage(object sender, LS.LogMessageEventArgs e) {
@@ -239,6 +242,7 @@ namespace Microsoft.PythonTools.Intellisense {
                     capabilities = new LS.ClientCapabilities {
                         python = new LS.PythonClientCapabilities {
                             analysisUpdates = true,
+                            completionsTimeout = 5000,
                             manualFileLoad = !request.analyzeAllFiles,
                             traceLogging = request.traceLogging
                         }
@@ -917,9 +921,9 @@ namespace Microsoft.PythonTools.Intellisense {
                 return default(VersionedAst);
             }
 
-            PythonAst ast;
-            IAnalysisCookie cookie;
-            entry.GetTreeAndCookie(out ast, out cookie);
+            var parse = entry.GetCurrentParse();
+            var ast = parse?.Tree;
+            var cookie = parse?.Cookie;
 
             if (cookie is VersionCookie vc) {
                 int i = _server.GetPart(documentUri);

--- a/Python/Product/Analyzer/PyLibAnalyzer.cs
+++ b/Python/Product/Analyzer/PyLibAnalyzer.cs
@@ -1340,7 +1340,10 @@ namespace Microsoft.PythonTools.Analysis {
                         }
 
                         if (item.Tree != null) {
-                            item.Entry.UpdateTree(item.Tree, null);
+                            using (var parse = item.Entry.BeginParse()) {
+                                parse.Tree = item.Tree;
+                                parse.Complete();
+                            }
                         }
                     }
 

--- a/Python/Product/Ipc.Json/Connection.cs
+++ b/Python/Product/Ipc.Json/Connection.cs
@@ -80,13 +80,16 @@ namespace Microsoft.PythonTools.Ipc.Json {
             _reader = reader;
             _disposeReader = disposeReader;
             _basicLog = basicLog ?? new DebugTextWriter();
-            _logFile = OpenLogFile(connectionLogKey);
+            _logFile = OpenLogFile(connectionLogKey, out var filename);
             // FxCop won't let us lock a MarshalByRefObject, so we create
             // a plain old object that we can log against.
             if (_logFile != null) {
                 _logFileLock = new object();
+                LogFilename = filename;
             }
         }
+
+        public string LogFilename { get; }
 
         /// <summary>
         /// Opens the log file for this connection. The log must be enabled in
@@ -94,7 +97,8 @@ namespace Microsoft.PythonTools.Ipc.Json {
         /// with the connectionLogKey value set to a non-zero integer or
         /// non-empty string.
         /// </summary>
-        private static TextWriter OpenLogFile(string connectionLogKey) {
+        private static TextWriter OpenLogFile(string connectionLogKey, out string filename) {
+            filename = null;
             if (!AlwaysLog) {
                 if (string.IsNullOrEmpty(connectionLogKey)) {
                     return null;
@@ -120,7 +124,7 @@ namespace Microsoft.PythonTools.Ipc.Json {
                 string.Format("PythonTools_{0}_{1}_{2:yyyyMMddHHmmss}", connectionLogKey, Process.GetCurrentProcess().Id.ToString(), DateTime.Now)
             );
 
-            string filename = filenameBase + ".log";
+            filename = filenameBase + ".log";
             for (int counter = 0; counter < int.MaxValue; ++counter) {
                 try {
                     var file = new FileStream(filename, FileMode.CreateNew, FileAccess.Write, FileShare.ReadWrite);

--- a/Python/Product/PythonTools/PythonTools/Intellisense/ProjectAnalyzer.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/ProjectAnalyzer.cs
@@ -226,6 +226,10 @@ namespace Microsoft.PythonTools.Intellisense {
                 _conn = StartThreadConnection(comment.IfNullOrEmpty(DefaultComment), out _analysisProcess);
             }
 
+            if (!string.IsNullOrEmpty(_conn.LogFilename)) {
+                Trace.TraceInformation($"Connection log: {_conn.LogFilename}");
+            }
+
             Task.Run(() => _conn.ProcessMessages()).DoNotWait();
 
             _userCount = 1;

--- a/Python/Tests/Analysis/AnalysisTest.Perf.cs
+++ b/Python/Tests/Analysis/AnalysisTest.Perf.cs
@@ -265,7 +265,10 @@ import System
                 var ast = nodes[i];
 
                 if (ast != null) {
-                    modules[i].UpdateTree(ast, null);
+                    using (var p = modules[i].BeginParse()) {
+                        p.Tree = ast;
+                        p.Complete();
+                    }
                 }
             }
 

--- a/Python/Tests/Analysis/AnalysisTest.cs
+++ b/Python/Tests/Analysis/AnalysisTest.cs
@@ -4712,7 +4712,10 @@ min(a, D())
                     var ast = nodes[i];
 
                     if (ast != null) {
-                        modules[i].UpdateTree(ast, null);
+                        using (var p = modules[i].BeginParse()) {
+                            p.Tree = ast;
+                            p.Complete();
+                        }
                     }
                 }
 
@@ -4740,7 +4743,10 @@ min(a, D())
                     using (var reader = new FileStreamReader(modules[index].FilePath)) {
                         var ast = Parser.CreateParser(reader, projectState.LanguageVersion).ParseFile();
 
-                        modules[index].UpdateTree(ast, null);
+                        using (var p = modules[index].BeginParse()) {
+                            p.Tree = ast;
+                            p.Complete();
+                        }
                     }
 
                     modules[index].Analyze(CancellationToken.None, true);

--- a/Python/Tests/Analysis/BaseAnalysisTest.cs
+++ b/Python/Tests/Analysis/BaseAnalysisTest.cs
@@ -78,14 +78,14 @@ namespace AnalysisTests {
 
         public PythonAnalysis ProcessTextV2(string text, bool allowParseErrors = false) {
             var analysis = CreateAnalyzer(DefaultFactoryV2, allowParseErrors);
-            var t = analysis.AddModule("test-module", text).WaitForCurrentTree();
+            analysis.AddModule("test-module", text).WaitForCurrentParse();
             analysis.WaitForAnalysis();
             return analysis;
         }
 
         public PythonAnalysis ProcessTextV3(string text, bool allowParseErrors = false) {
             var analysis = CreateAnalyzer(DefaultFactoryV3, allowParseErrors);
-            analysis.AddModule("test-module", text).WaitForCurrentTree();
+            analysis.AddModule("test-module", text).WaitForCurrentParse();
             analysis.WaitForAnalysis();
             return analysis;
         }
@@ -101,7 +101,7 @@ namespace AnalysisTests {
             }
 
             var analysis = CreateAnalyzer(InterpreterFactoryCreator.CreateAnalysisInterpreterFactory(version.ToVersion()), allowParseErrors);
-            analysis.AddModule("test-module", text).WaitForCurrentTree();
+            analysis.AddModule("test-module", text).WaitForCurrentParse();
             analysis.WaitForAnalysis();
             return analysis;
         }

--- a/Python/Tests/Analysis/ThreadingTest.cs
+++ b/Python/Tests/Analysis/ThreadingTest.cs
@@ -118,7 +118,10 @@ mc.fn([])
                 .Select(i => {
                     var entry = state.AddModule(string.Format("mod{0:000}", i), string.Format("mod{0:000}.py", i));
                     var parser = Parser.CreateParser(new StringReader(testCode.FormatInvariant(i + 1, PythonTypes[i % PythonTypes.Count])), PythonLanguageVersion.V34);
-                    entry.UpdateTree(parser.ParseFile(), null);
+                    using (var p = entry.BeginParse()) {
+                        p.Tree = parser.ParseFile();
+                        p.Complete();
+                    }
                     return entry;
                 })
                 .ToList();
@@ -161,7 +164,10 @@ mc.fn([])
                     foreach (var t in shufEntries) {
                         var i = t.Item3;
                         var parser = Parser.CreateParser(new StringReader(testCode.FormatInvariant(i + 1, PythonTypes[i % PythonTypes.Count])), PythonLanguageVersion.V34);
-                        t.Item2.UpdateTree(parser.ParseFile(), null);
+                        using (var p = t.Item2.BeginParse()) {
+                            p.Tree = parser.ParseFile();
+                            p.Complete();
+                        }
                     }
                     Thread.Sleep(1000);
                 }

--- a/Python/Tests/Core.UI/EditorTests.cs
+++ b/Python/Tests/Core.UI/EditorTests.cs
@@ -14,6 +14,9 @@
 // See the Apache Version 2.0 License for specific language governing
 // permissions and limitations under the License.
 
+extern alias analysis;
+extern alias pythontools;
+extern alias util;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -23,10 +26,11 @@ using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Windows;
 using EnvDTE;
-using Microsoft.PythonTools;
+using analysis::Microsoft.PythonTools;
+using pythontools::Microsoft.PythonTools;
 using Microsoft.PythonTools.Infrastructure;
-using Microsoft.PythonTools.Intellisense;
-using Microsoft.PythonTools.Parsing;
+using pythontools::Microsoft.PythonTools.Intellisense;
+using analysis::Microsoft.PythonTools.Parsing;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Language.Intellisense;
 using Microsoft.VisualStudio.Shell.Interop;
@@ -37,7 +41,7 @@ using Microsoft.VisualStudio.Text.Tagging;
 using Microsoft.VisualStudio.TextManager.Interop;
 using Microsoft.VisualStudioTools;
 using TestUtilities;
-using TestUtilities.UI;
+using util::TestUtilities.UI;
 using TestUtilities.UI.Python;
 
 namespace PythonToolsUITests {

--- a/Python/Tests/Core.UI/EditorTests.cs
+++ b/Python/Tests/Core.UI/EditorTests.cs
@@ -590,6 +590,8 @@ pass");
 
             var doc = app.GetDocument(item.Document.FullName);
             doc.InvokeTask(() => doc.WaitForAnalysisAtCaretAsync());
+            // A little extra time for things to load, because VS...
+            System.Threading.Thread.Sleep(500);
 
             Keyboard.Type(typedText);
 

--- a/Python/Tests/DjangoTests/DjangoAnalyzerTests.cs
+++ b/Python/Tests/DjangoTests/DjangoAnalyzerTests.cs
@@ -77,7 +77,10 @@ namespace DjangoTests {
                 new StringReader(File.ReadAllText(entry.FilePath).Replace("test_filter_2", "test_filter_3")),
                 PythonLanguageVersion.V27
             );
-            entry.UpdateTree(parser.ParseFile(), null);
+            using (var p = entry.BeginParse()) {
+                p.Tree = parser.ParseFile();
+                p.Complete();
+            }
             entry.Analyze(CancellationToken.None, false);
 
             AssertUtil.ContainsExactly(
@@ -104,7 +107,10 @@ namespace DjangoTests {
                 new StringReader(File.ReadAllText(entry.FilePath).Replace("test_tag_2", "test_tag_3")),
                 PythonLanguageVersion.V27
             );
-            entry.UpdateTree(parser.ParseFile(), null);
+            using (var p = entry.BeginParse()) {
+                p.Tree = parser.ParseFile();
+                p.Complete();
+            }
             entry.Analyze(CancellationToken.None, false);
 
             AssertUtil.ContainsExactly(
@@ -167,7 +173,10 @@ namespace DjangoTests {
                     new FileStream(file, FileMode.Open, FileAccess.Read),
                     PythonLanguageVersion.V27
                 );
-                entry.UpdateTree(parser.ParseFile(), null);
+                using (var p = entry.BeginParse()) {
+                    p.Tree = parser.ParseFile();
+                    p.Complete();
+                }
                 entries.Add(entry);
             }
 

--- a/Python/Tests/IronPython/IronPythonAnalysisTest.cs
+++ b/Python/Tests/IronPython/IronPythonAnalysisTest.cs
@@ -492,7 +492,10 @@ from System.Windows.Media import Colors
 
                 using (var stream = new FileStreamReader(pyPath)) {
                     var parser = Parser.CreateParser(stream, PythonLanguageVersion.V27, new ParserOptions() { BindReferences = true });
-                    pyEntry.UpdateTree(parser.ParseFile(), null);
+                    using (var p = pyEntry.BeginParse()) {
+                        p.Tree = parser.ParseFile();
+                        p.Complete();
+                    }
                 }
 
                 pyEntry.Analyze(CancellationToken.None);

--- a/Python/Tests/PythonToolsMockTests/CompletionTests.cs
+++ b/Python/Tests/PythonToolsMockTests/CompletionTests.cs
@@ -14,29 +14,24 @@
 // See the Apache Version 2.0 License for specific language governing
 // permissions and limitations under the License.
 
+extern alias analysis;
+extern alias pythontools;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
-using IronPython.Hosting;
-using Microsoft.PythonTools;
-using Microsoft.PythonTools.Analysis;
-using Microsoft.PythonTools.Intellisense;
-using Microsoft.PythonTools.Interpreter;
-using Microsoft.PythonTools.Parsing;
-using Microsoft.Scripting.Hosting;
+using analysis::Microsoft.PythonTools;
+using analysis::Microsoft.PythonTools.Interpreter;
+using analysis::Microsoft.PythonTools.Parsing;
 using Microsoft.VisualStudio.Language.Intellisense;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.VisualStudio.Text;
-using Microsoft.VisualStudio.Utilities;
-using Microsoft.VisualStudioTools;
 using Microsoft.VisualStudioTools.MockVsTests;
+using pythontools::Microsoft.PythonTools;
+using pythontools::Microsoft.PythonTools.Intellisense;
 using TestUtilities;
 using TestUtilities.Mocks;
-using TestUtilities.Python;
 
 namespace PythonToolsMockTests {
     [TestClass]

--- a/Python/Tests/TestAdapterTests/TestDiscovererTests.cs
+++ b/Python/Tests/TestAdapterTests/TestDiscovererTests.cs
@@ -249,7 +249,10 @@ class TestBase(unittest.TestCase):
                 );
 
                 var parser = Parser.CreateParser(source, PythonLanguageVersion.V27, new ParserOptions() { BindReferences = true });
-                entry.UpdateTree(parser.ParseFile(), null);
+                using (var p = entry.BeginParse()) {
+                    p.Tree = parser.ParseFile();
+                    p.Complete();
+                }
                 return entry;
             }
         }

--- a/Python/Tests/Utilities.Python.Analysis/MockPythonProjectEntry.cs
+++ b/Python/Tests/Utilities.Python.Analysis/MockPythonProjectEntry.cs
@@ -42,22 +42,6 @@ namespace TestUtilities.Python {
 
         public event EventHandler<EventArgs> OnNewAnalysis { add { } remove { } }
 
-        public void BeginParsingTree() {
-            throw new NotImplementedException();
-        }
-
-        public void UpdateTree(PythonAst ast, IAnalysisCookie fileCookie) {
-            throw new NotImplementedException();
-        }
-
-        public void GetTreeAndCookie(out PythonAst ast, out IAnalysisCookie cookie) {
-            throw new NotImplementedException();
-        }
-
-        public PythonAst WaitForCurrentTree(int timeout = -1) {
-            throw new NotImplementedException();
-        }
-
         public void Analyze(System.Threading.CancellationToken cancel, bool enqueueOnly) {
             throw new NotImplementedException();
         }
@@ -109,7 +93,15 @@ namespace TestUtilities.Python {
             throw new NotImplementedException();
         }
 
-        public PythonAst WaitForCurrentTree(int timeout, out IAnalysisCookie cookie) {
+        public IPythonParse BeginParse() {
+            throw new NotImplementedException();
+        }
+
+        public IPythonParse GetCurrentParse() {
+            throw new NotImplementedException();
+        }
+
+        public IPythonParse WaitForCurrentParse(int timeout = -1) {
             throw new NotImplementedException();
         }
     }

--- a/Python/Tests/Utilities.Python.Analysis/PythonAnalysis.cs
+++ b/Python/Tests/Utilities.Python.Analysis/PythonAnalysis.cs
@@ -144,15 +144,15 @@ namespace TestUtilities.Python {
         public void UpdateModule(IPythonProjectEntry entry, string code) {
             CollectingErrorSink errors = null;
             if (code != null) {
-                PythonAst ast;
                 errors = new CollectingErrorSink();
-                var p = Parser.CreateParser(
+                var parser = Parser.CreateParser(
                     new StringReader(code),
                     _analyzer.LanguageVersion,
                     new ParserOptions { BindReferences = true, ErrorSink = errors }
                 );
-                ast = p.ParseFile();
-                entry.UpdateTree(ast, null);
+                using (var p = entry.BeginParse()) {
+                    p.Tree = parser.ParseFile();
+                }
                 if (errors.Errors.Any() || errors.Warnings.Any()) {
                     if (AssertOnParseErrors) {
                         var errorMsg = MakeMessage(errors);

--- a/Python/Tests/Utilities.Python.Analysis/PythonAnalysis.cs
+++ b/Python/Tests/Utilities.Python.Analysis/PythonAnalysis.cs
@@ -152,6 +152,7 @@ namespace TestUtilities.Python {
                 );
                 using (var p = entry.BeginParse()) {
                     p.Tree = parser.ParseFile();
+                    p.Complete();
                 }
                 if (errors.Errors.Any() || errors.Warnings.Any()) {
                     if (AssertOnParseErrors) {


### PR DESCRIPTION
Currently, this fixes multiple parses being started simultaneously for the same document. I still need to verify that this was the underlying cause, but it's not too early to start reviewing this.

In short, the problem we had before is that `ConcurrentDictionary.AddOrUpdate` does not guarantee that it will only call one of the factory functions, so we could end up with two parsers for the one counter increment, as well as two conflicting results that _may_ have been causing incorrect responses and hence comparisons leading to the assertion.
