### PR TITLE
Fix browse filter to enable browse button in add reference dialog.

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Project/PythonProjectNode.cs
+++ b/Python/Product/PythonTools/PythonTools/Project/PythonProjectNode.cs
@@ -1500,7 +1500,7 @@ namespace Microsoft.PythonTools.Project {
 
         protected override string AddReferenceExtensions {
             get {
-                return null;
+                return Strings.AddReferenceExtensions;
             }
         }
 


### PR DESCRIPTION
Fix #3567 