### PR TITLE
Fixes #3603 Error after using snippet

### DIFF
--- a/Python/Product/Analysis/Intellisense/ClassifierWalker.cs
+++ b/Python/Product/Analysis/Intellisense/ClassifierWalker.cs
@@ -99,7 +99,7 @@ namespace Microsoft.PythonTools.Intellisense {
         private void AddParameter(Parameter node) {
             Debug.Assert(_head != null);
             _head.Parameters.Add(node.Name);
-            _head.Names.Add(Tuple.Create(node.Name, new Span(node.StartIndex, node.Name.Length)));
+            _head.Names.Add(Tuple.Create(node.Name, new Span(node.NameSpan.Start, node.NameSpan.Length)));
         }
 
         private void AddParameter(Node node) {

--- a/Python/Product/Analysis/Parsing/Tokenizer.cs
+++ b/Python/Product/Analysis/Parsing/Tokenizer.cs
@@ -2718,22 +2718,26 @@ namespace Microsoft.PythonTools.Parsing {
             if (lineLocations == null) {
                 return 0;
             }
+            int index = 0;
             if (lineLocations.Length == 0) {
                 // We have a single line, so the column is the index
-                return location.Column - 1;
+                index = location.Column - 1;
+                return endIndex >= 0 ? Math.Min(index, endIndex) : index;
             }
             int line = location.Line - 1;
+
             if (line > lineLocations.Length) {
-                return lineLocations[lineLocations.Length - 1].EndIndex;
+                index = lineLocations[lineLocations.Length - 1].EndIndex;
+                return endIndex >= 0 ? Math.Min(index, endIndex) : index;
             }
 
-            int index = 0;
             if (line > 0) {
                 index = lineLocations[line - 1].EndIndex;
             }
 
             if (line < lineLocations.Length && location.Column > (lineLocations[line].EndIndex - index)) {
-                return lineLocations[line].EndIndex;
+                index = lineLocations[line].EndIndex;
+                return endIndex >= 0 ? Math.Min(index, endIndex) : index;
             }
 
             if (endIndex < 0) {

--- a/Python/Product/PythonTools/PythonTools/Intellisense/LocationTracker.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/LocationTracker.cs
@@ -178,6 +178,9 @@ namespace Microsoft.PythonTools.Intellisense {
 #endif
                 List<NewLineLocation> asLengths = null;
                 while (ver.Changes != null && ver.VersionNumber < version) {
+#if DEBUG
+                    appliedVersions.Add(ver);
+#endif
                     if (asLengths == null) {
                         asLengths = LineEndsToLineLengths(initial).ToList();
                     }

--- a/Python/Product/PythonTools/PythonTools/Intellisense/LocationTracker.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/LocationTracker.cs
@@ -173,6 +173,9 @@ namespace Microsoft.PythonTools.Intellisense {
                     ver = ver.Next;
                 }
 
+#if DEBUG
+                var appliedVersions = new List<ITextVersion>();
+#endif
                 List<NewLineLocation> asLengths = null;
                 while (ver.Changes != null && ver.VersionNumber < version) {
                     if (asLengths == null) {
@@ -186,9 +189,9 @@ namespace Microsoft.PythonTools.Intellisense {
                         while (asLengths.Count <= lineNo) {
                             asLengths.Add(new NewLineLocation(0, NewLineKind.None));
                         }
-                        var line = asLengths[lineNo];
                         
                         if (c.OldLength > 0) {
+                            var line = asLengths[lineNo];
                             // Deletion may span lines, so combine them until we can delete
                             int cutAtCol = oldLoc.Column - 1;
                             for (int toRemove = c.OldLength; lineNo < asLengths.Count; lineNo += 1) {
@@ -212,6 +215,7 @@ namespace Microsoft.PythonTools.Intellisense {
                             }
                         }
                         if (!string.IsNullOrEmpty(c.NewText)) {
+                            var line = asLengths[lineNo];
                             NewLineLocation addedLine = new NewLineLocation(0, NewLineKind.None);
                             int lastLineEnd = 0, cutAtCol = oldLoc.Column - 1;
                             if (cutAtCol > line.EndIndex - line.Kind.GetSize() && lineNo + 1 < asLengths.Count) {
@@ -242,6 +246,14 @@ namespace Microsoft.PythonTools.Intellisense {
 
                     initial = LineLengthsToLineEnds(asLengths).ToArray();
                     _lineCache[ver.VersionNumber + 1] = initial;
+
+#if DEBUG
+                    if (System.Diagnostics.Debugger.IsAttached && initial.Length > 0 && ver.Next != null && initial.Last().EndIndex != ver.Next.Length) {
+                        // Line calculations were wrong
+                        // Asserts do not work properly here, so we just break if the debugger is attached
+                        System.Diagnostics.Debugger.Break();
+                    }
+#endif
 
                     ver = ver.Next;
                 }

--- a/Python/Product/PythonTools/PythonTools/Intellisense/PythonSignature.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/PythonSignature.cs
@@ -154,7 +154,7 @@ namespace Microsoft.PythonTools.Intellisense {
             }
 
             if (index < 0 || index >= _parameters.Count) {
-                Debug.Assert(_parameters.Count == 0, $"Failed to select parameter {index}//'{name ?? "(null)"}'");
+                Debug.Assert(_parameters.Count == 0 || index == int.MaxValue, $"Failed to select parameter {index}//'{name ?? "(null)"}'");
                 SetCurrentParameter(null);
                 return -1;
             }


### PR DESCRIPTION
Fixes #3603 Error after using snippet
Ensures the correct line length is used to calculate newlines after a deletion
Also fixes an unnecessary assertion and incorrect argument highlighting.