### PR TITLE
Fixes #3604 Analyzer stops responding

### DIFF
--- a/Python/Product/Analysis/Parsing/Ast/TypeAnnotation.cs
+++ b/Python/Product/Analysis/Parsing/Ast/TypeAnnotation.cs
@@ -66,10 +66,14 @@ namespace Microsoft.PythonTools.Parsing.Ast {
 
             public T GetResult<T>(TypeAnnotationConverter<T> converter) where T : class {
                 var stack = new Stack<KeyValuePair<string, T>>();
-                foreach (var op in _ops) {
-                    if (!op.Apply(converter, stack)) {
-                        return default(T);
+                try {
+                    foreach (var op in _ops) {
+                        if (!op.Apply(converter, stack)) {
+                            return default(T);
+                        }
                     }
+                } catch (InvalidOperationException) {
+                    return default(T);
                 }
 
                 if (stack.Count == 1) {

--- a/Python/Product/PythonTools/PythonTools/Intellisense/ProjectAnalyzer.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/ProjectAnalyzer.cs
@@ -254,6 +254,18 @@ namespace Microsoft.PythonTools.Intellisense {
                 _analysisOptions.traceLevel = LS.MessageType.Log;
             }
 
+            if (_analysisOptions.analysisLimits == null) {
+                using (var key = Registry.CurrentUser.OpenSubKey(AnalysisLimitsKey)) {
+                    _analysisOptions.analysisLimits = AnalysisLimits.LoadFromStorage(key).ToDictionary();
+                    var traceLogging = key?.GetValue("TraceLogging", null);
+                    if ((traceLogging is int i && i != 0) || (traceLogging is string s && s.IsTrue())) {
+                        initialize.traceLogging = true;
+                        _analysisOptions.traceLevel = LS.MessageType.Log;
+                    }
+                }
+            }
+
+
             var initResponse = await SendRequestAsync(initialize);
             if (initResponse == null || !string.IsNullOrWhiteSpace(initResponse.error)) {
                 if (initResponse?.error != null) {
@@ -287,12 +299,6 @@ namespace Microsoft.PythonTools.Intellisense {
                             break;
                     }
                     _analysisOptions.commentTokens[keyValue.Key] = sev;
-                }
-            }
-
-            if (_analysisOptions.analysisLimits == null) {
-                using (var key = Registry.CurrentUser.OpenSubKey(AnalysisLimitsKey)) {
-                    _analysisOptions.analysisLimits = AnalysisLimits.LoadFromStorage(key).ToDictionary();
                 }
             }
 


### PR DESCRIPTION
Fixes #3604 Analyzer stops responding
Handles incomplete type annotations that were previously causing the analyzer to crash.
Adds registry key to enable trace logging, currently only to the Trace system.