### PR TITLE
Fixes #3625 "Format Document" adds invalid code

### DIFF
--- a/Python/Product/Analysis/Intellisense/LineInfo.cs
+++ b/Python/Product/Analysis/Intellisense/LineInfo.cs
@@ -54,16 +54,16 @@ namespace Microsoft.PythonTools.Intellisense {
         public SourceSpan SourceExtent => new SourceSpan(SourceStart, SourceEnd);
 
 
-        public static IEnumerable<LineInfo> SplitLines(string text) {
+        public static IEnumerable<LineInfo> SplitLines(string text, int firstLineNumber = 0) {
             NewLineLocation nextLine;
-            List<LineInfo> lines = new List<LineInfo>();
+            int lineNo = firstLineNumber;
 
             int lastLineEnd = 0;
             while ((nextLine = NewLineLocation.FindNewLine(text, lastLineEnd)).EndIndex != lastLineEnd) {
                 yield return new LineInfo(
                     lastLineEnd,
                     nextLine.EndIndex - lastLineEnd - nextLine.Kind.GetSize(),
-                    lines.Count,
+                    lineNo++,
                     nextLine.Kind
                 );
 
@@ -74,7 +74,7 @@ namespace Microsoft.PythonTools.Intellisense {
                 yield return new LineInfo(
                     lastLineEnd,
                     text.Length - lastLineEnd,
-                    lines.Count,
+                    lineNo++,
                     NewLineKind.None
                 );
 

--- a/Python/Product/Analysis/Intellisense/LinePreservingCodeReplacer.cs
+++ b/Python/Product/Analysis/Intellisense/LinePreservingCodeReplacer.cs
@@ -29,12 +29,12 @@ namespace Microsoft.PythonTools.Intellisense {
         private readonly string _newLine, _oldCode, _newCode;
         private readonly IReadOnlyList<LineInfo> _newLines, _oldLines;
 
-        private LinePreservingCodeReplacer(string oldCode, string newCode, string newLine) {
+        private LinePreservingCodeReplacer(int startLine, string oldCode, string newCode, string newLine) {
             _newLine = newLine;
             _oldCode = oldCode;
             _newCode = newCode;
-            _oldLines = LineInfo.SplitLines(oldCode).ToArray();
-            _newLines = LineInfo.SplitLines(newCode).ToArray();
+            _oldLines = LineInfo.SplitLines(oldCode, startLine - 1).ToArray();
+            _newLines = LineInfo.SplitLines(newCode, startLine - 1).ToArray();
         }
 
         private string GetOldText(int line) {
@@ -45,8 +45,8 @@ namespace Microsoft.PythonTools.Intellisense {
             return _newCode.Substring(_newLines[line].Start, _newLines[line].Length);
         }
 
-        public static IReadOnlyList<DocumentChange> Replace(string oldCode, string newCode, string newLine = "\r\n") {
-            return new LinePreservingCodeReplacer(oldCode, newCode, newLine).ReplaceCode();
+        public static IReadOnlyList<DocumentChange> Replace(int startLine, string oldCode, string newCode, string newLine = "\r\n") {
+            return new LinePreservingCodeReplacer(startLine, oldCode, newCode, newLine).ReplaceCode();
         }
 
         public IReadOnlyList<DocumentChange> ReplaceCode() {
@@ -153,32 +153,8 @@ namespace Microsoft.PythonTools.Intellisense {
         /// Replaces a range of text with new text attempting only modifying lines which changed 
         /// and doing so in a single edit.
         /// </summary>
-        public static IReadOnlyList<DocumentChange> ReplaceByLines(this string oldCode, string newCode, string newLine = "\r\n") {
-            return LinePreservingCodeReplacer.Replace(oldCode, newCode, newLine);
-        }
-
-        private static SourceSpan OffsetSpan(SourceSpan span, SourceLocation offset) {
-            var newStart = new SourceLocation(
-                span.Start.Line + offset.Line - 1,
-                span.Start.Column + (span.Start.Line == 1 ? offset.Column - 1 : 0)
-            );
-
-            var newEnd = new SourceLocation(
-                span.End.Line + offset.Line - 1,
-                span.End.Column + (span.End.Line == 1 ? offset.Column - 1 : 0)
-            );
-
-            return new SourceSpan(newStart, newEnd);
-        }
-
-        public static IEnumerable<DocumentChange> ApplyOffset(this IEnumerable<DocumentChange> changes, SourceLocation offset) {
-            foreach (var c in changes) {
-                yield return new DocumentChange {
-                    WholeBuffer = c.WholeBuffer,
-                    InsertedText = c.InsertedText,
-                    ReplacedSpan = OffsetSpan(c.ReplacedSpan, offset)
-                };
-            }
+        public static IReadOnlyList<DocumentChange> ReplaceByLines(this string oldCode, int startLine, string newCode, string newLine = "\r\n") {
+            return LinePreservingCodeReplacer.Replace(startLine, oldCode, newCode, newLine);
         }
     }
 }

--- a/Python/Product/Analysis/Intellisense/LinePreservingCodeReplacer.cs
+++ b/Python/Product/Analysis/Intellisense/LinePreservingCodeReplacer.cs
@@ -156,5 +156,29 @@ namespace Microsoft.PythonTools.Intellisense {
         public static IReadOnlyList<DocumentChange> ReplaceByLines(this string oldCode, string newCode, string newLine = "\r\n") {
             return LinePreservingCodeReplacer.Replace(oldCode, newCode, newLine);
         }
+
+        private static SourceSpan OffsetSpan(SourceSpan span, SourceLocation offset) {
+            var newStart = new SourceLocation(
+                span.Start.Line + offset.Line - 1,
+                span.Start.Column + (span.Start.Line == 1 ? offset.Column - 1 : 0)
+            );
+
+            var newEnd = new SourceLocation(
+                span.End.Line + offset.Line - 1,
+                span.End.Column + (span.End.Line == 1 ? offset.Column - 1 : 0)
+            );
+
+            return new SourceSpan(newStart, newEnd);
+        }
+
+        public static IEnumerable<DocumentChange> ApplyOffset(this IEnumerable<DocumentChange> changes, SourceLocation offset) {
+            foreach (var c in changes) {
+                yield return new DocumentChange {
+                    WholeBuffer = c.WholeBuffer,
+                    InsertedText = c.InsertedText,
+                    ReplacedSpan = OffsetSpan(c.ReplacedSpan, offset)
+                };
+            }
+        }
     }
 }

--- a/Python/Product/Analyzer/Intellisense/AnalysisProtocol.cs
+++ b/Python/Product/Analyzer/Intellisense/AnalysisProtocol.cs
@@ -290,7 +290,8 @@ namespace Microsoft.PythonTools.Intellisense {
 
             [JsonConverter(typeof(UriJsonConverter))]
             public Uri documentUri;
-            public int startIndex, endIndex;
+            public int startLine, startColumn;
+            public int endLine, endColumn;
             public string newLine;
             public CodeFormattingOptions options;
 
@@ -299,10 +300,7 @@ namespace Microsoft.PythonTools.Intellisense {
 
         public sealed class FormatCodeResponse : Response {
             public ChangeInfo[] changes;
-
-            public int startLine, startColumn;
-            public int endLine, endColumn;
-            public int version = -1;
+            public int version;
         }
 
         public struct CodeSpan {

--- a/Python/Product/Analyzer/Intellisense/OutOfProcProjectAnalyzer.cs
+++ b/Python/Product/Analyzer/Intellisense/OutOfProcProjectAnalyzer.cs
@@ -666,7 +666,10 @@ namespace Microsoft.PythonTools.Intellisense {
                 return new AP.FormatCodeResponse();
             }
 
-            var walker = new EnclosingNodeWalker(ast, request.startIndex, request.endIndex);
+            int startIndex = ast.LocationToIndex(new SourceLocation(request.startLine, request.startColumn));
+            int endIndex = ast.LocationToIndex(new SourceLocation(request.endLine, request.endColumn));
+
+            var walker = new EnclosingNodeWalker(ast, startIndex, endIndex);
             ast.Walk(walker);
 
             if (walker.Target == null || !walker.Target.IsValidSelection) {
@@ -680,7 +683,7 @@ namespace Microsoft.PythonTools.Intellisense {
 
             int start = ast.LocationToIndex(walker.Target.StartIncludingLeadingWhiteSpace);
             int end = ast.LocationToIndex(walker.Target.End);
-            if (request.startIndex > start) {
+            if (startIndex > start) {
                 // the user didn't have any comments selected, don't reformat them
                 body.SetLeadingWhiteSpace(ast, body.GetIndentationLevel(ast));
 
@@ -690,9 +693,11 @@ namespace Microsoft.PythonTools.Intellisense {
             int length = end - start;
             if (end < code.Length) {
                 if (code[end] == '\r') {
+                    end++;
                     length++;
-                    if (end + 1 < code.Length &&
-                        code[end + 1] == '\n') {
+                    if (end < code.Length &&
+                        code[end] == '\n') {
+                        end++;
                         length++;
                     }
                 } else if (code[end] == '\n') {
@@ -702,18 +707,13 @@ namespace Microsoft.PythonTools.Intellisense {
 
             var selectedCode = code.Substring(start, length);
 
-            var startLoc = ast.IndexToLocation(start);
-            var endLoc = ast.IndexToLocation(end);
             return new AP.FormatCodeResponse() {
-                startLine = startLoc.Line,
-                startColumn = startLoc.Column,
-                endLine = endLoc.Line,
-                endColumn = endLoc.Column,
                 version = version,
                 changes = selectedCode.ReplaceByLines(
                     body.ToCodeString(ast, request.options),
                     request.newLine
-                ).Select(AP.ChangeInfo.FromDocumentChange).ToArray()
+                ).ApplyOffset(walker.Target.StartIncludingLeadingWhiteSpace)
+                .Select(AP.ChangeInfo.FromDocumentChange).ToArray()
             };
         }
 

--- a/Python/Product/Analyzer/Intellisense/OutOfProcProjectAnalyzer.cs
+++ b/Python/Product/Analyzer/Intellisense/OutOfProcProjectAnalyzer.cs
@@ -710,10 +710,10 @@ namespace Microsoft.PythonTools.Intellisense {
             return new AP.FormatCodeResponse() {
                 version = version,
                 changes = selectedCode.ReplaceByLines(
+                    walker.Target.StartIncludingLeadingWhiteSpace.Line,
                     body.ToCodeString(ast, request.options),
                     request.newLine
-                ).ApplyOffset(walker.Target.StartIncludingLeadingWhiteSpace)
-                .Select(AP.ChangeInfo.FromDocumentChange).ToArray()
+                ).Select(AP.ChangeInfo.FromDocumentChange).ToArray()
             };
         }
 

--- a/Python/Product/PythonTools/PythonTools/Intellisense/ProjectAnalyzer.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/ProjectAnalyzer.cs
@@ -2191,33 +2191,28 @@ namespace Microsoft.PythonTools.Intellisense {
 
             await entry.EnsureCodeSyncedAsync(bi.Buffer);
 
+            var lastSnapshot = bi.LastSentSnapshot;
+            var formatSpan = span.Snapshot.CreateTrackingSpan(span, SpanTrackingMode.EdgeInclusive).GetSpan(lastSnapshot).ToSourceSpan();
+
             var res = await SendRequestAsync(
-                new AP.FormatCodeRequest() {
+                new AP.FormatCodeRequest {
                     documentUri = entry.DocumentUri,
-                    startIndex = span.Start,
-                    endIndex = span.End,
+                    startLine = formatSpan.Start.Line,
+                    startColumn = formatSpan.Start.Column,
+                    endLine = formatSpan.End.Line,
+                    endColumn = formatSpan.End.Column,
                     options = options,
                     newLine = view.Options.GetNewLineCharacter()
                 }
             );
 
-            if (res != null && res.version != -1) {
-                SnapshotSpan selectionSpan = default(SnapshotSpan);
-                if (selectResult) {
-                    selectionSpan = bi.LocationTracker.Translate(
-                        new SourceSpan(
-                            new SourceLocation(res.startLine, res.startColumn),
-                            new SourceLocation(res.endLine, res.endColumn)
-                        ),
-                        res.version,
-                        span.Snapshot
-                    );
-                }
+            if (res != null && res.version >= 0) {
+                var selectionSpan = span.Snapshot.CreateTrackingSpan(span, SpanTrackingMode.EdgeInclusive);
 
                 ApplyChanges(res.changes, bi.Buffer, bi.LocationTracker, res.version);
 
                 if (selectResult && !view.IsClosed) {
-                    view.Selection.Select(selectionSpan, false);
+                    view.Selection.Select(selectionSpan.GetSpan(bi.CurrentSnapshot), false);
                 }
             }
         }

--- a/Python/Tests/Core/CodeFormatterTests.cs
+++ b/Python/Tests/Core/CodeFormatterTests.cs
@@ -14,16 +14,16 @@
 // See the Apache Version 2.0 License for specific language governing
 // permissions and limitations under the License.
 
+extern alias pythontools;
 using System;
 using System.IO;
 using System.Threading.Tasks;
-using Microsoft.PythonTools;
-using Microsoft.PythonTools.Infrastructure;
-using Microsoft.PythonTools.Intellisense;
 using Microsoft.PythonTools.Interpreter;
 using Microsoft.PythonTools.Parsing;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.VisualStudio.Text;
+using pythontools::Microsoft.PythonTools;
+using pythontools::Microsoft.PythonTools.Intellisense;
 using TestUtilities;
 using TestUtilities.Mocks;
 using TestUtilities.Python;
@@ -137,7 +137,7 @@ class Oar(object):
     def say_hello(self):
         method_end";
 
-            string selection = "def say_hello";
+            string selection = "def say_hello(s";
 
             string expected = @"print('Hello World')
 
@@ -157,7 +157,7 @@ class Oar(object):
                 SpaceWithinFunctionDeclarationParens = true
             };
 
-            await CodeFormattingTest(input, selection, expected, "    def say_hello .. method_end", options);
+            await CodeFormattingTest(input, selection, expected, "    def say_hello .. ):", options);
         }
 
         [TestMethod, Priority(0)]
@@ -173,8 +173,8 @@ class Oar(object):
             var fact = InterpreterFactoryCreator.CreateAnalysisInterpreterFactory(new Version(2, 7));
             var services = PythonToolsTestUtilities.CreateMockServiceProvider().GetEditorServices();
             using (var analyzer = await VsProjectAnalyzer.CreateForTestsAsync(services, fact)) {
-                var buffer = new MockTextBuffer(input, PythonCoreConstants.ContentType, Path.Combine(TestData.GetTempPath(), "fob.py"));
-                buffer.AddProperty(typeof(VsProjectAnalyzer), analyzer);
+                var buffer = new MockTextBuffer(input, PythonCoreConstants.ContentType);
+                buffer.AddProperty(VsProjectAnalyzer._testAnalyzer, analyzer);
                 var view = new MockTextView(buffer);
                 var bi = services.GetBufferInfo(buffer);
                 var entry = await analyzer.AnalyzeFileAsync(bi.Filename);

--- a/Python/Tests/Core/ExtractMethodTests.cs
+++ b/Python/Tests/Core/ExtractMethodTests.cs
@@ -1687,7 +1687,7 @@ async def f():
                 if (exStr.IndexOf(" .. ") != -1) {
                     var pieces = exStr.Split(new[] { " .. " }, 2, StringSplitOptions.None);
                     int start = input.IndexOf(pieces[0]);
-                    int end = input.IndexOf(pieces[1]) + pieces[1].Length;
+                    int end = input.IndexOf(pieces[1], start) + pieces[1].Length;
                     return Span.FromBounds(start, end);
                 } else {
                     int start = input.IndexOf(exStr);


### PR DESCRIPTION
Fixes #3625 "Format Document" adds invalid code
Ensures LineInfo.LineNumber is correctly initialized
Simplifies analysis protocol messages for formatting

All the tests pass manually, though some UI tests are still flakey.