### PR TITLE
Partial fix to the error message after program exit with VSC debugger

### DIFF
--- a/Python/Product/Debugger/DebugAdapterProcess.cs
+++ b/Python/Product/Debugger/DebugAdapterProcess.cs
@@ -123,7 +123,7 @@ namespace Microsoft.PythonTools.Debugger {
                 if (connection.Wait(_debuggerConnectionTimeout)) {
                     var socket = connection.Result;
                     if (socket != null) {
-                        _stream = new NetworkStream(connection.Result, ownsSocket: true);
+                        _stream = new DebugAdapterProcessStream(new NetworkStream(connection.Result, ownsSocket: true));
                     }
                 } else {
                     Debug.WriteLine("Timed out waiting for debuggee to connect.", nameof(DebugAdapterProcess));

--- a/Python/Product/Debugger/DebugAdapterProcessStream.cs
+++ b/Python/Product/Debugger/DebugAdapterProcessStream.cs
@@ -1,0 +1,63 @@
+﻿// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABLITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System.IO;
+using System.Net.Sockets;
+
+namespace Microsoft.PythonTools.Debugger {
+    internal sealed class DebugAdapterProcessStream : Stream {
+        private readonly NetworkStream _networkStream;
+        public DebugAdapterProcessStream(NetworkStream networkStream) {
+            _networkStream = networkStream;
+        }
+
+        public override bool CanRead => _networkStream.CanRead;
+
+        public override bool CanSeek => _networkStream.CanSeek;
+
+        public override bool CanWrite => _networkStream.CanWrite;
+
+        public override long Length => _networkStream.Length;
+
+        public override long Position {
+            get => _networkStream.Position;
+            set => _networkStream.Position = value;
+        }
+
+        public override void Flush() => _networkStream.Flush();
+
+        public override int Read(byte[] buffer, int offset, int count) {
+            try {
+                return _networkStream.Read(buffer, offset, count);
+            } catch (IOException ex) when ((ex.InnerException as SocketException)?.SocketErrorCode == SocketError.ConnectionReset) {
+                // This is a case where the debuggee has exited, but the adapter host attempts to read remaining messages.
+                // Returning 0 here will tell the debugger that the stream is empty.
+            }
+            return 0;
+        }
+
+        public override long Seek(long offset, SeekOrigin origin) => _networkStream.Seek(offset, origin);
+
+        public override void SetLength(long value) => _networkStream.SetLength(value);
+
+        public override void Write(byte[] buffer, int offset, int count) => _networkStream.Write(buffer, offset, count);
+
+        protected override void Dispose(bool disposing) {
+            _networkStream.Dispose();
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/Python/Product/Debugger/Debugger.csproj
+++ b/Python/Product/Debugger/Debugger.csproj
@@ -112,6 +112,7 @@
     <Compile Include="AssemblyInfo.cs" />
     <Compile Include="DebugAdapterLauncher.cs" />
     <Compile Include="DebugAdapterProcess.cs" />
+    <Compile Include="DebugAdapterProcessStream.cs" />
     <Compile Include="Debugger\DebugConnection.cs" />
     <Compile Include="Debugger\LegacyDebuggerProtocol.cs" />
     <Compile Include="Debugger\BreakpointHitEventArgs.cs" />


### PR DESCRIPTION
Fixes #3537
This is partial fix because there is a change needed in VSC debugger where we fire `exitedEvent` with correct error code on program exit.