### PR TITLE
Fixes #3646 Assertion on nested sequences in type annotation

### DIFF
--- a/Python/Product/Analysis/Analyzer/DDG.cs
+++ b/Python/Product/Analysis/Analyzer/DDG.cs
@@ -165,9 +165,8 @@ namespace Microsoft.PythonTools.Analysis.Analyzer {
             foreach (var left in node.Left) {
                 if (left is ExpressionWithAnnotation annoExpr && annoExpr.Annotation != null) {
                     var annoType = _eval.EvaluateAnnotation(annoExpr.Annotation);
-                    var annoInst = annoType?.GetInstanceType();
-                    if (annoInst?.Any() == true) {
-                        _eval.AssignTo(node, annoExpr.Expression, annoInst);
+                    if (annoType?.Any() == true) {
+                        _eval.AssignTo(node, annoExpr.Expression, annoType);
                     }
                 }
 

--- a/Python/Product/Analysis/Analyzer/ExpressionEvaluator.cs
+++ b/Python/Product/Analysis/Analyzer/ExpressionEvaluator.cs
@@ -410,8 +410,19 @@ namespace Microsoft.PythonTools.Analysis.Analyzer {
 
                 gen.AddYieldFrom(node, ee._unit, res);
 
-                gen.Returns.AddDependency(ee._unit);
-                return gen.Returns.Types;
+                var returned = AnalysisSet.Empty;
+                if (res.Split(out IReadOnlyList<GeneratorInfo> generators, out var rest)) {
+                    foreach (var g in generators) {
+                        g.Returns.AddDependency(ee._unit);
+                        returned = returned.Union(g.Returns.Types);
+                    }
+                }
+                if (rest.Split(out IReadOnlyList<ProtocolInfo> protocols, out rest)) {
+                    foreach (var g in protocols.SelectMany(pi => pi.GetProtocols<GeneratorProtocol>())) {
+                        returned = returned.Union(g.Returns);
+                    }
+                }
+                return returned;
             }
 
             return AnalysisSet.Empty;

--- a/Python/Product/Analysis/Analyzer/ExpressionEvaluator.cs
+++ b/Python/Product/Analysis/Analyzer/ExpressionEvaluator.cs
@@ -97,9 +97,10 @@ namespace Microsoft.PythonTools.Analysis.Analyzer {
             // don't care about the result.
             Evaluate(annotation);
 
-            return new TypeAnnotation(_unit.State.LanguageVersion, annotation)
-                .GetValue(new ExpressionEvaluatorAnnotationConverter(this, annotation, _unit)) ??
-                AnalysisSet.Empty;
+            return Scope.GetOrMakeNodeValue(annotation, NodeValueKind.EvaluatedTypeAnnotation, n =>
+                new TypeAnnotation(_unit.State.LanguageVersion, (Expression)n)
+                    .GetValue(new ExpressionEvaluatorAnnotationConverter(this, n, _unit)) ?? AnalysisSet.Empty
+            );
         }
 
         /// <summary>

--- a/Python/Product/Analysis/Analyzer/ExpressionEvaluatorAnnotationConverter.cs
+++ b/Python/Product/Analysis/Analyzer/ExpressionEvaluatorAnnotationConverter.cs
@@ -59,7 +59,7 @@ namespace Microsoft.PythonTools.Analysis.Analyzer {
                 return _unit.State._noneInst;
             }
 
-            var res = _eval.LookupAnalysisSetByName(_node, name);
+            var res = _eval.LookupAnalysisSetByName(_node, name, addDependency: true).GetInstanceType();
 
             if (res.Any()) {
                 return res;

--- a/Python/Product/Analysis/Analyzer/ExpressionEvaluatorAnnotationConverter.cs
+++ b/Python/Product/Analysis/Analyzer/ExpressionEvaluatorAnnotationConverter.cs
@@ -55,6 +55,10 @@ namespace Microsoft.PythonTools.Analysis.Analyzer {
         }
 
         public override IAnalysisSet LookupName(string name) {
+            if (name == "None") {
+                return _unit.State._noneInst;
+            }
+
             var res = _eval.LookupAnalysisSetByName(_node, name);
 
             if (res.Any()) {

--- a/Python/Product/Analysis/Analyzer/FunctionAnalysisUnit.cs
+++ b/Python/Product/Analysis/Analyzer/FunctionAnalysisUnit.cs
@@ -164,7 +164,7 @@ namespace Microsoft.PythonTools.Analysis.Analyzer {
             for (int i = 0; i < Ast.Parameters.Count; ++i) {
                 var p = Ast.Parameters[i];
                 if (p.Annotation != null) {
-                    var val = ddg._eval.EvaluateAnnotation(p.Annotation).GetInstanceType();
+                    var val = ddg._eval.EvaluateAnnotation(p.Annotation);
                     if (val?.Any() == true && Scope.TryGetVariable(p.Name, out param)) {
                         param.AddTypes(this, val, false);
                     }
@@ -193,7 +193,7 @@ namespace Microsoft.PythonTools.Analysis.Analyzer {
                 ((FunctionScope)Scope).AddReturnTypes(
                     Ast.ReturnAnnotation,
                     ddg._unit,
-                    resType.GetInstanceType()
+                    resType
                 );
             }
         }

--- a/Python/Product/Analysis/Analyzer/InterpreterScope.cs
+++ b/Python/Product/Analysis/Analyzer/InterpreterScope.cs
@@ -418,6 +418,7 @@ namespace Microsoft.PythonTools.Analysis.Analyzer {
         SpecializedInstance,
         Dictionary,
         TypeAnnotation,
+        EvaluatedTypeAnnotation,
     }
 
 }

--- a/Python/Product/Analysis/Analyzer/InterpreterScope.cs
+++ b/Python/Product/Analysis/Analyzer/InterpreterScope.cs
@@ -418,7 +418,6 @@ namespace Microsoft.PythonTools.Analysis.Analyzer {
         SpecializedInstance,
         Dictionary,
         TypeAnnotation,
-        EvaluatedTypeAnnotation,
     }
 
 }

--- a/Python/Product/Analysis/Intellisense/ClassifierWalker.cs
+++ b/Python/Product/Analysis/Intellisense/ClassifierWalker.cs
@@ -31,6 +31,7 @@ namespace Microsoft.PythonTools.Intellisense {
             public readonly HashSet<string> Parameters;
             public readonly HashSet<string> Functions;
             public readonly HashSet<string> Types;
+            public readonly HashSet<string> TypeHints;
             public readonly HashSet<string> Modules;
             public readonly List<Tuple<string, Span>> Names;
             public readonly StackData Previous;
@@ -41,6 +42,7 @@ namespace Microsoft.PythonTools.Intellisense {
                 Parameters = new HashSet<string>();
                 Functions = new HashSet<string>();
                 Types = new HashSet<string>();
+                TypeHints = new HashSet<string>();
                 Modules = new HashSet<string>();
                 Names = new List<Tuple<string, Span>>();
             }
@@ -67,6 +69,7 @@ namespace Microsoft.PythonTools.Intellisense {
             public const string Parameter = "parameter";
             public const string RegexLiteral = "regexliteral";
             public const string DocString = "docstring";
+            public const string TypeHint = "class";
         }
 
         public ClassifierWalker(PythonAst ast, ModuleAnalysis analysis) {
@@ -164,6 +167,8 @@ namespace Microsoft.PythonTools.Intellisense {
                     return Classifications.Function;
                 } else if (sd.Types.Contains(name)) {
                     return Classifications.Class;
+                } else if (sd.TypeHints.Contains(name)) {
+                    return Classifications.TypeHint;
                 } else if (sd.Modules.Contains(name)) {
                     return Classifications.Module;
                 }
@@ -171,14 +176,18 @@ namespace Microsoft.PythonTools.Intellisense {
 
             if (_analysis != null) {
                 var memberType = PythonMemberType.Unknown;
+                bool isTypeHint = false;
                 lock (_analysis) {
-                    memberType = _analysis
-                        .GetValuesByIndex(name, node.Item2.Start)
-                        .Select(v => v.MemberType)
+                    var values = _analysis.GetValuesByIndex(name, node.Item2.Start).ToArray();
+                    isTypeHint = values.Any(v => v is TypingTypeInfo || v.DeclaringModule?.ModuleName == "typing");
+                    memberType = values.Select(v => v.MemberType)
                         .DefaultIfEmpty(PythonMemberType.Unknown)
                         .Aggregate((a, b) => a == b ? a : PythonMemberType.Unknown);
                 }
 
+                if (isTypeHint) {
+                    return Classifications.TypeHint;
+                }
                 if (memberType == PythonMemberType.Module) {
                     return Classifications.Module;
                 } else if (memberType == PythonMemberType.Class) {
@@ -316,6 +325,7 @@ namespace Microsoft.PythonTools.Intellisense {
 
         public override bool Walk(FromImportStatement node) {
             Debug.Assert(_head != null);
+
             if (node.Root != null) {
                 foreach (var name in node.Root.Names) {
                     if (name != null && !string.IsNullOrEmpty(name.Name)) {

--- a/Python/Product/Analysis/Parsing/Ast/TypeAnnotation.cs
+++ b/Python/Product/Analysis/Parsing/Ast/TypeAnnotation.cs
@@ -87,6 +87,8 @@ namespace Microsoft.PythonTools.Parsing.Ast {
                     _parse(s)?.Walk(this);
                 } else if (node.Value is AsciiString a) {
                     _parse(a.String)?.Walk(this);
+                } else if (node.Value == null) {
+                    _ops.Add(new NameOp { Name = "None" });
                 }
                 return false;
             }

--- a/Python/Product/Analysis/Parsing/Ast/TypeAnnotation.cs
+++ b/Python/Product/Analysis/Parsing/Ast/TypeAnnotation.cs
@@ -162,7 +162,7 @@ namespace Microsoft.PythonTools.Parsing.Ast {
                     if (t == null) {
                         return false;
                     }
-                    stack.Push(new KeyValuePair<string, T>(null, t));
+                    stack.Push(new KeyValuePair<string, T>(Name, t));
                     return true;
                 }
 
@@ -177,10 +177,7 @@ namespace Microsoft.PythonTools.Parsing.Ast {
                         return false;
                     }
                     var t = stack.Pop();
-                    if (t.Key != null) {
-                        return false;
-                    }
-                    t = new KeyValuePair<string, T>(null, converter.GetTypeMember(t.Value, Member));
+                    t = new KeyValuePair<string, T>(t.Key == null ? null : $"{t.Key}.{Member}", converter.GetTypeMember(t.Value, Member));
                     if (t.Value == null) {
                         return false;
                     }
@@ -197,9 +194,6 @@ namespace Microsoft.PythonTools.Parsing.Ast {
                         return false;
                     }
                     var t = stack.Pop();
-                    if (t.Key != null) {
-                        return false;
-                    }
                     t = new KeyValuePair<string, T>(null, converter.MakeOptional(t.Value));
                     if (t.Value == null) {
                         return false;
@@ -269,9 +263,6 @@ namespace Microsoft.PythonTools.Parsing.Ast {
                         items.Add(t.Value);
                     }
                     var baseType = stack.Pop();
-                    if (baseType.Key != null) {
-                        return false;
-                    }
                     t = new KeyValuePair<string, T>(null, converter.MakeGeneric(baseType.Value, items));
                     if (t.Value == null) {
                         return false;

--- a/Python/Product/Analysis/Values/ProtocolInfo.cs
+++ b/Python/Product/Analysis/Values/ProtocolInfo.cs
@@ -53,6 +53,10 @@ namespace Microsoft.PythonTools.Analysis.Values {
             _memberType = null;
         }
 
+        public IEnumerable<T> GetProtocols<T>() {
+            return _protocols.OfType<T>();
+        }
+
         public override string Name => _protocols.OfType<NameProtocol>().FirstOrDefault()?.Name ?? string.Join(", ", _protocols.Select(p => p.Name));
         public override string Documentation => _protocols.OfType<NameProtocol>().FirstOrDefault()?.Documentation ?? string.Join(", ", _protocols.Select(p => p.Documentation).Where(d => !string.IsNullOrEmpty(d)));
         public override IEnumerable<OverloadResult> Overloads => _protocols.SelectMany(p => p.Overloads);

--- a/Python/Product/Analysis/Values/Protocols.cs
+++ b/Python/Product/Analysis/Values/Protocols.cs
@@ -423,8 +423,13 @@ namespace Microsoft.PythonTools.Analysis.Values {
             _returned = returns;
         }
 
+        public IAnalysisSet Returns => _returned;
+
         protected override void EnsureMembers(IDictionary<string, IAnalysisSet> members) {
             base.EnsureMembers(members);
+
+            members["send"] = MakeMethod("send", new[] { _sent }, _yielded);
+            members["throw"] = MakeMethod("throw", new[] { AnalysisSet.Empty }, AnalysisSet.Empty);
         }
 
         public override string Name => "generator";

--- a/Python/Product/Analysis/Values/TypingTypeInfo.cs
+++ b/Python/Product/Analysis/Values/TypingTypeInfo.cs
@@ -145,39 +145,95 @@ namespace Microsoft.PythonTools.Analysis.Values {
 
 
         private static IReadOnlyList<IAnalysisSet> GetTypeList(IAnalysisSet item) {
-            return item.OfType<TypingTypeInfo>().FirstOrDefault()?.ToTypeList();
+            return item.OfType<TypingTypeInfo>().FirstOrDefault()?.ToTypeList() ?? new[] { item };
         }
 
-        private SequenceBuiltinClassInfo GetSequenceType(string name) {
+        private IAnalysisSet MakeTuple(params IAnalysisSet[] types) {
+            var pi = new ProtocolInfo(Entry, State);
+            pi.AddProtocol(new NameProtocol(pi, Types[BuiltinTypeId.Tuple]));
+            pi.AddProtocol(new TupleProtocol(pi, types));
+            return pi;
+        }
+
+        private bool GetSequenceTypes(string name, IReadOnlyList<IAnalysisSet> args, out IPythonType realType, out IAnalysisSet keyTypes, out IAnalysisSet valueTypes) {
             switch (name) {
                 case "List":
                 case "Container":
                 case "MutableSequence":
-                    return ClassInfo[BuiltinTypeId.List] as SequenceBuiltinClassInfo;
+                    realType = Types[BuiltinTypeId.List];
+                    keyTypes = ClassInfo[BuiltinTypeId.Int].Instance;
+                    valueTypes = AnalysisSet.UnionAll(args.Select(ToInstance));
+                    return true;
                 case "Tuple":
-                case "Sequence":
-                    return ClassInfo[BuiltinTypeId.Tuple] as SequenceBuiltinClassInfo;
-            }
-
-            return null;
-        }
-
-        private BuiltinClassInfo GetSetType(string name) {
-            switch (name) {
+                    realType = Types[BuiltinTypeId.Tuple];
+                    keyTypes = ClassInfo[BuiltinTypeId.Int].Instance;
+                    valueTypes = AnalysisSet.UnionAll(args.Select(ToInstance));
+                    return true;
                 case "MutableSet":
                 case "Set":
-                    return ClassInfo[BuiltinTypeId.Set];
+                    realType = Types[BuiltinTypeId.Set];
+                    keyTypes = null;
+                    valueTypes = AnalysisSet.UnionAll(args.Select(ToInstance));
+                    return true;
                 case "FrozenSet":
-                    return ClassInfo[BuiltinTypeId.FrozenSet];
-            }
+                    realType = Types[BuiltinTypeId.FrozenSet];
+                    keyTypes = null;
+                    valueTypes = AnalysisSet.UnionAll(args.Select(ToInstance));
+                    return true;
 
-            return null;
+                case "KeysView":
+                    if (args.Count >= 1) {
+                        realType = Types[BuiltinTypeId.DictKeys];
+                        keyTypes = null;
+                        valueTypes = AnalysisSet.UnionAll(GetTypeList(args[0]).Select(ToInstance));
+                        return true;
+                    }
+                    break;
+                case "ValuesView":
+                    if (args.Count >= 1) {
+                        realType = Types[BuiltinTypeId.DictValues];
+                        keyTypes = null;
+                        valueTypes = AnalysisSet.UnionAll(GetTypeList(args[0]).Select(ToInstance));
+                        return true;
+                    }
+                    break;
+
+                case "ItemsView":
+                    if (args.Count >= 2) {
+                        realType = Types[BuiltinTypeId.DictItems];
+                        keyTypes = null;
+                        valueTypes = MakeTuple(
+                            AnalysisSet.UnionAll(GetTypeList(args[0]).Select(ToInstance)),
+                            AnalysisSet.UnionAll(GetTypeList(args[1]).Select(ToInstance))
+                        );
+                        return true;
+                    }
+                    break;
+
+                case "Dict":
+                case "Mapping":
+                    if (args.Count >= 2) {
+                        realType = Types[BuiltinTypeId.Dict];
+                        keyTypes = AnalysisSet.UnionAll(GetTypeList(args[0]).Select(ToInstance));
+                        valueTypes = AnalysisSet.UnionAll(GetTypeList(args[1]).Select(ToInstance));
+                        return true;
+                    }
+                    break;
+            }
+            realType = null;
+            keyTypes = null;
+            valueTypes = null;
+            return false;
         }
+
 
         public IAnalysisSet Finalize(string name, IReadOnlyList<IAnalysisSet> args) {
             if (string.IsNullOrEmpty(name) || args == null || args.Count == 0) {
                 return null;
             }
+
+            IPythonType realType;
+            IAnalysisSet keyTypes, valueTypes;
 
             switch (name) {
                 case "Union":
@@ -189,84 +245,51 @@ namespace Microsoft.PythonTools.Analysis.Values {
                 case "Container":
                 case "MutableSequence":
                 case "Sequence":
-                    try {
-                        return Scope.GetOrMakeNodeValue(_node, NodeValueKind.Sequence, n => {
-                            var t = GetSequenceType(name);
-                            if (t == null) {
-                                throw new KeyNotFoundException(name);
-                            }
-                            var seq = t.MakeFromIndexes(n, Entry);
-                            seq.AddTypes(_unit, args.Select(ToInstance).ToArray());
-                            return seq;
-                        });
-                    } catch (KeyNotFoundException) {
-                        return null;
-                    }
-                case "KeysView":
-                    return (Scope.GetOrMakeNodeValue(_node, NodeValueKind.DictLiteral, n => {
-                        var di = new DictionaryInfo(Entry, n);
-                        di.AddTypes(
-                            n,
-                            _unit,
-                            ToInstance(args[0]),
-                            None
-                        );
-                        return di;
-                    }) as DictionaryInfo)?.GetKeysView(_unit);
-                case "ValuesView":
-                    return (Scope.GetOrMakeNodeValue(_node, NodeValueKind.DictLiteral, n => {
-                        var di = new DictionaryInfo(Entry, n);
-                        di.AddTypes(
-                            n,
-                            _unit,
-                            None,
-                            ToInstance(args[0])
-                        );
-                        return di;
-                    }) as DictionaryInfo)?.GetValuesView(_unit);
-
                 case "MutableSet":
                 case "Set":
                 case "FrozenSet":
-                    try {
-                        return Scope.GetOrMakeNodeValue(_node, NodeValueKind.Set, n => {
-                            return new SetInfo(
-                                GetSetType(name) ?? throw new KeyNotFoundException(name),
-                                n,
-                                Entry,
-                                args.Select(ToVariableDef).ToArray()
-                            );
-                        });
-                    } catch (KeyNotFoundException) {
-                        return null;
+                case "KeysView":
+                case "ValuesView":
+                case "ItemsView":
+                    if (GetSequenceTypes(name, args, out realType, out keyTypes, out valueTypes)) {
+                        var p = new ProtocolInfo(Entry, State);
+                        p.AddReference(_node, _unit);
+                        if (realType == null) {
+                            p.AddProtocol(new NameProtocol(p, name));
+                        } else {
+                            p.AddProtocol(new NameProtocol(p, realType));
+                        }
+                        p.AddProtocol(new IterableProtocol(p, valueTypes));
+                        if (keyTypes != null) {
+                            p.AddProtocol(new GetItemProtocol(p, keyTypes, valueTypes));
+                        }
+                        return p;
                     }
+                    break;
+
                 case "Mapping":
                 case "MappingView":
                 case "MutableMapping":
                 case "Dict":
-                case "ItemsView":
-                    try {
-                        if (args.Count < 2) {
-                            return null;
+                    if (GetSequenceTypes(name, args, out realType, out keyTypes, out valueTypes)) {
+                        var p = new ProtocolInfo(Entry, State);
+                        p.AddReference(_node, _unit);
+                        if (realType == null) {
+                            p.AddProtocol(new NameProtocol(p, name));
+                        } else {
+                            p.AddProtocol(new NameProtocol(p, realType));
                         }
-                        var d = Scope.GetOrMakeNodeValue(_node, NodeValueKind.DictLiteral, n => {
-                            var di = new DictionaryInfo(Entry, n);
-                            di.AddTypes(n, _unit, ToInstance(args[0]), ToInstance(args[1]));
-                            return di;
-                        });
-                        if (name == "ItemsView") {
-                            return (d as DictionaryInfo).GetItemsView(_unit);
-                        }
-                        return d;
-                    } catch (KeyNotFoundException) {
-                        return null;
+                        p.AddProtocol(new MappingProtocol(p, keyTypes, valueTypes, MakeTuple(keyTypes, valueTypes)));
+                        return p;
                     }
+                    break;
 
                 case "Callable":
-                    return Scope.GetOrMakeNodeValue(_node, NodeValueKind.None, n => {
-                        var p = new ProtocolInfo(_unit.ProjectEntry);
-                        p.AddReference(n, _unit);
-                        var callArgs = GetTypeList(args[0]) ?? new[] { args[0] };
+                    if (args.Count > 0) {
+                        var p = new ProtocolInfo(Entry, State);
+                        p.AddReference(_node, _unit);
+                        var callArgs = GetTypeList(args[0]);
+                        p.AddProtocol(new NameProtocol(p, Types[BuiltinTypeId.Function]));
                         p.AddProtocol(new CallableProtocol(
                             p,
                             null,
@@ -274,36 +297,41 @@ namespace Microsoft.PythonTools.Analysis.Values {
                             ToInstance(args.ElementAtOrDefault(1) ?? AnalysisSet.Empty)
                         ));
                         return p;
-                    });
-
+                    }
+                    break;
 
                 case "Iterable":
-                case "Iterator": {
-                        var iter = Scope.GetOrMakeNodeValue(_node, NodeValueKind.Iterator, n => {
-                            var p = new ProtocolInfo(_unit.ProjectEntry);
-                            p.AddReference(n, _unit);
-                            p.AddProtocol(new IterableProtocol(p, AnalysisSet.UnionAll(args.Select(ToInstance))));
-                            return p;
-                        });
-                        return (name == "Iterator") ? iter.GetIterator(_node, _unit) : iter;
+                    if (args.Count > 0) {
+                        var p = new ProtocolInfo(Entry, State);
+                        p.AddReference(_node, _unit);
+                        p.AddProtocol(new IterableProtocol(p, AnalysisSet.UnionAll(args.Select(ToInstance))));
+                        return p;
                     }
+                    break;
+
+                case "Iterator": 
+                    if (args.Count > 0) {
+                        var p = new ProtocolInfo(Entry, State);
+                        p.AddReference(_node, _unit);
+                        p.AddProtocol(new IteratorProtocol(p, AnalysisSet.UnionAll(args.Select(ToInstance))));
+                        return p;
+                    }
+                    break;
 
                 case "Generator":
-                    return Scope.GetOrMakeNodeValue(_node, NodeValueKind.Iterator, n => {
-                        var gi = new GeneratorInfo(State, Entry);
-                        gi.AddYield(n, _unit, ToInstance(args[0]), false);
-                        if (args.Count >= 2) {
-                            gi.AddSend(n, _unit, ToInstance(args[1]), false);
-                        }
-                        if (args.Count >= 3) {
-                            gi.AddReturn(n, _unit, ToInstance(args[2]), false);
-                        }
-                        return gi;
-                    });
+                    if (args.Count > 0) {
+                        var p = new ProtocolInfo(Entry, State);
+                        p.AddReference(_node, _unit);
+                        var yielded = ToInstance(args[0]);
+                        var sent = args.Count > 1 ? ToInstance(args[1]) : AnalysisSet.Empty;
+                        var returned = args.Count > 2 ? ToInstance(args[2]) : AnalysisSet.Empty;
+                        p.AddProtocol(new GeneratorProtocol(p, yielded, sent, returned));
+                        return p;
+                    }
+                    break;
+
                 case "NamedTuple":
-                    return Scope.GetOrMakeNodeValue(_node, NodeValueKind.StrDict, n => CreateNamedTuple(
-                        n, _unit, args.ElementAtOrDefault(0), args.ElementAtOrDefault(1)
-                    ));
+                    return CreateNamedTuple(_node, _unit, args.ElementAtOrDefault(0), args.ElementAtOrDefault(1));
                 case " List":
                     return AnalysisSet.UnionAll(args.Select(ToInstance));
             }
@@ -314,7 +342,7 @@ namespace Microsoft.PythonTools.Analysis.Values {
         private static IAnalysisSet CreateNamedTuple(Node node, AnalysisUnit unit, IAnalysisSet namedTupleName, IAnalysisSet namedTupleArgs) {
             var args = namedTupleArgs == null ? null : TypingTypeInfo.ToTypeList(namedTupleArgs);
 
-            var res = new ProtocolInfo(unit.ProjectEntry);
+            var res = new ProtocolInfo(unit.ProjectEntry, unit.State);
 
             if (namedTupleName != null) {
                 var np = new NameProtocol(res, namedTupleName.GetConstantValueAsString().FirstOrDefault() ?? "tuple");
@@ -355,7 +383,7 @@ namespace Microsoft.PythonTools.Analysis.Values {
                 case "ItemsView": return ClassInfo[BuiltinTypeId.DictItems];
                 case "Iterable":
                 case "Iterator": {
-                        var p = new ProtocolInfo(Entry);
+                        var p = new ProtocolInfo(Entry, State);
                         p.AddReference(_node, _unit);
                         p.AddProtocol(name == "Iterable" ? (Protocol)new IterableProtocol(p, AnalysisSet.Empty) : new IteratorProtocol(p, AnalysisSet.Empty));
                         return p;

--- a/Python/Tests/Analysis/AnalysisTest.cs
+++ b/Python/Tests/Analysis/AnalysisTest.cs
@@ -1275,9 +1275,10 @@ def f():
     yield 1
     yield 2
     yield 3
+    return 3.14
 
 def g():
-    yield from f()
+    x = yield from f()
 
 a = g()
 a2 = iter(a)
@@ -1292,6 +1293,7 @@ for c in g():
             entry.AssertIsInstance("a2", BuiltinTypeId.Generator);
             entry.AssertIsInstance("b", BuiltinTypeId.Int);
             entry.AssertIsInstance("c", BuiltinTypeId.Int);
+            entry.AssertIsInstance("x", text.IndexOf("x ="), BuiltinTypeId.Float);
 
             text = @"
 def f(x):

--- a/Python/Tests/Analysis/TypeAnnotationTests.cs
+++ b/Python/Tests/Analysis/TypeAnnotationTests.cs
@@ -273,5 +273,30 @@ s = l_s[0]
             analyzer.AssertIsInstance("l_s", BuiltinTypeId.List);
             analyzer.AssertIsInstance("s", BuiltinTypeId.Str);
         }
+
+        [TestMethod, Priority(0)]
+        public void TypingModuleGenerator() {
+            var python = (PythonPaths.Python36_x64 ?? PythonPaths.Python36);
+            python.AssertInstalled();
+            var analyzer = CreateAnalyzer(
+                new AstPythonInterpreterFactory(python.Configuration, new InterpreterFactoryCreationOptions { WatchFileSystem = false })
+            );
+            var code = @"from typing import *
+
+gen : Generator[str, None, int] = ...
+
+def g():
+    x = yield from gen
+
+g_g = g()
+g_i = next(g_g)
+";
+            analyzer.AddModule("test-module", code);
+            analyzer.WaitForAnalysis();
+
+            analyzer.AssertIsInstance("g_g", BuiltinTypeId.Generator);
+            analyzer.AssertIsInstance("g_i", BuiltinTypeId.Str);
+            analyzer.AssertIsInstance("x", code.IndexOf("x ="), BuiltinTypeId.Int);
+        }
     }
 }

--- a/Python/Tests/Analysis/TypeAnnotationTests.cs
+++ b/Python/Tests/Analysis/TypeAnnotationTests.cs
@@ -213,12 +213,12 @@ call_iis_i_ret = call_iis_i()
             analyzer.AddModule("test-module", @"from typing import *
 
 n : NamedTuple = ...
-n1 : NamedTuple('n1', [('x', int), ['y', str]]) = ...
+n1 : NamedTuple('N1', [('x', int), ['y', str]]) = ...
 ");
             analyzer.WaitForAnalysis();
 
             analyzer.AssertDescription("n", "tuple");
-            analyzer.AssertDescription("n1", "n1(x, y)");
+            analyzer.AssertDescription("n1", "N1(x, y)");
 
             analyzer.AssertIsInstance("n1.x", BuiltinTypeId.Int);
             analyzer.AssertIsInstance("n1.y", BuiltinTypeId.Str);

--- a/Python/Tests/Analysis/TypeAnnotationTests.cs
+++ b/Python/Tests/Analysis/TypeAnnotationTests.cs
@@ -128,18 +128,18 @@ dct : Union[Mapping, MappingView, MutableMapping] = ...
 dct_s_i : Mapping[str, int] = ...
 dct_s_i_a = dct_s_i['a']
 dct_s_i_keys = dct_s_i.keys()
-dct_s_i_key = next(dct_s_i_keys)
+dct_s_i_key = next(iter(dct_s_i_keys))
 dct_s_i_values = dct_s_i.values()
-dct_s_i_value = next(dct_s_i_values)
+dct_s_i_value = next(iter(dct_s_i_values))
 dct_s_i_items = dct_s_i.items()
-dct_s_i_item_1, dct_s_i_item_2 = next(dct_s_i_items)
+dct_s_i_item_1, dct_s_i_item_2 = next(iter(dct_s_i_items))
 
 dctv_s_i_keys : KeysView[str] = ...
-dctv_s_i_key = next(dctv_s_i_keys)
+dctv_s_i_key = next(iter(dctv_s_i_keys))
 dctv_s_i_values : ValuesView[int] = ...
-dctv_s_i_value = next(dctv_s_i_values)
+dctv_s_i_value = next(iter(dctv_s_i_values))
 dctv_s_i_items : ItemsView[str, int] = ...
-dctv_s_i_item_1, dctv_s_i_item_2 = next(dctv_s_i_items)
+dctv_s_i_item_1, dctv_s_i_item_2 = next(iter(dctv_s_i_items))
 ");
             analyzer.WaitForAnalysis();
 
@@ -250,6 +250,28 @@ n1 : MyNamedTuple = ...
             analyzer.AssertDescription("n1", "MyNamedTuple(x)");
 
             analyzer.AssertIsInstance("n1.x", BuiltinTypeId.Int);
+        }
+
+        [TestMethod, Priority(0)]
+        public void TypingModuleNestedIndex() {
+            var python = (PythonPaths.Python36_x64 ?? PythonPaths.Python36);
+            python.AssertInstalled();
+            var analyzer = CreateAnalyzer(
+                new AstPythonInterpreterFactory(python.Configuration, new InterpreterFactoryCreationOptions { WatchFileSystem = false })
+            );
+            analyzer.AddModule("test-module", @"from typing import *
+
+MyList = List[List[str]]
+
+l_l_s : MyList = ...
+l_s = l_l_s[0]
+s = l_s[0]
+");
+            analyzer.WaitForAnalysis();
+
+            analyzer.AssertIsInstance("l_l_s", BuiltinTypeId.List);
+            analyzer.AssertIsInstance("l_s", BuiltinTypeId.List);
+            analyzer.AssertIsInstance("s", BuiltinTypeId.Str);
         }
     }
 }


### PR DESCRIPTION
Fixes #3646 Assertion on nested sequences in type annotation
Switches type annotation evaluations from real types to ProtocolInfo instances
Also fixes generator evaluation

This means we don't have to be as careful about minimizing instantiation, as the values will be fully recreated when we re-evaluate the annotation. So we can dispense with the node value storage completely and just store the entire evaluated annotation.