### PR TITLE
Adds missing code analysis rules and resolves existing issues.

### DIFF
--- a/Build/xTVS.ruleset
+++ b/Build/xTVS.ruleset
@@ -11,7 +11,7 @@
     <Rule Id="CA1033" Action="None" /> <!-- Explicit interface implementation on base classes -->
     <Rule Id="CA1060" Action="Warning" />
     <Rule Id="CA1061" Action="Warning" />
-    <Rule Id="CA1063" Action="Warning" />
+    <Rule Id="CA1063" Action="None" /> <!-- Implement IDisposable properly -->
     <Rule Id="CA1065" Action="None" /> <!-- Throw from property accessors -->
     <Rule Id="CA1301" Action="Warning" />
     <Rule Id="CA1400" Action="Warning" />

--- a/Build/xTVS.ruleset
+++ b/Build/xTVS.ruleset
@@ -96,5 +96,117 @@
     <Rule Id="CA2226" Action="Warning" />
     <Rule Id="CA2227" Action="Warning" />
     <Rule Id="CA2239" Action="Warning" />
+
+    <Rule Id="CA1304" Action="Error" /> <!-- specify CultureInfo -->
+    <Rule Id="CA1305" Action="None" />  <!-- provide IFormatProvider -->
+    <Rule Id="CA1307" Action="Error" /> <!-- specify StringComparison -->
+    <Rule Id="CA1309" Action="Warning" /> <!-- use StringComparison.Ordinal -->
+
+    <Rule Id="CA900" Action="Error" />
+
+    <Rule Id="CA2001" Action="Error" />
+    <Rule Id="CA2103" Action="Error" />
+    <Rule Id="CA2107" Action="Error" />
+    <Rule Id="CA2109" Action="Error" />
+    <Rule Id="CA2110" Action="None" />
+    <Rule Id="CA2118" Action="Error" />
+    <Rule Id="CA2135" Action="Error" />
+    <Rule Id="CA2136" Action="Error" />
+    <Rule Id="CA2139" Action="Error" />
+    <Rule Id="CA2142" Action="Error" />
+    <Rule Id="CA2143" Action="Error" />
+    <Rule Id="CA2144" Action="Error" />
+    <Rule Id="CA2145" Action="Error" />
+    <Rule Id="CA2151" Action="Error" />
+    <Rule Id="CA2153" Action="Error" />
+    <Rule Id="CA5122" Action="Error" />
+    <Rule Id="CA5350" Action="Error" />
+    <Rule Id="CA5351" Action="Error" />
+    <Rule Id="CA5352" Action="Error" />
+    <Rule Id="CA5353" Action="Error" />
+    <Rule Id="CA5354" Action="Error" />
+    <Rule Id="CA5355" Action="Error" />
+    <Rule Id="CA5356" Action="Error" />
+    <Rule Id="CA5357" Action="Error" />
+    <Rule Id="CA3001" Action="Error" />
+    <Rule Id="CA3002" Action="None" />  <!-- XSS detection -->
+    <Rule Id="CA3003" Action="Error" />
+    <Rule Id="CA3004" Action="Error" />
+    <Rule Id="CA3005" Action="Error" />
+    <Rule Id="CA3006" Action="Error" />
+    <Rule Id="CA3007" Action="Error" />
+    <Rule Id="CA3008" Action="Error" />
+    <Rule Id="CA3009" Action="Error" />
+    <Rule Id="CA3010" Action="Error" />
+    <Rule Id="CA3011" Action="Error" />
+    <Rule Id="CA3012" Action="Error" />
+    <Rule Id="CA3101" Action="None" />
+    <Rule Id="CA3102" Action="Error" />
+    <Rule Id="CA3103" Action="Error" />
+    <Rule Id="CA3104" Action="Error" />
+    <Rule Id="CA3105" Action="Error" />
+    <Rule Id="CA3106" Action="Error" />
+    <Rule Id="CA3107" Action="Error" />
+    <Rule Id="CA3108" Action="Error" />
+    <Rule Id="CA3109" Action="Error" />
+    <Rule Id="CA3110" Action="Error" />
+    <Rule Id="CA3111" Action="Error" />
+    <Rule Id="CA3112" Action="Error" />
+    <Rule Id="CA3113" Action="Error" />
+    <Rule Id="CA3114" Action="Error" />
+    <Rule Id="CA3115" Action="Error" />
+    <Rule Id="CA3116" Action="Error" />
+    <Rule Id="CA3117" Action="Error" />
+    <Rule Id="CA3118" Action="Error" />
+    <Rule Id="CA3119" Action="Error" />
+    <Rule Id="CA3120" Action="Error" />
+    <Rule Id="CA3121" Action="Error" />
+    <Rule Id="CA3122" Action="Error" />
+    <Rule Id="CA3123" Action="Error" />
+    <Rule Id="CA3124" Action="Error" />
+    <Rule Id="CA3125" Action="Error" />
+    <Rule Id="CA3127" Action="Error" />
+    <Rule Id="CA3129" Action="Error" />
+    <Rule Id="CA3130" Action="Error" />
+    <Rule Id="CA3131" Action="Error" />
+    <Rule Id="CA3132" Action="Error" />
+    <Rule Id="CA3133" Action="Error" />
+    <Rule Id="CA3134" Action="Error" />
+    <Rule Id="CA3135" Action="Error" />
+    <Rule Id="CA3137" Action="Error" />
+    <Rule Id="CA3138" Action="Error" />
+    <Rule Id="CA3139" Action="Error" />
+    <Rule Id="CA3140" Action="Error" />
+    <Rule Id="CA3141" Action="Error" />
+    <Rule Id="CA3142" Action="Error" />
+    <Rule Id="CA3143" Action="Error" />
+    <Rule Id="CA3145" Action="Error" />
+    <Rule Id="CA3146" Action="Error" />
+    <Rule Id="CA3147" Action="Error" />
+    <Rule Id="CA3050" Action="Error" />
+    <Rule Id="CA3051" Action="None" />
+    <Rule Id="CA3052" Action="None" />
+    <Rule Id="CA3053" Action="Error" />
+    <Rule Id="CA3054" Action="Error" />
+    <Rule Id="CA3055" Action="Error" />
+    <Rule Id="CA3056" Action="Error" />
+    <Rule Id="CA3057" Action="Error" />
+    <Rule Id="CA3058" Action="Error" />
+    <Rule Id="CA3059" Action="Error" />
+    <Rule Id="CA3060" Action="Error" />
+    <Rule Id="CA3061" Action="Error" />
+    <Rule Id="CA3062" Action="Error" />
+    <Rule Id="CA3063" Action="Error" />
+    <Rule Id="CA3064" Action="Error" />
+    <Rule Id="CA3065" Action="Error" />
+    <Rule Id="CA3066" Action="Error" />
+    <Rule Id="CA3067" Action="Error" />
+    <Rule Id="CA3068" Action="Error" />
+    <Rule Id="CA3069" Action="Error" />
+    <Rule Id="CA3070" Action="Error" />
+    <Rule Id="CA3071" Action="Error" />
+    <Rule Id="CA3072" Action="Error" />
+    <Rule Id="CA3073" Action="Error" />
+    <Rule Id="CA3074" Action="Error" />
   </Rules>
 </RuleSet>

--- a/Common/Product/SharedProject/Automation/OAProject.cs
+++ b/Common/Product/SharedProject/Automation/OAProject.cs
@@ -187,14 +187,14 @@ namespace Microsoft.VisualStudioTools.Project.Automation {
         public virtual object get_Extender(string name) {
             Utilities.ArgumentNotNull("name", name);
 
-            return DTE.ObjectExtenders.GetExtender(project.NodeProperties.ExtenderCATID.ToUpper(), name, project.NodeProperties);
+            return DTE.ObjectExtenders.GetExtender(project.NodeProperties.ExtenderCATID.ToUpperInvariant(), name, project.NodeProperties);
         }
 
         /// <summary>
         /// Gets a list of available Extenders for the object.
         /// </summary>
         public virtual object ExtenderNames {
-            get { return DTE.ObjectExtenders.GetExtenderNames(project.NodeProperties.ExtenderCATID.ToUpper(), project.NodeProperties); }
+            get { return DTE.ObjectExtenders.GetExtenderNames(project.NodeProperties.ExtenderCATID.ToUpperInvariant(), project.NodeProperties); }
         }
 
         /// <summary>

--- a/Common/Product/SharedProject/Automation/VSProject/OAReferences.cs
+++ b/Common/Product/SharedProject/Automation/VSProject/OAReferences.cs
@@ -88,7 +88,7 @@ namespace Microsoft.VisualStudioTools.Project.Automation
         public Reference Add(string bstrPath)
         {
             // ignore requests from the designer which are framework assemblies and start w/ a *.
-            if (string.IsNullOrEmpty(bstrPath) || bstrPath.StartsWith("*"))
+            if (string.IsNullOrEmpty(bstrPath) || bstrPath.StartsWith("*", StringComparison.Ordinal))
             {
                 return null;
             }

--- a/Common/Product/SharedProject/CommonEditorFactory.cs
+++ b/Common/Product/SharedProject/CommonEditorFactory.cs
@@ -16,7 +16,6 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Globalization;
 using System.Runtime.InteropServices;
 using Microsoft.VisualStudio.Designer.Interfaces;
 using Microsoft.VisualStudio.OLE.Interop;
@@ -226,7 +225,7 @@ namespace Microsoft.VisualStudioTools.Project {
             if (string.IsNullOrEmpty(physicalView)) {
                 // create code window as default physical view
                 return CreateCodeView(documentMoniker, textLines, ref editorCaption, ref cmdUI);
-            } else if (string.Compare(physicalView, "design", true, CultureInfo.InvariantCulture) == 0) {
+            } else if (string.Compare(physicalView, "design", StringComparison.OrdinalIgnoreCase) == 0) {
                 // Create Form view
                 return CreateFormView(hierarchy, itemid, textLines, ref editorCaption, ref cmdUI);
             }

--- a/Common/Product/SharedProject/CommonFileNode.cs
+++ b/Common/Product/SharedProject/CommonFileNode.cs
@@ -16,7 +16,6 @@
 
 using System;
 using System.Diagnostics;
-using System.Globalization;
 using System.IO;
 using System.Runtime.InteropServices;
 using Microsoft.VisualStudio;
@@ -53,7 +52,7 @@ namespace Microsoft.VisualStudioTools.Project {
         public bool IsFormSubType {
             get {
                 string result = this.ItemNode.GetMetadata(ProjectFileConstants.SubType);
-                if (!String.IsNullOrEmpty(result) && string.Compare(result, ProjectFileAttributeValue.Form, true, CultureInfo.InvariantCulture) == 0)
+                if (!String.IsNullOrEmpty(result) && string.Compare(result, ProjectFileAttributeValue.Form, StringComparison.OrdinalIgnoreCase) == 0)
                     return true;
                 else
                     return false;

--- a/Common/Product/SharedProject/CommonProjectNode.cs
+++ b/Common/Product/SharedProject/CommonProjectNode.cs
@@ -742,7 +742,7 @@ namespace Microsoft.VisualStudioTools.Project {
                     }
 
                     if (res != 0) {
-                        Debug.Assert(filePathBuilder.ToString().StartsWith("\\\\?\\"));
+                        Debug.Assert(filePathBuilder.ToString().StartsWith("\\\\?\\", StringComparison.Ordinal));
                         return filePathBuilder.ToString().Substring(4);
                     }
                 }

--- a/Common/Product/SharedProject/Misc/NativeMethods.cs
+++ b/Common/Product/SharedProject/Misc/NativeMethods.cs
@@ -904,7 +904,7 @@ namespace Microsoft.VisualStudioTools.Project {
 
                 // UNC Paths will start with \\?\.  Remove this if present as this isn't really expected on a path.
                 var pathString = path.ToString();
-                return pathString.StartsWith(@"\\?\") ? pathString.Substring(4) : pathString;
+                return pathString.StartsWith(@"\\?\", StringComparison.Ordinal) ? pathString.Substring(4) : pathString;
             }
         }
 

--- a/Common/Product/SharedProject/ProcessOutput.cs
+++ b/Common/Product/SharedProject/ProcessOutput.cs
@@ -349,7 +349,7 @@ namespace Microsoft.VisualStudioTools.Infrastructure {
                 return arg;
             }
 
-            if (arg.StartsWith("\"") && arg.EndsWith("\"")) {
+            if (arg.StartsWith("\"", StringComparison.Ordinal) && arg.EndsWith("\"", StringComparison.Ordinal)) {
                 bool inQuote = false;
                 int consecutiveBackslashes = 0;
                 foreach (var c in arg) {
@@ -371,7 +371,7 @@ namespace Microsoft.VisualStudioTools.Infrastructure {
             }
 
             var newArg = arg.Replace("\"", "\\\"");
-            if (newArg.EndsWith("\\")) {
+            if (newArg.EndsWith("\\", StringComparison.Ordinal)) {
                 newArg += "\\";
             }
             return "\"" + newArg + "\"";

--- a/Common/Product/SharedProject/ProjectConfig.cs
+++ b/Common/Product/SharedProject/ProjectConfig.cs
@@ -473,7 +473,7 @@ namespace Microsoft.VisualStudioTools.Project {
         /// <returns>S_OK if the method succeeds, otherwise an error code</returns>
         public virtual int QueryDebugLaunch(uint flags, out int fCanLaunch) {
             string assembly = this.project.GetAssemblyName(this.ConfigName);
-            fCanLaunch = (assembly != null && assembly.ToUpperInvariant().EndsWith(".exe", StringComparison.OrdinalIgnoreCase)) ? 1 : 0;
+            fCanLaunch = (assembly != null && assembly.EndsWith(".exe", StringComparison.OrdinalIgnoreCase)) ? 1 : 0;
             if (fCanLaunch == 0) {
                 string property = GetConfigurationProperty("StartProgram", true);
                 fCanLaunch = (property != null && property.Length > 0) ? 1 : 0;

--- a/Common/Product/SharedProject/ProjectNode.cs
+++ b/Common/Product/SharedProject/ProjectNode.cs
@@ -3666,16 +3666,20 @@ namespace Microsoft.VisualStudioTools.Project {
         /// <param name="iPersistXMLFragment">Object that support being initialized with an XML fragment</param>
         /// <param name="configName">Name of the configuration being initialized, null if it is the project</param>
         /// <param name="platformName">Name of the platform being initialized, null is ok</param>
+        [SuppressMessage("Microsoft.Security.Xml", "CA3053:UseXmlSecureResolver")]
         protected internal void LoadXmlFragment(IPersistXMLFragment persistXmlFragment, string configName, string platformName) {
             Utilities.ArgumentNotNull("persistXmlFragment", persistXmlFragment);
 
             if (xmlFragments == null) {
                 // Retrieve the xml fragments from MSBuild
-                xmlFragments = new XmlDocument();
+                xmlFragments = new XmlDocument { XmlResolver = null };
 
                 string fragments = GetProjectExtensions()[ProjectFileConstants.VisualStudio];
                 fragments = String.Format(CultureInfo.InvariantCulture, "<root>{0}</root>", fragments);
-                xmlFragments.LoadXml(fragments);
+
+                var settings = new XmlReaderSettings { XmlResolver = null };
+                using (var reader = XmlReader.Create(new StringReader(fragments), settings))
+                    xmlFragments.Load(reader);
             }
 
             // We need to loop through all the flavors
@@ -3732,6 +3736,7 @@ namespace Microsoft.VisualStudioTools.Project {
         /// <summary>
         /// Retrieve all XML fragments that need to be saved from the flavors and store the information in msbuild.
         /// </summary>
+        [SuppressMessage("Microsoft.Security.Xml", "CA3053:UseXmlSecureResolver")]
         protected void PersistXMLFragments() {
             if (IsFlavorDirty()) {
                 XmlDocument doc = new XmlDocument();

--- a/Common/Product/SharedProject/ProjectResources.cs
+++ b/Common/Product/SharedProject/ProjectResources.cs
@@ -222,7 +222,7 @@ namespace Microsoft.VisualStudioTools.Project {
                 string.Format(CultureInfo.InvariantCulture, "Resource string '{0}' does not use all {1} arguments", value, args.Length)
             );
             Debug.WriteLineIf(
-                result.IndexOf(string.Format(CultureInfo.InvariantCulture, "{{{0}", args.Length)) >= 0,
+                result.IndexOf(string.Format(CultureInfo.InvariantCulture, "{{{0}", args.Length), StringComparison.InvariantCulture) >= 0,
                 string.Format(CultureInfo.InvariantCulture, "Resource string '{0}' requires more than {1} argument(s)", value, args.Length)
             );
 

--- a/Common/Product/SharedProject/ProjectResources.cs
+++ b/Common/Product/SharedProject/ProjectResources.cs
@@ -222,7 +222,7 @@ namespace Microsoft.VisualStudioTools.Project {
                 string.Format(CultureInfo.InvariantCulture, "Resource string '{0}' does not use all {1} arguments", value, args.Length)
             );
             Debug.WriteLineIf(
-                result.IndexOf(string.Format(CultureInfo.InvariantCulture, "{{{0}", args.Length), StringComparison.InvariantCulture) >= 0,
+                result.IndexOf(string.Format(CultureInfo.InvariantCulture, "{{{0}", args.Length), StringComparison.Ordinal) >= 0,
                 string.Format(CultureInfo.InvariantCulture, "Resource string '{0}' requires more than {1} argument(s)", value, args.Length)
             );
 

--- a/Common/Product/SharedProject/ProjectResources.cs
+++ b/Common/Product/SharedProject/ProjectResources.cs
@@ -213,21 +213,21 @@ namespace Microsoft.VisualStudioTools.Project {
             }
 
             if (args.Length == 0) {
-                Debug.Assert(result.IndexOf("{0}") < 0, "Resource string '" + value + "' requires format arguments.");
+                Debug.Assert(result.IndexOf("{0}", StringComparison.Ordinal) < 0, "Resource string '" + value + "' requires format arguments.");
                 return result;
             }
 
             Debug.WriteLineIf(
-                Enumerable.Range(0, args.Length).Any(i => result.IndexOf(string.Format("{{{0}", i)) < 0),
-                string.Format("Resource string '{0}' does not use all {1} arguments", value, args.Length)
+                Enumerable.Range(0, args.Length).Any(i => result.IndexOf(string.Format(CultureInfo.InvariantCulture, "{{{0}", i), StringComparison.Ordinal) < 0),
+                string.Format(CultureInfo.InvariantCulture, "Resource string '{0}' does not use all {1} arguments", value, args.Length)
             );
             Debug.WriteLineIf(
-                result.IndexOf(string.Format("{{{0}", args.Length)) >= 0,
-                string.Format("Resource string '{0}' requires more than {1} argument(s)", value, args.Length)
+                result.IndexOf(string.Format(CultureInfo.InvariantCulture, "{{{0}", args.Length)) >= 0,
+                string.Format(CultureInfo.InvariantCulture, "Resource string '{0}' requires more than {1} argument(s)", value, args.Length)
             );
 
 
-            return string.Format(CultureInfo.CurrentUICulture, result, args);
+            return string.Format(CultureInfo.CurrentCulture, result, args);
         }
 
         public static string GetString(string value, params object[] args) {

--- a/Common/Product/SharedProject/WebPiComponentPickerControl.cs
+++ b/Common/Product/SharedProject/WebPiComponentPickerControl.cs
@@ -98,7 +98,12 @@ namespace Microsoft.VisualStudioTools.Project {
         }
 
         private void GetFeeds(string feed) {
-            var doc = new XPathDocument(feed);
+            XPathDocument doc;
+            var settings = new XmlReaderSettings();
+            settings.XmlResolver = null;
+            using (var reader = XmlReader.Create(feed, settings))
+                doc = new XPathDocument(reader);
+
             XmlNamespaceManager mngr = new XmlNamespaceManager(new NameTable());
             mngr.AddNamespace("x", "http://www.w3.org/2005/Atom");
 
@@ -198,7 +203,7 @@ namespace Microsoft.VisualStudioTools.Project {
                     res = String.Compare(
                        itemX.SubItems[0].Text,
                        itemY.SubItems[0].Text,
-                       true
+                       StringComparison.CurrentCultureIgnoreCase
                    );
                 }
 

--- a/Common/Tests/Utilities/FileUtils.cs
+++ b/Common/Tests/Utilities/FileUtils.cs
@@ -49,14 +49,14 @@ namespace TestUtilities {
             bool fullPaths = true
         ) {
             var queue = new Queue<string>();
-            if (!root.EndsWith("\\")) {
+            if (!root.EndsWith("\\", StringComparison.Ordinal)) {
                 root += "\\";
             }
             queue.Enqueue(root);
 
             while (queue.Any()) {
                 var path = queue.Dequeue();
-                if (!path.EndsWith("\\")) {
+                if (!path.EndsWith("\\", StringComparison.Ordinal)) {
                     path += "\\";
                 }
 
@@ -107,7 +107,7 @@ namespace TestUtilities {
             bool recurse = true,
             bool fullPaths = true
         ) {
-            if (!root.EndsWith("\\")) {
+            if (!root.EndsWith("\\", StringComparison.Ordinal)) {
                 root += "\\";
             }
 
@@ -118,7 +118,7 @@ namespace TestUtilities {
 
             foreach (var dir in dirs) {
                 var fullDir = Path.IsPathRooted(dir) ? dir : (root + dir);
-                var dirPrefix = Path.IsPathRooted(dir) ? "" : (dir.EndsWith("\\") ? dir : (dir + "\\"));
+                var dirPrefix = Path.IsPathRooted(dir) ? "" : (dir.EndsWith("\\", StringComparison.Ordinal) ? dir : (dir + "\\"));
 
                 IEnumerable<string> files = null;
                 try {

--- a/Python/Product/Analysis/AnalysisLogWriter.cs
+++ b/Python/Product/Analysis/AnalysisLogWriter.cs
@@ -261,7 +261,7 @@ namespace Microsoft.PythonTools.Analysis {
         private static readonly char[] _badChars = Enumerable.Range(0, 32).Select(c => (char)c).ToArray();
 
         private static string SafeFormat(string format, params object[] args) {
-            var s = string.Format(format, args);
+            var s = format.FormatInvariant(args);
 
             // Last chance attempt at producing output that can be embedded in
             // test results file.
@@ -270,7 +270,7 @@ namespace Microsoft.PythonTools.Analysis {
             }
 
             for (char c = '\0'; c < ' '; ++c) {
-                s = s.Replace(c.ToString(), string.Format("\\x{0:X2}", (int)c));
+                s = s.Replace(c.ToString(), "\\x{0:X2}".FormatInvariant((int)c));
             }
             return s;
         }

--- a/Python/Product/Analysis/AnalysisSet.cs
+++ b/Python/Product/Analysis/AnalysisSet.cs
@@ -18,6 +18,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using Microsoft.PythonTools.Analysis.Infrastructure;
 
 namespace Microsoft.PythonTools.Analysis {
     /// <summary>
@@ -130,7 +131,7 @@ namespace Microsoft.PythonTools.Analysis {
                 return set.AsUnion((UnionComparer)comparer, out _);
             }
 
-            throw new InvalidOperationException(string.Format("cannot use {0} as a comparer", comparer));
+            throw new InvalidOperationException("cannot use {0} as a comparer".FormatInvariant(comparer));
         }
 
         /// <summary>
@@ -574,9 +575,9 @@ namespace Microsoft.PythonTools.Analysis {
         public bool Equals(AnalysisValue x, AnalysisValue y) {
 #if FULL_VALIDATION
             if (x != null && y != null) {
-                Validation.Assert(x.UnionEquals(y, Strength) == y.UnionEquals(x, Strength), string.Format("{0}\n{1}\n{2}", Strength, x, y));
+                Validation.Assert(x.UnionEquals(y, Strength) == y.UnionEquals(x, Strength), $"{Strength}\n{x}\n{y}");
                 if (x.UnionEquals(y, Strength)) {
-                    Validation.Assert(x.UnionHashCode(Strength) == y.UnionHashCode(Strength), string.Format("Strength:{0}\n{1} - {2}\n{3} - {4}", Strength, x, x.UnionHashCode(Strength), y, y.UnionHashCode(Strength)));
+                    Validation.Assert(x.UnionHashCode(Strength) == y.UnionHashCode(Strength), "Strength:{Strength}\n{x} - {x.UnionHashCode(Strength)}\n{y} - {y.UnionHashCode(Strength)}");
                 }
             }
 #endif
@@ -600,8 +601,8 @@ namespace Microsoft.PythonTools.Analysis {
 #if FULL_VALIDATION
             var z2 = y.UnionMergeTypes(x, Strength);
             if (!object.ReferenceEquals(z, z2)) {
-                Validation.Assert(z.UnionEquals(z2, Strength), string.Format("{0}\n{1} + {2} => {3}\n{2} + {1} => {4}", Strength, x, y, z, z2));
-                Validation.Assert(z2.UnionEquals(z, Strength), string.Format("{0}\n{1} + {2} => {3}\n{2} + {1} => {4}", Strength, y, x, z2, z));
+                Validation.Assert(z.UnionEquals(z2, Strength), $"{Strength}\n{x} + {y} => {z}\n{y} + {x} => {z2}");
+                Validation.Assert(z2.UnionEquals(z, Strength), $"{Strength}\n{y} + {x} => {z2}\n{x} + {y} => {z}");
             }
 #endif
             return z;
@@ -653,7 +654,7 @@ namespace Microsoft.PythonTools.Analysis {
                 } else if (data.Length < 5) {
                     return "{" + string.Join(", ", data.AsEnumerable()) + "}";
                 } else {
-                    return string.Format("{{Size = {0}}}", data.Length);
+                    return "${{Size = {data.Length}}}";
                 }
             }
 

--- a/Python/Product/Analysis/AnalysisUnit.cs
+++ b/Python/Product/Analysis/AnalysisUnit.cs
@@ -20,6 +20,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using Microsoft.PythonTools.Analysis.Analyzer;
+using Microsoft.PythonTools.Analysis.Infrastructure;
 using Microsoft.PythonTools.Analysis.Values;
 using Microsoft.PythonTools.Interpreter;
 using Microsoft.PythonTools.Parsing;
@@ -198,13 +199,8 @@ namespace Microsoft.PythonTools.Analysis {
         }
 
         public override string ToString() {
-            return String.Format(
-                "<{3}: Name={0} ({1}), NodeType={2}>",
-                FullName,
-                GetHashCode(),
-                Ast != null ? Ast.GetType().Name : "<unknown>",
-                GetType().Name
-            );
+            return "{0}: Name={1} ({2}), NodeType={3}".FormatInvariant(
+                GetType().Name, FullName, GetHashCode(), Ast?.GetType().Name ?? "<unknown>");
         }
 
         /// <summary>

--- a/Python/Product/Analysis/AnalysisValue.cs
+++ b/Python/Product/Analysis/AnalysisValue.cs
@@ -19,6 +19,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using Microsoft.PythonTools.Analysis.Analyzer;
+using Microsoft.PythonTools.Analysis.Infrastructure;
 using Microsoft.PythonTools.Interpreter;
 using Microsoft.PythonTools.Parsing;
 using Microsoft.PythonTools.Parsing.Ast;
@@ -400,7 +401,7 @@ namespace Microsoft.PythonTools.Analysis {
 
         public void Pop() {
             bool wasRemoved = _processing.Remove(this);
-            Debug.Assert(wasRemoved, string.Format("Popped {0} but it wasn't pushed", GetType().FullName));
+            Debug.Assert(wasRemoved, $"Popped {GetType().FullName} but it wasn't pushed");
         }
 
         #endregion

--- a/Python/Product/Analysis/AnalysisValueSetExtensions.cs
+++ b/Python/Product/Analysis/AnalysisValueSetExtensions.cs
@@ -14,6 +14,7 @@
 // See the Apache Version 2.0 License for specific language governing
 // permissions and limitations under the License.
 
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -270,7 +271,7 @@ namespace Microsoft.PythonTools.Analysis {
                     return -1;
                 }
 
-                return x.CompareTo(y);
+                return string.Compare(x, y, StringComparison.CurrentCultureIgnoreCase);
             }
         }
 

--- a/Python/Product/Analysis/Analyzer/DDG.cs
+++ b/Python/Product/Analysis/Analyzer/DDG.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.Linq;
 using System.Threading;
 using Microsoft.PythonTools.Analysis.Infrastructure;
@@ -282,7 +283,7 @@ namespace Microsoft.PythonTools.Analysis.Analyzer {
                         userMod.Imported(_unit);
 
                         foreach (var varName in userMod.GetModuleMemberNames(GlobalScope.InterpreterContext)) {
-                            if (!varName.StartsWith("_")) {
+                            if (!varName.StartsWith("_", StringComparison.Ordinal)) {
                                 WalkFromImportWorker(nameNode, userMod, varName, null);
                             }
                         }

--- a/Python/Product/Analysis/Analyzer/DDG.cs
+++ b/Python/Product/Analysis/Analyzer/DDG.cs
@@ -283,7 +283,7 @@ namespace Microsoft.PythonTools.Analysis.Analyzer {
                         userMod.Imported(_unit);
 
                         foreach (var varName in userMod.GetModuleMemberNames(GlobalScope.InterpreterContext)) {
-                            if (!varName.StartsWith("_", StringComparison.Ordinal)) {
+                            if (!varName.StartsWithOrdinal("_")) {
                                 WalkFromImportWorker(nameNode, userMod, varName, null);
                             }
                         }

--- a/Python/Product/Analysis/Analyzer/FunctionAnalysisUnit.cs
+++ b/Python/Product/Analysis/Analyzer/FunctionAnalysisUnit.cs
@@ -17,6 +17,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+using Microsoft.PythonTools.Analysis.Infrastructure;
 using Microsoft.PythonTools.Analysis.Values;
 using Microsoft.PythonTools.Interpreter;
 using Microsoft.PythonTools.Parsing.Ast;
@@ -199,7 +200,7 @@ namespace Microsoft.PythonTools.Analysis.Analyzer {
         }
 
         public override string ToString() {
-            return string.Format("{0}{1}({2})->{3}",
+            return "{0}{1}({2})->{3}".FormatInvariant(
                 base.ToString(),
                 " def:",
                 string.Join(", ", Ast.Parameters.Select(p => Scope.GetVariable(p.Name).TypesNoCopy.ToString())),
@@ -246,7 +247,7 @@ namespace Microsoft.PythonTools.Analysis.Analyzer {
         }
 
         public override string ToString() {
-            return string.Format("{0}{1}({2})->{3}",
+            return "{0}{1}({2})->{3}".FormatInvariant(
                 base.ToString(),
                 "",
                 string.Join(", ", Ast.Parameters.Select(p => Scope.GetVariable(p.Name).TypesNoCopy.ToString())),

--- a/Python/Product/Analysis/Infrastructure/PathEqualityComparer.cs
+++ b/Python/Product/Analysis/Infrastructure/PathEqualityComparer.cs
@@ -173,7 +173,7 @@ namespace Microsoft.PythonTools.Analysis.Infrastructure {
                 return allowFullMatch;
             }
 
-            return x.StartsWith(prefix + Path.DirectorySeparatorChar, StringComparison.Ordinal);
+            return x.StartsWithOrdinal(prefix + Path.DirectorySeparatorChar);
         }
 
         public bool Equals(string x, string y) {

--- a/Python/Product/Analysis/Infrastructure/PathUtils.cs
+++ b/Python/Product/Analysis/Infrastructure/PathUtils.cs
@@ -177,7 +177,7 @@ namespace Microsoft.PythonTools.Analysis.Infrastructure {
                 }
 
                 foreach (var d in dirs) {
-                    if (!fullPaths && !d.StartsWith(root, StringComparison.OrdinalIgnoreCase)) {
+                    if (!fullPaths && !d.StartsWithOrdinal(root, ignoreCase: true)) {
                         continue;
                     }
                     if (recurse) {

--- a/Python/Product/Analysis/Infrastructure/PathUtils.cs
+++ b/Python/Product/Analysis/Infrastructure/PathUtils.cs
@@ -155,14 +155,14 @@ namespace Microsoft.PythonTools.Analysis.Infrastructure {
             bool fullPaths = true
         ) {
             var queue = new Queue<string>();
-            if (!root.EndsWith("\\")) {
+            if (!root.EndsWithOrdinal("\\")) {
                 root += "\\";
             }
             queue.Enqueue(root);
 
             while (queue.Any()) {
                 var path = queue.Dequeue();
-                if (!path.EndsWith("\\")) {
+                if (!path.EndsWithOrdinal("\\")) {
                     path += "\\";
                 }
 

--- a/Python/Product/Analysis/Infrastructure/StringExtensions.cs
+++ b/Python/Product/Analysis/Infrastructure/StringExtensions.cs
@@ -121,11 +121,15 @@ namespace Microsoft.PythonTools.Analysis.Infrastructure {
         }
 
         public static bool StartsWithOrdinal(this string s, string prefix, bool ignoreCase = false) {
-            return s?.StartsWith(prefix, ignoreCase ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase) ?? false;
+            return s?.StartsWith(prefix, ignoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal) ?? false;
         }
 
         public static bool EndsWithOrdinal(this string s, string suffix, bool ignoreCase = false) {
-            return s?.StartsWith(suffix, ignoreCase ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase) ?? false;
+            return s?.StartsWith(suffix, ignoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal) ?? false;
+        }
+
+        public static int IndexOfOrdinal(this string s, string value, int startIndex = 0, bool ignoreCase = false) {
+            return s?.IndexOf(value, startIndex, ignoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal) ?? -1;
         }
     }
 }

--- a/Python/Product/Analysis/Infrastructure/StringExtensions.cs
+++ b/Python/Product/Analysis/Infrastructure/StringExtensions.cs
@@ -119,5 +119,13 @@ namespace Microsoft.PythonTools.Analysis.Infrastructure {
 
             return "\"{0}\"".FormatInvariant(arg);
         }
+
+        public static bool StartsWithOrdinal(this string s, string prefix, bool ignoreCase = false) {
+            return s?.StartsWith(prefix, ignoreCase ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase) ?? false;
+        }
+
+        public static bool EndsWithOrdinal(this string s, string suffix, bool ignoreCase = false) {
+            return s?.StartsWith(suffix, ignoreCase ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase) ?? false;
+        }
     }
 }

--- a/Python/Product/Analysis/Intellisense/ExtractedMethodCreator.cs
+++ b/Python/Product/Analysis/Intellisense/ExtractedMethodCreator.cs
@@ -51,7 +51,7 @@ namespace Microsoft.PythonTools.Intellisense {
         }
 
         private static int CompareVariables(PythonVariable left, PythonVariable right) {
-            return String.Compare(left.Name, right.Name);
+            return string.CompareOrdinal(left.Name, right.Name);
         }
 
         public ExtractMethodResult GetExtractionResult() {

--- a/Python/Product/Analysis/Intellisense/FlowChecker.cs
+++ b/Python/Product/Analysis/Intellisense/FlowChecker.cs
@@ -17,6 +17,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using Microsoft.PythonTools.Parsing.Ast;
 
 /*
@@ -128,15 +129,17 @@ namespace Microsoft.PythonTools.Intellisense {
         [Conditional("DEBUG")]
         public void Dump(BitArray bits) {
             System.Text.StringBuilder sb = new System.Text.StringBuilder();
-            sb.AppendFormat("FlowChecker ({0})", _scope is FunctionDefinition ? ((FunctionDefinition)_scope).Name :
-                                                 _scope is ClassDefinition ? ((ClassDefinition)_scope).Name : "");
+            sb.AppendFormat(CultureInfo.InvariantCulture,
+                "FlowChecker ({0})",
+                _scope is FunctionDefinition ? ((FunctionDefinition)_scope).Name :
+                    _scope is ClassDefinition ? ((ClassDefinition)_scope).Name : "");
             sb.Append('{');
             bool comma = false;
             foreach (var binding in _variables) {
                 if (comma) sb.Append(", ");
                 else comma = true;
                 int index = 2 * _variableIndices[binding.Value];
-                sb.AppendFormat("{0}:{1}{2}",
+                sb.AppendFormat(CultureInfo.InvariantCulture, "{0}:{1}{2}",
                     binding.Key,
                     bits.Get(index) ? "*" : "-",
                     bits.Get(index + 1) ? "-" : "*");

--- a/Python/Product/Analysis/Interpreter/AnalysisOnlyInterpreterFactory.cs
+++ b/Python/Product/Analysis/Interpreter/AnalysisOnlyInterpreterFactory.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Collections.Generic;
 using Microsoft.PythonTools.Analysis;
+using Microsoft.PythonTools.Analysis.Infrastructure;
 
 namespace Microsoft.PythonTools.Interpreter {
     sealed class AnalysisOnlyInterpreterFactory : IPythonInterpreterFactory, ICustomInterpreterSerialization {
@@ -32,7 +33,7 @@ namespace Microsoft.PythonTools.Interpreter {
         }
 
         public AnalysisOnlyInterpreterFactory(Version version, string description = null)
-            : this(GetConfiguration(version, description ?? $"Analysis Interpreter {version}")) {
+            : this(GetConfiguration(version, description ?? "Analysis Interpreter {0}".FormatUI(version))) {
         }
 
 
@@ -42,7 +43,7 @@ namespace Microsoft.PythonTools.Interpreter {
 
         private static InterpreterConfiguration GetConfiguration(Version version, string description) {
             return new InterpreterConfiguration(
-                $"AnalysisOnly|{version}|{description}",
+                "AnalysisOnly|{0}|{1}".FormatInvariant(version, description),
                 description,
                 arch: InterpreterArchitecture.Unknown,
                 version: version,

--- a/Python/Product/Analysis/Interpreter/Ast/AstBuiltinPythonModule.cs
+++ b/Python/Product/Analysis/Interpreter/Ast/AstBuiltinPythonModule.cs
@@ -26,7 +26,7 @@ namespace Microsoft.PythonTools.Interpreter.Ast {
 
         private static string MakeFakeFilePath(string interpreterPath, string name) {
             if (string.IsNullOrEmpty(interpreterPath)) {
-                return $"python.{name}.exe";
+                return "python.{0}.exe".FormatInvariant(name);
             }
             var ext = Path.GetExtension(interpreterPath);
             return Path.ChangeExtension(interpreterPath, name) + ext;

--- a/Python/Product/Analysis/Interpreter/Ast/AstBuiltinsPythonModule.cs
+++ b/Python/Product/Analysis/Interpreter/Ast/AstBuiltinsPythonModule.cs
@@ -92,7 +92,7 @@ namespace Microsoft.PythonTools.Interpreter.Ast {
             foreach (BuiltinTypeId typeId in Enum.GetValues(typeof(BuiltinTypeId))) {
                 IMember m;
                 AstPythonBuiltinType biType;
-                if (_members.TryGetValue($"__{typeId}__", out m) && (biType = m as AstPythonBuiltinType) != null) {
+                if (_members.TryGetValue("__{0}__".FormatInvariant(typeId), out m) && (biType = m as AstPythonBuiltinType) != null) {
                     if (typeId != BuiltinTypeId.Str &&
                         typeId != BuiltinTypeId.StrIterator) {
                         biType.TrySetTypeId(typeId);
@@ -101,7 +101,7 @@ namespace Microsoft.PythonTools.Interpreter.Ast {
                     if (biType.IsHidden) {
                         _hiddenNames.Add(biType.Name);
                     }
-                    _hiddenNames.Add($"__{typeId}__");
+                    _hiddenNames.Add("__{0}__".FormatInvariant(typeId));
 
                     if (typeId == BuiltinTypeId.Bool) {
                         boolType = m as IPythonType;

--- a/Python/Product/Analysis/Interpreter/Ast/AstPythonInterpreter.cs
+++ b/Python/Product/Analysis/Interpreter/Ast/AstPythonInterpreter.cs
@@ -89,14 +89,14 @@ namespace Microsoft.PythonTools.Interpreter.Ast {
 
         public IPythonType GetBuiltinType(BuiltinTypeId id) {
             if (id < 0 || id > BuiltinTypeIdExtensions.LastTypeId) {
-                throw new KeyNotFoundException($"(BuiltinTypeId)({(int)id})");
+                throw new KeyNotFoundException("(BuiltinTypeId)({0})".FormatInvariant((int)id));
             }
 
             IPythonType res;
             lock (_builtinTypes) {
                 if (!_builtinTypes.TryGetValue(id, out res)) {
                     var bm = ImportModule(BuiltinModuleName) as AstBuiltinsPythonModule;
-                    res = bm?.GetAnyMember($"__{id}__") as IPythonType;
+                    res = bm?.GetAnyMember("__{0}__".FormatInvariant(id)) as IPythonType;
                     if (res == null) {
                         var name = id.GetTypeName(_factory.Configuration.Version);
                         if (string.IsNullOrEmpty(name)) {
@@ -300,9 +300,9 @@ namespace Microsoft.PythonTools.Interpreter.Ast {
                 return null;
             }
 
-            if (File.Exists(_factory.GetCacheFilePath($"python.{name}.pyi"))) {
-                return new AstCachedPythonModule(name, $"python.{name}");
-            } else if (File.Exists(_factory.GetCacheFilePath($"{name}.pyi"))) {
+            if (File.Exists(_factory.GetCacheFilePath("python.{0}.pyi".FormatInvariant(name)))) {
+                return new AstCachedPythonModule(name, "python.{0}".FormatInvariant(name));
+            } else if (File.Exists(_factory.GetCacheFilePath("{0}.pyi".FormatInvariant(name)))) {
                 return new AstCachedPythonModule(name, name);
             }
 
@@ -433,7 +433,7 @@ namespace Microsoft.PythonTools.Interpreter.Ast {
                 res = usp.Keys.Union(ssp.Keys);
             }
 
-            return res.Where(m => m == name || m.EndsWith(dotName));
+            return res.Where(m => m == name || m.EndsWith(dotName, StringComparison.Ordinal));
         }
 
         public IEnumerable<string> GetModulesContainingName(string name) {

--- a/Python/Product/Analysis/Interpreter/Ast/AstPythonInterpreter.cs
+++ b/Python/Product/Analysis/Interpreter/Ast/AstPythonInterpreter.cs
@@ -219,7 +219,7 @@ namespace Microsoft.PythonTools.Interpreter.Ast {
                 return null;
             }
 
-            Debug.Assert(!name.EndsWith("."), $"{name} should not end with '.'");
+            Debug.Assert(!name.EndsWithOrdinal("."), $"{name} should not end with '.'");
 
             // Handle builtins explicitly
             if (name == BuiltinModuleName) {

--- a/Python/Product/Analysis/Interpreter/Ast/AstPythonInterpreter.cs
+++ b/Python/Product/Analysis/Interpreter/Ast/AstPythonInterpreter.cs
@@ -433,7 +433,7 @@ namespace Microsoft.PythonTools.Interpreter.Ast {
                 res = usp.Keys.Union(ssp.Keys);
             }
 
-            return res.Where(m => m == name || m.EndsWith(dotName, StringComparison.Ordinal));
+            return res.Where(m => m == name || m.EndsWithOrdinal(dotName));
         }
 
         public IEnumerable<string> GetModulesContainingName(string name) {

--- a/Python/Product/Analysis/Interpreter/Ast/AstPythonInterpreterFactory.cs
+++ b/Python/Product/Analysis/Interpreter/Ast/AstPythonInterpreterFactory.cs
@@ -138,11 +138,11 @@ namespace Microsoft.PythonTools.Interpreter.Ast {
         }
 
         internal string FastRelativePath(string fullPath) {
-            if (!fullPath.StartsWith(Configuration.PrefixPath, StringComparison.OrdinalIgnoreCase)) {
+            if (!fullPath.StartsWithOrdinal(Configuration.PrefixPath, ignoreCase: true)) {
                 return fullPath;
             }
             var p = fullPath.Substring(Configuration.PrefixPath.Length);
-            if (p.StartsWith("\\", StringComparison.Ordinal)) {
+            if (p.StartsWithOrdinal("\\")) {
                 return p.Substring(1);
             }
             return p;

--- a/Python/Product/Analysis/Interpreter/Ast/AstPythonInterpreterFactory.cs
+++ b/Python/Product/Analysis/Interpreter/Ast/AstPythonInterpreterFactory.cs
@@ -69,7 +69,7 @@ namespace Microsoft.PythonTools.Interpreter.Ast {
                 _log.Rotate(LogRotationSize);
                 _log.MinimumLevel = CreationOptions.TraceLevel;
             } else {
-                if (InstallPath.TryGetFile($"DefaultDB\\v{Configuration.Version.Major}\\python.pyi", out string biPath)) {
+                if (InstallPath.TryGetFile("DefaultDB\\v{0}\\python.pyi".FormatInvariant(Configuration.Version.Major), out string biPath)) {
                     CreationOptions.DatabasePath = _databasePath = Path.GetDirectoryName(biPath);
                     _skipWriteToCache = true;
                 }
@@ -142,7 +142,7 @@ namespace Microsoft.PythonTools.Interpreter.Ast {
                 return fullPath;
             }
             var p = fullPath.Substring(Configuration.PrefixPath.Length);
-            if (p.StartsWith("\\")) {
+            if (p.StartsWith("\\", StringComparison.Ordinal)) {
                 return p.Substring(1);
             }
             return p;

--- a/Python/Product/Analysis/Interpreter/Ast/AstPythonModule.cs
+++ b/Python/Product/Analysis/Interpreter/Ast/AstPythonModule.cs
@@ -72,7 +72,7 @@ namespace Microsoft.PythonTools.Interpreter.Ast {
         ) {
             PythonAst ast;
             var parser = Parser.CreateParser(sourceFile, langVersion, new ParserOptions {
-                StubFile = fileName?.EndsWith(".pyi", StringComparison.OrdinalIgnoreCase) ?? false,
+                StubFile = fileName.EndsWithOrdinal(".pyi", ignoreCase: true),
                 Verbatim = true
             });
             ast = parser.ParseFile();

--- a/Python/Product/Analysis/Interpreter/Ast/AstPythonProperty.cs
+++ b/Python/Product/Analysis/Interpreter/Ast/AstPythonProperty.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using Microsoft.PythonTools.Analysis;
+using Microsoft.PythonTools.Analysis.Infrastructure;
 using Microsoft.PythonTools.Parsing.Ast;
 
 namespace Microsoft.PythonTools.Interpreter.Ast {
@@ -33,7 +34,7 @@ namespace Microsoft.PythonTools.Interpreter.Ast {
 
         public string Documentation { get; }
 
-        public string Description => Type == null ? "property of unknown type" : $"property of type {Type.Name}";
+        public string Description => Type == null ? "property of unknown type" : "property of type {0}".FormatUI(Type.Name);
 
         public PythonMemberType MemberType => PythonMemberType.Property;
         

--- a/Python/Product/Analysis/Interpreter/Ast/AstScrapedPythonModule.cs
+++ b/Python/Product/Analysis/Interpreter/Ast/AstScrapedPythonModule.cs
@@ -184,7 +184,7 @@ namespace Microsoft.PythonTools.Interpreter.Ast {
                     ast = parser.ParseFile();
                 }
 
-                ParseErrors = sink.Errors.Select(e => $"{_filePath ?? "(builtins)"} ({e.Span}): {e.Message}").ToArray();
+                ParseErrors = sink.Errors.Select(e => "{0} ({1}): {2}".FormatUI(_filePath ?? "(builtins)", e.Span, e.Message)).ToArray();
                 if (ParseErrors.Any()) {
                     fact.Log(TraceLevel.Error, "Parse", _filePath ?? "(builtins)");
                     foreach (var e in ParseErrors) {

--- a/Python/Product/Analysis/Interpreter/Ast/NameLookupContext.cs
+++ b/Python/Product/Analysis/Interpreter/Ast/NameLookupContext.cs
@@ -150,7 +150,7 @@ namespace Microsoft.PythonTools.Interpreter.Ast {
             }
 
             if (expr is MemberExpression me) {
-                return $"{GetNameFromExpressionWorker(me.Target)}.{me.Name}";
+                return "{0}.{1}".FormatInvariant(GetNameFromExpressionWorker(me.Target), me.Name);
             }
 
             throw new FormatException();

--- a/Python/Product/Analysis/Interpreter/InterpreterArchitecture.cs
+++ b/Python/Product/Analysis/Interpreter/InterpreterArchitecture.cs
@@ -15,9 +15,6 @@
 // permissions and limitations under the License.
 
 using System;
-using System.Diagnostics;
-using System.Reflection;
-using Microsoft.PythonTools.Analysis.Infrastructure;
 
 namespace Microsoft.PythonTools.Interpreter {
     public abstract class InterpreterArchitecture : 
@@ -108,7 +105,7 @@ namespace Microsoft.PythonTools.Interpreter {
                 return -1;
             }
 
-            return GetType().Name.CompareTo(other.GetType().Name);
+            return string.CompareOrdinal(GetType().Name, other.GetType().Name);
         }
 
         public static bool operator ==(InterpreterArchitecture x, InterpreterArchitecture y)

--- a/Python/Product/Analysis/Interpreter/InterpreterConfiguration.cs
+++ b/Python/Product/Analysis/Interpreter/InterpreterConfiguration.cs
@@ -18,6 +18,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using Microsoft.PythonTools.Analysis.Infrastructure;
 
 namespace Microsoft.PythonTools.Interpreter {
     public sealed class InterpreterConfiguration : IEquatable<InterpreterConfiguration> {
@@ -146,18 +147,18 @@ namespace Microsoft.PythonTools.Interpreter {
         /// </summary>
         private void SwitchToFullDescription() {
             bool hasVersion = _description.Contains(Version.ToString());
-            bool hasArch = _description.IndexOf(Architecture.ToString(), StringComparison.CurrentCultureIgnoreCase) >= 0 ||
-                _description.IndexOf(Architecture.ToString("x"), StringComparison.CurrentCultureIgnoreCase) >= 0;
+            bool hasArch = _description.IndexOf(Architecture.ToString(null, CultureInfo.CurrentCulture), StringComparison.CurrentCultureIgnoreCase) >= 0 ||
+                _description.IndexOf(Architecture.ToString("x", CultureInfo.CurrentCulture), StringComparison.CurrentCultureIgnoreCase) >= 0;
 
             if (hasVersion && hasArch) {
                 // Regular description is sufficient
                 _fullDescription = null;
             } else if (hasVersion) {
-                _fullDescription = string.Format(CultureInfo.CurrentUICulture, "{0} ({1})", _description, Architecture);
+                _fullDescription = "{0} ({1})".FormatUI(_description, Architecture);
             } else if (hasArch) {
-                _fullDescription = string.Format(CultureInfo.CurrentUICulture, "{0} ({1})", _description, Version);
+                _fullDescription = "{0} ({1})".FormatUI(_description, Version);
             } else {
-                _fullDescription = string.Format(CultureInfo.CurrentUICulture, "{0} ({1}, {2})", _description, Version, Architecture);
+                _fullDescription = "{0} ({1}, {2})".FormatUI(_description, Version, Architecture);
             }
         }
 

--- a/Python/Product/Analysis/Interpreter/InterpreterFactoryCreator.cs
+++ b/Python/Product/Analysis/Interpreter/InterpreterFactoryCreator.cs
@@ -49,8 +49,8 @@ namespace Microsoft.PythonTools.Interpreter {
             IEnumerable<string> searchPaths = null
         ) {
             var config = new InterpreterConfiguration(
-                $"AnalysisOnly|{languageVersion}",
-                description ?? $"Analysis Only {languageVersion}",
+                "AnalysisOnly|{0}".FormatInvariant(languageVersion),
+                description ?? "Analysis Only {0}".FormatUI(languageVersion),
                 version: languageVersion
             );
             config.SearchPaths.AddRange(searchPaths.MaybeEnumerate());

--- a/Python/Product/Analysis/Interpreter/NoInterpretersInterpreter.cs
+++ b/Python/Product/Analysis/Interpreter/NoInterpretersInterpreter.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Collections.Generic;
 using Microsoft.PythonTools.Analysis;
+using Microsoft.PythonTools.Analysis.Infrastructure;
 using Microsoft.PythonTools.Parsing;
 
 namespace Microsoft.PythonTools.Interpreter {
@@ -37,7 +38,7 @@ namespace Microsoft.PythonTools.Interpreter {
         public IPythonType GetBuiltinType(BuiltinTypeId id) {
             var res = _builtinModule.GetAnyMember(id.GetTypeName(PythonLanguageVersion.V37)) as IPythonType;
             if (res == null) {
-                throw new KeyNotFoundException(string.Format("{0} ({1})", id, (int)id));
+                throw new KeyNotFoundException("{0} ({1})".FormatInvariant(id, (int)id));
             }
             return res;
         }

--- a/Python/Product/Analysis/Interpreter/PackageSpec.cs
+++ b/Python/Product/Analysis/Interpreter/PackageSpec.cs
@@ -47,7 +47,7 @@ namespace Microsoft.PythonTools.Interpreter {
                 if (!string.IsNullOrEmpty(_fullSpec)) {
                     return _fullSpec;
                 }
-                return $"{Name}{Constraint}";
+                return Name + Constraint;
             }
         }
         public string Name { get; set; }
@@ -60,7 +60,7 @@ namespace Microsoft.PythonTools.Interpreter {
                 if (ExactVersion.IsEmpty) {
                     return "";
                 }
-                return $"=={ExactVersion}";
+                return "==" + ExactVersion;
             }
             set { _constraint = value; }
         }

--- a/Python/Product/Analysis/Interpreter/PackageVersion.cs
+++ b/Python/Product/Analysis/Interpreter/PackageVersion.cs
@@ -17,9 +17,11 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
+using Microsoft.PythonTools.Analysis.Infrastructure;
 
 namespace Microsoft.PythonTools.Interpreter {
     public struct PackageVersion : IComparable<PackageVersion>, IEquatable<PackageVersion> {
@@ -136,7 +138,7 @@ namespace Microsoft.PythonTools.Interpreter {
                     if (Release == null) {
                         sb.Append("0");
                     } else {
-                        sb.Append(string.Join(".", Release.Select(i => i.ToString())));
+                        sb.Append(string.Join(".", Release.Select(i => i.ToString(CultureInfo.InvariantCulture))));
                     }
                     if (PreReleaseName != PackageVersionPreReleaseName.None) {
                         switch (PreReleaseName) {
@@ -283,18 +285,18 @@ namespace Microsoft.PythonTools.Interpreter {
                 var p2 = lv2[i];
 
                 int i1, i2;
-                if (int.TryParse(p1, out i1)) {
-                    if (int.TryParse(p2, out i2)) {
+                if (int.TryParse(p1, NumberStyles.Integer, CultureInfo.InvariantCulture, out i1)) {
+                    if (int.TryParse(p2, NumberStyles.Integer, CultureInfo.InvariantCulture, out i2)) {
                         c = i1.CompareTo(i2);
                     } else {
                         // we have a number and other doesn't, so we sort later
                         return 1;
                     }
-                } else if (int.TryParse(p2, out i2)) {
+                } else if (int.TryParse(p2, NumberStyles.Integer, CultureInfo.InvariantCulture, out i2)) {
                     // other has a number and we don't, so we sort earlier
                     return -1;
                 } else {
-                    c = p1.CompareTo(p2);
+                    c = string.Compare(p1, p2, StringComparison.OrdinalIgnoreCase);
                 }
 
                 if (c != 0) {
@@ -356,9 +358,7 @@ namespace Microsoft.PythonTools.Interpreter {
             foreach (var v in m.Groups["release"].Value.Split('.')) {
                 int i;
                 if (!int.TryParse(v, out i)) {
-                    error = new FormatException(
-                        string.Format("'{0}' is not a valid version", m.Groups["release"].Value)
-                    );
+                    error = new FormatException("'{0}' is not a valid version".FormatUI(m.Groups["release"].Value));
                     return false;
                 }
                 release.Add(i);
@@ -366,7 +366,7 @@ namespace Microsoft.PythonTools.Interpreter {
 
             if (m.Groups["epoch"].Success) {
                 if (!int.TryParse(m.Groups["epoch"].Value, out epoch)) {
-                    error = new FormatException(string.Format("'{0}' is not a number", m.Groups["epoch"].Value));
+                    error = new FormatException("'{0}' is not a number".FormatUI(m.Groups["epoch"].Value));
                     return false;
                 }
             }
@@ -389,28 +389,28 @@ namespace Microsoft.PythonTools.Interpreter {
                         preName = PackageVersionPreReleaseName.RC;
                         break;
                     default:
-                        error = new FormatException(string.Format("'{0}' is not a valid prerelease name", preName));
+                        error = new FormatException("'{0}' is not a valid prerelease name".FormatUI(preName));
                         return false;
                 }
             }
 
             if (m.Groups["pre"].Success) {
                 if (!int.TryParse(m.Groups["pre"].Value, out pre)) {
-                    error = new FormatException(string.Format("'{0}' is not a number", m.Groups["pre"].Value));
+                    error = new FormatException("'{0}' is not a number".FormatUI(m.Groups["pre"].Value));
                     return false;
                 }
             }
 
             if (m.Groups["dev"].Success) {
                 if (!int.TryParse(m.Groups["dev"].Value, out dev)) {
-                    error = new FormatException(string.Format("'{0}' is not a number", m.Groups["dev"].Value));
+                    error = new FormatException("'{0}' is not a number".FormatUI(m.Groups["dev"].Value));
                     return false;
                 }
             }
 
             if (m.Groups["post"].Success) {
                 if (!int.TryParse(m.Groups["post"].Value, out post)) {
-                    error = new FormatException(string.Format("'{0}' is not a number", m.Groups["post"].Value));
+                    error = new FormatException("'{0}' is not a number".FormatUI(m.Groups["post"].Value));
                     return false;
                 }
             }

--- a/Python/Product/Analysis/Interpreter/PythonLibraryPath.cs
+++ b/Python/Product/Analysis/Interpreter/PythonLibraryPath.cs
@@ -189,7 +189,7 @@ namespace Microsoft.PythonTools.Analysis {
             }
 
             return lines.Select(s => {
-                if (s.StartsWith(tempWorkingDir, StringComparison.OrdinalIgnoreCase)) {
+                if (s.StartsWithOrdinal(tempWorkingDir, ignoreCase: true)) {
                     return null;
                 }
                 try {

--- a/Python/Product/Analysis/Interpreter/PythonLibraryPath.cs
+++ b/Python/Product/Analysis/Interpreter/PythonLibraryPath.cs
@@ -55,7 +55,7 @@ namespace Microsoft.PythonTools.Analysis {
         }
 
         public override string ToString() {
-            return string.Format("{0}|{1}|{2}", _path, _isStandardLibrary ? "stdlib" : "", _modulePrefix ?? "");
+            return "{0}|{1}|{2}".FormatInvariant(_path, _isStandardLibrary ? "stdlib" : "", _modulePrefix ?? "");
         }
 
         public static PythonLibraryPath Parse(string s) {

--- a/Python/Product/Analysis/LanguageServer/DiagnosticsErrorSink.cs
+++ b/Python/Product/Analysis/LanguageServer/DiagnosticsErrorSink.cs
@@ -53,7 +53,7 @@ namespace Microsoft.PythonTools.Analysis.LanguageServer {
             };
 
             foreach (var kv in _taskCommentMap.MaybeEnumerate()) {
-                if (text.IndexOf(kv.Key, StringComparison.OrdinalIgnoreCase) >= 0) {
+                if (text.IndexOfOrdinal(kv.Key, ignoreCase: true) >= 0) {
                     d.severity = kv.Value;
                     break;
                 }

--- a/Python/Product/Analysis/LanguageServer/ParseQueue.cs
+++ b/Python/Product/Analysis/LanguageServer/ParseQueue.cs
@@ -97,7 +97,7 @@ namespace Microsoft.PythonTools.Analysis.LanguageServer {
             }
 
             if (!buffers.Any()) {
-                throw new FileNotFoundException($"failed to parse file {entry.DocumentUri.AbsoluteUri}", entry.FilePath);
+                throw new FileNotFoundException("failed to parse file {0}".FormatInvariant(entry.DocumentUri.AbsoluteUri), entry.FilePath);
             }
 
             var cookie = new VersionCookie(buffers);

--- a/Python/Product/Analysis/LanguageServer/Server.cs
+++ b/Python/Product/Analysis/LanguageServer/Server.cs
@@ -397,7 +397,9 @@ namespace Microsoft.PythonTools.Analysis.LanguageServer {
         internal int GetPart(Uri documentUri) {
             var f = documentUri.Fragment;
             int i;
-            if (string.IsNullOrEmpty(f) || !f.StartsWith("#") || !int.TryParse(f.Substring(1), out i)) {
+            if (string.IsNullOrEmpty(f) ||
+                !f.StartsWith("#", StringComparison.Ordinal) ||
+                !int.TryParse(f.Substring(1), NumberStyles.Integer, CultureInfo.InvariantCulture, out i)) {
                 i = 0;
             }
             return i;

--- a/Python/Product/Analysis/LanguageServer/Server.cs
+++ b/Python/Product/Analysis/LanguageServer/Server.cs
@@ -398,7 +398,7 @@ namespace Microsoft.PythonTools.Analysis.LanguageServer {
             var f = documentUri.Fragment;
             int i;
             if (string.IsNullOrEmpty(f) ||
-                !f.StartsWith("#", StringComparison.Ordinal) ||
+                !f.StartsWithOrdinal("#") ||
                 !int.TryParse(f.Substring(1), NumberStyles.Integer, CultureInfo.InvariantCulture, out i)) {
                 i = 0;
             }
@@ -891,7 +891,7 @@ namespace Microsoft.PythonTools.Analysis.LanguageServer {
 
             foreach (var m in analysis.GetAllAvailableMembers(SourceLocation.None, opts)) {
                 if (m.Values.Any(v => v.DeclaringModule == entry)) {
-                    if (string.IsNullOrEmpty(prefix) || m.Name.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)) {
+                    if (string.IsNullOrEmpty(prefix) || m.Name.StartsWithOrdinal(prefix, ignoreCase: true)) {
                         yield return m;
                     }
                 }

--- a/Python/Product/Analysis/ModuleAnalysis.cs
+++ b/Python/Product/Analysis/ModuleAnalysis.cs
@@ -1147,7 +1147,7 @@ namespace Microsoft.PythonTools.Analysis {
         }
 
         private static string GetMemberName(string privatePrefix, GetMemberOptions options, string name) {
-            if (privatePrefix != null && name.StartsWith(privatePrefix, StringComparison.Ordinal) && !name.EndsWith("__", StringComparison.Ordinal)) {
+            if (privatePrefix != null && name.StartsWithOrdinal(privatePrefix) && !name.EndsWithOrdinal("__")) {
                 // private prefix inside of the class, filter out the prefix.
                 return name.Substring(privatePrefix.Length - 2);
             } else if (!_otherPrivateRegex.IsMatch(name) || !options.HideAdvanced()) {

--- a/Python/Product/Analysis/ModuleAnalysis.cs
+++ b/Python/Product/Analysis/ModuleAnalysis.cs
@@ -1147,7 +1147,7 @@ namespace Microsoft.PythonTools.Analysis {
         }
 
         private static string GetMemberName(string privatePrefix, GetMemberOptions options, string name) {
-            if (privatePrefix != null && name.StartsWith(privatePrefix) && !name.EndsWith("__")) {
+            if (privatePrefix != null && name.StartsWith(privatePrefix, StringComparison.Ordinal) && !name.EndsWith("__", StringComparison.Ordinal)) {
                 // private prefix inside of the class, filter out the prefix.
                 return name.Substring(privatePrefix.Length - 2);
             } else if (!_otherPrivateRegex.IsMatch(name) || !options.HideAdvanced()) {

--- a/Python/Product/Analysis/ModulePath.cs
+++ b/Python/Product/Analysis/ModulePath.cs
@@ -172,7 +172,7 @@ namespace Microsoft.PythonTools.Analysis {
                     }
                     if (match.Success) {
                         var name = match.Groups["name"].Value;
-                        if (name.EndsWith("_d") && file.EndsWith(".pyd", StringComparison.OrdinalIgnoreCase)) {
+                        if (name.EndsWithOrdinal("_d") && file.EndsWithOrdinal(".pyd")) {
                             name = name.Remove(name.Length - 2);
                         }
                         yield return new ModulePath(baseModule + name, file, libPath ?? path);
@@ -282,7 +282,7 @@ namespace Microsoft.PythonTools.Analysis {
                             string line;
                             while ((line = reader.ReadLine()) != null) {
                                 line = line.Trim();
-                                if (line.StartsWith("import ", StringComparison.Ordinal) ||
+                                if (line.StartsWithOrdinal("import ") ||
                                     !PathEqualityComparer.IsValidPath(line)) {
                                     continue;
                                 }

--- a/Python/Product/Analysis/ModulePath.cs
+++ b/Python/Product/Analysis/ModulePath.cs
@@ -157,7 +157,7 @@ namespace Microsoft.PythonTools.Analysis {
             bool requireInitPy,
             bool includePackages
         ) {
-            Debug.Assert(baseModule == "" || baseModule.EndsWith("."));
+            Debug.Assert(baseModule == "" || baseModule.EndsWithOrdinal("."));
 
             if (!Directory.Exists(path)) {
                 yield break;

--- a/Python/Product/Analysis/Parsing/Ast/ConstantExpression.cs
+++ b/Python/Product/Analysis/Parsing/Ast/ConstantExpression.cs
@@ -128,7 +128,7 @@ namespace Microsoft.PythonTools.Parsing.Ast {
                 string real = NegativeZeroAwareToString(n.Real);
                 string imag =  NegativeZeroAwareToString(n.Imaginary);
                 if (n.Real != 0) {
-                    if (!imag.StartsWith("-", StringComparison.Ordinal)) {
+                    if (!imag.StartsWithOrdinal("-")) {
                         imag = "+" + imag;
                     }
                     return "(" + real + imag + "j)";

--- a/Python/Product/Analysis/Parsing/Ast/ConstantExpression.cs
+++ b/Python/Product/Analysis/Parsing/Ast/ConstantExpression.cs
@@ -19,6 +19,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Numerics;
 using System.Text;
+using Microsoft.PythonTools.Analysis.Infrastructure;
 
 namespace Microsoft.PythonTools.Parsing.Ast {
     public class ConstantExpression : Expression {
@@ -93,9 +94,9 @@ namespace Microsoft.PythonTools.Parsing.Ast {
                     default:
                         ushort cp = (ushort)c;
                         if (cp > 0xFF) {
-                            res.AppendFormat("\\u{0:x04}", cp);
+                            res.AppendFormat(CultureInfo.InvariantCulture, "\\u{0:x04}", cp);
                         } else if (cp < 0x20 || (escape8bitStrings && cp >= 0x7F)) {
-                            res.AppendFormat("\\x{0:x02}", cp);
+                            res.AppendFormat(CultureInfo.InvariantCulture, "\\x{0:x02}", cp);
                         } else {
                             res.Append(c);
                         }
@@ -127,7 +128,7 @@ namespace Microsoft.PythonTools.Parsing.Ast {
                 string real = NegativeZeroAwareToString(n.Real);
                 string imag =  NegativeZeroAwareToString(n.Imaginary);
                 if (n.Real != 0) {
-                    if (!imag.StartsWith("-")) {
+                    if (!imag.StartsWith("-", StringComparison.Ordinal)) {
                         imag = "+" + imag;
                     }
                     return "(" + real + imag + "j)";
@@ -136,7 +137,7 @@ namespace Microsoft.PythonTools.Parsing.Ast {
                 }
             } else if (_value is BigInteger) {
                 if (!version.Is3x()) {
-                    return _value.ToString() + "L";
+                    return "{0}L".FormatInvariant(_value);
                 }
             } else if (_value is double) {
                 double n = (double)_value;

--- a/Python/Product/Analysis/Parsing/Ast/FunctionDefinition.cs
+++ b/Python/Product/Analysis/Parsing/Ast/FunctionDefinition.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+using Microsoft.PythonTools.Analysis.Infrastructure;
 
 namespace Microsoft.PythonTools.Parsing.Ast {
 
@@ -197,42 +198,27 @@ namespace Microsoft.PythonTools.Parsing.Ast {
         private void Verify(PythonNameBinder binder) {
             if (ContainsImportStar && IsClosure) {
                 binder.ReportSyntaxError(
-                    String.Format(
-                        System.Globalization.CultureInfo.InvariantCulture,
-                        "import * is not allowed in function '{0}' because it is a nested function",
-                        Name),
+                    "import * is not allowed in function '{0}' because it is a nested function".FormatUI(Name),
                     this);
             }
             if (ContainsImportStar && Parent is FunctionDefinition) {
                 binder.ReportSyntaxError(
-                    String.Format(
-                        System.Globalization.CultureInfo.InvariantCulture,
-                        "import * is not allowed in function '{0}' because it is a nested function",
-                        Name),
+                    "import * is not allowed in function '{0}' because it is a nested function".FormatUI(Name),
                     this);
             }
             if (ContainsImportStar && ContainsNestedFreeVariables) {
                 binder.ReportSyntaxError(
-                    String.Format(
-                        System.Globalization.CultureInfo.InvariantCulture,
-                        "import * is not allowed in function '{0}' because it contains a nested function with free variables",
-                        Name),
+                    "import * is not allowed in function '{0}' because it contains a nested function with free variables".FormatUI(Name),
                     this);
             }
             if (ContainsUnqualifiedExec && ContainsNestedFreeVariables) {
                 binder.ReportSyntaxError(
-                    String.Format(
-                        System.Globalization.CultureInfo.InvariantCulture,
-                        "unqualified exec is not allowed in function '{0}' because it contains a nested function with free variables",
-                        Name),
+                    "unqualified exec is not allowed in function '{0}' because it contains a nested function with free variables".FormatUI(Name),
                     this);
             }
             if (ContainsUnqualifiedExec && IsClosure) {
                 binder.ReportSyntaxError(
-                    String.Format(
-                        System.Globalization.CultureInfo.InvariantCulture,
-                        "unqualified exec is not allowed in function '{0}' because it is a nested function",
-                        Name),
+                    "unqualified exec is not allowed in function '{0}' because it is a nested function".FormatUI(Name),
                     this);
             }
         }

--- a/Python/Product/Analysis/Parsing/Ast/PythonNameBinder.cs
+++ b/Python/Product/Analysis/Parsing/Ast/PythonNameBinder.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using Microsoft.PythonTools.Analysis.Infrastructure;
 
 
 /*
@@ -464,21 +465,14 @@ namespace Microsoft.PythonTools.Parsing.Ast {
                         case VariableKind.Local:
                             assignedGlobal = true;
                             ReportSyntaxWarning(
-                                String.Format(
-                                    System.Globalization.CultureInfo.InvariantCulture,
-                                    "name '{0}' is assigned to before global declaration",
-                                    n
-                                ),
+                                "name '{0}' is assigned to before global declaration".FormatUI(n),
                                 node
                             );
                             break;
                         
                         case VariableKind.Parameter:
                             ReportSyntaxError(
-                                String.Format(
-                                    System.Globalization.CultureInfo.InvariantCulture,
-                                    "Name '{0}' is a function parameter and declared global",
-                                    n),
+                                "Name '{0}' is a function parameter and declared global".FormatUI(n),
                                 node);
                             break;
                     }
@@ -487,11 +481,8 @@ namespace Microsoft.PythonTools.Parsing.Ast {
                 // Check for the name being referenced previously. If it has been, issue warning.
                 if (_currentScope.IsReferenced(n) && !assignedGlobal) {
                     ReportSyntaxWarning(
-                        String.Format(
-                        System.Globalization.CultureInfo.InvariantCulture,
-                        "name '{0}' is used prior to global declaration",
-                        n),
-                    node);
+                        "name '{0}' is used prior to global declaration".FormatUI(n),
+                        node);
                 }
 
 
@@ -523,25 +514,18 @@ namespace Microsoft.PythonTools.Parsing.Ast {
                     // conflict?
                     switch (conflict.Kind) {
                         case VariableKind.Global:
-                            ReportSyntaxError(String.Format("name '{0}' is nonlocal and global", n), node);
+                            ReportSyntaxError("name '{0}' is nonlocal and global".FormatUI(n), node);
                             break;
                         case VariableKind.Local:
                             assignedLocal = true;
                             ReportSyntaxWarning(
-                                String.Format(
-                                    System.Globalization.CultureInfo.InvariantCulture,
-                                    "name '{0}' is assigned to before nonlocal declaration",
-                                    n
-                                ),
+                                "name '{0}' is assigned to before nonlocal declaration".FormatUI(n),
                                 node
                             );
                             break;
                         case VariableKind.Parameter:
                             ReportSyntaxError(
-                                String.Format(
-                                    System.Globalization.CultureInfo.InvariantCulture,
-                                    "name '{0}' is a parameter and nonlocal",
-                                    n),
+                                "name '{0}' is a parameter and nonlocal".FormatUI(n),
                                 node);
                             break;
                     }
@@ -550,11 +534,8 @@ namespace Microsoft.PythonTools.Parsing.Ast {
                 // Check for the name being referenced previously. If it has been, issue warning.
                 if (_currentScope.IsReferenced(n) && !assignedLocal) {
                     ReportSyntaxWarning(
-                        String.Format(
-                        System.Globalization.CultureInfo.InvariantCulture,
-                        "name '{0}' is used prior to nonlocal declaration",
-                        n),
-                    node);
+                        "name '{0}' is used prior to nonlocal declaration".FormatUI(n),
+                        node);
                 }
 
 

--- a/Python/Product/Analysis/Parsing/Ast/ScopeStatement.cs
+++ b/Python/Product/Analysis/Parsing/Ast/ScopeStatement.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using Microsoft.PythonTools.Analysis.Infrastructure;
 
 namespace Microsoft.PythonTools.Parsing.Ast {
 
@@ -255,11 +256,7 @@ namespace Microsoft.PythonTools.Parsing.Ast {
 
                                 // report syntax error
                                 binder.ReportSyntaxError(
-                                    String.Format(
-                                        System.Globalization.CultureInfo.InvariantCulture,
-                                        "can not delete variable '{0}' referenced in nested scope",
-                                        reference.Name
-                                        ),
+                                    "can not delete variable '{0}' referenced in nested scope".FormatUI(reference.Name),
                                     this);
                             }
                         }
@@ -284,7 +281,7 @@ namespace Microsoft.PythonTools.Parsing.Ast {
                     }
 
                     if (!bound) {
-                        binder.ReportSyntaxError(String.Format("no binding for nonlocal '{0}' found", variableName.Name), variableName);
+                        binder.ReportSyntaxError("no binding for nonlocal '{0}' found".FormatUI(variableName.Name), variableName);
                     }
                 }
             }

--- a/Python/Product/Analysis/Parsing/Ast/SublistParameter.cs
+++ b/Python/Product/Analysis/Parsing/Ast/SublistParameter.cs
@@ -15,6 +15,7 @@
 // permissions and limitations under the License.
 
 using System.Text;
+using Microsoft.PythonTools.Analysis.Infrastructure;
 
 namespace Microsoft.PythonTools.Parsing.Ast {
     public class SublistParameter : Parameter {
@@ -27,7 +28,7 @@ namespace Microsoft.PythonTools.Parsing.Ast {
             _tuple = tuple;
         }
 
-        public override string Name => $".{_position}";
+        public override string Name => ".{0}".FormatUI(_position);
 
         public TupleExpression Tuple => _tuple;
 

--- a/Python/Product/Analysis/Parsing/CodeFormattingOptions.cs
+++ b/Python/Product/Analysis/Parsing/CodeFormattingOptions.cs
@@ -369,7 +369,7 @@ namespace Microsoft.PythonTools.Parsing {
 
             var lines = text.Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.None);
             int lineCount = lines.Length;
-            if (text.EndsWith("\r") || text.EndsWith("\n")) {
+            if (text.EndsWith("\r", StringComparison.Ordinal) || text.EndsWith("\n", StringComparison.Ordinal)) {
                 // split will give us an extra entry, but there's not really an extra line
                 lineCount = lines.Length - 1;
             }

--- a/Python/Product/Analysis/Parsing/CodeFormattingOptions.cs
+++ b/Python/Product/Analysis/Parsing/CodeFormattingOptions.cs
@@ -19,6 +19,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
+using Microsoft.PythonTools.Analysis.Infrastructure;
 
 namespace Microsoft.PythonTools.Parsing {
     /// <summary>
@@ -369,7 +370,7 @@ namespace Microsoft.PythonTools.Parsing {
 
             var lines = text.Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.None);
             int lineCount = lines.Length;
-            if (text.EndsWith("\r", StringComparison.Ordinal) || text.EndsWith("\n", StringComparison.Ordinal)) {
+            if (text.EndsWithOrdinal("\r") || text.EndsWithOrdinal("\n")) {
                 // split will give us an extra entry, but there's not really an extra line
                 lineCount = lines.Length - 1;
             }

--- a/Python/Product/Analysis/Parsing/LiteralParser.cs
+++ b/Python/Product/Analysis/Parsing/LiteralParser.cs
@@ -535,7 +535,7 @@ namespace Microsoft.PythonTools.Parsing {
                 }
                 return ParseFloatNoCatch(text);
             } catch (OverflowException) {
-                return text.TrimStart().StartsWith("-", StringComparison.Ordinal) ? Double.NegativeInfinity : Double.PositiveInfinity;
+                return text.TrimStart().StartsWithOrdinal("-") ? Double.NegativeInfinity : Double.PositiveInfinity;
             }
         }
 
@@ -554,7 +554,7 @@ namespace Microsoft.PythonTools.Parsing {
                 default:
                     // pass NumberStyles to disallow ,'s in float strings.
                     double res = double.Parse(s.Replace("_", ""), NumberStyles.Float, CultureInfo.InvariantCulture);
-                    return (res == 0.0 && text.TrimStart().StartsWith("-", StringComparison.Ordinal)) ? NegativeZero : res;
+                    return (res == 0.0 && text.TrimStart().StartsWithOrdinal("-")) ? NegativeZero : res;
             }
         }
 

--- a/Python/Product/Analysis/Parsing/LiteralParser.cs
+++ b/Python/Product/Analysis/Parsing/LiteralParser.cs
@@ -20,6 +20,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.Numerics;
 using System.Text;
+using Microsoft.PythonTools.Analysis.Infrastructure;
 
 namespace Microsoft.PythonTools.Parsing {
     /// <summary>
@@ -67,7 +68,7 @@ namespace Microsoft.PythonTools.Parsing {
                                 buf.Append((char)val);
                                 i += len;
                             } else {
-                                throw new System.Text.DecoderFallbackException(String.Format(@"'unicodeescape' codec can't decode bytes in position {0}: truncated \uXXXX escape", i));
+                                throw new DecoderFallbackException(@"'unicodeescape' codec can't decode bytes in position {0}: truncated \uXXXX escape".FormatUI(i));
                             }
                         } else {
                             buf.Append('\\');
@@ -272,7 +273,7 @@ namespace Microsoft.PythonTools.Parsing {
         private static int CharValue(char ch, int b) {
             int val = HexValue(ch);
             if (val >= b) {
-                throw new ArgumentException(String.Format("bad char for the integer value: '{0}' (base {1})", ch, b));
+                throw new ArgumentException("bad char for the integer value: '{0}' (base {1})".FormatUI(ch, b));
             }
             return val;
         }
@@ -534,13 +535,13 @@ namespace Microsoft.PythonTools.Parsing {
                 }
                 return ParseFloatNoCatch(text);
             } catch (OverflowException) {
-                return text.TrimStart().StartsWith("-") ? Double.NegativeInfinity : Double.PositiveInfinity;
+                return text.TrimStart().StartsWith("-", StringComparison.Ordinal) ? Double.NegativeInfinity : Double.PositiveInfinity;
             }
         }
 
         private static double ParseFloatNoCatch(string text) {
             string s = ReplaceUnicodeDigits(text);
-            switch (s.ToLower().TrimStart()) {
+            switch (s.ToLowerInvariant().TrimStart()) {
                 case "nan":
                 case "+nan":
                 case "-nan":
@@ -553,7 +554,7 @@ namespace Microsoft.PythonTools.Parsing {
                 default:
                     // pass NumberStyles to disallow ,'s in float strings.
                     double res = double.Parse(s.Replace("_", ""), NumberStyles.Float, CultureInfo.InvariantCulture);
-                    return (res == 0.0 && text.TrimStart().StartsWith("-")) ? NegativeZero : res;
+                    return (res == 0.0 && text.TrimStart().StartsWith("-", StringComparison.Ordinal)) ? NegativeZero : res;
             }
         }
 

--- a/Python/Product/Analysis/Parsing/Parser.cs
+++ b/Python/Product/Analysis/Parsing/Parser.cs
@@ -293,7 +293,7 @@ namespace Microsoft.PythonTools.Parsing {
                 errorCode |= ErrorCodes.IncompleteStatement;
             }
 
-            string msg = String.Format(System.Globalization.CultureInfo.InvariantCulture, GetErrorMessage(t, errorCode), t.Image);
+            string msg = GetErrorMessage(t, errorCode);
 
             ReportSyntaxError(start, end, msg, errorCode);
         }
@@ -303,7 +303,7 @@ namespace Microsoft.PythonTools.Parsing {
             if ((errorCode & ~ErrorCodes.IncompleteMask) == ErrorCodes.IndentationError) {
                 msg = "expected an indented block";
             } else if (t.Kind != TokenKind.EndOfFile) {
-                msg = "unexpected token '{0}'";
+                msg = "unexpected token '{0}'".FormatUI(t.Image);
             } else {
                 msg = "unexpected EOF while parsing";
             }
@@ -337,7 +337,7 @@ namespace Microsoft.PythonTools.Parsing {
         #region LL(1) Parsing
 
         private static bool IsPrivateName(string name) {
-            return name.StartsWith("__") && !name.EndsWith("__");
+            return name.StartsWith("__", StringComparison.Ordinal) && !name.EndsWith("__", StringComparison.Ordinal);
         }
 
         private string FixName(string name) {
@@ -2120,7 +2120,7 @@ namespace Microsoft.PythonTools.Parsing {
                         continue;
                     }
                 } else if (!seenNames.Add(p.Name)) {
-                    ReportSyntaxError(p.StartIndex, p.EndIndex, $"duplicate argument '{p.Name}' in function definition");
+                    ReportSyntaxError(p.StartIndex, p.EndIndex, "duplicate argument '{0}' in function definition".FormatUI(p.Name));
                 }
 
                 if (p.Kind == ParameterKind.List) {
@@ -2190,7 +2190,7 @@ namespace Microsoft.PythonTools.Parsing {
                     if (string.IsNullOrEmpty(ne.Name)) {
                         ReportSyntaxError(e.StartIndex, e.EndIndex, "invalid sublist parameter");
                     } else if (!seenNames.Add(ne.Name)) {
-                        ReportSyntaxError(e.StartIndex, e.EndIndex, $"duplicate argument '{ne.Name}' in function definition");
+                        ReportSyntaxError(e.StartIndex, e.EndIndex, "duplicate argument '{0}' in function definition".FormatUI(ne.Name));
                     }
                 } else {
                     ReportSyntaxError(e.StartIndex, e.EndIndex, "invalid sublist parameter");
@@ -5002,7 +5002,8 @@ namespace Microsoft.PythonTools.Parsing {
 
                 if ((gotEncoding == null || gotEncoding == true) && isUtf8 && encodingName != "utf-8") {
                     // we have both a BOM & an encoding type, throw an error
-                    errors.Add("file has both Unicode marker and PEP-263 file encoding.  You must use \"utf-8\" as the encoding name when a BOM is present.",
+                    errors.Add(
+                        "file has both Unicode marker and PEP-263 file encoding.  You must use \"utf-8\" as the encoding name when a BOM is present.",
                         GetEncodingLineNumbers(readBytes),
                         encodingIndex,
                         encodingIndex + encodingName.Length,
@@ -5016,7 +5017,7 @@ namespace Microsoft.PythonTools.Parsing {
                     if (gotEncoding == null) {
                         // get line number information for the bytes we've read...
                         errors.Add(
-                            String.Format("encoding problem: unknown encoding (line {0})", lineNo),
+                            "encoding problem: unknown encoding (line {0})".FormatUI(lineNo),
                             GetEncodingLineNumbers(readBytes),
                             encodingIndex,
                             encodingIndex + encodingName.Length,
@@ -5134,7 +5135,7 @@ namespace Microsoft.PythonTools.Parsing {
                     // else we'll store as lower case w/ _                
                     switch (normalizedName) {
                         case "us_ascii":
-                            d["cp" + encs[i].CodePage.ToString()] = d[normalizedName] = d["us"] = d["ascii"] = d["646"] = d["us_ascii"] =
+                            d["cp{0}".FormatInvariant(encs[i].CodePage)] = d[normalizedName] = d["us"] = d["ascii"] = d["646"] = d["us_ascii"] =
                                 d["ansi_x3.4_1968"] = d["ansi_x3_4_1968"] = d["ansi_x3.4_1986"] = d["cp367"] = d["csascii"] = d["ibm367"] =
                                 d["iso646_us"] = d["iso_646.irv_1991"] = d["iso_ir_6"]
                                 = new AsciiEncodingInfoWrapper();
@@ -5222,9 +5223,9 @@ namespace Microsoft.PythonTools.Parsing {
                     // publish under normalized name (all lower cases, -s replaced with _s)
                     d[normalizedName] = encs[i];
                     // publish under Windows code page as well...                
-                    d["windows-" + encs[i].GetEncoding().WindowsCodePage.ToString()] = encs[i];
+                    d["windows-{0}".FormatInvariant(encs[i].GetEncoding().WindowsCodePage)] = encs[i];
                     // publish under code page number as well...
-                    d["cp" + encs[i].CodePage.ToString()] = d[encs[i].CodePage.ToString()] = encs[i];
+                    d["cp{0}".FormatInvariant(encs[i].CodePage)] = d["{0}".FormatInvariant(encs[i].CodePage)] = encs[i];
                 }
 
 #if DEBUG

--- a/Python/Product/Analysis/Parsing/Parser.cs
+++ b/Python/Product/Analysis/Parsing/Parser.cs
@@ -337,7 +337,7 @@ namespace Microsoft.PythonTools.Parsing {
         #region LL(1) Parsing
 
         private static bool IsPrivateName(string name) {
-            return name.StartsWith("__", StringComparison.Ordinal) && !name.EndsWith("__", StringComparison.Ordinal);
+            return name.StartsWithOrdinal("__") && !name.EndsWithOrdinal("__");
         }
 
         private string FixName(string name) {

--- a/Python/Product/Analysis/Parsing/PythonAsciiEncoding.cs
+++ b/Python/Product/Analysis/Parsing/PythonAsciiEncoding.cs
@@ -19,6 +19,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.Serialization;
 using System.Text;
+using Microsoft.PythonTools.Analysis.Infrastructure;
 
 namespace Microsoft.PythonTools.Parsing {
     /// <summary>
@@ -174,12 +175,12 @@ namespace Microsoft.PythonTools.Parsing {
         private int _index;
 
         public override bool Fallback(char charUnknownHigh, char charUnknownLow, int index) {
-            throw new EncoderFallbackException(String.Format("'ascii' codec can't encode character '\\u{0:X}{1:04X}' in position {2}", (int)charUnknownHigh, (int)charUnknownLow, index));
+            throw new EncoderFallbackException("'ascii' codec can't encode character '\\u{0:X}{1:04X}' in position {2}".FormatUI((int)charUnknownHigh, (int)charUnknownLow, index));
         }
 
         public override bool Fallback(char charUnknown, int index) {
             if (charUnknown > 0xff) {
-                throw new EncoderFallbackException(String.Format("'ascii' codec can't encode character '\\u{0:X}' in position {1}", (int)charUnknown, index));
+                throw new EncoderFallbackException("'ascii' codec can't encode character '\\u{0:X}' in position {1}".FormatUI((int)charUnknown, index));
             }
 
             _buffer.Add(charUnknown);

--- a/Python/Product/Analysis/Parsing/PythonLanguageVersion.cs
+++ b/Python/Product/Analysis/Parsing/PythonLanguageVersion.cs
@@ -15,6 +15,7 @@
 // permissions and limitations under the License.
 
 using System;
+using Microsoft.PythonTools.Analysis.Infrastructure;
 
 namespace Microsoft.PythonTools.Parsing {
     /// <summary>
@@ -60,7 +61,7 @@ namespace Microsoft.PythonTools.Parsing {
             if (Enum.IsDefined(typeof(PythonLanguageVersion), value)) {
                 return (PythonLanguageVersion)value;
             }
-            throw new InvalidOperationException(String.Format("Unsupported Python version: {0}", version.ToString()));
+            throw new InvalidOperationException("Unsupported Python version: {0}".FormatInvariant(version));
         }
 
     }

--- a/Python/Product/Analysis/Parsing/TokenInfo.cs
+++ b/Python/Product/Analysis/Parsing/TokenInfo.cs
@@ -15,6 +15,7 @@
 // permissions and limitations under the License.
 
 using System;
+using Microsoft.PythonTools.Analysis.Infrastructure;
 
 namespace Microsoft.PythonTools.Parsing {
 
@@ -55,7 +56,7 @@ namespace Microsoft.PythonTools.Parsing {
         #endregion
 
         public override string ToString() {
-            return String.Format("TokenInfo: {0}, {1}, {2}", _span, _category, _trigger);
+            return "TokenInfo: {0}, {1}, {2}".FormatInvariant(_span, _category, _trigger);
         }
     }
 }

--- a/Python/Product/Analysis/Parsing/Tokenizer.cs
+++ b/Python/Product/Analysis/Parsing/Tokenizer.cs
@@ -25,6 +25,7 @@ using System.IO;
 using System.Linq;
 using System.Numerics;
 using System.Text;
+using Microsoft.PythonTools.Analysis.Infrastructure;
 
 namespace Microsoft.PythonTools.Parsing {
 
@@ -1420,7 +1421,7 @@ namespace Microsoft.PythonTools.Parsing {
 
         private bool ReportInvalidNumericLiteral(string tokenStr, bool eIsForExponent = false, bool allowLeadingUnderscore = false) {
             if (_langVersion >= PythonLanguageVersion.V36 && tokenStr.Contains("_")) {
-                if (tokenStr.Contains("__") || (!allowLeadingUnderscore && tokenStr.StartsWith("_")) || tokenStr.EndsWith("_") ||
+                if (tokenStr.Contains("__") || (!allowLeadingUnderscore && tokenStr.StartsWith("_", StringComparison.Ordinal)) || tokenStr.EndsWith("_", StringComparison.Ordinal) ||
                     tokenStr.Contains("._") || tokenStr.Contains("_.")) {
                     ReportSyntaxError(TokenSpan, "invalid token", ErrorCodes.SyntaxError);
                     return true;
@@ -1431,7 +1432,7 @@ namespace Microsoft.PythonTools.Parsing {
                     return true;
                 }
             }
-            if (_langVersion.Is3x() && tokenStr.ToLowerInvariant().EndsWith("l")) {
+            if (_langVersion.Is3x() && tokenStr.EndsWith("l", StringComparison.OrdinalIgnoreCase)) {
                 ReportSyntaxError(new IndexSpan(_tokenEndIndex - 1, 1), "invalid token", ErrorCodes.SyntaxError);
                 return true;
             }
@@ -2605,8 +2606,7 @@ namespace Microsoft.PythonTools.Parsing {
                 StreamReader streamReader = _reader as StreamReader;
                 if (streamReader != null && streamReader.CurrentEncoding != PythonAsciiEncoding.SourceEncoding) {
                     _errors.Add(
-                        String.Format(
-                            "(unicode error) '{0}' codec can't decode byte 0x{1:x} in position {2}",
+                        "(unicode error) '{0}' codec can't decode byte 0x{1:x} in position {2}".FormatUI(
                             Parser.NormalizeEncodingName(streamReader.CurrentEncoding.WebName),
                             bse.BadByte,
                             bse.Index + CurrentIndex
@@ -2619,7 +2619,10 @@ namespace Microsoft.PythonTools.Parsing {
                     );
                 } else {
                     _errors.Add(
-                        String.Format("Non-ASCII character '\\x{0:x}' at position {1}, but no encoding declared; see http://www.python.org/peps/pep-0263.html for details", bse.BadByte, bse.Index + CurrentIndex),
+                        "Non-ASCII character '\\x{0:x}' at position {1}, but no encoding declared; see http://www.python.org/peps/pep-0263.html for details".FormatUI(
+                            bse.BadByte,
+                            bse.Index + CurrentIndex
+                        ),
                         null,
                         CurrentIndex + bse.Index,
                         CurrentIndex + bse.Index + 1,

--- a/Python/Product/Analysis/Parsing/Tokenizer.cs
+++ b/Python/Product/Analysis/Parsing/Tokenizer.cs
@@ -1421,7 +1421,7 @@ namespace Microsoft.PythonTools.Parsing {
 
         private bool ReportInvalidNumericLiteral(string tokenStr, bool eIsForExponent = false, bool allowLeadingUnderscore = false) {
             if (_langVersion >= PythonLanguageVersion.V36 && tokenStr.Contains("_")) {
-                if (tokenStr.Contains("__") || (!allowLeadingUnderscore && tokenStr.StartsWith("_", StringComparison.Ordinal)) || tokenStr.EndsWith("_", StringComparison.Ordinal) ||
+                if (tokenStr.Contains("__") || (!allowLeadingUnderscore && tokenStr.StartsWithOrdinal("_")) || tokenStr.EndsWithOrdinal("_") ||
                     tokenStr.Contains("._") || tokenStr.Contains("_.")) {
                     ReportSyntaxError(TokenSpan, "invalid token", ErrorCodes.SyntaxError);
                     return true;
@@ -1432,7 +1432,7 @@ namespace Microsoft.PythonTools.Parsing {
                     return true;
                 }
             }
-            if (_langVersion.Is3x() && tokenStr.EndsWith("l", StringComparison.OrdinalIgnoreCase)) {
+            if (_langVersion.Is3x() && tokenStr.EndsWithOrdinal("l", ignoreCase: true)) {
                 ReportSyntaxError(new IndexSpan(_tokenEndIndex - 1, 1), "invalid token", ErrorCodes.SyntaxError);
                 return true;
             }

--- a/Python/Product/Analysis/ProjectEntry.cs
+++ b/Python/Product/Analysis/ProjectEntry.cs
@@ -71,7 +71,7 @@ namespace Microsoft.PythonTools.Analysis {
         internal static Uri MakeDocumentUri(string filePath) {
             Uri u;
             if (!Path.IsPathRooted(filePath)) {
-                u = new Uri($"file:///LOCAL-PATH/{filePath.Replace('\\', '/')}");
+                u = new Uri("file:///LOCAL-PATH/{0}".FormatInvariant(filePath.Replace('\\', '/')));
             } else {
                 u = new Uri(filePath);
             }
@@ -247,7 +247,7 @@ namespace Microsoft.PythonTools.Analysis {
                     from pair in ProjectState.ModulesByFilename
                     // Is the candidate child package in a subdirectory of our package?
                     let fileName = pair.Key
-                    where fileName.StartsWith(pathPrefix)
+                    where fileName.StartsWith(pathPrefix, StringComparison.OrdinalIgnoreCase)
                     let moduleName = pair.Value.Name
                     // Is the full name of the candidate child package qualified with the name of our package?
                     let lastDot = moduleName.LastIndexOf('.')

--- a/Python/Product/Analysis/ProjectEntry.cs
+++ b/Python/Product/Analysis/ProjectEntry.cs
@@ -247,7 +247,7 @@ namespace Microsoft.PythonTools.Analysis {
                     from pair in ProjectState.ModulesByFilename
                     // Is the candidate child package in a subdirectory of our package?
                     let fileName = pair.Key
-                    where fileName.StartsWith(pathPrefix, StringComparison.OrdinalIgnoreCase)
+                    where fileName.StartsWithOrdinal(pathPrefix, ignoreCase: true)
                     let moduleName = pair.Value.Name
                     // Is the full name of the candidate child package qualified with the name of our package?
                     let lastDot = moduleName.LastIndexOf('.')

--- a/Python/Product/Analysis/PythonAnalyzer.Specializations.cs
+++ b/Python/Product/Analysis/PythonAnalyzer.Specializations.cs
@@ -49,7 +49,7 @@ namespace Microsoft.PythonTools.Analysis {
         /// <remarks>New in 2.0</remarks>
         public void SpecializeFunction(string moduleName, string name, string returnType, bool mergeOriginalAnalysis = false) {
             if (returnType.LastIndexOf('.') == -1) {
-                throw new ArgumentException(String.Format("Expected module.typename for return type, got '{0}'", returnType));
+                throw new ArgumentException("Expected module.typename for return type, got '{0}'".FormatInvariant(returnType));
             }
 
             SpecializeFunction(moduleName, name, (n, u, a, k) => u.FindAnalysisValueByName(n, returnType), mergeOriginalAnalysis, true);

--- a/Python/Product/Analysis/PythonAnalyzer.cs
+++ b/Python/Product/Analysis/PythonAnalyzer.cs
@@ -625,7 +625,7 @@ namespace Microsoft.PythonTools.Analysis {
             }
 
             packageName = fullName.Remove(lastDot);
-            return String.Compare(fullName, lastDot + 1, name, 0, name.Length) == 0;
+            return String.Compare(fullName, lastDot + 1, name, 0, name.Length, StringComparison.Ordinal) == 0;
         }
 
         /// <summary>
@@ -942,7 +942,7 @@ namespace Microsoft.PythonTools.Analysis {
                     break;
             }
 
-            Debug.Fail($"unsupported constant type <{value.GetType().FullName}> value '{value}'");
+            Debug.Fail("unsupported constant type <{0}> value '{1}'".FormatInvariant(value.GetType().FullName, value));
             return Types[BuiltinTypeId.Object];
         }
 

--- a/Python/Product/Analysis/SourceLocation.cs
+++ b/Python/Product/Analysis/SourceLocation.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Diagnostics;
 using System.Globalization;
+using Microsoft.PythonTools.Analysis.Infrastructure;
 
 namespace Microsoft.PythonTools {
     /// <summary>
@@ -70,7 +71,7 @@ namespace Microsoft.PythonTools {
         }
 
         private static Exception ErrorOutOfRange(object p0, object p1) {
-            return new ArgumentOutOfRangeException(string.Format("{0} must be greater than or equal to {1}", p0, p1));
+            return new ArgumentOutOfRangeException("{0} must be greater than or equal to {1}".FormatInvariant(p0, p1));
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters")]
@@ -257,7 +258,7 @@ namespace Microsoft.PythonTools {
         }
 
         internal string ToDebugString() {
-            return String.Format(CultureInfo.CurrentCulture, "({0},{1},{2})", _index, _line, _column);
+            return "({0},{1},{2})".FormatInvariant(_index, _line, _column);
         }
 
         public bool Equals(SourceLocation other) {

--- a/Python/Product/Analysis/SourceSpan.cs
+++ b/Python/Product/Analysis/SourceSpan.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Diagnostics;
 using System.Globalization;
+using Microsoft.PythonTools.Analysis.Infrastructure;
 using Microsoft.PythonTools.Parsing.Ast;
 
 namespace Microsoft.PythonTools {
@@ -122,7 +123,7 @@ namespace Microsoft.PythonTools {
         }
 
         internal string ToDebugString() {
-            return String.Format(CultureInfo.CurrentCulture, "{0}-{1}", _start.ToDebugString(), _end.ToDebugString());
+            return "{0}-{1}".FormatInvariant(_start.ToDebugString(), _end.ToDebugString());
         }
     }
 }

--- a/Python/Product/Analysis/Validation.cs
+++ b/Python/Product/Analysis/Validation.cs
@@ -15,6 +15,7 @@
 // permissions and limitations under the License.
 
 using System;
+using Microsoft.PythonTools.Analysis.Infrastructure;
 
 namespace Microsoft.PythonTools.Analysis {
 #if FULL_VALIDATION || DEBUG
@@ -64,7 +65,7 @@ namespace Microsoft.PythonTools.Analysis {
         public static void Assert(bool expression, string message, params object[] args) {
             if (!expression) {
                 try {
-                    throw new ValidationException(string.Format(message, args));
+                    throw new ValidationException(message.FormatInvariant(args));
                 } catch (ValidationException ex) {
                     Console.Error.WriteLine(ex.ToString());
                 }

--- a/Python/Product/Analysis/Values/BuiltinNamespace.cs
+++ b/Python/Product/Analysis/Values/BuiltinNamespace.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Collections.Generic;
+using Microsoft.PythonTools.Analysis.Infrastructure;
 using Microsoft.PythonTools.Interpreter;
 using Microsoft.PythonTools.Parsing.Ast;
 
@@ -67,7 +68,7 @@ namespace Microsoft.PythonTools.Analysis.Values {
                 if (TryGetMember(name, out value)) {
                     return value;
                 }
-                throw new KeyNotFoundException(String.Format("Key {0} not found", name));
+                throw new KeyNotFoundException("Key {0} not found".FormatInvariant(name));
             }
             set {
                 if (_specializedValues == null) {

--- a/Python/Product/Analysis/Values/ClassInfo.cs
+++ b/Python/Product/Analysis/Values/ClassInfo.cs
@@ -563,7 +563,7 @@ namespace Microsoft.PythonTools.Analysis.Values {
             if (cd1.StartIndex != cd2.StartIndex) {
                 return cd1.StartIndex > cd2.StartIndex;
             }
-            return cd1.NameExpression.Name.CompareTo(cd2.NameExpression.Name) > 0;
+            return string.CompareOrdinal(cd1.NameExpression.Name, cd2.NameExpression.Name) > 0;
         }
 
         internal override AnalysisValue UnionMergeTypes(AnalysisValue ns, int strength) {

--- a/Python/Product/Analysis/Values/ConstantInfo.cs
+++ b/Python/Product/Analysis/Values/ConstantInfo.cs
@@ -15,6 +15,7 @@
 // permissions and limitations under the License.
 
 using System.Collections.Generic;
+using Microsoft.PythonTools.Analysis.Infrastructure;
 using Microsoft.PythonTools.Interpreter;
 using Microsoft.PythonTools.Parsing;
 using Microsoft.PythonTools.Parsing.Ast;
@@ -185,7 +186,7 @@ namespace Microsoft.PythonTools.Analysis.Values {
             var valueStr = (_value == null || _value is IPythonConstant) ? "" : (" '" + _value.ToString() + "'");
             valueStr = valueStr.Replace("\r", "\\r").Replace("\n", "\\n");
             for (char c = '\0'; c < ' '; ++c) {
-                valueStr = valueStr.Replace(c.ToString(), string.Format("\\x{0:X2}", (int)c));
+                valueStr = valueStr.Replace(c.ToString(), "\\x{0:X2}".FormatInvariant((int)c));
             }
             return "<" + Description + valueStr + ">"; // " at " + hex(id(self))
         }

--- a/Python/Product/Analysis/Values/Protocols.cs
+++ b/Python/Product/Analysis/Values/Protocols.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.PythonTools.Analysis.Infrastructure;
 using Microsoft.PythonTools.Interpreter;
 using Microsoft.PythonTools.Parsing;
 using Microsoft.PythonTools.Parsing.Ast;
@@ -128,7 +129,7 @@ namespace Microsoft.PythonTools.Analysis.Values {
         }
 
         private ParameterResult ToParameterResult(IAnalysisSet set, int i) {
-            return new ParameterResult($"${i + 1}", $"Parameter {i + 1}", string.Join(", ", set.GetShortDescriptions()));
+            return new ParameterResult("${0}".FormatInvariant(i + 1), "Parameter {0}".FormatUI(i + 1), string.Join(", ", set.GetShortDescriptions()));
         }
 
         public IReadOnlyList<IAnalysisSet> Arguments { get; }

--- a/Python/Product/Analyzer/Intellisense/OutOfProcProjectAnalyzer.cs
+++ b/Python/Product/Analyzer/Intellisense/OutOfProcProjectAnalyzer.cs
@@ -1854,9 +1854,9 @@ namespace Microsoft.PythonTools.Intellisense {
 
             if (match.Success) {
                 return match.Value;
-            } else if (result.Name.StartsWith("**")) {
+            } else if (result.Name.StartsWith("**", StringComparison.Ordinal)) {
                 return "**kwargs";
-            } else if (result.Name.StartsWith("*")) {
+            } else if (result.Name.StartsWith("*", StringComparison.Ordinal)) {
                 return "*args";
             } else {
                 return "arg" + index.ToString();

--- a/Python/Product/Analyzer/Intellisense/OutOfProcProjectAnalyzer.cs
+++ b/Python/Product/Analyzer/Intellisense/OutOfProcProjectAnalyzer.cs
@@ -1854,9 +1854,9 @@ namespace Microsoft.PythonTools.Intellisense {
 
             if (match.Success) {
                 return match.Value;
-            } else if (result.Name.StartsWith("**", StringComparison.Ordinal)) {
+            } else if (result.Name.StartsWithOrdinal("**")) {
                 return "**kwargs";
-            } else if (result.Name.StartsWith("*", StringComparison.Ordinal)) {
+            } else if (result.Name.StartsWithOrdinal("*")) {
                 return "*args";
             } else {
                 return "arg" + index.ToString();

--- a/Python/Product/Analyzer/Interpreter/LegacyDB/PythonInterpreterFactoryWithDatabase.cs
+++ b/Python/Product/Analyzer/Interpreter/LegacyDB/PythonInterpreterFactoryWithDatabase.cs
@@ -466,7 +466,7 @@ namespace Microsoft.PythonTools.Interpreter.LegacyDB {
 
             return new HashSet<string>(
                 PathUtils.EnumerateFiles(databasePath, "*.idb").Select(f => Path.GetFileNameWithoutExtension(f)),
-                StringComparer.InvariantCultureIgnoreCase
+                StringComparer.OrdinalIgnoreCase
             );
         }
 
@@ -493,7 +493,7 @@ namespace Microsoft.PythonTools.Interpreter.LegacyDB {
                 // No cached search paths means our database is out of date.
                 return existingDatabase
                     .Except(RequiredBuiltinModules)
-                    .OrderBy(name => name, StringComparer.InvariantCultureIgnoreCase)
+                    .OrderBy(name => name, StringComparer.CurrentCultureIgnoreCase)
                     .ToArray();
             }
             
@@ -502,7 +502,7 @@ namespace Microsoft.PythonTools.Interpreter.LegacyDB {
                 .Select(mp => mp.ModuleName)
                 .Concat(RequiredBuiltinModules)
                 .Where(m => !existingDatabase.Contains(m))
-                .OrderBy(name => name, StringComparer.InvariantCultureIgnoreCase)
+                .OrderBy(name => name, StringComparer.CurrentCultureIgnoreCase)
                 .ToArray();
         }
 

--- a/Python/Product/Analyzer/Interpreter/LegacyDB/SharedDatabaseState.cs
+++ b/Python/Product/Analyzer/Interpreter/LegacyDB/SharedDatabaseState.cs
@@ -22,6 +22,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading;
+using Microsoft.PythonTools.Analysis.Infrastructure;
 using Microsoft.PythonTools.Parsing;
 
 namespace Microsoft.PythonTools.Interpreter.LegacyDB {
@@ -101,7 +102,7 @@ namespace Microsoft.PythonTools.Interpreter.LegacyDB {
             }
 
             foreach (var file in Directory.GetFiles(databaseDirectory)) {
-                if (!file.EndsWith(".idb", StringComparison.OrdinalIgnoreCase) || file.IndexOf('$') != -1) {
+                if (!file.EndsWithOrdinal(".idb", ignoreCase: true) || file.IndexOf('$') != -1) {
                     continue;
                 } else if (String.Equals(Path.GetFileNameWithoutExtension(file), _builtinName, StringComparison.OrdinalIgnoreCase)) {
                     continue;
@@ -733,15 +734,15 @@ namespace Microsoft.PythonTools.Interpreter.LegacyDB {
 
         private bool OneVersionApplies(string strVer) {
             Version specifiedVer;
-            if (strVer.StartsWith(">=", StringComparison.Ordinal)) {
+            if (strVer.StartsWithOrdinal(">=")) {
                 if (Version.TryParse(strVer.Substring(2), out specifiedVer) && _langVersion >= specifiedVer) {
                     return true;
                 }
-            } else if (strVer.StartsWith("<=", StringComparison.Ordinal)) {
+            } else if (strVer.StartsWithOrdinal("<=")) {
                 if (Version.TryParse(strVer.Substring(2), out specifiedVer) && _langVersion <= specifiedVer) {
                     return true;
                 }
-            } else if (strVer.StartsWith("==", StringComparison.Ordinal)) {
+            } else if (strVer.StartsWithOrdinal("==")) {
                 if (Version.TryParse(strVer.Substring(2), out specifiedVer) && _langVersion == specifiedVer) {
                     return true;
                 }

--- a/Python/Product/Analyzer/Interpreter/LegacyDB/SharedDatabaseState.cs
+++ b/Python/Product/Analyzer/Interpreter/LegacyDB/SharedDatabaseState.cs
@@ -733,15 +733,15 @@ namespace Microsoft.PythonTools.Interpreter.LegacyDB {
 
         private bool OneVersionApplies(string strVer) {
             Version specifiedVer;
-            if (strVer.StartsWith(">=")) {
+            if (strVer.StartsWith(">=", StringComparison.Ordinal)) {
                 if (Version.TryParse(strVer.Substring(2), out specifiedVer) && _langVersion >= specifiedVer) {
                     return true;
                 }
-            } else if (strVer.StartsWith("<=")) {
+            } else if (strVer.StartsWith("<=", StringComparison.Ordinal)) {
                 if (Version.TryParse(strVer.Substring(2), out specifiedVer) && _langVersion <= specifiedVer) {
                     return true;
                 }
-            } else if (strVer.StartsWith("==")) {
+            } else if (strVer.StartsWith("==", StringComparison.Ordinal)) {
                 if (Version.TryParse(strVer.Substring(2), out specifiedVer) && _langVersion == specifiedVer) {
                     return true;
                 }

--- a/Python/Product/Analyzer/Interpreter/LegacyDB/Unpickler.cs
+++ b/Python/Product/Analyzer/Interpreter/LegacyDB/Unpickler.cs
@@ -20,6 +20,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Numerics;
 using System.Text;
+using Microsoft.PythonTools.Analysis.Infrastructure;
 using Microsoft.PythonTools.Parsing;
 
 namespace Microsoft.PythonTools.Interpreter.LegacyDB {
@@ -268,7 +269,7 @@ namespace Microsoft.PythonTools.Interpreter.LegacyDB {
 
             private object ReadLongFromString() {
                 var i = ReadLineNoNewline();
-                if (i.EndsWith("L", StringComparison.Ordinal)) {
+                if (i.EndsWithOrdinal("L")) {
                     i = i.Substring(0, i.Length - 1);
                 }
                 return BigInteger.Parse(i);

--- a/Python/Product/Analyzer/Interpreter/LegacyDB/Unpickler.cs
+++ b/Python/Product/Analyzer/Interpreter/LegacyDB/Unpickler.cs
@@ -268,7 +268,7 @@ namespace Microsoft.PythonTools.Interpreter.LegacyDB {
 
             private object ReadLongFromString() {
                 var i = ReadLineNoNewline();
-                if (i.EndsWith("L")) {
+                if (i.EndsWith("L", StringComparison.Ordinal)) {
                     i = i.Substring(0, i.Length - 1);
                 }
                 return BigInteger.Parse(i);

--- a/Python/Product/Analyzer/PyLibAnalyzer.cs
+++ b/Python/Product/Analyzer/PyLibAnalyzer.cs
@@ -1203,7 +1203,7 @@ namespace Microsoft.PythonTools.Analysis {
             if (!string.IsNullOrEmpty(_logDiagnostic) && AnalysisLog.Output == null) {
                 try {
                     AnalysisLog.Output = _logDiagnostic;
-                    AnalysisLog.AsCSV = _logDiagnostic.EndsWith(".csv", StringComparison.OrdinalIgnoreCase);
+                    AnalysisLog.AsCSV = _logDiagnostic.EndsWithOrdinal(".csv", ignoreCase: true);
                 } catch (Exception ex) {
                     TraceWarning("Failed to open \"{0}\" for logging{1}{2}", _logDiagnostic, Environment.NewLine, ex.ToString());
                 }

--- a/Python/Product/Analyzer/PyLibAnalyzer.cs
+++ b/Python/Product/Analyzer/PyLibAnalyzer.cs
@@ -108,7 +108,7 @@ namespace Microsoft.PythonTools.Analysis {
 
             using (var e = args.GetEnumerator()) {
                 while (e.MoveNext()) {
-                    if (e.Current.StartsWith("/")) {
+                    if (e.Current.StartsWithOrdinal("/")) {
                         if (currentKey != null) {
                             yield return new KeyValuePair<string, string>(currentKey, null);
                         }
@@ -807,7 +807,7 @@ namespace Microsoft.PythonTools.Analysis {
             analyzeFileGroups.RemoveAll(g => _treatPathsAsStandardLibrary.Contains(g[0].LibraryPath));
             foreach (var package in GetPackageOrder()) {
                 var matching = analyzeFileGroups
-                    .Where(g => g[0].ModuleName.StartsWith(package + ".") || g[0].ModuleName == package)
+                    .Where(g => g[0].ModuleName.StartsWithOrdinal(package + ".") || g[0].ModuleName == package)
                     .ToList();
                 firstPackages.AddRange(matching);
                 analyzeFileGroups.RemoveAll(g => matching.Contains(g));

--- a/Python/Product/Analyzer/PyLibAnalyzer.cs
+++ b/Python/Product/Analyzer/PyLibAnalyzer.cs
@@ -317,7 +317,7 @@ namespace Microsoft.PythonTools.Analysis {
 
         private static PyLibAnalyzer MakeFromArguments(IEnumerable<string> args) {
             var options = ParseArguments(args)
-                .ToDictionary(kv => kv.Key, kv => kv.Value, StringComparer.InvariantCultureIgnoreCase);
+                .ToDictionary(kv => kv.Key, kv => kv.Value, StringComparer.OrdinalIgnoreCase);
 
             string value;
 
@@ -1203,7 +1203,7 @@ namespace Microsoft.PythonTools.Analysis {
             if (!string.IsNullOrEmpty(_logDiagnostic) && AnalysisLog.Output == null) {
                 try {
                     AnalysisLog.Output = _logDiagnostic;
-                    AnalysisLog.AsCSV = _logDiagnostic.EndsWith(".csv", StringComparison.InvariantCultureIgnoreCase);
+                    AnalysisLog.AsCSV = _logDiagnostic.EndsWith(".csv", StringComparison.OrdinalIgnoreCase);
                 } catch (Exception ex) {
                     TraceWarning("Failed to open \"{0}\" for logging{1}{2}", _logDiagnostic, Environment.NewLine, ex.ToString());
                 }

--- a/Python/Product/BuildTasks/PythonCommand.cs
+++ b/Python/Product/BuildTasks/PythonCommand.cs
@@ -65,7 +65,7 @@ namespace Microsoft.PythonTools.BuildTasks {
                 return _targetType;
             }
             set {
-                if (!_targetTypes.Contains(value, StringComparer.InvariantCultureIgnoreCase)) {
+                if (!_targetTypes.Contains(value, StringComparer.OrdinalIgnoreCase)) {
                     throw new ArgumentException("TargetType must be one of: " + string.Join(", ", _targetTypes.Select(s => '"' + s + '"')));
                 }
                 _targetType = value;
@@ -76,7 +76,7 @@ namespace Microsoft.PythonTools.BuildTasks {
 
         protected virtual bool IsValidExecuteInValue(string value, out string message) {
             message = "ExecuteIn must be one of: " + string.Join(", ", _executeIns.Select(s => '"' + s + '"'));;
-            return _executeIns.Any(s => s.Equals(value, StringComparison.InvariantCultureIgnoreCase));
+            return _executeIns.Any(s => s.Equals(value, StringComparison.OrdinalIgnoreCase));
         }
 
         /// <summary>
@@ -181,8 +181,8 @@ namespace Microsoft.PythonTools.BuildTasks {
 
         protected override bool IsValidExecuteInValue(string value, out string message) {
             message = "ExecuteIn must be one of: " + string.Join(", ", _executeIns.Select(s => '"' + s + '"')); ;
-            return _executeIns.Any(s => s.Equals(value, StringComparison.InvariantCultureIgnoreCase)) ||
-                value.StartsWith(ExecuteInRepl, StringComparison.InvariantCultureIgnoreCase);
+            return _executeIns.Any(s => s.Equals(value, StringComparison.OrdinalIgnoreCase)) ||
+                value.StartsWith(ExecuteInRepl, StringComparison.OrdinalIgnoreCase);
         }
 
         /// <summary>
@@ -192,7 +192,7 @@ namespace Microsoft.PythonTools.BuildTasks {
         public ITaskItem[] Command { get; private set; }
 
         public override bool Execute() {
-            if (!ExecuteInOutput.Equals(ExecuteIn, StringComparison.InvariantCultureIgnoreCase) &&
+            if (!ExecuteInOutput.Equals(ExecuteIn, StringComparison.OrdinalIgnoreCase) &&
                 !(string.IsNullOrEmpty(ErrorRegex) && string.IsNullOrEmpty(WarningRegex))) {
                 Log.LogError("ErrorRegex and WarningRegex are only valid for ExecuteIn='output'");
                 return false;
@@ -262,7 +262,7 @@ namespace Microsoft.PythonTools.BuildTasks {
             var psi = new ProcessStartInfo();
             psi.UseShellExecute = false;
 
-            if (TargetTypeExecutable.Equals(TargetType, StringComparison.InvariantCultureIgnoreCase)) {
+            if (TargetTypeExecutable.Equals(TargetType, StringComparison.OrdinalIgnoreCase)) {
                 psi.FileName = Target;
                 psi.Arguments = Arguments;
             } else {
@@ -273,11 +273,11 @@ namespace Microsoft.PythonTools.BuildTasks {
                 }
                 psi.FileName = resolver.InterpreterPath;
 
-                if (TargetTypeModule.Equals(TargetType, StringComparison.InvariantCultureIgnoreCase)) {
+                if (TargetTypeModule.Equals(TargetType, StringComparison.OrdinalIgnoreCase)) {
                     psi.Arguments = string.Format("-m {0} {1}", Target, Arguments);
-                } else if (TargetTypeScript.Equals(TargetType, StringComparison.InvariantCultureIgnoreCase)) {
+                } else if (TargetTypeScript.Equals(TargetType, StringComparison.OrdinalIgnoreCase)) {
                     psi.Arguments = string.Format("\"{0}\" {1}", Target, Arguments);
-                } else if (TargetTypeCode.Equals(TargetType, StringComparison.InvariantCultureIgnoreCase)) {
+                } else if (TargetTypeCode.Equals(TargetType, StringComparison.OrdinalIgnoreCase)) {
                     psi.Arguments = string.Format("-c \"{0}\"", Target);
                 }
 
@@ -297,10 +297,10 @@ namespace Microsoft.PythonTools.BuildTasks {
                 }
             }
 
-            if (ExecuteInNone.Equals(ExecuteIn, StringComparison.InvariantCultureIgnoreCase)) {
+            if (ExecuteInNone.Equals(ExecuteIn, StringComparison.OrdinalIgnoreCase)) {
                 psi.CreateNoWindow = true;
                 psi.WindowStyle = ProcessWindowStyle.Hidden;
-            } else if (ExecuteInConsolePause.Equals(ExecuteIn, StringComparison.InvariantCultureIgnoreCase)) {
+            } else if (ExecuteInConsolePause.Equals(ExecuteIn, StringComparison.OrdinalIgnoreCase)) {
                 psi.Arguments = string.Format(
                     "/C \"\"{0}\" {1}\" & pause",
                     psi.FileName,

--- a/Python/Product/BuildTasks/PythonCommand.cs
+++ b/Python/Product/BuildTasks/PythonCommand.cs
@@ -182,7 +182,7 @@ namespace Microsoft.PythonTools.BuildTasks {
         protected override bool IsValidExecuteInValue(string value, out string message) {
             message = "ExecuteIn must be one of: " + string.Join(", ", _executeIns.Select(s => '"' + s + '"')); ;
             return _executeIns.Any(s => s.Equals(value, StringComparison.OrdinalIgnoreCase)) ||
-                value.StartsWith(ExecuteInRepl, StringComparison.OrdinalIgnoreCase);
+                value.StartsWithOrdinal(ExecuteInRepl, ignoreCase: true);
         }
 
         /// <summary>

--- a/Python/Product/Common/Infrastructure/PathUtils.cs
+++ b/Python/Product/Common/Infrastructure/PathUtils.cs
@@ -182,7 +182,7 @@ namespace Microsoft.PythonTools.Infrastructure {
         /// root or a subdirectory of root.
         /// </summary>
         public static bool IsSubpathOf(string root, string path) {
-            if (HasEndSeparator(root) && !path.Contains("..") && path.StartsWith(root, StringComparison.Ordinal)) {
+            if (HasEndSeparator(root) && !path.Contains("..") && path.StartsWithOrdinal(root)) {
                 // Quick return, but only where the paths are already normalized and
                 // have matching case.
                 return true;
@@ -665,7 +665,7 @@ namespace Microsoft.PythonTools.Infrastructure {
                 }
 
                 foreach (var d in dirs) {
-                    if (!fullPaths && !d.StartsWith(root, StringComparison.OrdinalIgnoreCase)) {
+                    if (!fullPaths && !d.StartsWithOrdinal(root, ignoreCase: true)) {
                         continue;
                     }
                     if (recurse) {

--- a/Python/Product/Common/Infrastructure/PathUtils.cs
+++ b/Python/Product/Common/Infrastructure/PathUtils.cs
@@ -643,14 +643,14 @@ namespace Microsoft.PythonTools.Infrastructure {
             bool fullPaths = true
         ) {
             var queue = new Queue<string>();
-            if (!root.EndsWith("\\", StringComparison.Ordinal)) {
+            if (!root.EndsWithOrdinal("\\")) {
                 root += "\\";
             }
             queue.Enqueue(root);
 
             while (queue.Any()) {
                 var path = queue.Dequeue();
-                if (!path.EndsWith("\\", StringComparison.Ordinal)) {
+                if (!path.EndsWithOrdinal("\\")) {
                     path += "\\";
                 }
 
@@ -701,7 +701,7 @@ namespace Microsoft.PythonTools.Infrastructure {
             bool recurse = true,
             bool fullPaths = true
         ) {
-            if (!root.EndsWith("\\", StringComparison.Ordinal)) {
+            if (!root.EndsWithOrdinal("\\")) {
                 root += "\\";
             }
 

--- a/Python/Product/Common/Infrastructure/PathUtils.cs
+++ b/Python/Product/Common/Infrastructure/PathUtils.cs
@@ -643,14 +643,14 @@ namespace Microsoft.PythonTools.Infrastructure {
             bool fullPaths = true
         ) {
             var queue = new Queue<string>();
-            if (!root.EndsWith("\\")) {
+            if (!root.EndsWith("\\", StringComparison.Ordinal)) {
                 root += "\\";
             }
             queue.Enqueue(root);
 
             while (queue.Any()) {
                 var path = queue.Dequeue();
-                if (!path.EndsWith("\\")) {
+                if (!path.EndsWith("\\", StringComparison.Ordinal)) {
                     path += "\\";
                 }
 
@@ -701,7 +701,7 @@ namespace Microsoft.PythonTools.Infrastructure {
             bool recurse = true,
             bool fullPaths = true
         ) {
-            if (!root.EndsWith("\\")) {
+            if (!root.EndsWith("\\", StringComparison.Ordinal)) {
                 root += "\\";
             }
 

--- a/Python/Product/Common/Infrastructure/ProcessOutput.cs
+++ b/Python/Product/Common/Infrastructure/ProcessOutput.cs
@@ -367,9 +367,9 @@ namespace Microsoft.PythonTools.Infrastructure {
                     Task.Run(() => {
                         try {
                             for (var line = reader.ReadLine(); line != null; line = reader.ReadLine()) {
-                                if (line.StartsWith("OUT:")) {
+                                if (line.StartsWith("OUT:", StringComparison.Ordinal)) {
                                     redirector.WriteLine(line.Substring(4));
-                                } else if (line.StartsWith("ERR:")) {
+                                } else if (line.StartsWith("ERR:", StringComparison.Ordinal)) {
                                     redirector.WriteErrorLine(line.Substring(4));
                                 } else {
                                     redirector.WriteLine(line);
@@ -418,7 +418,7 @@ namespace Microsoft.PythonTools.Infrastructure {
                 return arg;
             }
 
-            if (arg.StartsWith("\"") && arg.EndsWith("\"")) {
+            if (arg.StartsWith("\"", StringComparison.Ordinal) && arg.EndsWith("\"", StringComparison.Ordinal)) {
                 bool inQuote = false;
                 int consecutiveBackslashes = 0;
                 foreach (var c in arg) {
@@ -440,7 +440,7 @@ namespace Microsoft.PythonTools.Infrastructure {
             }
 
             var newArg = arg.Replace("\"", "\\\"");
-            if (newArg.EndsWith("\\")) {
+            if (newArg.EndsWith("\\", StringComparison.Ordinal)) {
                 newArg += "\\";
             }
             return "\"" + newArg + "\"";

--- a/Python/Product/Common/Infrastructure/ProcessOutput.cs
+++ b/Python/Product/Common/Infrastructure/ProcessOutput.cs
@@ -367,9 +367,9 @@ namespace Microsoft.PythonTools.Infrastructure {
                     Task.Run(() => {
                         try {
                             for (var line = reader.ReadLine(); line != null; line = reader.ReadLine()) {
-                                if (line.StartsWith("OUT:", StringComparison.Ordinal)) {
+                                if (line.StartsWithOrdinal("OUT:")) {
                                     redirector.WriteLine(line.Substring(4));
-                                } else if (line.StartsWith("ERR:", StringComparison.Ordinal)) {
+                                } else if (line.StartsWithOrdinal("ERR:")) {
                                     redirector.WriteErrorLine(line.Substring(4));
                                 } else {
                                     redirector.WriteLine(line);
@@ -418,7 +418,7 @@ namespace Microsoft.PythonTools.Infrastructure {
                 return arg;
             }
 
-            if (arg.StartsWith("\"", StringComparison.Ordinal) && arg.EndsWith("\"", StringComparison.Ordinal)) {
+            if (arg.StartsWithOrdinal("\"") && arg.EndsWithOrdinal("\"")) {
                 bool inQuote = false;
                 int consecutiveBackslashes = 0;
                 foreach (var c in arg) {
@@ -440,7 +440,7 @@ namespace Microsoft.PythonTools.Infrastructure {
             }
 
             var newArg = arg.Replace("\"", "\\\"");
-            if (newArg.EndsWith("\\", StringComparison.Ordinal)) {
+            if (newArg.EndsWithOrdinal("\\")) {
                 newArg += "\\";
             }
             return "\"" + newArg + "\"";

--- a/Python/Product/Common/Infrastructure/StringExtensions.cs
+++ b/Python/Product/Common/Infrastructure/StringExtensions.cs
@@ -111,11 +111,15 @@ namespace Microsoft.PythonTools.Infrastructure {
         }
 
         public static bool StartsWithOrdinal(this string s, string prefix, bool ignoreCase = false) {
-            return s?.StartsWith(prefix, ignoreCase ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase) ?? false;
+            return s?.StartsWith(prefix, ignoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal) ?? false;
         }
 
         public static bool EndsWithOrdinal(this string s, string suffix, bool ignoreCase = false) {
-            return s?.EndsWith(suffix, ignoreCase ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase) ?? false;
+            return s?.StartsWith(suffix, ignoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal) ?? false;
+        }
+
+        public static int IndexOfOrdinal(this string s, string value, int startIndex = 0, bool ignoreCase = false) {
+            return s?.IndexOf(value, startIndex, ignoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal) ?? -1;
         }
     }
 }

--- a/Python/Product/Common/Infrastructure/StringExtensions.cs
+++ b/Python/Product/Common/Infrastructure/StringExtensions.cs
@@ -43,17 +43,17 @@ namespace Microsoft.PythonTools.Infrastructure {
 
         public static string FormatUI(this string str, object arg0) {
             ValidateFormatString(str, 1);
-            return string.Format(CultureInfo.CurrentUICulture, str, arg0);
+            return string.Format(CultureInfo.CurrentCulture, str, arg0);
         }
 
         public static string FormatUI(this string str, object arg0, object arg1) {
             ValidateFormatString(str, 2);
-            return string.Format(CultureInfo.CurrentUICulture, str, arg0, arg1);
+            return string.Format(CultureInfo.CurrentCulture, str, arg0, arg1);
         }
 
         public static string FormatUI(this string str, params object[] args) {
             ValidateFormatString(str, args.Length);
-            return string.Format(CultureInfo.CurrentUICulture, str, args);
+            return string.Format(CultureInfo.CurrentCulture, str, args);
         }
 
         public static string FormatInvariant(this string str, object arg0) {
@@ -78,8 +78,8 @@ namespace Microsoft.PythonTools.Infrastructure {
         public static bool IsTrue(this string str) {
             bool asBool;
             return !string.IsNullOrWhiteSpace(str) && (
-                str.Equals("1") ||
-                str.Equals("yes", StringComparison.InvariantCultureIgnoreCase) ||
+                str.Equals("1", StringComparison.Ordinal) ||
+                str.Equals("yes", StringComparison.OrdinalIgnoreCase) ||
                 (bool.TryParse(str, out asBool) && asBool)
             );
         }
@@ -96,6 +96,18 @@ namespace Microsoft.PythonTools.Infrastructure {
                 return str.Remove(str.Length - 1);
             }
             return str;
+        }
+
+        public static string Truncate(this string str, int length) {
+            if (string.IsNullOrEmpty(str)) {
+                return str;
+            }
+
+            if (str.Length < length) {
+                return str;
+            }
+
+            return str.Substring(0, length);
         }
     }
 }

--- a/Python/Product/Common/Infrastructure/StringExtensions.cs
+++ b/Python/Product/Common/Infrastructure/StringExtensions.cs
@@ -109,5 +109,13 @@ namespace Microsoft.PythonTools.Infrastructure {
 
             return str.Substring(0, length);
         }
+
+        public static bool StartsWithOrdinal(this string s, string prefix, bool ignoreCase = false) {
+            return s?.StartsWith(prefix, ignoreCase ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase) ?? false;
+        }
+
+        public static bool EndsWithOrdinal(this string s, string suffix, bool ignoreCase = false) {
+            return s?.EndsWith(suffix, ignoreCase ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase) ?? false;
+        }
     }
 }

--- a/Python/Product/Cookiecutter/CookiecutterPackage.cs
+++ b/Python/Product/Cookiecutter/CookiecutterPackage.cs
@@ -68,7 +68,7 @@ namespace Microsoft.CookiecutterTools {
         /// initialization is the Initialize method.
         /// </summary>
         public CookiecutterPackage() {
-            Trace.WriteLine(string.Format(CultureInfo.CurrentCulture, "Entering constructor for: {0}", this.ToString()));
+            Trace.WriteLine("Entering constructor for: {0}".FormatInvariant(this));
             Instance = this;
         }
 
@@ -81,7 +81,7 @@ namespace Microsoft.CookiecutterTools {
         /// where you can put all the initilaization code that rely on services provided by VisualStudio.
         /// </summary>
         protected override void Initialize() {
-            Trace.WriteLine(string.Format(CultureInfo.CurrentCulture, "Entering Initialize() of: {0}", this.ToString()));
+            Trace.WriteLine("Entering Initialize() of: {0}".FormatInvariant(this));
             base.Initialize();
 
             UIThread.EnsureService(this);

--- a/Python/Product/Cookiecutter/Model/ContextItem.cs
+++ b/Python/Product/Cookiecutter/Model/ContextItem.cs
@@ -15,6 +15,7 @@
 // permissions and limitations under the License.
 
 using System;
+using Microsoft.CookiecutterTools.Infrastructure;
 
 namespace Microsoft.CookiecutterTools.Model {
     class ContextItem {
@@ -23,7 +24,7 @@ namespace Microsoft.CookiecutterTools.Model {
             Selector = selector;
             DefaultValue = defaultValue;
             Values = items ?? new string[0];
-            Visible = !name.StartsWith("_", StringComparison.Ordinal);
+            Visible = !name.StartsWithOrdinal("_");
         }
 
         public string Name { get; }

--- a/Python/Product/Cookiecutter/Model/ContextItem.cs
+++ b/Python/Product/Cookiecutter/Model/ContextItem.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CookiecutterTools.Model {
             Selector = selector;
             DefaultValue = defaultValue;
             Values = items ?? new string[0];
-            Visible = !name.StartsWith("_", StringComparison.InvariantCulture);
+            Visible = !name.StartsWith("_", StringComparison.Ordinal);
         }
 
         public string Name { get; }

--- a/Python/Product/Cookiecutter/Model/CookiecutterClient.cs
+++ b/Python/Product/Cookiecutter/Model/CookiecutterClient.cs
@@ -162,7 +162,7 @@ namespace Microsoft.CookiecutterTools.Model {
                 foreach (JProperty prop in context) {
                     // Properties that start with underscore are for internal use,
                     // and cookiecutter doesn't prompt for them.
-                    if (!prop.Name.StartsWith("_")) {
+                    if (!prop.Name.StartsWith("_", StringComparison.Ordinal)) {
                         if (prop.Value.Type == JTokenType.String ||
                             prop.Value.Type == JTokenType.Integer ||
                             prop.Value.Type == JTokenType.Float) {
@@ -214,7 +214,7 @@ namespace Microsoft.CookiecutterTools.Model {
                 foreach (JProperty prop in context) {
                     // Properties that start with underscore are for internal use,
                     // and cookiecutter doesn't prompt for them.
-                    if (!prop.Name.StartsWith("_")) {
+                    if (!prop.Name.StartsWith("_", StringComparison.Ordinal)) {
                         if (prop.Value.Type == JTokenType.String ||
                             prop.Value.Type == JTokenType.Integer ||
                             prop.Value.Type == JTokenType.Float) {
@@ -392,7 +392,7 @@ namespace Microsoft.CookiecutterTools.Model {
                     args.Append(" ");
                 }
 
-                if (val.EndsWith(":")) {
+                if (val.EndsWith(":", StringComparison.Ordinal)) {
                     args.Append(val);
                     // no space after a switch that takes a value
                     insertSpace = false;

--- a/Python/Product/Cookiecutter/Model/CookiecutterClient.cs
+++ b/Python/Product/Cookiecutter/Model/CookiecutterClient.cs
@@ -162,7 +162,7 @@ namespace Microsoft.CookiecutterTools.Model {
                 foreach (JProperty prop in context) {
                     // Properties that start with underscore are for internal use,
                     // and cookiecutter doesn't prompt for them.
-                    if (!prop.Name.StartsWith("_", StringComparison.Ordinal)) {
+                    if (!prop.Name.StartsWithOrdinal("_")) {
                         if (prop.Value.Type == JTokenType.String ||
                             prop.Value.Type == JTokenType.Integer ||
                             prop.Value.Type == JTokenType.Float) {
@@ -214,7 +214,7 @@ namespace Microsoft.CookiecutterTools.Model {
                 foreach (JProperty prop in context) {
                     // Properties that start with underscore are for internal use,
                     // and cookiecutter doesn't prompt for them.
-                    if (!prop.Name.StartsWith("_", StringComparison.Ordinal)) {
+                    if (!prop.Name.StartsWithOrdinal("_")) {
                         if (prop.Value.Type == JTokenType.String ||
                             prop.Value.Type == JTokenType.Integer ||
                             prop.Value.Type == JTokenType.Float) {
@@ -392,7 +392,7 @@ namespace Microsoft.CookiecutterTools.Model {
                     args.Append(" ");
                 }
 
-                if (val.EndsWith(":", StringComparison.Ordinal)) {
+                if (val.EndsWithOrdinal(":")) {
                     args.Append(val);
                     // no space after a switch that takes a value
                     insertSpace = false;

--- a/Python/Product/Cookiecutter/Model/CookiecutterClientProvider.cs
+++ b/Python/Product/Cookiecutter/Model/CookiecutterClientProvider.cs
@@ -47,7 +47,7 @@ namespace Microsoft.CookiecutterTools.Model {
             // Prefer a CPython installation if there is one because
             // some Anaconda installs have trouble creating a venv.
             var cpython = all
-                .Where(x => x.Vendor.IndexOf("Python Software Foundation", StringComparison.OrdinalIgnoreCase) == 0);
+                .Where(x => x.Vendor.IndexOfOrdinal("Python Software Foundation", ignoreCase: true) == 0);
             var best = cpython.FirstOrDefault() ?? all.FirstOrDefault();
 
             return best != null ? new CookiecutterPythonInterpreter(

--- a/Python/Product/Cookiecutter/Model/GitClient.cs
+++ b/Python/Product/Cookiecutter/Model/GitClient.cs
@@ -107,7 +107,7 @@ namespace Microsoft.CookiecutterTools.Model {
                 foreach (var line in output.StandardOutputLines) {
                     // Line with date starts with 'Date'. Example:
                     // Date:   2016-07-28 10:03:07 +0200
-                    if (line.StartsWith("Date:")) {
+                    if (line.StartsWith("Date:", StringComparison.Ordinal)) {
                         try {
                             var text = line.Substring("Date:".Length);
                             return Convert.ToDateTime(text).ToUniversalTime();
@@ -160,7 +160,7 @@ namespace Microsoft.CookiecutterTools.Model {
         }
 
         private static bool HasFatalError(IEnumerable<string> standardErrorLines) {
-            return standardErrorLines.Any(line => line.StartsWith("fatal:", StringComparison.InvariantCultureIgnoreCase));
+            return standardErrorLines.Any(line => line.StartsWith("fatal:", StringComparison.OrdinalIgnoreCase));
         }
 
         private static string GetClonedFolder(string repoUrl, string targetParentFolderPath) {
@@ -169,7 +169,7 @@ namespace Microsoft.CookiecutterTools.Model {
                 throw new ArgumentOutOfRangeException(nameof(repoUrl));
             }
 
-            if (name.EndsWith(".git", StringComparison.InvariantCultureIgnoreCase)) {
+            if (name.EndsWith(".git", StringComparison.OrdinalIgnoreCase)) {
                 name = name.Substring(0, name.Length - 4);
             }
 
@@ -180,8 +180,8 @@ namespace Microsoft.CookiecutterTools.Model {
         private bool ParseOrigin(string remote, out string url) {
             url = null;
 
-            if (remote.StartsWith("origin")) {
-                int start = remote.IndexOf("https", StringComparison.InvariantCultureIgnoreCase);
+            if (remote.StartsWith("origin", StringComparison.Ordinal)) {
+                int start = remote.IndexOf("https", StringComparison.OrdinalIgnoreCase);
                 if (start >= 0) {
                     int end = remote.IndexOf(' ', start);
                     if (end >= 0) {

--- a/Python/Product/Cookiecutter/Model/GitClient.cs
+++ b/Python/Product/Cookiecutter/Model/GitClient.cs
@@ -181,7 +181,7 @@ namespace Microsoft.CookiecutterTools.Model {
             url = null;
 
             if (remote.StartsWithOrdinal("origin")) {
-                int start = remote.IndexOf("https", StringComparison.OrdinalIgnoreCase);
+                int start = remote.IndexOfOrdinal("https", ignoreCase: true);
                 if (start >= 0) {
                     int end = remote.IndexOf(' ', start);
                     if (end >= 0) {

--- a/Python/Product/Cookiecutter/Model/GitClient.cs
+++ b/Python/Product/Cookiecutter/Model/GitClient.cs
@@ -107,7 +107,7 @@ namespace Microsoft.CookiecutterTools.Model {
                 foreach (var line in output.StandardOutputLines) {
                     // Line with date starts with 'Date'. Example:
                     // Date:   2016-07-28 10:03:07 +0200
-                    if (line.StartsWith("Date:", StringComparison.Ordinal)) {
+                    if (line.StartsWithOrdinal("Date:")) {
                         try {
                             var text = line.Substring("Date:".Length);
                             return Convert.ToDateTime(text).ToUniversalTime();
@@ -160,7 +160,7 @@ namespace Microsoft.CookiecutterTools.Model {
         }
 
         private static bool HasFatalError(IEnumerable<string> standardErrorLines) {
-            return standardErrorLines.Any(line => line.StartsWith("fatal:", StringComparison.OrdinalIgnoreCase));
+            return standardErrorLines.Any(line => line.StartsWithOrdinal("fatal:", ignoreCase: true));
         }
 
         private static string GetClonedFolder(string repoUrl, string targetParentFolderPath) {
@@ -169,7 +169,7 @@ namespace Microsoft.CookiecutterTools.Model {
                 throw new ArgumentOutOfRangeException(nameof(repoUrl));
             }
 
-            if (name.EndsWith(".git", StringComparison.OrdinalIgnoreCase)) {
+            if (name.EndsWithOrdinal(".git", ignoreCase: true)) {
                 name = name.Substring(0, name.Length - 4);
             }
 
@@ -180,7 +180,7 @@ namespace Microsoft.CookiecutterTools.Model {
         private bool ParseOrigin(string remote, out string url) {
             url = null;
 
-            if (remote.StartsWith("origin", StringComparison.Ordinal)) {
+            if (remote.StartsWithOrdinal("origin")) {
                 int start = remote.IndexOf("https", StringComparison.OrdinalIgnoreCase);
                 if (start >= 0) {
                     int end = remote.IndexOf(' ', start);

--- a/Python/Product/Cookiecutter/Model/ProcessException.cs
+++ b/Python/Product/Cookiecutter/Model/ProcessException.cs
@@ -15,7 +15,7 @@
 // permissions and limitations under the License.
 
 using System;
-using System.Globalization;
+using Microsoft.CookiecutterTools.Infrastructure;
 
 namespace Microsoft.CookiecutterTools.Model {
     [Serializable]
@@ -23,7 +23,7 @@ namespace Microsoft.CookiecutterTools.Model {
         public ProcessOutputResult Result { get; }
 
         public ProcessException(ProcessOutputResult result) :
-            base(string.Format(CultureInfo.CurrentUICulture, Strings.ProcessExitCodeMessage, result.ExeFileName, result.ExitCode)) {
+            base(Strings.ProcessExitCodeMessage.FormatUI(result.ExeFileName, result.ExitCode)) {
             Result = result;
         }
     }

--- a/Python/Product/Cookiecutter/Shared/Infrastructure/ExceptionExtensions.cs
+++ b/Python/Product/Cookiecutter/Shared/Infrastructure/ExceptionExtensions.cs
@@ -15,6 +15,7 @@
 // permissions and limitations under the License.
 
 using System;
+using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using Microsoft.CookiecutterTools;
@@ -46,6 +47,7 @@ namespace Microsoft.CookiecutterTools.Infrastructure {
             }
 
             return string.Format(
+                CultureInfo.CurrentCulture,
                 Strings.UnhandledException,
                 ex,
                 callerFile ?? String.Empty,

--- a/Python/Product/Cookiecutter/Shared/Infrastructure/PathUtils.cs
+++ b/Python/Product/Cookiecutter/Shared/Infrastructure/PathUtils.cs
@@ -149,7 +149,7 @@ namespace Microsoft.CookiecutterTools.Infrastructure {
         /// root or a subdirectory of root.
         /// </summary>
         public static bool IsSubpathOf(string root, string path) {
-            if (HasEndSeparator(root) && !path.Contains("..") && path.StartsWith(root, StringComparison.Ordinal)) {
+            if (HasEndSeparator(root) && !path.Contains("..") && path.StartsWithOrdinal(root)) {
                 // Quick return, but only where the paths are already normalized and
                 // have matching case.
                 return true;
@@ -637,7 +637,7 @@ namespace Microsoft.CookiecutterTools.Infrastructure {
                 }
 
                 foreach (var d in dirs) {
-                    if (!fullPaths && !d.StartsWith(root, StringComparison.OrdinalIgnoreCase)) {
+                    if (!fullPaths && !d.StartsWithOrdinal(root, ignoreCase: true)) {
                         continue;
                     }
                     if (recurse) {

--- a/Python/Product/Cookiecutter/Shared/Infrastructure/PathUtils.cs
+++ b/Python/Product/Cookiecutter/Shared/Infrastructure/PathUtils.cs
@@ -257,7 +257,7 @@ namespace Microsoft.CookiecutterTools.Infrastructure {
                     relPath = Uri.UnescapeDataString(relUri.ToString());
                 }
             } catch (InvalidOperationException ex) {
-                Trace.WriteLine(string.Format("Error finding path from {0} to {1}", fromUri, toUri));
+                Trace.WriteLine("Error finding path from {0} to {1}".FormatInvariant(fromUri, toUri));
                 Trace.WriteLine(ex);
                 relPath = toUri.IsFile ? toUri.LocalPath : toUri.AbsoluteUri;
             }
@@ -293,7 +293,7 @@ namespace Microsoft.CookiecutterTools.Infrastructure {
                     relPath = Uri.UnescapeDataString(relUri.ToString());
                 }
             } catch (InvalidOperationException ex) {
-                Trace.WriteLine(string.Format("Error finding path from {0} to {1}", fromUri, toUri));
+                Trace.WriteLine("Error finding path from {0} to {1}".FormatInvariant(fromUri, toUri));
                 Trace.WriteLine(ex);
                 relPath = toUri.IsFile ? toUri.LocalPath : toUri.AbsoluteUri;
             }
@@ -584,7 +584,7 @@ namespace Microsoft.CookiecutterTools.Infrastructure {
             if (File.Exists(newPath + extension)) {
                 string candidateNewPath;
                 do {
-                    candidateNewPath = string.Format("{0}{1}", newPath, ++index);
+                    candidateNewPath = "{0}{1}".FormatInvariant(newPath, ++index);
                 } while (File.Exists(candidateNewPath + extension));
                 newPath = candidateNewPath;
             }

--- a/Python/Product/Cookiecutter/Shared/Infrastructure/PathUtils.cs
+++ b/Python/Product/Cookiecutter/Shared/Infrastructure/PathUtils.cs
@@ -615,14 +615,14 @@ namespace Microsoft.CookiecutterTools.Infrastructure {
             bool fullPaths = true
         ) {
             var queue = new Queue<string>();
-            if (!root.EndsWith("\\")) {
+            if (!root.EndsWithOrdinal("\\")) {
                 root += "\\";
             }
             queue.Enqueue(root);
 
             while (queue.Any()) {
                 var path = queue.Dequeue();
-                if (!path.EndsWith("\\")) {
+                if (!path.EndsWithOrdinal("\\")) {
                     path += "\\";
                 }
 
@@ -673,7 +673,7 @@ namespace Microsoft.CookiecutterTools.Infrastructure {
             bool recurse = true,
             bool fullPaths = true
         ) {
-            if (!root.EndsWith("\\")) {
+            if (!root.EndsWithOrdinal("\\")) {
                 root += "\\";
             }
 
@@ -774,7 +774,7 @@ namespace Microsoft.CookiecutterTools.Infrastructure {
                     }
 
                     if (res != 0) {
-                        Debug.Assert(filePathBuilder.ToString().StartsWith("\\\\?\\"));
+                        Debug.Assert(filePathBuilder.ToString().StartsWithOrdinal("\\\\?\\"));
                         return filePathBuilder.ToString().Substring(4);
                     }
                 }

--- a/Python/Product/Cookiecutter/Shared/Infrastructure/ProcessOutput.cs
+++ b/Python/Product/Cookiecutter/Shared/Infrastructure/ProcessOutput.cs
@@ -367,9 +367,9 @@ namespace Microsoft.CookiecutterTools.Infrastructure {
                     Task.Run(() => {
                         try {
                             for (var line = reader.ReadLine(); line != null; line = reader.ReadLine()) {
-                                if (line.StartsWith("OUT:")) {
+                                if (line.StartsWith("OUT:", StringComparison.Ordinal)) {
                                     redirector.WriteLine(line.Substring(4));
-                                } else if (line.StartsWith("ERR:")) {
+                                } else if (line.StartsWith("ERR:", StringComparison.Ordinal)) {
                                     redirector.WriteErrorLine(line.Substring(4));
                                 } else {
                                     redirector.WriteLine(line);
@@ -418,7 +418,7 @@ namespace Microsoft.CookiecutterTools.Infrastructure {
                 return arg;
             }
 
-            if (arg.StartsWith("\"") && arg.EndsWith("\"")) {
+            if (arg.StartsWith("\"", StringComparison.Ordinal) && arg.EndsWith("\"", StringComparison.Ordinal)) {
                 bool inQuote = false;
                 int consecutiveBackslashes = 0;
                 foreach (var c in arg) {
@@ -440,7 +440,7 @@ namespace Microsoft.CookiecutterTools.Infrastructure {
             }
 
             var newArg = arg.Replace("\"", "\\\"");
-            if (newArg.EndsWith("\\")) {
+            if (newArg.EndsWith("\\", StringComparison.Ordinal)) {
                 newArg += "\\";
             }
             return "\"" + newArg + "\"";

--- a/Python/Product/Cookiecutter/Shared/Infrastructure/ProcessOutput.cs
+++ b/Python/Product/Cookiecutter/Shared/Infrastructure/ProcessOutput.cs
@@ -367,9 +367,9 @@ namespace Microsoft.CookiecutterTools.Infrastructure {
                     Task.Run(() => {
                         try {
                             for (var line = reader.ReadLine(); line != null; line = reader.ReadLine()) {
-                                if (line.StartsWith("OUT:", StringComparison.Ordinal)) {
+                                if (line.StartsWithOrdinal("OUT:")) {
                                     redirector.WriteLine(line.Substring(4));
-                                } else if (line.StartsWith("ERR:", StringComparison.Ordinal)) {
+                                } else if (line.StartsWithOrdinal("ERR:")) {
                                     redirector.WriteErrorLine(line.Substring(4));
                                 } else {
                                     redirector.WriteLine(line);
@@ -418,7 +418,7 @@ namespace Microsoft.CookiecutterTools.Infrastructure {
                 return arg;
             }
 
-            if (arg.StartsWith("\"", StringComparison.Ordinal) && arg.EndsWith("\"", StringComparison.Ordinal)) {
+            if (arg.StartsWithOrdinal("\"") && arg.EndsWithOrdinal("\"")) {
                 bool inQuote = false;
                 int consecutiveBackslashes = 0;
                 foreach (var c in arg) {
@@ -440,7 +440,7 @@ namespace Microsoft.CookiecutterTools.Infrastructure {
             }
 
             var newArg = arg.Replace("\"", "\\\"");
-            if (newArg.EndsWith("\\", StringComparison.Ordinal)) {
+            if (newArg.EndsWithOrdinal("\\")) {
                 newArg += "\\";
             }
             return "\"" + newArg + "\"";

--- a/Python/Product/Cookiecutter/Shared/Infrastructure/StringExtensions.cs
+++ b/Python/Product/Cookiecutter/Shared/Infrastructure/StringExtensions.cs
@@ -111,11 +111,15 @@ namespace Microsoft.CookiecutterTools.Infrastructure {
         }
 
         public static bool StartsWithOrdinal(this string s, string prefix, bool ignoreCase = false) {
-            return s?.StartsWith(prefix, ignoreCase ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase) ?? false;
+            return s?.StartsWith(prefix, ignoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal) ?? false;
         }
 
         public static bool EndsWithOrdinal(this string s, string suffix, bool ignoreCase = false) {
-            return s?.StartsWith(suffix, ignoreCase ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase) ?? false;
+            return s?.StartsWith(suffix, ignoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal) ?? false;
+        }
+
+        public static int IndexOfOrdinal(this string s, string value, int startIndex = 0, bool ignoreCase = false) {
+            return s?.IndexOf(value, startIndex, ignoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal) ?? -1;
         }
     }
 }

--- a/Python/Product/Cookiecutter/Shared/Infrastructure/StringExtensions.cs
+++ b/Python/Product/Cookiecutter/Shared/Infrastructure/StringExtensions.cs
@@ -109,5 +109,13 @@ namespace Microsoft.CookiecutterTools.Infrastructure {
 
             return str.Substring(0, length);
         }
+
+        public static bool StartsWithOrdinal(this string s, string prefix, bool ignoreCase = false) {
+            return s?.StartsWith(prefix, ignoreCase ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase) ?? false;
+        }
+
+        public static bool EndsWithOrdinal(this string s, string suffix, bool ignoreCase = false) {
+            return s?.StartsWith(suffix, ignoreCase ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase) ?? false;
+        }
     }
 }

--- a/Python/Product/Cookiecutter/Shared/Infrastructure/StringExtensions.cs
+++ b/Python/Product/Cookiecutter/Shared/Infrastructure/StringExtensions.cs
@@ -17,12 +17,10 @@
 using System;
 using System.Diagnostics;
 using System.Globalization;
-using System.Security.Cryptography;
-using System.Text;
 using System.Text.RegularExpressions;
 
 namespace Microsoft.CookiecutterTools.Infrastructure {
-    public static class StringExtensions {
+    static class StringExtensions {
 #if DEBUG
         private static readonly Regex SubstitutionRegex = new Regex(
             @"\{(\d+)",
@@ -45,17 +43,17 @@ namespace Microsoft.CookiecutterTools.Infrastructure {
 
         public static string FormatUI(this string str, object arg0) {
             ValidateFormatString(str, 1);
-            return string.Format(CultureInfo.CurrentUICulture, str, arg0);
+            return string.Format(CultureInfo.CurrentCulture, str, arg0);
         }
 
         public static string FormatUI(this string str, object arg0, object arg1) {
             ValidateFormatString(str, 2);
-            return string.Format(CultureInfo.CurrentUICulture, str, arg0, arg1);
+            return string.Format(CultureInfo.CurrentCulture, str, arg0, arg1);
         }
 
         public static string FormatUI(this string str, params object[] args) {
             ValidateFormatString(str, args.Length);
-            return string.Format(CultureInfo.CurrentUICulture, str, args);
+            return string.Format(CultureInfo.CurrentCulture, str, args);
         }
 
         public static string FormatInvariant(this string str, object arg0) {
@@ -73,13 +71,31 @@ namespace Microsoft.CookiecutterTools.Infrastructure {
             return string.Format(CultureInfo.InvariantCulture, str, args);
         }
 
+        public static string IfNullOrEmpty(this string str, string fallback) {
+            return string.IsNullOrEmpty(str) ? fallback : str;
+        }
+
         public static bool IsTrue(this string str) {
             bool asBool;
             return !string.IsNullOrWhiteSpace(str) && (
-                str.Equals("1") ||
-                str.Equals("yes", StringComparison.InvariantCultureIgnoreCase) ||
+                str.Equals("1", StringComparison.Ordinal) ||
+                str.Equals("yes", StringComparison.OrdinalIgnoreCase) ||
                 (bool.TryParse(str, out asBool) && asBool)
             );
+        }
+
+        public static string TrimEndNewline(this string str) {
+            if (string.IsNullOrEmpty(str)) {
+                return string.Empty;
+            }
+
+            if (str[str.Length - 1] == '\n') {
+                if (str.Length >= 2 && str[str.Length - 2] == '\r') {
+                    return str.Remove(str.Length - 2);
+                }
+                return str.Remove(str.Length - 1);
+            }
+            return str;
         }
 
         public static string Truncate(this string str, int length) {

--- a/Python/Product/Cookiecutter/Shared/Infrastructure/VSTaskExtensions.cs
+++ b/Python/Product/Cookiecutter/Shared/Infrastructure/VSTaskExtensions.cs
@@ -75,7 +75,7 @@ namespace Microsoft.CookiecutterTools.Infrastructure {
             if (allowUI) {
                 lock (_displayedMessages) {
                     if (!string.IsNullOrEmpty(logFile) &&
-                        _displayedMessages.Add(string.Format("{0}:{1}", callerFile, callerLineNumber))) {
+                        _displayedMessages.Add("{0}:{1}".FormatInvariant(callerFile, callerLineNumber))) {
                         // First time we've seen this error, so let the user know
                         MessageBox.Show(Strings.SeeActivityLog.FormatUI(logFile), Strings.ProductTitle);
                     }

--- a/Python/Product/Cookiecutter/Shared/Interpreters/InterpreterArchitecture.cs
+++ b/Python/Product/Cookiecutter/Shared/Interpreters/InterpreterArchitecture.cs
@@ -17,7 +17,10 @@
 using System;
 
 namespace Microsoft.CookiecutterTools.Interpreters {
-    public abstract class InterpreterArchitecture : IFormattable, IComparable<InterpreterArchitecture> {
+    public abstract class InterpreterArchitecture :
+        IFormattable,
+        IComparable<InterpreterArchitecture>,
+        IEquatable<InterpreterArchitecture> {
         protected abstract bool Equals(string value);
 
         public virtual string ToString(string format, IFormatProvider formatProvider, string defaultString) {
@@ -74,7 +77,7 @@ namespace Microsoft.CookiecutterTools.Interpreters {
             // subclasses so that we have some way to handle extra
             // architectures being injected while ensuring that the
             // standard ones take priority.
-            
+
             // The ordering is:
             //      x86
             //      x64
@@ -101,8 +104,16 @@ namespace Microsoft.CookiecutterTools.Interpreters {
                 return -1;
             }
 
-            return GetType().Name.CompareTo(other.GetType().Name);
+            return string.CompareOrdinal(GetType().Name, other.GetType().Name);
         }
+
+        public static bool operator ==(InterpreterArchitecture x, InterpreterArchitecture y)
+            => x?.Equals(y) ?? object.ReferenceEquals(y, null);
+        public static bool operator !=(InterpreterArchitecture x, InterpreterArchitecture y)
+            => !(x?.Equals(y) ?? object.ReferenceEquals(y, null));
+        public override bool Equals(object obj) => Equals(obj as InterpreterArchitecture);
+        public bool Equals(InterpreterArchitecture other) => other != null && GetType().IsEquivalentTo(other.GetType());
+        public override int GetHashCode() => GetType().GetHashCode();
 
         private sealed class UnknownArchitecture : InterpreterArchitecture {
             public UnknownArchitecture() { }

--- a/Python/Product/Cookiecutter/Shared/Interpreters/PythonLanguageVersion.cs
+++ b/Python/Product/Cookiecutter/Shared/Interpreters/PythonLanguageVersion.cs
@@ -15,6 +15,7 @@
 // permissions and limitations under the License.
 
 using System;
+using Microsoft.CookiecutterTools.Infrastructure;
 
 namespace Microsoft.CookiecutterTools.Interpreters {
     /// <summary>
@@ -83,7 +84,7 @@ namespace Microsoft.CookiecutterTools.Interpreters {
                     }
                     break;
             }
-            throw new InvalidOperationException(String.Format("Unsupported Python version: {0}", version.ToString()));
+            throw new InvalidOperationException("Unsupported Python version: {0}".FormatInvariant(version));
         }
 
     }

--- a/Python/Product/Cookiecutter/View/CookiecutterContainerPage.xaml.cs
+++ b/Python/Product/Cookiecutter/View/CookiecutterContainerPage.xaml.cs
@@ -220,7 +220,7 @@ namespace Microsoft.CookiecutterTools.View {
                 return;
             }
 
-            var result = MessageBox.Show(string.Format(CultureInfo.CurrentUICulture, Strings.DeleteConfirmation, ViewModel.SelectedTemplate.ClonedPath), Strings.ProductTitle, MessageBoxButton.YesNo, MessageBoxImage.Exclamation);
+            var result = MessageBox.Show(Strings.DeleteConfirmation.FormatUI(ViewModel.SelectedTemplate.ClonedPath), Strings.ProductTitle, MessageBoxButton.YesNo, MessageBoxImage.Exclamation);
             if (result == MessageBoxResult.Yes) {
                 ViewModel.DeleteTemplateAsync(ViewModel.SelectedTemplate).DoNotWait();
             }

--- a/Python/Product/Cookiecutter/View/CookiecutterSearchPage.xaml.cs
+++ b/Python/Product/Cookiecutter/View/CookiecutterSearchPage.xaml.cs
@@ -158,7 +158,7 @@ namespace Microsoft.CookiecutterTools.View {
         public void LoadTemplate() {
             TemplateViewModel collidingTemplate;
             if (ViewModel.IsCloneNeeded(ViewModel.SelectedTemplate) && ViewModel.IsCloneCollision(ViewModel.SelectedTemplate, out collidingTemplate)) {
-                MessageBox.Show(string.Format(CultureInfo.CurrentUICulture, Strings.CloneCollisionMessage, ViewModel.SelectedTemplate.RepositoryName, collidingTemplate.ClonedPath), Strings.ProductTitle, MessageBoxButton.OK, MessageBoxImage.Error);
+                MessageBox.Show(Strings.CloneCollisionMessage.FormatUI(ViewModel.SelectedTemplate.RepositoryName, collidingTemplate.ClonedPath), Strings.ProductTitle, MessageBoxButton.OK, MessageBoxImage.Error);
                 return;
             }
 

--- a/Python/Product/Cookiecutter/ViewModel/CookiecutterViewModel.cs
+++ b/Python/Product/Cookiecutter/ViewModel/CookiecutterViewModel.cs
@@ -698,7 +698,7 @@ namespace Microsoft.CookiecutterTools.ViewModel {
             var searchTermTemplate = new TemplateViewModel();
             searchTermTemplate.IsSearchTerm = true;
 
-            if (possibleUri.StartsWith("http")) {
+            if (possibleUri.StartsWith("http", StringComparison.Ordinal)) {
                 searchTermTemplate.DisplayName = possibleUri;
                 searchTermTemplate.RemoteUrl = possibleUri;
                 searchTermTemplate.Category = Custom.DisplayName;

--- a/Python/Product/Cookiecutter/ViewModel/CookiecutterViewModel.cs
+++ b/Python/Product/Cookiecutter/ViewModel/CookiecutterViewModel.cs
@@ -698,7 +698,7 @@ namespace Microsoft.CookiecutterTools.ViewModel {
             var searchTermTemplate = new TemplateViewModel();
             searchTermTemplate.IsSearchTerm = true;
 
-            if (possibleUri.StartsWith("http", StringComparison.Ordinal)) {
+            if (possibleUri.StartsWithOrdinal("http")) {
                 searchTermTemplate.DisplayName = possibleUri;
                 searchTermTemplate.RemoteUrl = possibleUri;
                 searchTermTemplate.Category = Custom.DisplayName;

--- a/Python/Product/Debugger/Debugger/DebugEngine/AD7StackFrame.cs
+++ b/Python/Product/Debugger/Debugger/DebugEngine/AD7StackFrame.cs
@@ -76,9 +76,9 @@ namespace Microsoft.PythonTools.Debugger.DebugEngine {
                 if (funcName == "<module>") {
                     if (PathUtils.IsValidPath(_stackFrame.FileName)) {
                         funcName = Strings.DebugFileModule.FormatUI(Path.GetFileNameWithoutExtension(_stackFrame.FileName));
-                    } else if (_stackFrame.FileName.EndsWith("<string>", StringComparison.Ordinal)) {
+                    } else if (_stackFrame.FileName.EndsWithOrdinal("<string>")) {
                         funcName = Strings.DebugExecEvalFunctionName;
-                    } else if (_stackFrame.FileName.EndsWith("<stdin>", StringComparison.Ordinal)) {
+                    } else if (_stackFrame.FileName.EndsWithOrdinal("<stdin>")) {
                         funcName = Strings.DebugReplInputFunctionName;
                     } else {
                         funcName = Strings.DebugFileUnknownCode.FormatUI(_stackFrame.FileName);
@@ -119,9 +119,9 @@ namespace Microsoft.PythonTools.Debugger.DebugEngine {
             if ((dwFieldSpec & enum_FRAMEINFO_FLAGS.FIF_MODULE) != 0) {
                 if (PathUtils.IsValidPath(_stackFrame.FileName)) {
                     frameInfo.m_bstrModule = Path.GetFileNameWithoutExtension(this._stackFrame.FileName);
-                } else if (_stackFrame.FileName.EndsWith("<string>", StringComparison.Ordinal)) {
+                } else if (_stackFrame.FileName.EndsWithOrdinal("<string>")) {
                     frameInfo.m_bstrModule = Strings.DebugExecEvalModuleName;
-                } else if (_stackFrame.FileName.EndsWith("<stdin>", StringComparison.Ordinal)) {
+                } else if (_stackFrame.FileName.EndsWithOrdinal("<stdin>")) {
                     frameInfo.m_bstrModule = Strings.DebugReplModuleName;
                 } else {
                     frameInfo.m_bstrModule = Strings.DebugUnknownModuleName;

--- a/Python/Product/Debugger/Debugger/DebugEngine/AD7StackFrame.cs
+++ b/Python/Product/Debugger/Debugger/DebugEngine/AD7StackFrame.cs
@@ -76,9 +76,9 @@ namespace Microsoft.PythonTools.Debugger.DebugEngine {
                 if (funcName == "<module>") {
                     if (PathUtils.IsValidPath(_stackFrame.FileName)) {
                         funcName = Strings.DebugFileModule.FormatUI(Path.GetFileNameWithoutExtension(_stackFrame.FileName));
-                    } else if (_stackFrame.FileName.EndsWith("<string>")) {
+                    } else if (_stackFrame.FileName.EndsWith("<string>", StringComparison.Ordinal)) {
                         funcName = Strings.DebugExecEvalFunctionName;
-                    } else if (_stackFrame.FileName.EndsWith("<stdin>")) {
+                    } else if (_stackFrame.FileName.EndsWith("<stdin>", StringComparison.Ordinal)) {
                         funcName = Strings.DebugReplInputFunctionName;
                     } else {
                         funcName = Strings.DebugFileUnknownCode.FormatUI(_stackFrame.FileName);
@@ -119,9 +119,9 @@ namespace Microsoft.PythonTools.Debugger.DebugEngine {
             if ((dwFieldSpec & enum_FRAMEINFO_FLAGS.FIF_MODULE) != 0) {
                 if (PathUtils.IsValidPath(_stackFrame.FileName)) {
                     frameInfo.m_bstrModule = Path.GetFileNameWithoutExtension(this._stackFrame.FileName);
-                } else if (_stackFrame.FileName.EndsWith("<string>")) {
+                } else if (_stackFrame.FileName.EndsWith("<string>", StringComparison.Ordinal)) {
                     frameInfo.m_bstrModule = Strings.DebugExecEvalModuleName;
-                } else if (_stackFrame.FileName.EndsWith("<stdin>")) {
+                } else if (_stackFrame.FileName.EndsWith("<stdin>", StringComparison.Ordinal)) {
                     frameInfo.m_bstrModule = Strings.DebugReplModuleName;
                 } else {
                     frameInfo.m_bstrModule = Strings.DebugUnknownModuleName;

--- a/Python/Product/Debugger/Debugger/PythonException.cs
+++ b/Python/Product/Debugger/Debugger/PythonException.cs
@@ -92,7 +92,7 @@ namespace Microsoft.PythonTools.Debugger {
                 if (endQuote == null) {
                     if (string.IsNullOrEmpty(bit)) {
                         yield return string.Empty;
-                    } else if (bit.StartsWith("\"") || bit.StartsWith("'")) {
+                    } else if (bit.StartsWithOrdinal("\"") || bit.StartsWithOrdinal("'")) {
                         endQuote = bit.Remove(1);
                         element.Append(bit.Substring(1));
                         added = true;
@@ -101,7 +101,7 @@ namespace Microsoft.PythonTools.Debugger {
                     }
                 }
 
-                if (endQuote != null && bit.EndsWith(endQuote)) {
+                if (endQuote != null && bit.EndsWithOrdinal(endQuote)) {
                     if (!added) {
                         element.Append(',');
                         element.Append(bit);

--- a/Python/Product/Debugger/Debugger/PythonProcess.cs
+++ b/Python/Product/Debugger/Debugger/PythonProcess.cs
@@ -100,7 +100,7 @@ namespace Microsoft.PythonTools.Debugger {
 
             ListenForConnection();
 
-            if (dir.EndsWith("\\")) {
+            if (dir.EndsWith("\\", StringComparison.Ordinal)) {
                 dir = dir.Substring(0, dir.Length - 1);
             }
             _dirMapping = dirMapping;
@@ -943,7 +943,7 @@ namespace Microsoft.PythonTools.Debugger {
 
                     if (file.StartsWith(mapFrom, StringComparison.OrdinalIgnoreCase)) {
                         int len = mapFrom.Length;
-                        if (!mappingInfo[0].EndsWith("\\")) {
+                        if (!mappingInfo[0].EndsWith("\\", StringComparison.Ordinal)) {
                             len++;
                         }
 

--- a/Python/Product/Debugger/Debugger/PythonProcess.cs
+++ b/Python/Product/Debugger/Debugger/PythonProcess.cs
@@ -100,7 +100,7 @@ namespace Microsoft.PythonTools.Debugger {
 
             ListenForConnection();
 
-            if (dir.EndsWith("\\", StringComparison.Ordinal)) {
+            if (dir.EndsWithOrdinal("\\")) {
                 dir = dir.Substring(0, dir.Length - 1);
             }
             _dirMapping = dirMapping;
@@ -941,9 +941,9 @@ namespace Microsoft.PythonTools.Debugger {
                     string mapFrom = mappingInfo[toDebuggee ? 0 : 1];
                     string mapTo = mappingInfo[toDebuggee ? 1 : 0];
 
-                    if (file.StartsWith(mapFrom, StringComparison.OrdinalIgnoreCase)) {
+                    if (file.StartsWithOrdinal(mapFrom, ignoreCase: true)) {
                         int len = mapFrom.Length;
-                        if (!mappingInfo[0].EndsWith("\\", StringComparison.Ordinal)) {
+                        if (!mappingInfo[0].EndsWithOrdinal("\\")) {
                             len++;
                         }
 

--- a/Python/Product/Debugger/DkmDebugger/DkmExtensions.cs
+++ b/Python/Product/Debugger/DkmDebugger/DkmExtensions.cs
@@ -19,6 +19,7 @@ using System.Diagnostics;
 using System.Linq;
 using Microsoft.Dia;
 using Microsoft.PythonTools.DkmDebugger.Proxies;
+using Microsoft.PythonTools.Infrastructure;
 using Microsoft.VisualStudio.Debugger;
 using Microsoft.VisualStudio.Debugger.Breakpoints;
 using Microsoft.VisualStudio.Debugger.CustomRuntimes;
@@ -133,7 +134,7 @@ namespace Microsoft.PythonTools.DkmDebugger {
             uint rva;
             using (var moduleSym = moduleInstance.GetSymbols()) {
                 if (objFileName != null) {
-                    using (var compiland = moduleSym.Object.GetSymbol(SymTagEnum.SymTagCompiland, null, cmp => cmp.name.EndsWith(objFileName, StringComparison.OrdinalIgnoreCase)))
+                    using (var compiland = moduleSym.Object.GetSymbol(SymTagEnum.SymTagCompiland, null, cmp => cmp.name.EndsWithOrdinal(objFileName, ignoreCase: true)))
                     using (var varSym = compiland.Object.GetSymbol(SymTagEnum.SymTagData, name)) {
                         rva = varSym.Object.relativeVirtualAddress;
                     }

--- a/Python/Product/Debugger/DkmDebugger/DkmExtensions.cs
+++ b/Python/Product/Debugger/DkmDebugger/DkmExtensions.cs
@@ -133,7 +133,7 @@ namespace Microsoft.PythonTools.DkmDebugger {
             uint rva;
             using (var moduleSym = moduleInstance.GetSymbols()) {
                 if (objFileName != null) {
-                    using (var compiland = moduleSym.Object.GetSymbol(SymTagEnum.SymTagCompiland, null, cmp => cmp.name.EndsWith(objFileName)))
+                    using (var compiland = moduleSym.Object.GetSymbol(SymTagEnum.SymTagCompiland, null, cmp => cmp.name.EndsWith(objFileName, StringComparison.OrdinalIgnoreCase)))
                     using (var varSym = compiland.Object.GetSymbol(SymTagEnum.SymTagData, name)) {
                         rva = varSym.Object.relativeVirtualAddress;
                     }

--- a/Python/Product/Debugger/DkmDebugger/ExpressionEvaluator.cs
+++ b/Python/Product/Debugger/DkmDebugger/ExpressionEvaluator.cs
@@ -217,10 +217,10 @@ namespace Microsoft.PythonTools.DkmDebugger {
 
                         string childFullName = child.Name;
                         if (FullName != null) {
-                            if (childFullName.EndsWith("()")) { // len()
+                            if (childFullName.EndsWith("()", StringComparison.Ordinal)) { // len()
                                 childFullName = childFullName.Substring(0, childFullName.Length - 2) + "(" + FullName + ")";
                             } else {
-                                if (!childFullName.StartsWith("[")) { // [0], ['fob'] etc
+                                if (!childFullName.StartsWith("[", StringComparison.Ordinal)) { // [0], ['fob'] etc
                                     childFullName = "." + childFullName;
                                 }
                                 childFullName = FullName + childFullName;
@@ -350,7 +350,7 @@ namespace Microsoft.PythonTools.DkmDebugger {
 
             string fullName = name;
             if (parentName != null) {
-                if (!fullName.StartsWith("[")) {
+                if (!fullName.StartsWith("[", StringComparison.Ordinal)) {
                     fullName = "." + fullName;
                 }
                 fullName = parentName + fullName;

--- a/Python/Product/Debugger/DkmDebugger/ExpressionEvaluator.cs
+++ b/Python/Product/Debugger/DkmDebugger/ExpressionEvaluator.cs
@@ -217,10 +217,10 @@ namespace Microsoft.PythonTools.DkmDebugger {
 
                         string childFullName = child.Name;
                         if (FullName != null) {
-                            if (childFullName.EndsWith("()", StringComparison.Ordinal)) { // len()
+                            if (childFullName.EndsWithOrdinal("()")) { // len()
                                 childFullName = childFullName.Substring(0, childFullName.Length - 2) + "(" + FullName + ")";
                             } else {
-                                if (!childFullName.StartsWith("[", StringComparison.Ordinal)) { // [0], ['fob'] etc
+                                if (!childFullName.StartsWithOrdinal("[")) { // [0], ['fob'] etc
                                     childFullName = "." + childFullName;
                                 }
                                 childFullName = FullName + childFullName;
@@ -350,7 +350,7 @@ namespace Microsoft.PythonTools.DkmDebugger {
 
             string fullName = name;
             if (parentName != null) {
-                if (!fullName.StartsWith("[", StringComparison.Ordinal)) {
+                if (!fullName.StartsWithOrdinal("[")) {
                     fullName = "." + fullName;
                 }
                 fullName = parentName + fullName;

--- a/Python/Product/Debugger/DkmDebugger/ModuleManager.cs
+++ b/Python/Product/Debugger/DkmDebugger/ModuleManager.cs
@@ -19,6 +19,7 @@ using System.IO;
 using System.Linq;
 using Microsoft.PythonTools.DkmDebugger.Proxies;
 using Microsoft.PythonTools.DkmDebugger.Proxies.Structs;
+using Microsoft.PythonTools.Infrastructure;
 using Microsoft.VisualStudio.Debugger;
 using Microsoft.VisualStudio.Debugger.CustomRuntimes;
 using Microsoft.VisualStudio.Debugger.Evaluation;
@@ -95,10 +96,10 @@ namespace Microsoft.PythonTools.DkmDebugger {
                         var name = (entry.Key as IPyBaseStringObject).ToStringOrNull();
                         if (name == "__file__") {
                             var fileName = (entry.Value.TryRead() as IPyBaseStringObject).ToStringOrNull();
-                            if (fileName != null && !fileName.EndsWith(".pyd", StringComparison.OrdinalIgnoreCase)) {
+                            if (fileName != null && !fileName.EndsWithOrdinal(".pyd", ignoreCase: true)) {
                                 // Unlike co_filename, __file__ usually reflects the actual name of the file from which the module
                                 // was created, which will be .pyc rather than .py if it was available, so fix that up.
-                                if (fileName.EndsWith(".pyc", StringComparison.OrdinalIgnoreCase)) {
+                                if (fileName.EndsWithOrdinal(".pyc", ignoreCase: true)) {
                                     fileName = fileName.Substring(0, fileName.Length - 1);
                                 }
 

--- a/Python/Product/Debugger/DkmDebugger/ModuleManager.cs
+++ b/Python/Product/Debugger/DkmDebugger/ModuleManager.cs
@@ -95,10 +95,10 @@ namespace Microsoft.PythonTools.DkmDebugger {
                         var name = (entry.Key as IPyBaseStringObject).ToStringOrNull();
                         if (name == "__file__") {
                             var fileName = (entry.Value.TryRead() as IPyBaseStringObject).ToStringOrNull();
-                            if (fileName != null && !fileName.EndsWith(".pyd")) {
+                            if (fileName != null && !fileName.EndsWith(".pyd", StringComparison.OrdinalIgnoreCase)) {
                                 // Unlike co_filename, __file__ usually reflects the actual name of the file from which the module
                                 // was created, which will be .pyc rather than .py if it was available, so fix that up.
-                                if (fileName.EndsWith(".pyc")) {
+                                if (fileName.EndsWith(".pyc", StringComparison.OrdinalIgnoreCase)) {
                                     fileName = fileName.Substring(0, fileName.Length - 1);
                                 }
 

--- a/Python/Product/Debugger/DkmDebugger/Proxies/Structs/PyObject.cs
+++ b/Python/Product/Debugger/DkmDebugger/Proxies/Structs/PyObject.cs
@@ -20,6 +20,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Linq.Expressions;
+using Microsoft.PythonTools.Infrastructure;
 using Microsoft.PythonTools.Parsing;
 using Microsoft.VisualStudio.Debugger;
 
@@ -99,7 +100,7 @@ namespace Microsoft.PythonTools.DkmDebugger.Proxies.Structs {
             }
 
             private static string ComputeVariableName(Type proxyType) {
-                if (!proxyType.Name.EndsWith("Object", StringComparison.Ordinal)) {
+                if (!proxyType.Name.EndsWithOrdinal("Object")) {
                     Debug.Fail("PyObject-derived type " + proxyType.Name + " must have name ending with 'Object' to infer type variable name.");
                     throw new NotSupportedException();
                 }

--- a/Python/Product/Debugger/DkmDebugger/Proxies/Structs/PyObject.cs
+++ b/Python/Product/Debugger/DkmDebugger/Proxies/Structs/PyObject.cs
@@ -99,7 +99,7 @@ namespace Microsoft.PythonTools.DkmDebugger.Proxies.Structs {
             }
 
             private static string ComputeVariableName(Type proxyType) {
-                if (!proxyType.Name.EndsWith("Object")) {
+                if (!proxyType.Name.EndsWith("Object", StringComparison.Ordinal)) {
                     Debug.Fail("PyObject-derived type " + proxyType.Name + " must have name ending with 'Object' to infer type variable name.");
                     throw new NotSupportedException();
                 }

--- a/Python/Product/Django.Analysis/DjangoAnalyzer.cs
+++ b/Python/Product/Django.Analysis/DjangoAnalyzer.cs
@@ -18,6 +18,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
@@ -122,7 +123,7 @@ namespace Microsoft.PythonTools.Django.Analysis {
                                 }
                             }
 
-                            var dict = newTags.ToDictionary(x => x.Key, x => x.Value.ToString().ToLower());
+                            var dict = newTags.ToDictionary(x => x.Key, x => x.Value.ToString().ToLowerInvariant());
                             return serializer.Serialize(dict);
                         }
                     }
@@ -308,7 +309,7 @@ namespace Microsoft.PythonTools.Django.Analysis {
                 }
 
                 foreach (var modelInst in model) {
-                    string baseName = appName + "/" + modelInst.Name.ToLower();
+                    string baseName = appName + "/" + modelInst.Name.ToLowerInvariant();
                     foreach (var suffix in templateNameSuffix.DefaultIfEmpty(defaultTemplateNameSuffix)) {
                         AddViewTemplate(unit, model, querySet, contextObjName, baseName + suffix);
                     }
@@ -336,7 +337,7 @@ namespace Microsoft.PythonTools.Django.Analysis {
                 }
             } else if (model != null) {
                 foreach (var modelInst in model) {
-                    foreach (var name in contextObjName.DefaultIfEmpty(modelInst.Name.ToLower())) {
+                    foreach (var name in contextObjName.DefaultIfEmpty(modelInst.Name.ToLowerInvariant())) {
                         tags.UpdateVariable(name, unit, modelInst.GetInstanceType());
                     }
                 }

--- a/Python/Product/Django/TemplateParsing/DjangoBlock.cs
+++ b/Python/Product/Django/TemplateParsing/DjangoBlock.cs
@@ -41,7 +41,7 @@ namespace Microsoft.PythonTools.Django.TemplateParsing {
         /// </summary>
         public static DjangoBlock Parse(string text, bool trim = false) {
             int start = 0;
-            if (text.StartsWith("{%")) {
+            if (text.StartsWith("{%", StringComparison.Ordinal)) {
                 text = DjangoVariable.GetTrimmedFilterText(text, ref start);
                 if (text == null) {
                     return null;

--- a/Python/Product/Django/TemplateParsing/DjangoBlock.cs
+++ b/Python/Product/Django/TemplateParsing/DjangoBlock.cs
@@ -20,6 +20,7 @@ using System.Linq;
 using Microsoft.VisualStudio.Language.Intellisense;
 using Microsoft.VisualStudio.Text;
 using Microsoft.PythonTools.Django.TemplateParsing.DjangoBlocks;
+using Microsoft.PythonTools.Infrastructure;
 
 namespace Microsoft.PythonTools.Django.TemplateParsing {
     class DjangoBlock {
@@ -41,7 +42,7 @@ namespace Microsoft.PythonTools.Django.TemplateParsing {
         /// </summary>
         public static DjangoBlock Parse(string text, bool trim = false) {
             int start = 0;
-            if (text.StartsWith("{%", StringComparison.Ordinal)) {
+            if (text.StartsWithOrdinal("{%")) {
                 text = DjangoVariable.GetTrimmedFilterText(text, ref start);
                 if (text == null) {
                     return null;

--- a/Python/Product/Django/TemplateParsing/DjangoBlocks/DjangoAutoEscapeBlock.cs
+++ b/Python/Product/Django/TemplateParsing/DjangoBlocks/DjangoAutoEscapeBlock.cs
@@ -14,6 +14,7 @@
 // See the Apache Version 2.0 License for specific language governing
 // permissions and limitations under the License.
 
+using Microsoft.PythonTools.Infrastructure;
 using Microsoft.VisualStudio.Language.Intellisense;
 using Microsoft.VisualStudio.Text;
 using System;
@@ -38,7 +39,7 @@ namespace Microsoft.PythonTools.Django.TemplateParsing.DjangoBlocks {
             for (int i = 0; i < args.Length; i++) {
                 var word = args[i];
                 if (!String.IsNullOrEmpty(word)) {
-                    if (word.StartsWith("\r", StringComparison.Ordinal) || word.StartsWith("\n", StringComparison.Ordinal)) {
+                    if (word.StartsWithOrdinal("\r") || word.StartsWithOrdinal("\n")) {
                         // unterminated tag
                         break;
                     }

--- a/Python/Product/Django/TemplateParsing/DjangoBlocks/DjangoAutoEscapeBlock.cs
+++ b/Python/Product/Django/TemplateParsing/DjangoBlocks/DjangoAutoEscapeBlock.cs
@@ -38,7 +38,7 @@ namespace Microsoft.PythonTools.Django.TemplateParsing.DjangoBlocks {
             for (int i = 0; i < args.Length; i++) {
                 var word = args[i];
                 if (!String.IsNullOrEmpty(word)) {
-                    if (word.StartsWith("\r") || word.StartsWith("\n")) {
+                    if (word.StartsWith("\r", StringComparison.Ordinal) || word.StartsWith("\n", StringComparison.Ordinal)) {
                         // unterminated tag
                         break;
                     }

--- a/Python/Product/Django/TemplateParsing/DjangoBlocks/DjangoTemplateTagBlock.cs
+++ b/Python/Product/Django/TemplateParsing/DjangoBlocks/DjangoTemplateTagBlock.cs
@@ -66,7 +66,7 @@ namespace Microsoft.PythonTools.Django.TemplateParsing.DjangoBlocks {
             } else if (position >= _argStart && position < _argStart + _tagType.Length) {
                 // filter based upon entered text
                 string filter = _tagType.Substring(0, position - _argStart);
-                return GetTagList().Where(tag => tag.DisplayText.StartsWith(filter));
+                return GetTagList().Where(tag => tag.DisplayText.StartsWith(filter, StringComparison.CurrentCultureIgnoreCase));
             }
             return new CompletionInfo[0];
         }

--- a/Python/Product/Django/TemplateParsing/DjangoBlocks/DjangoUrlBlock.cs
+++ b/Python/Product/Django/TemplateParsing/DjangoBlocks/DjangoUrlBlock.cs
@@ -63,17 +63,17 @@ namespace Microsoft.PythonTools.Django.TemplateParsing.DjangoBlocks {
 
                     // Get url name
                     if (urlName == null) {
-                        if (word.StartsWith("'", StringComparison.Ordinal)) {
+                        if (word.StartsWithOrdinal("'")) {
                             urlName = word.TrimStart('\'').TrimEnd('\'');
                             afterUrl = true;
-                        } else if (word.StartsWith("\"", StringComparison.Ordinal)) {
+                        } else if (word.StartsWithOrdinal("\"")) {
                             urlName = word.TrimStart('"').TrimEnd('"');
                             afterUrl = true;
                         }
                     }
 
                     // Test if word is a named parameter (but not in a string)
-                    if (word.Contains('=') && !word.StartsWith("'", StringComparison.Ordinal) && !word.StartsWith("\"", StringComparison.Ordinal)) {
+                    if (word.Contains('=') && !word.StartsWithOrdinal("'") && !word.StartsWithOrdinal("\"")) {
                         usedNamedParameters.Add(word.Split('=').First());
                     }
                 }

--- a/Python/Product/Django/TemplateParsing/DjangoBlocks/DjangoUrlBlock.cs
+++ b/Python/Product/Django/TemplateParsing/DjangoBlocks/DjangoUrlBlock.cs
@@ -63,17 +63,17 @@ namespace Microsoft.PythonTools.Django.TemplateParsing.DjangoBlocks {
 
                     // Get url name
                     if (urlName == null) {
-                        if (word.StartsWith("'")) {
+                        if (word.StartsWith("'", StringComparison.Ordinal)) {
                             urlName = word.TrimStart('\'').TrimEnd('\'');
                             afterUrl = true;
-                        } else if (word.StartsWith("\"")) {
+                        } else if (word.StartsWith("\"", StringComparison.Ordinal)) {
                             urlName = word.TrimStart('"').TrimEnd('"');
                             afterUrl = true;
                         }
                     }
 
                     // Test if word is a named parameter (but not in a string)
-                    if (word.Contains('=') && !word.StartsWith("'") && !word.StartsWith("\"")) {
+                    if (word.Contains('=') && !word.StartsWith("'", StringComparison.Ordinal) && !word.StartsWith("\"", StringComparison.Ordinal)) {
                         usedNamedParameters.Add(word.Split('=').First());
                     }
                 }

--- a/Python/Product/Django/TemplateParsing/DjangoVariable.cs
+++ b/Python/Product/Django/TemplateParsing/DjangoVariable.cs
@@ -80,7 +80,7 @@ namespace Microsoft.PythonTools.Django.TemplateParsing {
         }
 
         public static DjangoVariable Parse(string filterText, int start = 0) {
-            if (filterText.StartsWith("{{")) {
+            if (filterText.StartsWith("{{", StringComparison.Ordinal)) {
                 filterText = GetTrimmedFilterText(filterText, ref start);
                 if (filterText == null) {
                     return null;
@@ -144,7 +144,7 @@ namespace Microsoft.PythonTools.Django.TemplateParsing {
                 }
             }
             if (tmpStart != null) {
-                if (text.EndsWith("%}") || text.EndsWith("}}")) {
+                if (text.EndsWith("%}", StringComparison.Ordinal) || text.EndsWith("}}", StringComparison.Ordinal)) {
                     for (int i = text.Length - 3; i >= tmpStart.Value; i--) {
                         if (!Char.IsWhiteSpace(text[i])) {
                             filterText = text.Substring(tmpStart.Value, i + 1 - tmpStart.Value);

--- a/Python/Product/Django/TemplateParsing/DjangoVariable.cs
+++ b/Python/Product/Django/TemplateParsing/DjangoVariable.cs
@@ -19,6 +19,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 using Microsoft.PythonTools.Django.Analysis;
+using Microsoft.PythonTools.Infrastructure;
 using Microsoft.PythonTools.Interpreter;
 using Microsoft.VisualStudio.Language.Intellisense;
 
@@ -80,7 +81,7 @@ namespace Microsoft.PythonTools.Django.TemplateParsing {
         }
 
         public static DjangoVariable Parse(string filterText, int start = 0) {
-            if (filterText.StartsWith("{{", StringComparison.Ordinal)) {
+            if (filterText.StartsWithOrdinal("{{")) {
                 filterText = GetTrimmedFilterText(filterText, ref start);
                 if (filterText == null) {
                     return null;
@@ -144,7 +145,7 @@ namespace Microsoft.PythonTools.Django.TemplateParsing {
                 }
             }
             if (tmpStart != null) {
-                if (text.EndsWith("%}", StringComparison.Ordinal) || text.EndsWith("}}", StringComparison.Ordinal)) {
+                if (text.EndsWithOrdinal("%}") || text.EndsWithOrdinal("}}")) {
                     for (int i = text.Length - 3; i >= tmpStart.Value; i--) {
                         if (!Char.IsWhiteSpace(text[i])) {
                             filterText = text.Substring(tmpStart.Value, i + 1 - tmpStart.Value);

--- a/Python/Product/Django/TemplateParsing/TemplateArtifactCollection.cs
+++ b/Python/Product/Django/TemplateParsing/TemplateArtifactCollection.cs
@@ -19,6 +19,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Html.Core.Artifacts;
 using Microsoft.Html.Core.Parser.Def;
+using Microsoft.PythonTools.Infrastructure;
 using Microsoft.Web.Core.Text;
 
 namespace Microsoft.PythonTools.Django.TemplateParsing {
@@ -98,7 +99,7 @@ namespace Microsoft.PythonTools.Django.TemplateParsing {
                 // { and % or added { to the existing % so extend search range accordingly.
                 int fragmentStart = Math.Max(0, start - leftSeparator.Length + 1);
                 int fragmentEnd = Math.Min(newText.Length, start + newLength + leftSeparator.Length - 1);
-                return newText.IndexOf(leftSeparator, fragmentStart, fragmentEnd - fragmentStart, true) >= 0;
+                return newText.IndexOfOrdinal(leftSeparator, fragmentStart, fragmentEnd - fragmentStart, true) >= 0;
             }
 
             // Is change completely inside an existing item?

--- a/Python/Product/EnvironmentsList/DBExtension.xaml.cs
+++ b/Python/Product/EnvironmentsList/DBExtension.xaml.cs
@@ -241,7 +241,7 @@ namespace Microsoft.PythonTools.EnvironmentsList {
                 package._moduleCount = 1;
 
                 var dotName = package._fullname + ".";
-                for (++i; i < modules.Count && modules[i].StartsWith(dotName, StringComparison.Ordinal); ++i) {
+                for (++i; i < modules.Count && modules[i].StartsWithOrdinal(dotName); ++i) {
                     package._isUpToDate &= knownModules == null ||
                         knownModules.Contains(modules[i]) == areKnownModulesUpToDate;
                     package._moduleCount += 1;

--- a/Python/Product/IronPython/Debugger/IronPythonLauncher.cs
+++ b/Python/Product/IronPython/Debugger/IronPythonLauncher.cs
@@ -88,7 +88,7 @@ namespace Microsoft.IronPythonTools.Debugger {
                 if (debug) {
                     if (string.IsNullOrEmpty(config.InterpreterArguments)) {
                         config.InterpreterArguments = "-X:Debug";
-                    } else if (config.InterpreterArguments.IndexOf("-X:Debug", StringComparison.InvariantCultureIgnoreCase) < 0) {
+                    } else if (config.InterpreterArguments.IndexOf("-X:Debug", StringComparison.OrdinalIgnoreCase) < 0) {
                         config.InterpreterArguments = "-X:Debug " + config.InterpreterArguments;
                     }
 

--- a/Python/Product/IronPython/Interpreter/RemoteInterpreter.cs
+++ b/Python/Product/IronPython/Interpreter/RemoteInterpreter.cs
@@ -28,6 +28,7 @@ using IronPython.Modules;
 using IronPython.Runtime;
 using IronPython.Runtime.Operations;
 using IronPython.Runtime.Types;
+using Microsoft.PythonTools.Infrastructure;
 using Microsoft.PythonTools.Interpreter;
 using Microsoft.Scripting;
 using Microsoft.Scripting.Actions;
@@ -870,7 +871,7 @@ namespace Microsoft.IronPythonTools.Interpreter {
                     BuiltinFunction overload = (ov as BuiltinFunction);
                     if (overload.Overloads.Targets[0].DeclaringType.IsAssignableFrom(func.DeclaringType) ||
                         (overload.Overloads.Targets[0].DeclaringType.FullName != null &&
-                        overload.Overloads.Targets[0].DeclaringType.FullName.StartsWith("IronPython.Runtime.Operations.", StringComparison.Ordinal))) {
+                        overload.Overloads.Targets[0].DeclaringType.FullName.StartsWithOrdinal("IronPython.Runtime.Operations."))) {
                         result.Add(MakeHandle(overload.Targets[0]));
                     }
                 }

--- a/Python/Product/IronPython/Interpreter/RemoteInterpreter.cs
+++ b/Python/Product/IronPython/Interpreter/RemoteInterpreter.cs
@@ -63,6 +63,7 @@ namespace Microsoft.IronPythonTools.Interpreter {
             : this(Python.CreateEngine(new Dictionary<string, object> { { "NoAssemblyResolveHook", true } })) {
         }
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Reliability", "CA2001:AvoidCallingProblematicMethods", MessageId = "System.Reflection.Assembly.LoadFile")]
         public RemoteInterpreter(ScriptEngine engine) {
             AppDomain.CurrentDomain.AssemblyResolve += CurrentDomain_AssemblyResolve;
 
@@ -328,6 +329,7 @@ namespace Microsoft.IronPythonTools.Interpreter {
             });
         }
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Reliability", "CA2001:AvoidCallingProblematicMethods", MessageId = "System.Reflection.Assembly.LoadFrom")]
         internal ObjectHandle LoadAssemblyFrom(string path) {
             return CallAndHandle(() => {
                 var res = Assembly.LoadFrom(path);
@@ -868,7 +870,7 @@ namespace Microsoft.IronPythonTools.Interpreter {
                     BuiltinFunction overload = (ov as BuiltinFunction);
                     if (overload.Overloads.Targets[0].DeclaringType.IsAssignableFrom(func.DeclaringType) ||
                         (overload.Overloads.Targets[0].DeclaringType.FullName != null &&
-                        overload.Overloads.Targets[0].DeclaringType.FullName.StartsWith("IronPython.Runtime.Operations."))) {
+                        overload.Overloads.Targets[0].DeclaringType.FullName.StartsWith("IronPython.Runtime.Operations.", StringComparison.Ordinal))) {
                         result.Add(MakeHandle(overload.Targets[0]));
                     }
                 }

--- a/Python/Product/IronPythonResolver/Resolver.cs
+++ b/Python/Product/IronPythonResolver/Resolver.cs
@@ -21,6 +21,7 @@ using Microsoft.Win32;
 
 namespace Microsoft.IronPythonTools.Interpreter {
     internal class IronPythonResolver {
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Reliability", "CA2001")]
         public static Assembly domain_AssemblyResolve(object sender, ResolveEventArgs args) {
             var pythonInstallDir = GetPythonInstallDir();
             var asmName = new AssemblyName(args.Name);

--- a/Python/Product/Profiling/Profiling/ProfilingSessionEditorFactory.cs
+++ b/Python/Product/Profiling/Profiling/ProfilingSessionEditorFactory.cs
@@ -21,6 +21,7 @@ using System.IO;
 using System.Runtime.InteropServices;
 using System.Security.Permissions;
 using System.Windows;
+using System.Xml;
 using Microsoft.PythonTools.Infrastructure;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Shell;
@@ -144,6 +145,7 @@ namespace Microsoft.PythonTools.Profiling {
         /// <param name="pgrfCDW">Flags for CreateDocumentWindow</param>
         /// <returns></returns>
         [SecurityPermission(SecurityAction.Demand, Flags = SecurityPermissionFlag.UnmanagedCode)]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security.Xml", "CA3053:UseXmlSecureResolver")]
         public int CreateEditorInstance(
                         uint grfCreateDoc,
                         string pszMkDocument,
@@ -178,9 +180,10 @@ namespace Microsoft.PythonTools.Profiling {
 
             ProfilingTarget target;
             try {
-                using (var fs = new FileStream(pszMkDocument, FileMode.Open)) {
-                    target = (ProfilingTarget)ProfilingTarget.Serializer.Deserialize(fs);
-                    fs.Close();
+                var settings = new XmlReaderSettings { XmlResolver = null };
+                using (var fs = new FileStream(pszMkDocument, FileMode.Open))
+                using (var reader = XmlReader.Create(fs, settings)) {
+                    target = (ProfilingTarget)ProfilingTarget.Serializer.Deserialize(reader);
                 }
             } catch (IOException e) {
                 MessageBox.Show(Strings.FailedToOpenPerformanceSessionFile.FormatUI(pszMkDocument, e.Message), Strings.ProductTitle);

--- a/Python/Product/Profiling/Profiling/SessionsNode.cs
+++ b/Python/Product/Profiling/Profiling/SessionsNode.cs
@@ -47,7 +47,7 @@ namespace Microsoft.PythonTools.Profiling {
         }
 
         internal SessionNode AddTarget(ProfilingTarget target, string filename, bool save) {
-            Debug.Assert(filename.EndsWith(".pyperf"));
+            Debug.Assert(filename.EndsWithOrdinal(".pyperf", ignoreCase: true));
 
             // ensure a unique name
             string newBaseName = Path.GetFileNameWithoutExtension(filename);

--- a/Python/Product/ProjectWizards/CloudServiceWizard.cs
+++ b/Python/Product/ProjectWizards/CloudServiceWizard.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Reflection;
 using System.Runtime.CompilerServices;
@@ -101,7 +102,7 @@ namespace Microsoft.PythonTools.ProjectWizards {
                     // install the required packages.
                     var asm = Assembly.Load("Microsoft.VisualStudio.CloudService.Wizard,Version=1.0.0.0,Culture=neutral,PublicKeyToken=b03f5f7f11d50a3a");
                     var type = asm.GetType("Microsoft.VisualStudio.CloudService.Wizard.CloudServiceWizard");
-                    _wizard = type.InvokeMember(null, BindingFlags.CreateInstance, null, null, new object[0]) as IWizard;
+                    _wizard = type.InvokeMember(null, BindingFlags.CreateInstance, null, null, new object[0], CultureInfo.CurrentCulture) as IWizard;
                 }
             } catch (ArgumentException) {
             } catch (BadImageFormatException) {

--- a/Python/Product/ProjectWizards/CookiecutterWizard.cs
+++ b/Python/Product/ProjectWizards/CookiecutterWizard.cs
@@ -156,7 +156,7 @@ namespace Microsoft.PythonTools.ProjectWizards {
 
         private static Uri Resolve(Uri uri) {
             var hosts = new string[] { "go.microsoft.com", "aka.ms" };
-            if (!hosts.Any(h => uri.Host.StartsWith(h, StringComparison.InvariantCultureIgnoreCase))) {
+            if (!hosts.Any(h => uri.Host.StartsWith(h, StringComparison.OrdinalIgnoreCase))) {
                 return uri;
             }
 

--- a/Python/Product/ProjectWizards/CookiecutterWizard.cs
+++ b/Python/Product/ProjectWizards/CookiecutterWizard.cs
@@ -156,7 +156,7 @@ namespace Microsoft.PythonTools.ProjectWizards {
 
         private static Uri Resolve(Uri uri) {
             var hosts = new string[] { "go.microsoft.com", "aka.ms" };
-            if (!hosts.Any(h => uri.Host.StartsWith(h, StringComparison.OrdinalIgnoreCase))) {
+            if (!hosts.Any(h => uri.Host.StartsWithOrdinal(h, ignoreCase: true))) {
                 return uri;
             }
 

--- a/Python/Product/PythonTools/PythonTools/CodeCoverage/CoveragePyConverter.cs
+++ b/Python/Product/PythonTools/PythonTools/CodeCoverage/CoveragePyConverter.cs
@@ -34,9 +34,12 @@ namespace Microsoft.PythonTools.CodeCoverage {
             _input = input;
         }
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security.Xml", "CA3053:UseXmlSecureResolver")]
         public CoverageFileInfo[] Parse() {
-            XmlDocument doc = new XmlDocument();
-            doc.Load(_input);
+            XmlDocument doc = new XmlDocument { XmlResolver = null };
+            var settings = new XmlReaderSettings { XmlResolver = null };
+            using (var reader = XmlReader.Create(_input, settings))
+                doc.Load(reader);
             Dictionary<string, HashSet<int>> data = new Dictionary<string, HashSet<int>>();
 
             var root = doc.DocumentElement.CreateNavigator();

--- a/Python/Product/PythonTools/PythonTools/Commands/FillParagraphCommand.cs
+++ b/Python/Product/PythonTools/PythonTools/Commands/FillParagraphCommand.cs
@@ -163,7 +163,7 @@ namespace Microsoft.PythonTools.Commands {
 
         private bool PrevNotParaStart(FillPrefix prefix, int prev_num, int ln_num, string prev_txt, Regex regexp) {
             var notBufFirstLn = prev_num != ln_num;
-            var notFileDocStrAndHasPrefix = !string.IsNullOrEmpty(prefix.Prefix) && prev_txt.StartsWith(prefix.Prefix);
+            var notFileDocStrAndHasPrefix = !string.IsNullOrEmpty(prefix.Prefix) && prev_txt.StartsWith(prefix.Prefix, StringComparison.Ordinal);
             var isFileDocStrAndNotEmptyLine = string.IsNullOrEmpty(prefix.Prefix) && !string.IsNullOrEmpty(prev_txt);
             var notDocStringOrNoTripleQuotesYet = !(prefix.IsDocString && regexp.Match(prev_txt).Success);
             return (notBufFirstLn &&
@@ -222,7 +222,7 @@ namespace Microsoft.PythonTools.Commands {
 
         private bool NextNotParaEnd(FillPrefix prefix, int next_num, int ln_num, string next_txt, Regex regexp) {
             var notBufLastLn = next_num != ln_num;
-            var notFileDocStrAndHasPrefix = !string.IsNullOrEmpty(prefix.Prefix) && next_txt.StartsWith(prefix.Prefix);
+            var notFileDocStrAndHasPrefix = !string.IsNullOrEmpty(prefix.Prefix) && next_txt.StartsWith(prefix.Prefix, StringComparison.Ordinal);
             var isFileDocStrAndNotEmptyLine = string.IsNullOrEmpty(prefix.Prefix) && string.IsNullOrEmpty(next_txt);
             var notDocStringOrNoTripleQuotesYet = !(prefix.IsDocString && regexp.Match(next_txt).Success);
             return (notBufLastLn &&

--- a/Python/Product/PythonTools/PythonTools/Commands/FillParagraphCommand.cs
+++ b/Python/Product/PythonTools/PythonTools/Commands/FillParagraphCommand.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Text;
 using System.Text.RegularExpressions;
+using Microsoft.PythonTools.Infrastructure;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Language.StandardClassification;
 using Microsoft.VisualStudio.OLE.Interop;
@@ -163,7 +164,7 @@ namespace Microsoft.PythonTools.Commands {
 
         private bool PrevNotParaStart(FillPrefix prefix, int prev_num, int ln_num, string prev_txt, Regex regexp) {
             var notBufFirstLn = prev_num != ln_num;
-            var notFileDocStrAndHasPrefix = !string.IsNullOrEmpty(prefix.Prefix) && prev_txt.StartsWith(prefix.Prefix, StringComparison.Ordinal);
+            var notFileDocStrAndHasPrefix = !string.IsNullOrEmpty(prefix.Prefix) && prev_txt.StartsWithOrdinal(prefix.Prefix);
             var isFileDocStrAndNotEmptyLine = string.IsNullOrEmpty(prefix.Prefix) && !string.IsNullOrEmpty(prev_txt);
             var notDocStringOrNoTripleQuotesYet = !(prefix.IsDocString && regexp.Match(prev_txt).Success);
             return (notBufFirstLn &&
@@ -222,7 +223,7 @@ namespace Microsoft.PythonTools.Commands {
 
         private bool NextNotParaEnd(FillPrefix prefix, int next_num, int ln_num, string next_txt, Regex regexp) {
             var notBufLastLn = next_num != ln_num;
-            var notFileDocStrAndHasPrefix = !string.IsNullOrEmpty(prefix.Prefix) && next_txt.StartsWith(prefix.Prefix, StringComparison.Ordinal);
+            var notFileDocStrAndHasPrefix = !string.IsNullOrEmpty(prefix.Prefix) && next_txt.StartsWithOrdinal(prefix.Prefix);
             var isFileDocStrAndNotEmptyLine = string.IsNullOrEmpty(prefix.Prefix) && string.IsNullOrEmpty(next_txt);
             var notDocStringOrNoTripleQuotesYet = !(prefix.IsDocString && regexp.Match(next_txt).Success);
             return (notBufLastLn &&

--- a/Python/Product/PythonTools/PythonTools/Commands/SendToReplCommand.cs
+++ b/Python/Product/PythonTools/PythonTools/Commands/SendToReplCommand.cs
@@ -78,7 +78,7 @@ namespace Microsoft.PythonTools.Commands {
             if (selection.StreamSelectionSpan.Length > 0) {
                 // Easy, just send the selection to the interactive window.
                 input = activeView.Selection.StreamSelectionSpan.GetText();
-                if (!input.EndsWith("\n") && !input.EndsWith("\r")) {
+                if (!input.EndsWithOrdinal("\n") && !input.EndsWithOrdinal("\r")) {
                     input += activeView.Options.GetNewLineCharacter();
                 }
                 focusRepl = true;

--- a/Python/Product/PythonTools/PythonTools/Debugger/DebugLaunchHelper.cs
+++ b/Python/Product/PythonTools/PythonTools/Debugger/DebugLaunchHelper.cs
@@ -280,7 +280,7 @@ namespace Microsoft.PythonTools.Debugger {
         }
 
         private static string UnquotePath(string p) {
-            if (string.IsNullOrEmpty(p) || !p.StartsWith("\"") || !p.EndsWith("\"")) {
+            if (string.IsNullOrEmpty(p) || !p.StartsWith("\"", StringComparison.Ordinal) || !p.EndsWith("\"", StringComparison.Ordinal)) {
                 return p;
             }
             return p.Substring(1, p.Length - 2);

--- a/Python/Product/PythonTools/PythonTools/Debugger/DebugLaunchHelper.cs
+++ b/Python/Product/PythonTools/PythonTools/Debugger/DebugLaunchHelper.cs
@@ -280,7 +280,7 @@ namespace Microsoft.PythonTools.Debugger {
         }
 
         private static string UnquotePath(string p) {
-            if (string.IsNullOrEmpty(p) || !p.StartsWith("\"", StringComparison.Ordinal) || !p.EndsWith("\"", StringComparison.Ordinal)) {
+            if (string.IsNullOrEmpty(p) || !p.StartsWithOrdinal("\"") || !p.EndsWithOrdinal("\"")) {
                 return p;
             }
             return p.Substring(1, p.Length - 2);

--- a/Python/Product/PythonTools/PythonTools/Intellisense/AnalysisEntryService.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/AnalysisEntryService.cs
@@ -329,7 +329,7 @@ namespace Microsoft.PythonTools.Intellisense {
                     var withSlash = "\\" + filename;
                     foreach (var project in sln.EnumerateLoadedPythonProjects()) {
                         if (project.AllVisibleDescendants.Any(n => n.Url.Equals(filename, StringComparison.OrdinalIgnoreCase) ||
-                            n.Url.EndsWith(withSlash, StringComparison.OrdinalIgnoreCase))) {
+                            n.Url.EndsWithOrdinal(withSlash, ignoreCase: true))) {
                             var analyzer = project.GetAnalyzer();
                             if (analyzer != null && seen.Add(analyzer)) {
                                 yield return analyzer;

--- a/Python/Product/PythonTools/PythonTools/Intellisense/CodeCellAnalysis.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/CodeCellAnalysis.cs
@@ -14,6 +14,7 @@
 // See the Apache Version 2.0 License for specific language governing
 // permissions and limitations under the License.
 
+using System;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using Microsoft.VisualStudio.Text;
@@ -57,7 +58,7 @@ namespace Microsoft.PythonTools.Intellisense {
                     break;
                 } else if (string.IsNullOrWhiteSpace(text)) {
                     seenWhitespace = true;
-                } else if (text.TrimStart().StartsWith("#")) {
+                } else if (text.TrimStart().StartsWith("#", StringComparison.Ordinal)) {
                     // In a comment that may precede a cell, so keep looking
                     seenComment = true;
                 } else {
@@ -79,7 +80,7 @@ namespace Microsoft.PythonTools.Intellisense {
                         break;
                     } else if (string.IsNullOrWhiteSpace(text)) {
                         // Still not sure
-                    } else if (text.TrimStart().StartsWith("#")) {
+                    } else if (text.TrimStart().StartsWith("#", StringComparison.Ordinal)) {
                         // In the following cell
                         break;
                     } else {
@@ -106,7 +107,7 @@ namespace Microsoft.PythonTools.Intellisense {
                 } else if (string.IsNullOrWhiteSpace(text)) {
                     // Keep looking for top of the comment. If we don't find
                     // one, we won't want to have updated the start line.
-                } else if (text.TrimStart().StartsWith("#")) {
+                } else if (text.TrimStart().StartsWith("#", StringComparison.Ordinal)) {
                     // Update the start to this line
                     start = current;
                 } else {
@@ -157,7 +158,7 @@ namespace Microsoft.PythonTools.Intellisense {
                         // Not inside the next comment yet, so keep the whitespace.
                         endInclWhitespace = current;
                     }
-                } else if (text.TrimStart().StartsWith("#")) {
+                } else if (text.TrimStart().StartsWith("#", StringComparison.Ordinal)) {
                     // Keep looking for the next cell marker. If we find it, we
                     // won't want to have updated the end line.
                     endInclComment = current;

--- a/Python/Product/PythonTools/PythonTools/Intellisense/CodeCellAnalysis.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/CodeCellAnalysis.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
+using Microsoft.PythonTools.Infrastructure;
 using Microsoft.VisualStudio.Text;
 
 namespace Microsoft.PythonTools.Intellisense {
@@ -58,7 +59,7 @@ namespace Microsoft.PythonTools.Intellisense {
                     break;
                 } else if (string.IsNullOrWhiteSpace(text)) {
                     seenWhitespace = true;
-                } else if (text.TrimStart().StartsWith("#", StringComparison.Ordinal)) {
+                } else if (text.TrimStart().StartsWithOrdinal("#")) {
                     // In a comment that may precede a cell, so keep looking
                     seenComment = true;
                 } else {
@@ -80,7 +81,7 @@ namespace Microsoft.PythonTools.Intellisense {
                         break;
                     } else if (string.IsNullOrWhiteSpace(text)) {
                         // Still not sure
-                    } else if (text.TrimStart().StartsWith("#", StringComparison.Ordinal)) {
+                    } else if (text.TrimStart().StartsWithOrdinal("#")) {
                         // In the following cell
                         break;
                     } else {
@@ -107,7 +108,7 @@ namespace Microsoft.PythonTools.Intellisense {
                 } else if (string.IsNullOrWhiteSpace(text)) {
                     // Keep looking for top of the comment. If we don't find
                     // one, we won't want to have updated the start line.
-                } else if (text.TrimStart().StartsWith("#", StringComparison.Ordinal)) {
+                } else if (text.TrimStart().StartsWithOrdinal("#")) {
                     // Update the start to this line
                     start = current;
                 } else {
@@ -158,7 +159,7 @@ namespace Microsoft.PythonTools.Intellisense {
                         // Not inside the next comment yet, so keep the whitespace.
                         endInclWhitespace = current;
                     }
-                } else if (text.TrimStart().StartsWith("#", StringComparison.Ordinal)) {
+                } else if (text.TrimStart().StartsWithOrdinal("#")) {
                     // Keep looking for the next cell marker. If we find it, we
                     // won't want to have updated the end line.
                     endInclComment = current;

--- a/Python/Product/PythonTools/PythonTools/Intellisense/CompletionComparer.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/CompletionComparer.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Collections.Generic;
 using Microsoft.PythonTools.Analysis;
+using Microsoft.PythonTools.Infrastructure;
 using Microsoft.VisualStudio.Language.Intellisense;
 
 namespace Microsoft.PythonTools.Intellisense {
@@ -53,16 +54,16 @@ namespace Microsoft.PythonTools.Intellisense {
             }
 
             if (_sortUnderscoresLast) {
-                bool xUnder = xName.StartsWith("__", StringComparison.Ordinal) && xName.EndsWith("__", StringComparison.Ordinal);
-                bool yUnder = yName.StartsWith("__", StringComparison.Ordinal) && yName.EndsWith("__", StringComparison.Ordinal);
+                bool xUnder = xName.StartsWithOrdinal("__") && xName.EndsWithOrdinal("__");
+                bool yUnder = yName.StartsWithOrdinal("__") && yName.EndsWithOrdinal("__");
 
                 if (xUnder != yUnder) {
                     // The one that starts with an underscore comes later
                     return xUnder ? 1 : -1;
                 }
 
-                bool xSingleUnder = xName.StartsWith("_", StringComparison.Ordinal);
-                bool ySingleUnder = yName.StartsWith("_", StringComparison.Ordinal);
+                bool xSingleUnder = xName.StartsWithOrdinal("_");
+                bool ySingleUnder = yName.StartsWithOrdinal("_");
                 if (xSingleUnder != ySingleUnder) {
                     // The one that starts with an underscore comes later
                     return xSingleUnder ? 1 : -1;

--- a/Python/Product/PythonTools/PythonTools/Intellisense/CompletionComparer.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/CompletionComparer.cs
@@ -53,16 +53,16 @@ namespace Microsoft.PythonTools.Intellisense {
             }
 
             if (_sortUnderscoresLast) {
-                bool xUnder = xName.StartsWith("__") && xName.EndsWith("__");
-                bool yUnder = yName.StartsWith("__") && yName.EndsWith("__");
+                bool xUnder = xName.StartsWith("__", StringComparison.Ordinal) && xName.EndsWith("__", StringComparison.Ordinal);
+                bool yUnder = yName.StartsWith("__", StringComparison.Ordinal) && yName.EndsWith("__", StringComparison.Ordinal);
 
                 if (xUnder != yUnder) {
                     // The one that starts with an underscore comes later
                     return xUnder ? 1 : -1;
                 }
 
-                bool xSingleUnder = xName.StartsWith("_");
-                bool ySingleUnder = yName.StartsWith("_");
+                bool xSingleUnder = xName.StartsWith("_", StringComparison.Ordinal);
+                bool ySingleUnder = yName.StartsWith("_", StringComparison.Ordinal);
                 if (xSingleUnder != ySingleUnder) {
                     // The one that starts with an underscore comes later
                     return xSingleUnder ? 1 : -1;

--- a/Python/Product/PythonTools/PythonTools/Intellisense/ExpansionClient.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/ExpansionClient.cs
@@ -161,7 +161,7 @@ namespace Microsoft.PythonTools.Intellisense {
                     templateText = templateText.Replace("$end$", "");
 
                     // we can finally figure out where the selected text began witin the original template...
-                    int selectedIndex = templateText.IndexOf("$selected$", StringComparison.OrdinalIgnoreCase);
+                    int selectedIndex = templateText.IndexOfOrdinal("$selected$", ignoreCase: true);
                     if (selectedIndex != -1) {
                         var selection = _textView.Selection;
                         

--- a/Python/Product/PythonTools/PythonTools/Intellisense/ExpansionClient.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/ExpansionClient.cs
@@ -161,7 +161,7 @@ namespace Microsoft.PythonTools.Intellisense {
                     templateText = templateText.Replace("$end$", "");
 
                     // we can finally figure out where the selected text began witin the original template...
-                    int selectedIndex = templateText.IndexOf("$selected$");
+                    int selectedIndex = templateText.IndexOf("$selected$", StringComparison.OrdinalIgnoreCase);
                     if (selectedIndex != -1) {
                         var selection = _textView.Selection;
                         

--- a/Python/Product/PythonTools/PythonTools/Intellisense/FuzzyCompletionSet.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/FuzzyCompletionSet.cs
@@ -297,7 +297,7 @@ namespace Microsoft.PythonTools.Intellisense {
         }
 
         private void FilterToText(string filterText) {
-            bool hideAdvanced = _shouldHideAdvanced && !filterText.StartsWith("__", StringComparison.Ordinal);
+            bool hideAdvanced = _shouldHideAdvanced && !filterText.StartsWithOrdinal("__");
             bool anyVisible = false;
             foreach (var c in _completions.Cast<DynamicallyVisibleCompletion>()) {
                 if (hideAdvanced && IsAdvanced(c)) {

--- a/Python/Product/PythonTools/PythonTools/Intellisense/FuzzyCompletionSet.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/FuzzyCompletionSet.cs
@@ -297,7 +297,7 @@ namespace Microsoft.PythonTools.Intellisense {
         }
 
         private void FilterToText(string filterText) {
-            bool hideAdvanced = _shouldHideAdvanced && !filterText.StartsWith("__");
+            bool hideAdvanced = _shouldHideAdvanced && !filterText.StartsWith("__", StringComparison.Ordinal);
             bool anyVisible = false;
             foreach (var c in _completions.Cast<DynamicallyVisibleCompletion>()) {
                 if (hideAdvanced && IsAdvanced(c)) {

--- a/Python/Product/PythonTools/PythonTools/Intellisense/FuzzyStringMatcher.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/FuzzyStringMatcher.cs
@@ -88,9 +88,9 @@ namespace Microsoft.PythonTools.Intellisense {
         }
 
         static int PrefixMatch(string text, string pattern, bool ignoreCase) {
-            if (text.StartsWith(pattern, StringComparison.InvariantCulture) || text.StartsWith(pattern, StringComparison.CurrentCulture)) {
+            if (text.StartsWith(pattern, StringComparison.Ordinal) || text.StartsWith(pattern, StringComparison.CurrentCulture)) {
                 return pattern.Length * 2 + (text.Length == pattern.Length ? 1 : 0);
-            } else if (ignoreCase && (text.StartsWith(pattern, StringComparison.InvariantCultureIgnoreCase) || text.StartsWith(pattern, StringComparison.CurrentCultureIgnoreCase))) {
+            } else if (ignoreCase && (text.StartsWith(pattern, StringComparison.OrdinalIgnoreCase) || text.StartsWith(pattern, StringComparison.CurrentCultureIgnoreCase))) {
                 return pattern.Length + (text.Length == pattern.Length ? 1 : 0);
             } else {
                 return 0;
@@ -98,7 +98,7 @@ namespace Microsoft.PythonTools.Intellisense {
         }
 
         static int SubstringMatch(string text, string pattern, bool ignoreCase) {
-            int position = text.IndexOf(pattern, StringComparison.InvariantCulture);
+            int position = text.IndexOf(pattern, StringComparison.Ordinal);
             if (position >= 0) {
                 return pattern.Length * 2 + (position == 0 ? 1 : 0);
             }
@@ -107,7 +107,7 @@ namespace Microsoft.PythonTools.Intellisense {
                 return pattern.Length * 2 + (position == 0 ? 1 : 0);
             }
             if (ignoreCase) {
-                position = text.IndexOf(pattern, StringComparison.InvariantCultureIgnoreCase);
+                position = text.IndexOf(pattern, StringComparison.OrdinalIgnoreCase);
                 if (position >= 0) {
                     return pattern.Length + (position == 0 ? 1 : 0);
                 }

--- a/Python/Product/PythonTools/PythonTools/Intellisense/FuzzyStringMatcher.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/FuzzyStringMatcher.cs
@@ -18,6 +18,7 @@ using System;
 using System.Diagnostics;
 using System.Globalization;
 using System.Text.RegularExpressions;
+using Microsoft.PythonTools.Infrastructure;
 
 namespace Microsoft.PythonTools.Intellisense {
     /// <summary>
@@ -88,9 +89,9 @@ namespace Microsoft.PythonTools.Intellisense {
         }
 
         static int PrefixMatch(string text, string pattern, bool ignoreCase) {
-            if (text.StartsWith(pattern, StringComparison.Ordinal) || text.StartsWith(pattern, StringComparison.CurrentCulture)) {
+            if (text.StartsWithOrdinal(pattern) || text.StartsWith(pattern, StringComparison.CurrentCulture)) {
                 return pattern.Length * 2 + (text.Length == pattern.Length ? 1 : 0);
-            } else if (ignoreCase && (text.StartsWith(pattern, StringComparison.OrdinalIgnoreCase) || text.StartsWith(pattern, StringComparison.CurrentCultureIgnoreCase))) {
+            } else if (ignoreCase && (text.StartsWithOrdinal(pattern, ignoreCase: true) || text.StartsWith(pattern, StringComparison.CurrentCultureIgnoreCase))) {
                 return pattern.Length + (text.Length == pattern.Length ? 1 : 0);
             } else {
                 return 0;

--- a/Python/Product/PythonTools/PythonTools/Intellisense/FuzzyStringMatcher.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/FuzzyStringMatcher.cs
@@ -99,7 +99,7 @@ namespace Microsoft.PythonTools.Intellisense {
         }
 
         static int SubstringMatch(string text, string pattern, bool ignoreCase) {
-            int position = text.IndexOf(pattern, StringComparison.Ordinal);
+            int position = text.IndexOfOrdinal(pattern);
             if (position >= 0) {
                 return pattern.Length * 2 + (position == 0 ? 1 : 0);
             }
@@ -108,7 +108,7 @@ namespace Microsoft.PythonTools.Intellisense {
                 return pattern.Length * 2 + (position == 0 ? 1 : 0);
             }
             if (ignoreCase) {
-                position = text.IndexOf(pattern, StringComparison.OrdinalIgnoreCase);
+                position = text.IndexOfOrdinal(pattern, ignoreCase: true);
                 if (position >= 0) {
                     return pattern.Length + (position == 0 ? 1 : 0);
                 }

--- a/Python/Product/PythonTools/PythonTools/Intellisense/OVERRIDECOMPLETIONANALYSIS.CS
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/OVERRIDECOMPLETIONANALYSIS.CS
@@ -36,7 +36,7 @@ namespace Microsoft.PythonTools.Intellisense {
             var start = _stopwatch.ElapsedMilliseconds;
 
             var line = Span.GetStartPoint(TextBuffer.CurrentSnapshot).GetContainingLine();
-            var startPos = line.Start.Position + line.GetText().IndexOf("def", StringComparison.Ordinal);
+            var startPos = line.Start.Position + line.GetText().IndexOfOrdinal("def");
 
             var analysis = GetAnalysisEntry();
             if (analysis == null) {
@@ -44,7 +44,7 @@ namespace Microsoft.PythonTools.Intellisense {
             }
 
             var span = Span.GetSpan(TextBuffer.CurrentSnapshot);
-            int defIndent = span.Start.GetContainingLine().GetText().IndexOf("def", StringComparison.Ordinal);
+            int defIndent = span.Start.GetContainingLine().GetText().IndexOfOrdinal("def");
 
             string indentation;
             if (_options.ConvertTabsToSpaces) {

--- a/Python/Product/PythonTools/PythonTools/Intellisense/OVERRIDECOMPLETIONANALYSIS.CS
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/OVERRIDECOMPLETIONANALYSIS.CS
@@ -36,7 +36,7 @@ namespace Microsoft.PythonTools.Intellisense {
             var start = _stopwatch.ElapsedMilliseconds;
 
             var line = Span.GetStartPoint(TextBuffer.CurrentSnapshot).GetContainingLine();
-            var startPos = line.Start.Position + line.GetText().IndexOf("def");
+            var startPos = line.Start.Position + line.GetText().IndexOf("def", StringComparison.Ordinal);
 
             var analysis = GetAnalysisEntry();
             if (analysis == null) {
@@ -44,7 +44,7 @@ namespace Microsoft.PythonTools.Intellisense {
             }
 
             var span = Span.GetSpan(TextBuffer.CurrentSnapshot);
-            int defIndent = span.Start.GetContainingLine().GetText().IndexOf("def");
+            int defIndent = span.Start.GetContainingLine().GetText().IndexOf("def", StringComparison.Ordinal);
 
             string indentation;
             if (_options.ConvertTabsToSpaces) {

--- a/Python/Product/PythonTools/PythonTools/Intellisense/ProjectAnalyzer.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/ProjectAnalyzer.cs
@@ -1672,7 +1672,7 @@ namespace Microsoft.PythonTools.Intellisense {
         private SignatureAnalysis TryGetLiveSignatures(ITextSnapshot snapshot, int paramIndex, string text, ITrackingSpan applicableSpan, string lastKeywordArg) {
             var eval = snapshot.TextBuffer.GetInteractiveWindow()?.Evaluator as IPythonInteractiveIntellisense;
             if (eval != null) {
-                if (text.EndsWith("(")) {
+                if (text.EndsWith("(", StringComparison.Ordinal)) {
                     text = text.Substring(0, text.Length - 1);
                 }
                 var liveSigs = eval.GetSignatureDocumentation(text);

--- a/Python/Product/PythonTools/PythonTools/Intellisense/ProjectAnalyzer.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/ProjectAnalyzer.cs
@@ -1672,7 +1672,7 @@ namespace Microsoft.PythonTools.Intellisense {
         private SignatureAnalysis TryGetLiveSignatures(ITextSnapshot snapshot, int paramIndex, string text, ITrackingSpan applicableSpan, string lastKeywordArg) {
             var eval = snapshot.TextBuffer.GetInteractiveWindow()?.Evaluator as IPythonInteractiveIntellisense;
             if (eval != null) {
-                if (text.EndsWith("(", StringComparison.Ordinal)) {
+                if (text.EndsWithOrdinal("(")) {
                     text = text.Substring(0, text.Length - 1);
                 }
                 var liveSigs = eval.GetSignatureDocumentation(text);

--- a/Python/Product/PythonTools/PythonTools/Intellisense/PythonSignature.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/PythonSignature.cs
@@ -85,8 +85,8 @@ namespace Microsoft.PythonTools.Intellisense {
                 }
 
                 var name = param.name ?? "";
-                var isDict = name.StartsWith("**", StringComparison.Ordinal);
-                var isList = !isDict && name.StartsWith("*", StringComparison.Ordinal);
+                var isDict = name.StartsWithOrdinal("**");
+                var isList = !isDict && name.StartsWithOrdinal("*");
 
                 content.Append(name);
                 ppContent.Append(name);

--- a/Python/Product/PythonTools/PythonTools/Intellisense/PythonSignature.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/PythonSignature.cs
@@ -85,8 +85,8 @@ namespace Microsoft.PythonTools.Intellisense {
                 }
 
                 var name = param.name ?? "";
-                var isDict = name.StartsWith("**");
-                var isList = !isDict && name.StartsWith("*");
+                var isDict = name.StartsWith("**", StringComparison.Ordinal);
+                var isList = !isDict && name.StartsWith("*", StringComparison.Ordinal);
 
                 content.Append(name);
                 ppContent.Append(name);

--- a/Python/Product/PythonTools/PythonTools/Intellisense/PythonSuggestedImportAction.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/PythonSuggestedImportAction.cs
@@ -169,13 +169,13 @@ namespace Microsoft.PythonTools.Intellisense {
             }
 
             // Keys sort alphabetically
-            r = key1.CompareTo(key2);
+            r = string.Compare(key1, key2, StringComparison.CurrentCultureIgnoreCase);
             if (r != 0) {
                 return r;
             }
 
             // Sort by display text
-            return (DisplayText ?? "").CompareTo(other.DisplayText ?? "");
+            return string.Compare(DisplayText ?? "", other.DisplayText ?? "", StringComparison.CurrentCultureIgnoreCase);
         }
     }
 }

--- a/Python/Product/PythonTools/PythonTools/Intellisense/StringLiteralCompletionList.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/StringLiteralCompletionList.cs
@@ -50,7 +50,7 @@ namespace Microsoft.PythonTools.Intellisense {
         }
 
         private static string RestorePrefix(string path, string prefix, string prefixRepl) {
-            if (!path.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)) {
+            if (!path.StartsWithOrdinal(prefix, ignoreCase: true)) {
                 return path;
             }
             return prefixRepl + path.Substring(prefix.Length);
@@ -175,8 +175,8 @@ namespace Microsoft.PythonTools.Intellisense {
                 var filter = PathUtils.GetFileOrDirectoryName(text);
                 if (!string.IsNullOrEmpty(filter)) {
                     Debug.WriteLine($"Filtering filenames with '{filter}'");
-                    dirNames.RemoveAll(d => !d.StartsWith(filter, StringComparison.OrdinalIgnoreCase));
-                    fileNames.RemoveAll(f => !f.StartsWith(filter, StringComparison.OrdinalIgnoreCase));
+                    dirNames.RemoveAll(d => !d.StartsWithOrdinal(filter, ignoreCase: true));
+                    fileNames.RemoveAll(f => !f.StartsWithOrdinal(filter, ignoreCase: true));
                 }
             }
             if (dirNames.Count + fileNames.Count > MaxItems) {

--- a/Python/Product/PythonTools/PythonTools/Navigation/DropDownBarClient.cs
+++ b/Python/Product/PythonTools/PythonTools/Navigation/DropDownBarClient.cs
@@ -20,6 +20,7 @@ using System.Diagnostics;
 using System.Threading.Tasks;
 using System.Windows.Threading;
 using Microsoft.PythonTools.Editor;
+using Microsoft.PythonTools.Infrastructure;
 using Microsoft.PythonTools.Intellisense;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Shell.Interop;
@@ -251,8 +252,8 @@ namespace Microsoft.PythonTools.Navigation {
 
                 ImageListOverlay overlay = ImageListOverlay.ImageListOverlayNone;
                 string name = child.Name;
-                if (name != null && name.StartsWith("_", StringComparison.Ordinal) &&
-                    !(name.StartsWith("__", StringComparison.Ordinal) && name.EndsWith("__", StringComparison.Ordinal))) {
+                if (name != null && name.StartsWithOrdinal("_") &&
+                    !(name.StartsWithOrdinal("__") && name.EndsWithOrdinal("__"))) {
                     overlay = ImageListOverlay.ImageListOverlayPrivate;
                 }
 

--- a/Python/Product/PythonTools/PythonTools/Navigation/DropDownBarClient.cs
+++ b/Python/Product/PythonTools/PythonTools/Navigation/DropDownBarClient.cs
@@ -251,7 +251,8 @@ namespace Microsoft.PythonTools.Navigation {
 
                 ImageListOverlay overlay = ImageListOverlay.ImageListOverlayNone;
                 string name = child.Name;
-                if (name != null && name.StartsWith("_") && !(name.StartsWith("__") && name.EndsWith("__"))) {
+                if (name != null && name.StartsWith("_", StringComparison.Ordinal) &&
+                    !(name.StartsWith("__", StringComparison.Ordinal) && name.EndsWith("__", StringComparison.Ordinal))) {
                     overlay = ImageListOverlay.ImageListOverlayPrivate;
                 }
 

--- a/Python/Product/PythonTools/PythonTools/Project/CustomCommand.cs
+++ b/Python/Product/PythonTools/PythonTools/Project/CustomCommand.cs
@@ -762,7 +762,7 @@ namespace Microsoft.PythonTools.Project {
         public bool ExecuteInRepl {
             get {
                 return !string.IsNullOrEmpty(ExecuteIn) &&
-                    ExecuteIn.StartsWith(CreatePythonCommandItem.ExecuteInRepl, StringComparison.OrdinalIgnoreCase);
+                    ExecuteIn.StartsWithOrdinal(CreatePythonCommandItem.ExecuteInRepl, ignoreCase: true);
             }
         }
 

--- a/Python/Product/PythonTools/PythonTools/Project/CustomCommand.cs
+++ b/Python/Product/PythonTools/PythonTools/Project/CustomCommand.cs
@@ -589,7 +589,7 @@ namespace Microsoft.PythonTools.Project {
 
         private async Task<bool> RunInRepl(IPythonProject project, CommandStartInfo startInfo) {
             var executeIn = string.IsNullOrEmpty(startInfo.ExecuteIn) ? CreatePythonCommandItem.ExecuteInRepl : startInfo.ExecuteIn;
-            bool resetRepl = executeIn.StartsWith("R", StringComparison.InvariantCulture);
+            bool resetRepl = executeIn.StartsWithOrdinal("R");
 
             var replTitle = executeIn.Substring(4).TrimStart(' ', ':');
             if (string.IsNullOrEmpty(replTitle)) {

--- a/Python/Product/PythonTools/PythonTools/Project/CustomCommand.cs
+++ b/Python/Product/PythonTools/PythonTools/Project/CustomCommand.cs
@@ -144,9 +144,9 @@ namespace Microsoft.PythonTools.Project {
         private static string PerformSubstitutions(IPythonProject project, string label) {
             return Regex.Replace(label, @"\{(?<key>\w+)\}", m => {
                 var key = m.Groups["key"].Value;
-                if ("projectname".Equals(key, StringComparison.InvariantCultureIgnoreCase)) {
+                if ("projectname".Equals(key, StringComparison.OrdinalIgnoreCase)) {
                     return Path.ChangeExtension(project.ProjectFile, null);
-                } else if ("projectfile".Equals(key, StringComparison.InvariantCultureIgnoreCase)) {
+                } else if ("projectfile".Equals(key, StringComparison.OrdinalIgnoreCase)) {
                     return project.ProjectFile;
                 }
 
@@ -762,61 +762,61 @@ namespace Microsoft.PythonTools.Project {
         public bool ExecuteInRepl {
             get {
                 return !string.IsNullOrEmpty(ExecuteIn) &&
-                    ExecuteIn.StartsWith(CreatePythonCommandItem.ExecuteInRepl, StringComparison.InvariantCultureIgnoreCase);
+                    ExecuteIn.StartsWith(CreatePythonCommandItem.ExecuteInRepl, StringComparison.OrdinalIgnoreCase);
             }
         }
 
         public bool ExecuteInOutput {
             get {
-                return CreatePythonCommandItem.ExecuteInOutput.Equals(ExecuteIn, StringComparison.InvariantCultureIgnoreCase);
+                return CreatePythonCommandItem.ExecuteInOutput.Equals(ExecuteIn, StringComparison.OrdinalIgnoreCase);
             }
         }
 
         public bool ExecuteInConsole {
             get {
-                return PythonCommandTask.ExecuteInConsole.Equals(ExecuteIn, StringComparison.InvariantCultureIgnoreCase);
+                return PythonCommandTask.ExecuteInConsole.Equals(ExecuteIn, StringComparison.OrdinalIgnoreCase);
             }
         }
 
         public bool ExecuteInConsoleAndPause {
             get {
-                return PythonCommandTask.ExecuteInConsolePause.Equals(ExecuteIn, StringComparison.InvariantCultureIgnoreCase);
+                return PythonCommandTask.ExecuteInConsolePause.Equals(ExecuteIn, StringComparison.OrdinalIgnoreCase);
             }
         }
 
         public bool ExecuteHidden {
             get {
-                return PythonCommandTask.ExecuteInNone.Equals(ExecuteIn, StringComparison.InvariantCultureIgnoreCase);
+                return PythonCommandTask.ExecuteInNone.Equals(ExecuteIn, StringComparison.OrdinalIgnoreCase);
             }
         }
 
         public bool IsScript {
             get {
-                return PythonCommandTask.TargetTypeScript.Equals(TargetType, StringComparison.InvariantCultureIgnoreCase);
+                return PythonCommandTask.TargetTypeScript.Equals(TargetType, StringComparison.OrdinalIgnoreCase);
             }
         }
 
         public bool IsModule {
             get {
-                return PythonCommandTask.TargetTypeModule.Equals(TargetType, StringComparison.InvariantCultureIgnoreCase);
+                return PythonCommandTask.TargetTypeModule.Equals(TargetType, StringComparison.OrdinalIgnoreCase);
             }
         }
 
         public bool IsCode {
             get {
-                return PythonCommandTask.TargetTypeCode.Equals(TargetType, StringComparison.InvariantCultureIgnoreCase);
+                return PythonCommandTask.TargetTypeCode.Equals(TargetType, StringComparison.OrdinalIgnoreCase);
             }
         }
 
         public bool IsExecuable {
             get {
-                return PythonCommandTask.TargetTypeExecutable.Equals(TargetType, StringComparison.InvariantCultureIgnoreCase);
+                return PythonCommandTask.TargetTypeExecutable.Equals(TargetType, StringComparison.OrdinalIgnoreCase);
             }
         }
 
         public bool IsPip {
             get {
-                return PythonCommandTask.TargetTypePip.Equals(TargetType, StringComparison.InvariantCultureIgnoreCase);
+                return PythonCommandTask.TargetTypePip.Equals(TargetType, StringComparison.OrdinalIgnoreCase);
             }
         }
 

--- a/Python/Product/PythonTools/PythonTools/Project/ImportWizard/ImportSettings.cs
+++ b/Python/Product/PythonTools/PythonTools/Project/ImportWizard/ImportSettings.cs
@@ -513,7 +513,7 @@ namespace Microsoft.PythonTools.Project.ImportWizard {
             }
 
             return files
-                .Where(path => path.StartsWith(source))
+                .Where(path => path.StartsWith(source, StringComparison.OrdinalIgnoreCase))
                 .Select(path => path.Substring(source.Length).TrimStart(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar))
                 .Distinct(StringComparer.OrdinalIgnoreCase);
         }

--- a/Python/Product/PythonTools/PythonTools/Project/ImportWizard/ImportSettings.cs
+++ b/Python/Product/PythonTools/PythonTools/Project/ImportWizard/ImportSettings.cs
@@ -235,7 +235,7 @@ namespace Microsoft.PythonTools.Project.ImportWizard {
                     // Also include *.pyw files if they were in the filter list
                     foreach (var pywFilters in filters
                         .Split(';')
-                        .Where(filter => filter.TrimEnd().EndsWith(".pyw", StringComparison.OrdinalIgnoreCase))
+                        .Where(filter => filter.TrimEnd().EndsWithOrdinal(".pyw", ignoreCase: true))
                     ) {
                         files = files.Concat(PathUtils.EnumerateFiles(sourcePath, pywFilters, recurse: false));
                     }
@@ -513,7 +513,7 @@ namespace Microsoft.PythonTools.Project.ImportWizard {
             }
 
             return files
-                .Where(path => path.StartsWith(source, StringComparison.OrdinalIgnoreCase))
+                .Where(path => path.StartsWithOrdinal(source, ignoreCase: true))
                 .Select(path => path.Substring(source.Length).TrimStart(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar))
                 .Distinct(StringComparer.OrdinalIgnoreCase);
         }

--- a/Python/Product/PythonTools/PythonTools/Project/PythonFileNode.cs
+++ b/Python/Product/PythonTools/PythonTools/Project/PythonFileNode.cs
@@ -163,7 +163,7 @@ namespace Microsoft.PythonTools.Project {
                 ((PythonProjectNode)ProjectMgr).GetAnalyzer().UnloadFileAsync(analysis).DoNotWait();
             }
 
-            if (Url.EndsWith(PythonConstants.FileExtension, StringComparison.OrdinalIgnoreCase) && removeFromStorage) {
+            if (Url.EndsWithOrdinal(PythonConstants.FileExtension, ignoreCase: true) && removeFromStorage) {
                 TryDelete(Url + "c");
                 TryDelete(Url + "o");
             }
@@ -218,7 +218,7 @@ namespace Microsoft.PythonTools.Project {
         internal override FileNode RenameFileNode(string oldFileName, string newFileName) {
             var res = base.RenameFileNode(oldFileName, newFileName);
 
-            if (newFileName.EndsWith(PythonConstants.FileExtension, StringComparison.OrdinalIgnoreCase)) {
+            if (newFileName.EndsWithOrdinal(PythonConstants.FileExtension, ignoreCase: true)) {
                 TryRename(oldFileName + "c", newFileName + "c");
                 TryRename(oldFileName + "o", newFileName + "o");
             }

--- a/Python/Product/PythonTools/PythonTools/Project/PythonProjectNode.cs
+++ b/Python/Product/PythonTools/PythonTools/Project/PythonProjectNode.cs
@@ -2736,7 +2736,7 @@ namespace Microsoft.PythonTools.Project {
                 if (ErrorHandler.Succeeded(project.GetGuidProperty(id, (int)__VSHPROPID.VSHPROPID_TypeGuid, out itemType)) &&
                     itemType == VSConstants.GUID_ItemType_PhysicalFile &&
                     ErrorHandler.Succeeded(project.GetProperty(id, (int)__VSHPROPID.VSHPROPID_Name, out obj)) &&
-                    "ServiceDefinition.csdef".Equals(obj as string, StringComparison.InvariantCultureIgnoreCase) &&
+                    "ServiceDefinition.csdef".Equals(obj as string, StringComparison.OrdinalIgnoreCase) &&
                     ErrorHandler.Succeeded(project.GetCanonicalName(id, out mkDoc)) &&
                     !string.IsNullOrEmpty(mkDoc)
                 ) {
@@ -2822,6 +2822,7 @@ namespace Microsoft.PythonTools.Project {
             }
         }
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security.Xml", "CA3053:UseXmlSecureResolver")]
         private static void UpdateServiceDefinition(IVsTextLines lines, string roleType, string projectName) {
             if (lines == null) {
                 throw new ArgumentException("lines");
@@ -2833,8 +2834,10 @@ namespace Microsoft.PythonTools.Project {
             ErrorHandler.ThrowOnFailure(lines.GetLastLineIndex(out lastLine, out lastIndex));
             ErrorHandler.ThrowOnFailure(lines.GetLineText(0, 0, lastLine, lastIndex, out text));
 
-            var doc = new XmlDocument();
-            doc.LoadXml(text);
+            var doc = new XmlDocument { XmlResolver = null };
+            var settings = new XmlReaderSettings { XmlResolver = null };
+            using (var reader = XmlReader.Create(new StringReader(text), settings))
+                doc.Load(reader);
 
             UpdateServiceDefinition(doc, roleType, projectName);
 
@@ -2924,9 +2927,14 @@ namespace Microsoft.PythonTools.Project {
             }
         }
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security.Xml", "CA3053:UseXmlSecureResolver")]
         private static void UpdateServiceDefinition(string path, string roleType, string projectName) {
-            var doc = new XmlDocument();
-            doc.Load(path);
+            var doc = new XmlDocument { XmlResolver = null };
+            var settings = new XmlReaderSettings { XmlResolver = null };
+            using (var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read))
+            using (var reader = XmlReader.Create(stream, settings)) {
+                doc.Load(reader);
+            }
 
             UpdateServiceDefinition(doc, roleType, projectName);
 

--- a/Python/Product/PythonTools/PythonTools/Project/PythonProjectNode.cs
+++ b/Python/Product/PythonTools/PythonTools/Project/PythonProjectNode.cs
@@ -285,7 +285,7 @@ namespace Microsoft.PythonTools.Project {
         }
 
         private string ReplaceMSBuildPath(string id) {
-            int index = id.IndexOf(BuildProject.FullPath, StringComparison.OrdinalIgnoreCase);
+            int index = id.IndexOfOrdinal(BuildProject.FullPath, ignoreCase: true);
             if (index != -1) {
                 id = id.Substring(0, index) + "$(MSBuildProjectFullPath)" + id.Substring(index + BuildProject.FullPath.Length);
             }

--- a/Python/Product/PythonTools/PythonTools/Refactoring/ExtractMethodRequestView.cs
+++ b/Python/Product/PythonTools/PythonTools/Refactoring/ExtractMethodRequestView.cs
@@ -379,7 +379,7 @@ namespace Microsoft.PythonTools.Refactoring {
             /// Compares two ClosureVariable instances by name.
             /// </summary>
             public int CompareTo(ClosureVariable other) {
-                return Name.CompareTo((other == null) ? string.Empty : other.Name);
+                return string.CompareOrdinal(Name, other?.Name ?? "");
             }
         }
     }

--- a/Python/Product/PythonTools/PythonTools/Refactoring/LocationPreviewItem.cs
+++ b/Python/Product/PythonTools/PythonTools/Refactoring/LocationPreviewItem.cs
@@ -137,7 +137,7 @@ namespace Microsoft.PythonTools.Refactoring {
                 return false;
             }
 
-            if (newName.StartsWith("__", StringComparison.Ordinal) && newName.Length > 2) {
+            if (newName.StartsWithOrdinal("__") && newName.Length > 2) {
                 // renaming from private name to private name, so just rename the non-prefixed portion
                 start += prefix.Length;
                 length -= prefix.Length;

--- a/Python/Product/PythonTools/PythonTools/Refactoring/LocationPreviewItem.cs
+++ b/Python/Product/PythonTools/PythonTools/Refactoring/LocationPreviewItem.cs
@@ -137,7 +137,7 @@ namespace Microsoft.PythonTools.Refactoring {
                 return false;
             }
 
-            if (newName.StartsWith("__") && newName.Length > 2) {
+            if (newName.StartsWith("__", StringComparison.Ordinal) && newName.Length > 2) {
                 // renaming from private name to private name, so just rename the non-prefixed portion
                 start += prefix.Length;
                 length -= prefix.Length;

--- a/Python/Product/PythonTools/PythonTools/Refactoring/VariableRenamer.cs
+++ b/Python/Product/PythonTools/PythonTools/Refactoring/VariableRenamer.cs
@@ -62,7 +62,7 @@ namespace Microsoft.PythonTools.Refactoring {
             string privatePrefix = null;
             var originalName = analysis.MemberName;
 
-            if (analysis.PrivatePrefix != null && originalName != null && originalName.StartsWith("_" + analysis.PrivatePrefix)) {
+            if (analysis.PrivatePrefix != null && originalName != null && originalName.StartsWithOrdinal("_" + analysis.PrivatePrefix)) {
                 originalName = originalName.Substring(analysis.PrivatePrefix.Length + 1);
                 privatePrefix = analysis.PrivatePrefix;
             }

--- a/Python/Product/PythonTools/PythonTools/Repl/LoadReplCommand.cs
+++ b/Python/Product/PythonTools/PythonTools/Repl/LoadReplCommand.cs
@@ -62,11 +62,11 @@ namespace Microsoft.PythonTools.Repl {
                 var currentSubmission = new List<string>();
 
                 foreach (var line in lines) {
-                    if (line.StartsWith(_commentPrefix)) {
+                    if (line.StartsWith(_commentPrefix, StringComparison.OrdinalIgnoreCase)) {
                         continue;
                     }
 
-                    if (line.StartsWith(commandPrefix)) {
+                    if (line.StartsWith(commandPrefix, StringComparison.OrdinalIgnoreCase)) {
                         AddSubmission(submissionList, currentSubmission, lineBreak);
 
                         submissionList.Add(line);
@@ -86,7 +86,7 @@ namespace Microsoft.PythonTools.Repl {
         }
 
         private static bool CommentPrefixPredicate(string input) {
-            return !input.StartsWith(_commentPrefix);
+            return !input.StartsWith(_commentPrefix, StringComparison.OrdinalIgnoreCase);
         }
 
         private static void AddSubmission(List<string> submissions, List<string> lines, string lineBreak) {

--- a/Python/Product/PythonTools/PythonTools/Repl/LoadReplCommand.cs
+++ b/Python/Product/PythonTools/PythonTools/Repl/LoadReplCommand.cs
@@ -62,11 +62,11 @@ namespace Microsoft.PythonTools.Repl {
                 var currentSubmission = new List<string>();
 
                 foreach (var line in lines) {
-                    if (line.StartsWith(_commentPrefix, StringComparison.OrdinalIgnoreCase)) {
+                    if (line.StartsWithOrdinal(_commentPrefix, ignoreCase: true)) {
                         continue;
                     }
 
-                    if (line.StartsWith(commandPrefix, StringComparison.OrdinalIgnoreCase)) {
+                    if (line.StartsWithOrdinal(commandPrefix, ignoreCase: true)) {
                         AddSubmission(submissionList, currentSubmission, lineBreak);
 
                         submissionList.Add(line);
@@ -86,7 +86,7 @@ namespace Microsoft.PythonTools.Repl {
         }
 
         private static bool CommentPrefixPredicate(string input) {
-            return !input.StartsWith(_commentPrefix, StringComparison.OrdinalIgnoreCase);
+            return !input.StartsWithOrdinal(_commentPrefix, ignoreCase: true);
         }
 
         private static void AddSubmission(List<string> submissions, List<string> lines, string lineBreak) {

--- a/Python/Product/PythonTools/PythonTools/Repl/PythonCommonInteractiveEvaluator.cs
+++ b/Python/Product/PythonTools/PythonTools/Repl/PythonCommonInteractiveEvaluator.cs
@@ -307,7 +307,7 @@ namespace Microsoft.PythonTools.Repl {
             if (string.IsNullOrEmpty(text)) {
                 return true;
             }
-            if (string.IsNullOrWhiteSpace(text) && text.EndsWith("\n")) {
+            if (string.IsNullOrWhiteSpace(text) && text.EndsWith("\n", StringComparison.Ordinal)) {
                 pr = ParseResult.Empty;
                 return true;
             }
@@ -316,7 +316,7 @@ namespace Microsoft.PythonTools.Repl {
             var parser = Parser.CreateParser(new StringReader(text), LanguageVersion);
             parser.ParseInteractiveCode(out pr);
             if (pr == ParseResult.IncompleteStatement || pr == ParseResult.Empty) {
-                return text.EndsWith("\n");
+                return text.EndsWith("\n", StringComparison.Ordinal);
             }
             if (pr == ParseResult.IncompleteToken) {
                 return false;
@@ -628,7 +628,7 @@ namespace Microsoft.PythonTools.Repl {
             bool addNewLine,
             bool isError
         ) {
-            int start = 0, escape = text.IndexOf("\x1b[");
+            int start = 0, escape = text.IndexOf("\x1b[", StringComparison.Ordinal);
             var colors = window.OutputBuffer.Properties.GetOrCreateSingletonProperty(
                 ReplOutputClassifier.ColorKey,
                 () => new List<ColoredSpan>()
@@ -646,7 +646,7 @@ namespace Microsoft.PythonTools.Repl {
 
                 start = escape + 2;
                 color = GetColorFromEscape(text, ref start);
-                escape = text.IndexOf("\x1b[", start);
+                escape = text.IndexOf("\x1b[", start, StringComparison.Ordinal);
             }
 
             var rest = text.Substring(start);

--- a/Python/Product/PythonTools/PythonTools/Repl/PythonCommonInteractiveEvaluator.cs
+++ b/Python/Product/PythonTools/PythonTools/Repl/PythonCommonInteractiveEvaluator.cs
@@ -628,7 +628,7 @@ namespace Microsoft.PythonTools.Repl {
             bool addNewLine,
             bool isError
         ) {
-            int start = 0, escape = text.IndexOf("\x1b[", StringComparison.Ordinal);
+            int start = 0, escape = text.IndexOfOrdinal("\x1b[");
             var colors = window.OutputBuffer.Properties.GetOrCreateSingletonProperty(
                 ReplOutputClassifier.ColorKey,
                 () => new List<ColoredSpan>()
@@ -646,7 +646,7 @@ namespace Microsoft.PythonTools.Repl {
 
                 start = escape + 2;
                 color = GetColorFromEscape(text, ref start);
-                escape = text.IndexOf("\x1b[", start, StringComparison.Ordinal);
+                escape = text.IndexOfOrdinal("\x1b[", start);
             }
 
             var rest = text.Substring(start);

--- a/Python/Product/PythonTools/PythonTools/Repl/PythonCommonInteractiveEvaluator.cs
+++ b/Python/Product/PythonTools/PythonTools/Repl/PythonCommonInteractiveEvaluator.cs
@@ -307,7 +307,7 @@ namespace Microsoft.PythonTools.Repl {
             if (string.IsNullOrEmpty(text)) {
                 return true;
             }
-            if (string.IsNullOrWhiteSpace(text) && text.EndsWith("\n", StringComparison.Ordinal)) {
+            if (string.IsNullOrWhiteSpace(text) && text.EndsWithOrdinal("\n")) {
                 pr = ParseResult.Empty;
                 return true;
             }
@@ -316,7 +316,7 @@ namespace Microsoft.PythonTools.Repl {
             var parser = Parser.CreateParser(new StringReader(text), LanguageVersion);
             parser.ParseInteractiveCode(out pr);
             if (pr == ParseResult.IncompleteStatement || pr == ParseResult.Empty) {
-                return text.EndsWith("\n", StringComparison.Ordinal);
+                return text.EndsWithOrdinal("\n");
             }
             if (pr == ParseResult.IncompleteToken) {
                 return false;

--- a/Python/Product/PythonTools/PythonTools/Repl/PythonDebugReplEvaluatorProvider.cs
+++ b/Python/Product/PythonTools/PythonTools/Repl/PythonDebugReplEvaluatorProvider.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
+using Microsoft.PythonTools.Infrastructure;
 using Microsoft.VisualStudio.InteractiveWindow;
 using Microsoft.VisualStudio.Shell;
 
@@ -34,7 +35,7 @@ namespace Microsoft.PythonTools.Repl {
         }
 
         public IInteractiveEvaluator GetEvaluator(string replId) {
-            if (replId.StartsWith(_debugReplGuid, StringComparison.OrdinalIgnoreCase)) {
+            if (replId.StartsWithOrdinal(_debugReplGuid, ignoreCase: true)) {
                 return new PythonDebugReplEvaluator(_serviceProvider);
             }
             return null;

--- a/Python/Product/PythonTools/PythonTools/Repl/PythonDebugReplEvaluatorProvider.cs
+++ b/Python/Product/PythonTools/PythonTools/Repl/PythonDebugReplEvaluatorProvider.cs
@@ -34,7 +34,7 @@ namespace Microsoft.PythonTools.Repl {
         }
 
         public IInteractiveEvaluator GetEvaluator(string replId) {
-            if (replId.StartsWith(_debugReplGuid)) {
+            if (replId.StartsWith(_debugReplGuid, StringComparison.OrdinalIgnoreCase)) {
                 return new PythonDebugReplEvaluator(_serviceProvider);
             }
             return null;

--- a/Python/Product/PythonTools/PythonTools/Repl/PythonInteractiveEvaluator.CommandProcessorThread.cs
+++ b/Python/Product/PythonTools/PythonTools/Repl/PythonInteractiveEvaluator.CommandProcessorThread.cs
@@ -644,7 +644,7 @@ namespace Microsoft.PythonTools.Repl {
             }
 
             public Task<ExecutionResult> ExecuteText(string text) {
-                if (text.StartsWith("$", StringComparison.Ordinal)) {
+                if (text.StartsWithOrdinal("$")) {
                     _eval.WriteError(Strings.ReplUnknownCommand.FormatUI(text.Trim()));
                     return ExecutionResult.Failed;
                 }

--- a/Python/Product/PythonTools/PythonTools/Repl/PythonInteractiveEvaluator.CommandProcessorThread.cs
+++ b/Python/Product/PythonTools/PythonTools/Repl/PythonInteractiveEvaluator.CommandProcessorThread.cs
@@ -644,7 +644,7 @@ namespace Microsoft.PythonTools.Repl {
             }
 
             public Task<ExecutionResult> ExecuteText(string text) {
-                if (text.StartsWith("$")) {
+                if (text.StartsWith("$", StringComparison.Ordinal)) {
                     _eval.WriteError(Strings.ReplUnknownCommand.FormatUI(text.Trim()));
                     return ExecutionResult.Failed;
                 }

--- a/Python/Product/PythonTools/PythonTools/Repl/PythonInteractiveEvaluator.cs
+++ b/Python/Product/PythonTools/PythonTools/Repl/PythonInteractiveEvaluator.cs
@@ -166,7 +166,7 @@ namespace Microsoft.PythonTools.Repl {
                     if (File.Exists(modeFile)) {
                         try {
                             BackendName = File.ReadAllLines(modeFile).FirstOrDefault(line =>
-                                !string.IsNullOrEmpty(line) && !line.TrimStart().StartsWith("#")
+                                !string.IsNullOrEmpty(line) && !line.TrimStart().StartsWithOrdinal("#")
                             );
                         } catch (Exception ex) when (!ex.IsCriticalException()) {
                             WriteError(Strings.ReplCannotReadFile.FormatUI(modeFile));

--- a/Python/Product/PythonTools/PythonTools/Repl/ReplEditFilter.cs
+++ b/Python/Product/PythonTools/PythonTools/Repl/ReplEditFilter.cs
@@ -509,7 +509,7 @@ namespace Microsoft.PythonTools.Repl {
                 }
             }
 
-            bool submitLast = pasting.EndsWith("\n");
+            bool submitLast = pasting.EndsWithOrdinal("\n");
 
             if (inputPoint == null) {
                 // we didn't find a point to insert, insert at the beginning.
@@ -579,7 +579,7 @@ namespace Microsoft.PythonTools.Repl {
                     indent = line.Substring(0, line.TakeWhile(char.IsWhiteSpace).Count());
                 }
 
-                if (line.StartsWith(indent)) {
+                if (line.StartsWithOrdinal(indent)) {
                     yield return line.Substring(indent.Length);
                 } else {
                     yield return line.TrimStart();

--- a/Python/Product/PythonTools/PythonTools/Repl/ReplEditFilter.cs
+++ b/Python/Product/PythonTools/PythonTools/Repl/ReplEditFilter.cs
@@ -657,7 +657,7 @@ namespace Microsoft.PythonTools.Repl {
             }
 
             var leadingIndent = lines[0].Substring(0, lines[0].TakeWhile(char.IsWhiteSpace).Count());
-            if (!lines.All(line => line.StartsWith(leadingIndent) || string.IsNullOrEmpty(line))) {
+            if (!lines.All(line => line.StartsWith(leadingIndent, StringComparison.Ordinal) || string.IsNullOrEmpty(line))) {
                 return lines;
             }
 
@@ -677,9 +677,9 @@ namespace Microsoft.PythonTools.Repl {
             if ((prevText.IndexOf('\n') == prevText.LastIndexOf('\n')) &&
                 (prevText.IndexOf('\r') == prevText.LastIndexOf('\r'))) {
                 prevText = prevText.TrimEnd();
-            } else if (prevText.EndsWith("\r\n\r\n")) {
+            } else if (prevText.EndsWith("\r\n\r\n", StringComparison.Ordinal)) {
                 prevText = prevText.Substring(0, prevText.Length - 2);
-            } else if (prevText.EndsWith("\n\n") || prevText.EndsWith("\r\r")) {
+            } else if (prevText.EndsWith("\n\n", StringComparison.Ordinal) || prevText.EndsWith("\r\r", StringComparison.Ordinal)) {
                 prevText = prevText.Substring(0, prevText.Length - 1);
             }
             return prevText;

--- a/Python/Product/PythonTools/PythonTools/Repl/ReplEditFilter.cs
+++ b/Python/Product/PythonTools/PythonTools/Repl/ReplEditFilter.cs
@@ -657,7 +657,7 @@ namespace Microsoft.PythonTools.Repl {
             }
 
             var leadingIndent = lines[0].Substring(0, lines[0].TakeWhile(char.IsWhiteSpace).Count());
-            if (!lines.All(line => line.StartsWith(leadingIndent, StringComparison.Ordinal) || string.IsNullOrEmpty(line))) {
+            if (!lines.All(line => line.StartsWithOrdinal(leadingIndent) || string.IsNullOrEmpty(line))) {
                 return lines;
             }
 
@@ -677,9 +677,9 @@ namespace Microsoft.PythonTools.Repl {
             if ((prevText.IndexOf('\n') == prevText.LastIndexOf('\n')) &&
                 (prevText.IndexOf('\r') == prevText.LastIndexOf('\r'))) {
                 prevText = prevText.TrimEnd();
-            } else if (prevText.EndsWith("\r\n\r\n", StringComparison.Ordinal)) {
+            } else if (prevText.EndsWithOrdinal("\r\n\r\n")) {
                 prevText = prevText.Substring(0, prevText.Length - 2);
-            } else if (prevText.EndsWith("\n\n", StringComparison.Ordinal) || prevText.EndsWith("\r\r", StringComparison.Ordinal)) {
+            } else if (prevText.EndsWithOrdinal("\n\n") || prevText.EndsWithOrdinal("\r\r")) {
                 prevText = prevText.Substring(0, prevText.Length - 1);
             }
             return prevText;

--- a/Python/Product/PythonTools/PythonTools/WebProject/PythonWebLauncherProvider.cs
+++ b/Python/Product/PythonTools/PythonTools/WebProject/PythonWebLauncherProvider.cs
@@ -142,7 +142,7 @@ namespace Microsoft.PythonTools.Project.Web {
             // TODO: Add generic breakpoint extension point
             // to avoid having to pass this property for Django and any future
             // extensions.
-            if (projectGuids.IndexOf("5F0BE9CA-D677-4A4D-8806-6076C0FAAD37", StringComparison.OrdinalIgnoreCase) >= 0) {
+            if (projectGuids.IndexOfOrdinal("5F0BE9CA-D677-4A4D-8806-6076C0FAAD37", ignoreCase: true) >= 0) {
                 debugConfig.LaunchOptions["DjangoDebug"] = "true";
                 defaultConfig.LaunchOptions["DjangoDebug"] = "true";
             }

--- a/Python/Product/TestAdapter.Analysis/TestAnalysisExtension.cs
+++ b/Python/Product/TestAdapter.Analysis/TestAnalysisExtension.cs
@@ -19,7 +19,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Web.Script.Serialization;
 using Microsoft.PythonTools.Analysis;
-using Microsoft.PythonTools.Infrastructure;
+using Microsoft.PythonTools.Analysis.Infrastructure;
 using Microsoft.PythonTools.Interpreter;
 using Microsoft.PythonTools.Interpreter.Ast;
 using Microsoft.PythonTools.Parsing.Ast;
@@ -227,7 +227,7 @@ namespace Microsoft.PythonTools.TestAdapter {
                 if (cls != null) {
                     foreach (var baseCls in cls.Mro.MaybeEnumerate()) {
                         if (baseCls.Name == "TestCase" ||
-                            baseCls.Name.StartsWith("unittest.") && baseCls.Name.EndsWith(".TestCase")) {
+                            baseCls.Name.StartsWithOrdinal("unittest.") && baseCls.Name.EndsWithOrdinal(".TestCase")) {
                             yield return cls;
                         }
                     }

--- a/Python/Product/TestAdapter.Analysis/TestAnalysisExtension.cs
+++ b/Python/Product/TestAdapter.Analysis/TestAnalysisExtension.cs
@@ -175,7 +175,7 @@ namespace Microsoft.PythonTools.TestAdapter {
                 return false;
             }
             var mod = cls.DeclaringModule.Name;
-            return (mod == "unittest" || mod.StartsWith("unittest.", StringComparison.Ordinal)) && cls.Name == "TestCase";
+            return (mod == "unittest" || mod.StartsWithOrdinal("unittest.")) && cls.Name == "TestCase";
         }
         /// <summary>
         /// Get Test Case Members for a class.  If the class has 'test*' tests 
@@ -193,7 +193,7 @@ namespace Microsoft.PythonTools.TestAdapter {
             if (ast != null && !string.IsNullOrEmpty(sourceFile)) {
                 var walker = new TestMethodWalker(ast, sourceFile, classValue.Locations);
                 ast.Walk(walker);
-                tests = walker.Methods.Where(v => v.Key.StartsWith("test", StringComparison.Ordinal));
+                tests = walker.Methods.Where(v => v.Key.StartsWithOrdinal("test"));
                 runTest = walker.Methods.Where(v => v.Key.Equals("runTest"));
             }
 
@@ -201,7 +201,7 @@ namespace Microsoft.PythonTools.TestAdapter {
                 .Where(v => v.Value.Any(m => m.MemberType == PythonMemberType.Function || m.MemberType == PythonMemberType.Method))
                 .Select(v => new KeyValuePair<string, LocationInfo>(v.Key, v.Value.SelectMany(av => av.Locations).FirstOrDefault(l => l != null)));
 
-            var analysisTests = methodFunctions.Where(v => v.Key.StartsWith("test", StringComparison.Ordinal));
+            var analysisTests = methodFunctions.Where(v => v.Key.StartsWithOrdinal("test"));
             var analysisRunTest = methodFunctions.Where(v => v.Key.Equals("runTest"));
 
             tests = tests?.Concat(analysisTests) ?? analysisTests;
@@ -240,7 +240,7 @@ namespace Microsoft.PythonTools.TestAdapter {
                 .OfType<IPythonFunction>()
                 .ToArray();
 
-            var tests = methodFunctions.Where(v => v.Name.StartsWith("test", StringComparison.Ordinal));
+            var tests = methodFunctions.Where(v => v.Name.StartsWithOrdinal("test"));
             var runTest = methodFunctions.Where(v => v.Name.Equals("runTest"));
 
             if (tests.Any()) {

--- a/Python/Product/TestAdapter.Analysis/TestAnalysisExtension.cs
+++ b/Python/Product/TestAdapter.Analysis/TestAnalysisExtension.cs
@@ -175,7 +175,7 @@ namespace Microsoft.PythonTools.TestAdapter {
                 return false;
             }
             var mod = cls.DeclaringModule.Name;
-            return (mod == "unittest" || mod.StartsWith("unittest.")) && cls.Name == "TestCase";
+            return (mod == "unittest" || mod.StartsWith("unittest.", StringComparison.Ordinal)) && cls.Name == "TestCase";
         }
         /// <summary>
         /// Get Test Case Members for a class.  If the class has 'test*' tests 
@@ -193,7 +193,7 @@ namespace Microsoft.PythonTools.TestAdapter {
             if (ast != null && !string.IsNullOrEmpty(sourceFile)) {
                 var walker = new TestMethodWalker(ast, sourceFile, classValue.Locations);
                 ast.Walk(walker);
-                tests = walker.Methods.Where(v => v.Key.StartsWith("test"));
+                tests = walker.Methods.Where(v => v.Key.StartsWith("test", StringComparison.Ordinal));
                 runTest = walker.Methods.Where(v => v.Key.Equals("runTest"));
             }
 
@@ -201,7 +201,7 @@ namespace Microsoft.PythonTools.TestAdapter {
                 .Where(v => v.Value.Any(m => m.MemberType == PythonMemberType.Function || m.MemberType == PythonMemberType.Method))
                 .Select(v => new KeyValuePair<string, LocationInfo>(v.Key, v.Value.SelectMany(av => av.Locations).FirstOrDefault(l => l != null)));
 
-            var analysisTests = methodFunctions.Where(v => v.Key.StartsWith("test"));
+            var analysisTests = methodFunctions.Where(v => v.Key.StartsWith("test", StringComparison.Ordinal));
             var analysisRunTest = methodFunctions.Where(v => v.Key.Equals("runTest"));
 
             tests = tests?.Concat(analysisTests) ?? analysisTests;
@@ -240,7 +240,7 @@ namespace Microsoft.PythonTools.TestAdapter {
                 .OfType<IPythonFunction>()
                 .ToArray();
 
-            var tests = methodFunctions.Where(v => v.Name.StartsWith("test"));
+            var tests = methodFunctions.Where(v => v.Name.StartsWith("test", StringComparison.Ordinal));
             var runTest = methodFunctions.Where(v => v.Name.Equals("runTest"));
 
             if (tests.Any()) {

--- a/Python/Product/TestAdapter.Executor/TestDiscoverer.cs
+++ b/Python/Product/TestAdapter.Executor/TestDiscoverer.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Xml;
 using System.Xml.XPath;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
@@ -35,13 +36,20 @@ namespace Microsoft.PythonTools.TestAdapter {
             DiscoverTests(sources, logger, discoverySink, settings);
         }
 
+        private static XPathDocument Read(string xml) {
+            var settings = new XmlReaderSettings();
+            settings.XmlResolver = null;
+            return new XPathDocument(XmlReader.Create(new StringReader(xml), settings));
+        }
+
+
         static void DiscoverTests(IEnumerable<string> sources, IMessageLogger logger, ITestCaseDiscoverySink discoverySink, IRunSettings settings) {
             var sourcesSet = new HashSet<string>(sources, StringComparer.OrdinalIgnoreCase);
 
             var executorUri = new Uri(PythonConstants.TestExecutorUriString);
             // Test list is sent to us via our run settings which we use to smuggle the
             // data we have in our analysis process.
-            var doc = new XPathDocument(new StringReader(settings.SettingsXml));
+            var doc = Read(settings.SettingsXml);
             foreach (var t in TestReader.ReadTests(doc, sourcesSet, m => {
                 logger?.SendMessage(TestMessageLevel.Warning, m);
             })) {

--- a/Python/Product/Uwp.Interpreter/PythonUwpInterpreterFactoryProvider.cs
+++ b/Python/Product/Uwp.Interpreter/PythonUwpInterpreterFactoryProvider.cs
@@ -279,7 +279,7 @@ namespace Microsoft.PythonTools.Uwp.Interpreter {
 
             private bool SetNotFoundInterpreterFactory(string interpreterId, Version ver) {
                 var factory = Factory as NotFoundInterpreterFactory;
-                if (factory != null && string.Compare(factory.Configuration.Id, interpreterId) == 0 && factory.Configuration.Version == ver) {
+                if (factory != null && string.CompareOrdinal(factory.Configuration.Id, interpreterId) == 0 && factory.Configuration.Version == ver) {
                     // No updates.
                     return false;
                 } else {
@@ -318,7 +318,7 @@ namespace Microsoft.PythonTools.Uwp.Interpreter {
                     }
 
                     // Compare the tag name and the project full path
-                    if (string.Compare(id[0], InterpreterFactoryProviderId) != 0) {
+                    if (string.CompareOrdinal(id[0], InterpreterFactoryProviderId) != 0) {
                         return false;
                     }
 

--- a/Python/Product/VSInterpreters/Interpreter/IPythonInterpreterFactoryProvider.cs
+++ b/Python/Product/VSInterpreters/Interpreter/IPythonInterpreterFactoryProvider.cs
@@ -65,7 +65,7 @@ namespace Microsoft.PythonTools.Interpreter {
         }
 
         public static bool CanBeDeleted(this IPythonInterpreterFactory factory) {
-            return factory.Configuration.Id.StartsWith(CondaEnvironmentFactoryProvider.EnvironmentCompanyName);
+            return factory.Configuration.Id.StartsWith(CondaEnvironmentFactoryProvider.EnvironmentCompanyName, StringComparison.Ordinal);
         }
 
         public static IEnumerable<IPythonInterpreterFactory> GetInterpreterFactories(this IPythonInterpreterFactoryProvider self) {

--- a/Python/Product/VSInterpreters/Interpreter/IPythonInterpreterFactoryProvider.cs
+++ b/Python/Product/VSInterpreters/Interpreter/IPythonInterpreterFactoryProvider.cs
@@ -18,6 +18,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using Microsoft.PythonTools.Infrastructure;
 
 namespace Microsoft.PythonTools.Interpreter {
     /// <summary>
@@ -65,7 +66,7 @@ namespace Microsoft.PythonTools.Interpreter {
         }
 
         public static bool CanBeDeleted(this IPythonInterpreterFactory factory) {
-            return factory.Configuration.Id.StartsWith(CondaEnvironmentFactoryProvider.EnvironmentCompanyName, StringComparison.Ordinal);
+            return factory.Configuration.Id.StartsWithOrdinal(CondaEnvironmentFactoryProvider.EnvironmentCompanyName);
         }
 
         public static IEnumerable<IPythonInterpreterFactory> GetInterpreterFactories(this IPythonInterpreterFactoryProvider self) {

--- a/Python/Product/VSInterpreters/Interpreter/MSBuildProjectInterpreterFactoryProvider.cs
+++ b/Python/Product/VSInterpreters/Interpreter/MSBuildProjectInterpreterFactoryProvider.cs
@@ -438,16 +438,6 @@ namespace Microsoft.PythonTools.Interpreter {
             }
         }
 
-        private static ProcessorArchitecture ParseArchitecture(string value) {
-            if (string.IsNullOrEmpty(value)) {
-                return ProcessorArchitecture.None;
-            } else if (value.Equals("x64", StringComparison.InvariantCultureIgnoreCase)) {
-                return ProcessorArchitecture.Amd64;
-            } else {
-                return ProcessorArchitecture.X86;
-            }
-        }
-
         private static string GetValue(Dictionary<string, string> from, string name) {
             string res;
             if (!from.TryGetValue(name, out res)) {

--- a/Python/Product/VSInterpreters/Interpreter/MSBuildProjectInterpreterFactoryProvider.cs
+++ b/Python/Product/VSInterpreters/Interpreter/MSBuildProjectInterpreterFactoryProvider.cs
@@ -185,7 +185,7 @@ namespace Microsoft.PythonTools.Interpreter {
             var projContext = context as MSBuild.Project;
             if (projContext == null) {
                 var projectFile = context as string;
-                if (projectFile != null && projectFile.EndsWith(".pyproj", StringComparison.OrdinalIgnoreCase)) {
+                if (projectFile != null && projectFile.EndsWithOrdinal(".pyproj", ignoreCase: true)) {
                     projContext = new MSBuild.Project(projectFile);
                 }
             }

--- a/Python/Product/VSInterpreters/PackageManager/CondaUtils.cs
+++ b/Python/Product/VSInterpreters/PackageManager/CondaUtils.cs
@@ -57,7 +57,7 @@ namespace Microsoft.PythonTools.Interpreter {
                 if (output.ExitCode == 0) {
                     // Version is currently being printed to stderr, and nothing in stdout
                     foreach (var line in output.StandardErrorLines.Union(output.StandardOutputLines)) {
-                        if (!string.IsNullOrEmpty(line) && line.StartsWith("conda ")) {
+                        if (!string.IsNullOrEmpty(line) && line.StartsWith("conda ", StringComparison.Ordinal)) {
                             var version = line.Substring("conda ".Length);
                             if (PackageVersion.TryParse(version, out PackageVersion ver)) {
                                 return ver;

--- a/Python/Product/VSInterpreters/PackageManager/CondaUtils.cs
+++ b/Python/Product/VSInterpreters/PackageManager/CondaUtils.cs
@@ -57,7 +57,7 @@ namespace Microsoft.PythonTools.Interpreter {
                 if (output.ExitCode == 0) {
                     // Version is currently being printed to stderr, and nothing in stdout
                     foreach (var line in output.StandardErrorLines.Union(output.StandardOutputLines)) {
-                        if (!string.IsNullOrEmpty(line) && line.StartsWith("conda ", StringComparison.Ordinal)) {
+                        if (!string.IsNullOrEmpty(line) && line.StartsWithOrdinal("conda ")) {
                             var version = line.Substring("conda ".Length);
                             if (PackageVersion.TryParse(version, out PackageVersion ver)) {
                                 return ver;

--- a/Python/Product/VSInterpreters/PackageManager/PipPackageCache.cs
+++ b/Python/Product/VSInterpreters/PackageManager/PipPackageCache.cs
@@ -483,7 +483,7 @@ namespace Microsoft.PythonTools.Interpreter {
                 while ((spec = await file.ReadLineAsync()) != null) {
                     cancel.ThrowIfCancellationRequested();
                     try {
-                        int descriptionStart = spec.IndexOf(" #");
+                        int descriptionStart = spec.IndexOfOrdinal(" #");
                         if (descriptionStart > 0) {
                             var pv = PackageSpec.FromRequirement(spec.Remove(descriptionStart));
                             pv.Description = Uri.UnescapeDataString(spec.Substring(descriptionStart + 2));

--- a/Python/Product/VSInterpreters/RegistryWatcher.cs
+++ b/Python/Product/VSInterpreters/RegistryWatcher.cs
@@ -23,6 +23,7 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using System.Security.AccessControl;
 using System.Threading;
+using Microsoft.PythonTools.Infrastructure;
 using Microsoft.Win32;
 
 namespace Microsoft.PythonTools {
@@ -485,7 +486,7 @@ namespace Microsoft.PythonTools {
 
         private static RegistryHive ParseRegistryKey(string key, out string subkey) {
             int firstPart = key.IndexOf('\\');
-            if (firstPart < 0 || !key.StartsWith("HKEY", StringComparison.OrdinalIgnoreCase)) {
+            if (firstPart < 0 || !key.StartsWithOrdinal("HKEY", ignoreCase: true)) {
                 throw new ArgumentException("Invalid registry key: " + key, "key");
             }
             var hive = key.Remove(firstPart);

--- a/Python/Product/VSInterpreters/RegistryWatcher.cs
+++ b/Python/Product/VSInterpreters/RegistryWatcher.cs
@@ -485,24 +485,24 @@ namespace Microsoft.PythonTools {
 
         private static RegistryHive ParseRegistryKey(string key, out string subkey) {
             int firstPart = key.IndexOf('\\');
-            if (firstPart < 0 || !key.StartsWith("HKEY", StringComparison.InvariantCultureIgnoreCase)) {
+            if (firstPart < 0 || !key.StartsWith("HKEY", StringComparison.OrdinalIgnoreCase)) {
                 throw new ArgumentException("Invalid registry key: " + key, "key");
             }
             var hive = key.Remove(firstPart);
             subkey = key.Substring(firstPart + 1);
-            if (hive.Equals("HKEY_CURRENT_USER", StringComparison.InvariantCultureIgnoreCase)) {
+            if (hive.Equals("HKEY_CURRENT_USER", StringComparison.OrdinalIgnoreCase)) {
                 return RegistryHive.CurrentUser;
-            } else if (hive.Equals("HKEY_LOCAL_MACHINE", StringComparison.InvariantCultureIgnoreCase)) {
+            } else if (hive.Equals("HKEY_LOCAL_MACHINE", StringComparison.OrdinalIgnoreCase)) {
                 return RegistryHive.LocalMachine;
-            } else if (hive.Equals("HKEY_CLASSES_ROOT", StringComparison.InvariantCultureIgnoreCase)) {
+            } else if (hive.Equals("HKEY_CLASSES_ROOT", StringComparison.OrdinalIgnoreCase)) {
                 return RegistryHive.ClassesRoot;
-            } else if (hive.Equals("HKEY_USERS", StringComparison.InvariantCultureIgnoreCase)) {
+            } else if (hive.Equals("HKEY_USERS", StringComparison.OrdinalIgnoreCase)) {
                 return RegistryHive.Users;
-            } else if (hive.Equals("HKEY_CURRENT_CONFIG", StringComparison.InvariantCultureIgnoreCase)) {
+            } else if (hive.Equals("HKEY_CURRENT_CONFIG", StringComparison.OrdinalIgnoreCase)) {
                 return RegistryHive.CurrentConfig;
-            } else if (hive.Equals("HKEY_PERFORMANCE_DATA", StringComparison.InvariantCultureIgnoreCase)) {
+            } else if (hive.Equals("HKEY_PERFORMANCE_DATA", StringComparison.OrdinalIgnoreCase)) {
                 return RegistryHive.PerformanceData;
-            } else if (hive.Equals("HKEY_DYN_DATA", StringComparison.InvariantCultureIgnoreCase)) {
+            } else if (hive.Equals("HKEY_DYN_DATA", StringComparison.OrdinalIgnoreCase)) {
                 return RegistryHive.DynData;
             }
             throw new ArgumentException("Invalid registry key: " + key, "key");

--- a/Python/Product/Wsl/Debugger/WslLauncher.cs
+++ b/Python/Product/Wsl/Debugger/WslLauncher.cs
@@ -295,7 +295,7 @@ namespace Microsoft.PythonTools.Wsl.Debugger {
                     }
 
                     if (res != 0) {
-                        Debug.Assert(filePathBuilder.ToString().StartsWith("\\\\?\\"));
+                        Debug.Assert(filePathBuilder.ToString().StartsWithOrdinal("\\\\?\\"));
                         return filePathBuilder.ToString().Substring(4);
                     }
                 }

--- a/Python/Tests/Analysis/AnalysisTest.Perf.cs
+++ b/Python/Tests/Analysis/AnalysisTest.Perf.cs
@@ -325,7 +325,7 @@ import System
 
         private static void CollectFiles(string dir, List<string> files, ISet<string> excludeDirectories = null) {
             foreach (string file in Directory.GetFiles(dir)) {
-                if (file.EndsWith(".py", StringComparison.OrdinalIgnoreCase)) {
+                if (file.EndsWithOrdinal(".py", ignoreCase: true)) {
                     files.Add(file);
                 }
             }

--- a/Python/Tests/Analysis/ParserTests.cs
+++ b/Python/Tests/Analysis/ParserTests.cs
@@ -23,6 +23,7 @@ using System.Numerics;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.PythonTools;
+using Microsoft.PythonTools.Analysis.Infrastructure;
 using Microsoft.PythonTools.Parsing;
 using Microsoft.PythonTools.Parsing.Ast;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -4112,7 +4113,7 @@ namespace AnalysisTests {
 
         private static void CollectFiles(string dir, List<string> files, IEnumerable<string> exceptions = null) {
             foreach (string file in Directory.GetFiles(dir)) {
-                if (file.EndsWith(".py", StringComparison.OrdinalIgnoreCase)) {
+                if (file.EndsWithOrdinal(".py", ignoreCase: true)) {
                     files.Add(file);
                 }
             }


### PR DESCRIPTION
This enables most of the code analysis rules we are supposed to be meeting in order to release. The majority of the fixes are for string comparisons (all comparisons apart from `==` and `!=` default to `CurrentCulture`, and the invariant culture doesn't define comparison - only conversion - so we should use ordinal for non-UI comparisons) and `XmlDocument` (which FxCop can't properly detect, so the messages are fixed and suppressed).

I suppressed the rule requiring you to pass a `CultureInfo` to `string.Format`, which prevents use of `$""` strings. Bear in mind that `$""` strings default to the current culture and not invariant, though for most cases this is okay and we don't need to mangle our code too much just to satisfy the static analyzer.