### PR TITLE
Fixes #3630 Error after completing import wizard

### DIFF
--- a/Common/Product/SharedProject/ProjectNode.cs
+++ b/Common/Product/SharedProject/ProjectNode.cs
@@ -631,15 +631,16 @@ namespace Microsoft.VisualStudioTools.Project {
         /// </summary>
         public string ProjectHome {
             get {
-                if (projectHome == null) {
-                    projectHome = CommonUtils.GetAbsoluteDirectoryPath(
+                var home = projectHome;
+                if (home == null) {
+                    home = CommonUtils.GetAbsoluteDirectoryPath(
                         this.ProjectFolder,
                         this.GetProjectProperty(CommonConstants.ProjectHome, resetCache: false));
-                    projectHome = CommonUtils.TrimEndSeparator(projectHome);
+                    projectHome = home = CommonUtils.TrimEndSeparator(home);
                 }
 
-                Debug.Assert(projectHome != null, "ProjectHome should not be null");
-                return projectHome;
+                Debug.Assert(home != null, "ProjectHome should not be null");
+                return home;
             }
         }
 

--- a/Python/Product/PythonTools/PythonTools/Project/PythonProjectNode.cs
+++ b/Python/Product/PythonTools/PythonTools/Project/PythonProjectNode.cs
@@ -1375,7 +1375,9 @@ namespace Microsoft.PythonTools.Project {
         }
 
         private async Task ReanalyzeProjectHelper(Redirector log) {
-            if (IsClosing || IsClosed) {
+            var projectHome = ProjectHome;
+
+            if (IsClosing || IsClosed || string.IsNullOrEmpty(projectHome)) {
                 // This deferred event is no longer important.
                 log?.WriteLine("Project has closed");
                 return;
@@ -1421,7 +1423,7 @@ namespace Microsoft.PythonTools.Project {
                     log?.WriteLine("Unhooked events");
                 }
                 var oldWatcher = _projectFileWatcher;
-                _projectFileWatcher = new FileWatcher(ProjectHome) {
+                _projectFileWatcher = new FileWatcher(projectHome) {
                     EnableRaisingEvents = true,
                     IncludeSubdirectories = true,
                     NotifyFilter = NotifyFilters.FileName | NotifyFilters.LastWrite


### PR DESCRIPTION
Fixes #3630 Error after completing import wizard
Reduces likelihood of a race condition when setting a new ProjectHome
Avoids code path leading to error dialog.