### PR TITLE
Fixes #3667 Handle string literals in type annotations later

### DIFF
--- a/Python/Tests/Analysis/TypeAnnotationTests.cs
+++ b/Python/Tests/Analysis/TypeAnnotationTests.cs
@@ -214,14 +214,18 @@ call_iis_i_ret = call_iis_i()
 
 n : NamedTuple = ...
 n1 : NamedTuple('n1', [('x', int), ['y', str]]) = ...
+n2 : ""NamedTuple('n2', [('x', int), ['y', str]])"" = ...
 ");
             analyzer.WaitForAnalysis();
 
             analyzer.AssertDescription("n", "tuple");
             analyzer.AssertDescription("n1", "n1(x, y)");
+            analyzer.AssertDescription("n2", "n2(x, y)");
 
             analyzer.AssertIsInstance("n1.x", BuiltinTypeId.Int);
             analyzer.AssertIsInstance("n1.y", BuiltinTypeId.Str);
+            analyzer.AssertIsInstance("n2.x", BuiltinTypeId.Int);
+            analyzer.AssertIsInstance("n2.y", BuiltinTypeId.Str);
         }
 
         [TestMethod, Priority(0)]

--- a/Python/Tests/Analysis/TypeAnnotationTests.cs
+++ b/Python/Tests/Analysis/TypeAnnotationTests.cs
@@ -213,12 +213,12 @@ call_iis_i_ret = call_iis_i()
             analyzer.AddModule("test-module", @"from typing import *
 
 n : NamedTuple = ...
-n1 : NamedTuple('N1', [('x', int), ['y', str]]) = ...
+n1 : NamedTuple('n1', [('x', int), ['y', str]]) = ...
 ");
             analyzer.WaitForAnalysis();
 
             analyzer.AssertDescription("n", "tuple");
-            analyzer.AssertDescription("n1", "N1(x, y)");
+            analyzer.AssertDescription("n1", "n1(x, y)");
 
             analyzer.AssertIsInstance("n1.x", BuiltinTypeId.Int);
             analyzer.AssertIsInstance("n1.y", BuiltinTypeId.Str);


### PR DESCRIPTION
Fixes #3667 Handle string literals in type annotations later
Defers name lookup as late as possible for type annotations so that names are not misinterpreted as forward references.