### PR TITLE
Fix build.

### DIFF
--- a/Python/Product/Common/Infrastructure/StringExtensions.cs
+++ b/Python/Product/Common/Infrastructure/StringExtensions.cs
@@ -121,5 +121,9 @@ namespace Microsoft.PythonTools.Infrastructure {
         public static int IndexOfOrdinal(this string s, string value, int startIndex = 0, bool ignoreCase = false) {
             return s?.IndexOf(value, startIndex, ignoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal) ?? -1;
         }
+
+        public static int IndexOfOrdinal(this string s, string value, int startIndex, int count, bool ignoreCase = false) {
+            return s?.IndexOf(value, startIndex, count, ignoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal) ?? -1;
+        }
     }
 }

--- a/Python/Product/Django/TemplateParsing/TemplateArtifactCollection.cs
+++ b/Python/Product/Django/TemplateParsing/TemplateArtifactCollection.cs
@@ -99,7 +99,7 @@ namespace Microsoft.PythonTools.Django.TemplateParsing {
                 // { and % or added { to the existing % so extend search range accordingly.
                 int fragmentStart = Math.Max(0, start - leftSeparator.Length + 1);
                 int fragmentEnd = Math.Min(newText.Length, start + newLength + leftSeparator.Length - 1);
-                return newText.IndexOfOrdinal(leftSeparator, fragmentStart, fragmentEnd - fragmentStart, true) >= 0;
+                return newText.IndexOf(leftSeparator, fragmentStart, fragmentEnd - fragmentStart, true) >= 0;
             }
 
             // Is change completely inside an existing item?


### PR DESCRIPTION
One `IndexOfOrdinal` in Django was passing in a count but we didn't have that overload.

`newText` is `ITextProvider`, not a `string`, I've reverted back to how it was before.