### PR TITLE
Protect against possible null AnalysisEntry in GetQuickInfoAsync.

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Intellisense/ProjectAnalyzer.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/ProjectAnalyzer.cs
@@ -2520,7 +2520,7 @@ namespace Microsoft.PythonTools.Intellisense {
 
             var analysis = await GetExpressionAtPointAsync(point, ExpressionAtPointPurpose.Hover, TimeSpan.FromMilliseconds(200.0)).ConfigureAwait(false);
 
-            if (analysis != null) {
+            if (analysis?.Entry != null) {
                 var location = analysis.Location;
                 var req = new AP.QuickInfoRequest() {
                     expr = analysis.Text,


### PR DESCRIPTION
Fix #3696 

I checked that we don't want to proceed with a null entry, the server will throw invalid operation if it gets a null document uri.

Calling code already knows how to deal with GetQuickInfoAsync returning null.