### PR TITLE
Fixes #3706 Type hint isn't properly recognized for complex types

### DIFF
--- a/Python/Product/Analysis/IHasRichDescription.cs
+++ b/Python/Product/Analysis/IHasRichDescription.cs
@@ -35,18 +35,20 @@ namespace Microsoft.PythonTools.Analysis {
     }
 
     static class RichDescriptionExtensions {
-        public static IEnumerable<KeyValuePair<string, string>> GetRichDescriptions(this IAnalysisSet set, string prefix = null, bool useLongDescription = false, string unionPrefix = null, string unionSuffix = null) {
+        public static IEnumerable<KeyValuePair<string, string>> GetRichDescriptions(this IAnalysisSet set, string prefix = null, bool useLongDescription = false, string unionPrefix = null, string unionSuffix = null, bool alwaysUsePrefixSuffix = false, string defaultIfEmpty = null) {
             var items = new List<KeyValuePair<string, string>>();
+            int itemCount = 0;
             foreach (var d in (useLongDescription ? set.GetDescriptions() : set.GetShortDescriptions())) {
                 items.Add(new KeyValuePair<string, string>(WellKnownRichDescriptionKinds.Type, d));
                 items.Add(new KeyValuePair<string, string>(WellKnownRichDescriptionKinds.Comma, ", "));
+                itemCount += 1;
             }
 
-            if (items.Count == 2) {
-                items.RemoveAt(1);
+            if (itemCount == 1) {
+                items.RemoveAt(items.Count - 1);
             }
 
-            if (items.Count > 2) {
+            if (alwaysUsePrefixSuffix || itemCount >= 2) {
                 if (!string.IsNullOrEmpty(unionPrefix)) {
                     items.Insert(0, new KeyValuePair<string, string>(WellKnownRichDescriptionKinds.Misc, unionPrefix));
                 }
@@ -55,8 +57,12 @@ namespace Microsoft.PythonTools.Analysis {
                 }
             }
 
-            if (items.Count > 0 && !string.IsNullOrEmpty(prefix)) {
+            if (itemCount > 0 && !string.IsNullOrEmpty(prefix)) {
                 items.Insert(0, new KeyValuePair<string, string>(WellKnownRichDescriptionKinds.Misc, prefix));
+            }
+
+            if (items.Count == 0 && !string.IsNullOrEmpty(defaultIfEmpty)) {
+                items.Add(new KeyValuePair<string, string>(WellKnownRichDescriptionKinds.Misc, defaultIfEmpty));
             }
 
             return items;

--- a/Python/Product/Analysis/Values/ConstantInfo.cs
+++ b/Python/Product/Analysis/Values/ConstantInfo.cs
@@ -111,6 +111,16 @@ namespace Microsoft.PythonTools.Analysis.Values {
         }
 
         public override IAnalysisSet UnaryOperation(Node node, AnalysisUnit unit, PythonOperator operation) {
+            if (operation == PythonOperator.Negate && _value != null) {
+                if (_value is int i) {
+                    return ProjectState.GetConstant(-i);
+                } else if (_value is float f) {
+                    return ProjectState.GetConstant(-f);
+                } else if (_value is double d) {
+                    return ProjectState.GetConstant(-d);
+                }
+            }
+
             return _builtinInfo.UnaryOperation(node, unit, operation);
         }
 

--- a/Python/Tests/Analysis/TypeAnnotationTests.cs
+++ b/Python/Tests/Analysis/TypeAnnotationTests.cs
@@ -152,12 +152,16 @@ dctv_s_i_item_1, dctv_s_i_item_2 = next(iter(dctv_s_i_items))
             analyzer.AssertIsInstance("lst_i_0", BuiltinTypeId.Int);
             analyzer.AssertIsInstance("dct", BuiltinTypeId.Dict);
             analyzer.AssertIsInstance("dct_s_i", BuiltinTypeId.Dict);
+            analyzer.AssertDescription("dct_s_i", "dict[str, int]");
             analyzer.AssertIsInstance("dct_s_i_a", BuiltinTypeId.Int);
             analyzer.AssertIsInstance("dct_s_i_keys", BuiltinTypeId.DictKeys);
+            analyzer.AssertDescription("dct_s_i_keys", "dict_keys[str]");
             analyzer.AssertIsInstance("dct_s_i_key", BuiltinTypeId.Str);
             analyzer.AssertIsInstance("dct_s_i_values", BuiltinTypeId.DictValues);
+            analyzer.AssertDescription("dct_s_i_values", "dict_values[int]");
             analyzer.AssertIsInstance("dct_s_i_value", BuiltinTypeId.Int);
             analyzer.AssertIsInstance("dct_s_i_items", BuiltinTypeId.DictItems);
+            analyzer.AssertDescription("dct_s_i_items", "dict_items[tuple[str, int]]");
             analyzer.AssertIsInstance("dct_s_i_item_1", BuiltinTypeId.Str);
             analyzer.AssertIsInstance("dct_s_i_item_2", BuiltinTypeId.Int);
             analyzer.AssertIsInstance("dctv_s_i_keys", BuiltinTypeId.DictKeys);
@@ -215,17 +219,50 @@ call_iis_i_ret = call_iis_i()
 n : NamedTuple = ...
 n1 : NamedTuple('n1', [('x', int), ['y', str]]) = ...
 n2 : ""NamedTuple('n2', [('x', int), ['y', str]])"" = ...
+
+n1_x = n1.x
+n1_y = n1.y
+n2_x = n2.x
+n2_y = n2.y
+
+n1_0 = n1[0]
+n1_1 = n1[1]
+n2_0 = n2[0]
+n2_1 = n2[1]
+
+n1_m2 = n1[-2]
+n1_m1 = n1[-1]
+n2_m2 = n2[-2]
+n2_m1 = n2[-1]
+
+i = 0
+i = 1
+n1_i = n1[i]
+n2_i = n2[i]
 ");
             analyzer.WaitForAnalysis();
 
             analyzer.AssertDescription("n", "tuple");
-            analyzer.AssertDescription("n1", "n1(x, y)");
-            analyzer.AssertDescription("n2", "n2(x, y)");
+            analyzer.AssertDescription("n1", "n1(x : int, y : str)");
+            analyzer.AssertDescription("n2", "n2(x : int, y : str)");
 
-            analyzer.AssertIsInstance("n1.x", BuiltinTypeId.Int);
-            analyzer.AssertIsInstance("n1.y", BuiltinTypeId.Str);
-            analyzer.AssertIsInstance("n2.x", BuiltinTypeId.Int);
-            analyzer.AssertIsInstance("n2.y", BuiltinTypeId.Str);
+            analyzer.AssertIsInstance("n1_x", BuiltinTypeId.Int);
+            analyzer.AssertIsInstance("n1_y", BuiltinTypeId.Str);
+            analyzer.AssertIsInstance("n2_x", BuiltinTypeId.Int);
+            analyzer.AssertIsInstance("n2_y", BuiltinTypeId.Str);
+
+            analyzer.AssertIsInstance("n1_0", BuiltinTypeId.Int);
+            analyzer.AssertIsInstance("n1_1", BuiltinTypeId.Str);
+            analyzer.AssertIsInstance("n2_0", BuiltinTypeId.Int);
+            analyzer.AssertIsInstance("n2_1", BuiltinTypeId.Str);
+
+            analyzer.AssertIsInstance("n1_m2", BuiltinTypeId.Int);
+            analyzer.AssertIsInstance("n1_m1", BuiltinTypeId.Str);
+            analyzer.AssertIsInstance("n2_m2", BuiltinTypeId.Int);
+            analyzer.AssertIsInstance("n2_m1", BuiltinTypeId.Str);
+
+            analyzer.AssertIsInstance("n1_i", BuiltinTypeId.Int, BuiltinTypeId.Str);
+            analyzer.AssertIsInstance("n2_i", BuiltinTypeId.Int, BuiltinTypeId.Str);
         }
 
         [TestMethod, Priority(0)]
@@ -251,7 +288,7 @@ n1 : MyNamedTuple = ...
             analyzer.AssertIsInstance("i", BuiltinTypeId.Int);
             analyzer.AssertIsInstance("sl", BuiltinTypeId.List);
             analyzer.AssertIsInstance("sl_0", BuiltinTypeId.Str);
-            analyzer.AssertDescription("n1", "MyNamedTuple(x)");
+            analyzer.AssertDescription("n1", "MyNamedTuple(x : int)");
 
             analyzer.AssertIsInstance("n1.x", BuiltinTypeId.Int);
         }


### PR DESCRIPTION
Fixes #3706 Type hint isn't properly recognized for complex types
Fixes handling of tuple type annotation
Improves handling of protocol object descriptions
Improves unary operation on numeric literals.