### PR TITLE
Port TaskObserver into PTVS

### DIFF
--- a/Common/Tests/Utilities/Ben.Demystifier/ILReader.cs
+++ b/Common/Tests/Utilities/Ben.Demystifier/ILReader.cs
@@ -1,0 +1,108 @@
+// Copyright (c) Ben A Adams. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+// 
+// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABLITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System;
+using System.Reflection;
+using System.Reflection.Emit;
+
+namespace TestUtilities.Ben.Demystifier {
+    internal sealed class ILReader {
+        private static readonly OpCode[] singleByteOpCode;
+        private static readonly OpCode[] doubleByteOpCode;
+
+        private readonly byte[] _cil;
+        private int _ptr;
+
+        public ILReader(byte[] cil) => _cil = cil;
+
+        public OpCode OpCode { get; private set; }
+        public int MetadataToken { get; private set; }
+        public MemberInfo Operand { get; private set; }
+
+        public bool Read(MethodBase methodInfo) {
+            if (_ptr < _cil.Length) {
+                OpCode = ReadOpCode();
+                Operand = ReadOperand(OpCode, methodInfo);
+                return true;
+            }
+            return false;
+        }
+
+        private OpCode ReadOpCode() {
+            var instruction = ReadByte();
+            return instruction < 254 ? singleByteOpCode[instruction] : doubleByteOpCode[ReadByte()];
+        }
+
+        private MemberInfo ReadOperand(OpCode code, MethodBase methodInfo) {
+            MetadataToken = 0;
+            switch (code.OperandType) {
+                case OperandType.InlineMethod:
+                    MetadataToken = ReadInt();
+                    Type[] methodArgs = null;
+                    if (methodInfo.GetType() != typeof(ConstructorInfo) && !methodInfo.GetType().IsSubclassOf(typeof(ConstructorInfo))) {
+                        methodArgs = methodInfo.GetGenericArguments();
+                    }
+
+                    Type[] typeArgs = null;
+                    if (methodInfo.DeclaringType != null) {
+                        typeArgs = methodInfo.DeclaringType.GetGenericArguments();
+                    }
+
+                    try {
+                        return methodInfo.Module.ResolveMember(MetadataToken, typeArgs, methodArgs);
+                    } catch {
+                        // Can return System.ArgumentException : Token xxx is not a valid MemberInfo token in the scope of module xxx.dll
+                        return null;
+                    }
+                default:
+                    return null;
+            }
+        }
+
+        private byte ReadByte() => _cil[_ptr++];
+
+        private int ReadInt() {
+            var b1 = ReadByte();
+            var b2 = ReadByte();
+            var b3 = ReadByte();
+            var b4 = ReadByte();
+            return b1 | b2 << 8 | b3 << 16 | b4 << 24;
+        }
+
+        static ILReader(){
+            singleByteOpCode = new OpCode[225];
+            doubleByteOpCode = new OpCode[31];
+
+            var fields = GetOpCodeFields();
+
+            foreach (var field in fields) {
+                var code = (OpCode)field.GetValue(null);
+                if (code.OpCodeType == OpCodeType.Nternal)
+                    continue;
+
+                if (code.Size == 1)
+                    singleByteOpCode[code.Value] = code;
+                else
+                    doubleByteOpCode[code.Value & 0xff] = code;
+            }
+        }
+
+        private static FieldInfo[] GetOpCodeFields() => typeof(OpCodes).GetFields(BindingFlags.Public | BindingFlags.Static);
+    }
+}

--- a/Common/Tests/Utilities/Ben.Demystifier/StringBuilderExtensions.cs
+++ b/Common/Tests/Utilities/Ben.Demystifier/StringBuilderExtensions.cs
@@ -1,0 +1,795 @@
+// Copyright (c) Ben A Adams. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+// 
+// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABLITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.ExceptionServices;
+using System.Security;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace TestUtilities.Ben.Demystifier {
+    internal static class StringBuilderExtensions {
+        public static StringBuilder AppendException(this StringBuilder stringBuilder, Exception exception) {
+            stringBuilder.Append(exception.Message);
+
+            if (exception.InnerException != null) {
+                stringBuilder
+                    .Append(" ---> ")
+                    .AppendException(exception.InnerException)
+                    .AppendLine()
+                    .Append("   --- End of inner exception stack trace ---");
+            }
+
+            var frames = new StackTrace(exception, true).GetFrames();
+            if (frames != null && frames.Length > 0) {
+                stringBuilder.AppendLine().AppendFrames(frames);
+            }
+
+            return stringBuilder;
+        }
+
+        public static StringBuilder AppendFrames(this StringBuilder stringBuilder, StackFrame[] frames) {
+            if (frames == null || frames.Length == 0) {
+                return stringBuilder;
+            }
+
+            for (var i = 0; i < frames.Length; i++) {
+                if (i > 0) {
+                    stringBuilder.AppendLine();
+                }
+
+                var frame = frames[i];
+                var method = frame.GetMethod();
+
+                // Always show last stackFrame
+                if (!ShowInStackTrace(method) && i != frames.Length - 1) {
+                    continue;
+                }
+
+                stringBuilder
+                    .Append("   at ")
+                    .AppendMethod(GetMethodDisplay(method));
+
+                var filePath = frame.GetFileName();
+                if (!string.IsNullOrEmpty(filePath) && Uri.TryCreate(filePath, UriKind.Absolute, out var uri)) {
+                    try {
+                        filePath = uri.IsFile ? Path.GetFullPath(filePath) : uri.ToString();
+                        stringBuilder.Append(" in ").Append(filePath);
+                    } catch (PathTooLongException) { } catch (SecurityException) { }
+                }
+
+                var lineNo = frame.GetFileLineNumber();
+                if (lineNo != 0) {
+                    stringBuilder.Append(":line ");
+                    stringBuilder.Append(lineNo);
+                }
+            }
+
+            return stringBuilder;
+        }
+
+        private static void AppendMethod(this StringBuilder builder, ResolvedMethod method) {
+            if (method.IsAsync) {
+                builder.Append("async ");
+            }
+
+            if (method.ReturnParameter.Type != null) {
+                builder
+                    .AppendParameter(method.ReturnParameter)
+                    .Append(" ");
+            }
+
+            var isSubMethodOrLambda = !string.IsNullOrEmpty(method.SubMethod) || method.IsLambda;
+
+            builder
+                .AppendMethodName(method.Name, method.DeclaringTypeName, isSubMethodOrLambda)
+                .Append(method.GenericArguments)
+                .AppendParameters(method.Parameters, method.MethodBase != null);
+
+            if (isSubMethodOrLambda) {
+                builder
+                    .Append("+")
+                    .Append(method.SubMethod)
+                    .AppendParameters(method.SubMethodParameters, method.SubMethodBase != null);
+
+                if (method.IsLambda) {
+                    builder.Append(" => { }");
+
+                    if (method.Ordinal.HasValue){
+                        builder.Append(" [");
+                        builder.Append(method.Ordinal);
+                        builder.Append("]");
+                    }
+                }
+            }
+        }
+
+        public static StringBuilder AppendMethodName(this StringBuilder stringBuilder, string name, string declaringTypeName, bool isSubMethodOrLambda) {
+            if (!string.IsNullOrEmpty(declaringTypeName)) {
+                if (name == ".ctor") {
+                    if (!isSubMethodOrLambda)
+                        stringBuilder.Append("new ");
+
+                    stringBuilder.Append(declaringTypeName);
+                } else if (name == ".cctor") {
+                    stringBuilder
+                        .Append("static ")
+                        .Append(declaringTypeName);
+                } else {
+                    stringBuilder
+                        .Append(declaringTypeName)
+                        .Append(".")
+                        .Append(name);
+                }
+            } else {
+                stringBuilder.Append(name);
+            }
+
+            return stringBuilder;
+        }
+
+        private static void AppendParameters(this StringBuilder stringBuilder, List<ResolvedParameter> parameters, bool condition) {
+            stringBuilder.Append("(");
+            if (parameters != null) {
+                if (condition) {
+                    stringBuilder.AppendParameters(parameters);
+                } else {
+                    stringBuilder.Append("?");
+                }
+            }
+            stringBuilder.Append(")");
+        }
+
+        private static void AppendParameters(this StringBuilder stringBuilder, List<ResolvedParameter> parameters) {
+            var isFirst = true;
+            foreach (var param in parameters) {
+                if (isFirst) {
+                    isFirst = false;
+                } else {
+                    stringBuilder.Append(", ");
+                }
+                stringBuilder.AppendParameter(param);
+            }
+        }
+
+        private static StringBuilder AppendParameter(this StringBuilder stringBuilder, ResolvedParameter parameter) {
+            if (!string.IsNullOrEmpty(parameter.Prefix)) {
+                stringBuilder.Append(parameter.Prefix).Append(" ");
+            }
+
+            stringBuilder.Append(parameter.Type);
+            if (!string.IsNullOrEmpty(parameter.Name)) {
+                stringBuilder.Append(" ").Append(parameter.Name);
+            }
+
+            return stringBuilder;
+        }
+        
+        private static bool ShowInStackTrace(MethodBase method) {
+            try {
+                var type = method.DeclaringType;
+                if (type == null) {
+                    return true;
+                }
+
+                if (type == typeof(Task<>) && method.Name == "InnerInvoke") {
+                    return false;
+                }
+
+                if (type == typeof(Task)) {
+                    switch (method.Name) {
+                        case "ExecuteWithThreadLocal":
+                        case "Execute":
+                        case "ExecutionContextCallback":
+                        case "ExecuteEntry":
+                        case "InnerInvoke":
+                            return false;
+                    }
+                }
+
+                if (type == typeof(ExecutionContext)) {
+                    switch (method.Name) {
+                        case "RunInternal":
+                        case "Run":
+                            return false;
+                    }
+                }
+
+                // Don't show any methods marked with the StackTraceHiddenAttribute
+                // https://github.com/dotnet/coreclr/pull/14652
+                foreach (var attibute in method.GetCustomAttributesData()) {
+                    // internal Attribute, match on name
+                    if (attibute.AttributeType.Name == "StackTraceHiddenAttribute") {
+                        return false;
+                    }
+                }
+
+                foreach (var attibute in type.GetCustomAttributesData()) {
+                    // internal Attribute, match on name
+                    if (attibute.AttributeType.Name == "StackTraceHiddenAttribute") {
+                        return false;
+                    }
+                }
+
+                // Fallbacks for runtime pre-StackTraceHiddenAttribute
+                if (type == typeof(ExceptionDispatchInfo) && method.Name == nameof(ExceptionDispatchInfo)) {
+                    return false;
+                }
+
+                if (type == typeof(TaskAwaiter) ||
+                    type == typeof(TaskAwaiter<>) ||
+                    type == typeof(ConfiguredTaskAwaitable.ConfiguredTaskAwaiter) ||
+                    type == typeof(ConfiguredTaskAwaitable<>.ConfiguredTaskAwaiter)) {
+                    switch (method.Name) {
+                        case "HandleNonSuccessAndDebuggerNotification":
+                        case "ThrowForNonSuccess":
+                        case "ValidateEnd":
+                        case "GetResult":
+                            return false;
+                    }
+                } else if (type.FullName == "System.ThrowHelper") {
+                    return false;
+                }
+            } catch {
+                // GetCustomAttributesData can throw
+                return true;
+            }
+
+            return true;
+        }
+
+        private static ResolvedMethod GetMethodDisplay(MethodBase originMethod) {
+            var methodDisplayInfo = new ResolvedMethod();
+
+            // Special case: no method available
+            if (originMethod == null) {
+                return methodDisplayInfo;
+            }
+
+            var method = originMethod;
+            methodDisplayInfo.SubMethodBase = method;
+
+            // Type name
+            var type = method.DeclaringType;
+            var subMethodName = method.Name;
+            var methodName = method.Name;
+
+            if (type != null && type.IsDefined(typeof(CompilerGeneratedAttribute)) &&
+                (typeof(IAsyncStateMachine).IsAssignableFrom(type) || typeof(IEnumerator).IsAssignableFrom(type))) {
+
+                methodDisplayInfo.IsAsync = typeof(IAsyncStateMachine).IsAssignableFrom(type);
+
+                // Convert StateMachine methods to correct overload +MoveNext()
+                if (!TryResolveStateMachineMethod(ref method, out type)) {
+                    methodDisplayInfo.SubMethodBase = null;
+                    subMethodName = null;
+                }
+
+                methodName = method.Name;
+            }
+
+            // Method name
+            methodDisplayInfo.MethodBase = method;
+            methodDisplayInfo.Name = methodName;
+            if (method.Name.IndexOf("<", StringComparison.Ordinal) >= 0) {
+                if (TryResolveGeneratedName(ref method, out type, out methodName, out subMethodName, out var kind, out var ordinal)) {
+                    methodName = method.Name;
+                    methodDisplayInfo.MethodBase = method;
+                    methodDisplayInfo.Name = methodName;
+                    methodDisplayInfo.Ordinal = ordinal;
+                } else {
+                    methodDisplayInfo.MethodBase = null;
+                }
+
+                methodDisplayInfo.IsLambda = (kind == GeneratedNameKind.LambdaMethod);
+
+                if (methodDisplayInfo.IsLambda && type != null) {
+                    if (methodName == ".cctor") {
+                        var fields = type.GetFields(BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+                        foreach (var field in fields) {
+                            var value = field.GetValue(field);
+                            if (value is Delegate d) {
+                                if (ReferenceEquals(d.Method, originMethod) && d.Target.ToString() == originMethod.DeclaringType?.ToString()) {
+                                    methodDisplayInfo.Name = field.Name;
+                                    methodDisplayInfo.IsLambda = false;
+                                    method = originMethod;
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            if (subMethodName != methodName) {
+                methodDisplayInfo.SubMethod = subMethodName;
+            }
+
+            // ResolveStateMachineMethod may have set declaringType to null
+            if (type != null) {
+                var declaringTypeName = TypeNameHelper.GetTypeDisplayName(type, fullName: true, includeGenericParameterNames: true);
+                methodDisplayInfo.DeclaringTypeName = declaringTypeName;
+            }
+
+            if (method is MethodInfo mi) {
+                var returnParameter = mi.ReturnParameter;
+                if (returnParameter != null) {
+                    methodDisplayInfo.ReturnParameter = GetParameter(mi.ReturnParameter);
+                } else {
+                    methodDisplayInfo.ReturnParameter = new ResolvedParameter(string.Empty
+                        , TypeNameHelper.GetTypeDisplayName(mi.ReturnType, fullName: false, includeGenericParameterNames: true)
+                        , mi.ReturnType
+                        , string.Empty);
+                }
+            }
+
+            if (method.IsGenericMethod) {
+                var genericArguments = method.GetGenericArguments();
+                var genericArgumentsString = string.Join(", ", genericArguments
+                    .Select(arg => TypeNameHelper.GetTypeDisplayName(arg, fullName: false, includeGenericParameterNames: true)));
+                methodDisplayInfo.GenericArguments += "<" + genericArgumentsString + ">";
+                methodDisplayInfo.ResolvedGenericArguments = genericArguments;
+            }
+
+            // Method parameters
+            var parameters = method.GetParameters();
+            if (parameters.Length > 0) {
+                var resolvedParameters = new List<ResolvedParameter>(parameters.Length);
+                for (var i = 0; i < parameters.Length; i++) {
+                    resolvedParameters.Add(GetParameter(parameters[i]));
+                }
+                methodDisplayInfo.Parameters = resolvedParameters;
+            }
+
+            if (methodDisplayInfo.SubMethodBase == methodDisplayInfo.MethodBase) {
+                methodDisplayInfo.SubMethodBase = null;
+            } else if (methodDisplayInfo.SubMethodBase != null) {
+                parameters = methodDisplayInfo.SubMethodBase.GetParameters();
+                if (parameters.Length > 0) {
+                    var parameterList = new List<ResolvedParameter>(parameters.Length);
+                    foreach (var parameter in parameters) {
+                        var param = GetParameter(parameter);
+                        if (param.Name?.StartsWith("<") ?? true) {
+                            continue;
+                        }
+
+                        parameterList.Add(param);
+                    }
+
+                    methodDisplayInfo.SubMethodParameters = parameterList;
+                }
+            }
+
+            return methodDisplayInfo;
+        }
+
+        private static bool TryResolveGeneratedName(ref MethodBase method
+            , out Type type
+            , out string methodName
+            , out string subMethodName
+            , out GeneratedNameKind kind
+            , out int? ordinal) {
+
+            kind = GeneratedNameKind.None;
+            type = method.DeclaringType;
+            subMethodName = null;
+            ordinal = null;
+            methodName = method.Name;
+
+            var generatedName = methodName;
+
+            if (!TryParseGeneratedName(generatedName, out kind, out var openBracketOffset, out var closeBracketOffset)) {
+                return false;
+            }
+
+            methodName = generatedName.Substring(openBracketOffset + 1, closeBracketOffset - openBracketOffset - 1);
+
+            switch (kind) {
+                case GeneratedNameKind.LocalFunction: {
+                        var localNameStart = generatedName.IndexOf((char)kind, closeBracketOffset + 1);
+                        if (localNameStart < 0) break;
+                        localNameStart += 3;
+
+                        if (localNameStart < generatedName.Length) {
+                            var localNameEnd = generatedName.IndexOf("|", localNameStart, StringComparison.Ordinal);
+                            if (localNameEnd > 0) {
+                                subMethodName = generatedName.Substring(localNameStart, localNameEnd - localNameStart);
+                            }
+                        }
+                        break;
+                    }
+                case GeneratedNameKind.LambdaMethod:
+                    subMethodName = "";
+                    break;
+            }
+
+            var dt = method.DeclaringType;
+            if (dt == null) {
+                return false;
+            }
+
+            var matchHint = GetMatchHint(kind, method);
+            var matchName = methodName;
+
+            var candidateMethods = dt.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance | BindingFlags.DeclaredOnly).Where(m => m.Name == matchName);
+            if (TryResolveSourceMethod(candidateMethods, kind, matchHint, ref method, ref type, out ordinal)) return true;
+
+            var candidateConstructors = dt.GetConstructors(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance | BindingFlags.DeclaredOnly).Where(m => m.Name == matchName);
+            if (TryResolveSourceMethod(candidateConstructors, kind, matchHint, ref method, ref type, out ordinal)) return true;
+
+            const int MaxResolveDepth = 10;
+            for (var i = 0; i < MaxResolveDepth; i++) {
+                dt = dt.DeclaringType;
+                if (dt == null) {
+                    return false;
+                }
+
+                candidateMethods = dt.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance | BindingFlags.DeclaredOnly).Where(m => m.Name == matchName);
+                if (TryResolveSourceMethod(candidateMethods, kind, matchHint, ref method, ref type, out ordinal)) return true;
+
+                candidateConstructors = dt.GetConstructors(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance | BindingFlags.DeclaredOnly).Where(m => m.Name == matchName);
+                if (TryResolveSourceMethod(candidateConstructors, kind, matchHint, ref method, ref type, out ordinal)) return true;
+
+                if (methodName == ".cctor") {
+                    candidateConstructors = dt.GetConstructors(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.DeclaredOnly).Where(m => m.Name == matchName);
+                    foreach (var cctor in candidateConstructors)
+                    {
+                        method = cctor;
+                        type = dt;
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        private static bool TryResolveSourceMethod(IEnumerable<MethodBase> candidateMethods
+            , GeneratedNameKind kind
+            , string matchHint
+            , ref MethodBase method
+            , ref Type type
+            , out int? ordinal) {
+
+            ordinal = null;
+            foreach (var candidateMethod in candidateMethods) {
+                var methodBody = candidateMethod.GetMethodBody();
+                if (methodBody != null && kind == GeneratedNameKind.LambdaMethod) {
+                    foreach (var v in methodBody.LocalVariables) {
+                        if (v.LocalType == type) {
+                            GetOrdinal(method, ref ordinal);
+                        }
+                        method = candidateMethod;
+                        type = method.DeclaringType;
+                        return true;
+                    }
+                }
+
+                try {
+                    var rawIL = methodBody?.GetILAsByteArray();
+                    if (rawIL == null) {
+                        continue;
+                    }
+
+                    var reader = new ILReader(rawIL);
+                    while (reader.Read(candidateMethod)) {
+                        if (reader.Operand is MethodBase mb) {
+                            if (method == mb || (matchHint != null && method.Name.Contains(matchHint))) {
+                                if (kind == GeneratedNameKind.LambdaMethod) {
+                                    GetOrdinal(method, ref ordinal);
+                                }
+
+                                method = candidateMethod;
+                                type = method.DeclaringType;
+                                return true;
+                            }
+                        }
+                    }
+                } catch {
+                    // https://github.com/benaadams/Ben.Demystifier/issues/32
+                    // Skip methods where il can't be interpreted
+                }
+            }
+
+            return false;
+        }
+
+        private static void GetOrdinal(MethodBase method, ref int? ordinal) {
+            var lamdaStart = method.Name.IndexOf((char)GeneratedNameKind.LambdaMethod + "__", StringComparison.Ordinal) + 3;
+            if (lamdaStart > 3) {
+                var secondStart = method.Name.IndexOf("_", lamdaStart, StringComparison.Ordinal) + 1;
+                if (secondStart > 0) {
+                    lamdaStart = secondStart;
+                }
+
+                if (!int.TryParse(method.Name.Substring(lamdaStart), out var foundOrdinal)) {
+                    ordinal = null;
+                    return;
+                }
+
+                ordinal = foundOrdinal;
+
+                var methods = method.DeclaringType.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance | BindingFlags.DeclaredOnly);
+
+                var startName = method.Name.Substring(0, lamdaStart);
+                var count = 0;
+                foreach (var m in methods) {
+                    if (m.Name.Length > lamdaStart && m.Name.StartsWith(startName)) {
+                        count++;
+
+                        if (count > 1) {
+                            break;
+                        }
+                    }
+                }
+
+                if (count <= 1) {
+                    ordinal = null;
+                }
+            }
+        }
+
+        private static string GetMatchHint(GeneratedNameKind kind, MethodBase method) {
+            var methodName = method.Name;
+
+            switch (kind) {
+                case GeneratedNameKind.LocalFunction:
+                    var start = methodName.IndexOf("|", StringComparison.Ordinal);
+                    if (start < 1) return null;
+                    var end = methodName.IndexOf("_", start, StringComparison.Ordinal) + 1;
+                    if (end <= start) return null;
+
+                    return methodName.Substring(start, end - start);
+                default:
+                    return null;
+            }
+        }
+
+        // Parse the generated name. Returns true for names of the form
+        // [CS$]<[middle]>c[__[suffix]] where [CS$] is included for certain
+        // generated names, where [middle] and [__[suffix]] are optional,
+        // and where c is a single character in [1-9a-z]
+        // (csharp\LanguageAnalysis\LIB\SpecialName.cpp).
+        private static bool TryParseGeneratedName(string name, out GeneratedNameKind kind, out int openBracketOffset, out int closeBracketOffset) {
+            openBracketOffset = -1;
+            if (name.StartsWith("CS$<", StringComparison.Ordinal)) {
+                openBracketOffset = 3;
+            } else if (name.StartsWith("<", StringComparison.Ordinal)) {
+                openBracketOffset = 0;
+            }
+
+            if (openBracketOffset >= 0) {
+                closeBracketOffset = IndexOfBalancedParenthesis(name, openBracketOffset, '>');
+                if (closeBracketOffset >= 0 && closeBracketOffset + 1 < name.Length) {
+                    int c = name[closeBracketOffset + 1];
+                    // Note '0' is not special.
+                    if ((c >= '1' && c <= '9') || (c >= 'a' && c <= 'z'))  {
+                        kind = (GeneratedNameKind)c;
+                        return true;
+                    }
+                }
+            }
+
+            kind = GeneratedNameKind.None;
+            openBracketOffset = -1;
+            closeBracketOffset = -1;
+            return false;
+        }
+        
+        private static int IndexOfBalancedParenthesis(string str, int openingOffset, char closing) {
+            var opening = str[openingOffset];
+
+            var depth = 1;
+            for (var i = openingOffset + 1; i < str.Length; i++) {
+                var c = str[i];
+                if (c == opening) {
+                    depth++;
+                } else if (c == closing) {
+                    depth--;
+                    if (depth == 0) {
+                        return i;
+                    }
+                }
+            }
+
+            return -1;
+        }
+
+        private static string GetPrefix(ParameterInfo parameter, Type parameterType) {
+            if (parameter.IsOut) {
+                return "out";
+            }
+
+            if (parameterType != null && parameterType.IsByRef) {
+                var attribs = parameter.GetCustomAttributes(inherit: false);
+                if (attribs?.Length > 0) {
+                    foreach (var attrib in attribs) {
+                        if (attrib is Attribute att && att.GetType().Namespace == "System.Runtime.CompilerServices" && att.GetType().Name == "IsReadOnlyAttribute") {
+                            return "in";
+                        }
+                    }
+                }
+
+                return "ref";
+            }
+
+            return string.Empty;
+        }
+
+        private static ResolvedParameter GetParameter(ParameterInfo parameter) {
+            var parameterType = parameter.ParameterType;
+            var prefix = GetPrefix(parameter, parameterType);
+            var parameterTypeString = "?";
+
+            if (parameterType.IsGenericType) {
+                var customAttribs = parameter.GetCustomAttributes(inherit: false);
+
+                // We don't use System.ValueTuple yet
+
+                //if (customAttribs.Length > 0) {
+                //    var tupleNames = customAttribs.OfType<TupleElementNamesAttribute>().FirstOrDefault()?.TransformNames;
+
+                //    if (tupleNames?.Count > 0) {
+                //        return GetValueTupleParameter(tupleNames, prefix, parameter.Name, parameterType);
+                //    }
+                //}
+            }
+
+            if (parameterType.IsByRef) {
+                parameterType = parameterType.GetElementType();
+            }
+
+            parameterTypeString = TypeNameHelper.GetTypeDisplayName(parameterType, fullName: false, includeGenericParameterNames: true);
+
+            return new ResolvedParameter(parameter.Name, parameterTypeString, parameterType, prefix);
+        }
+
+        private static ResolvedParameter GetValueTupleParameter(List<string> tupleNames, string prefix, string name, Type parameterType) {
+            var sb = new StringBuilder();
+            sb.Append("(");
+            var args = parameterType.GetGenericArguments();
+            for (var i = 0; i < args.Length; i++) {
+                if (i > 0) {
+                    sb.Append(", ");
+                }
+
+                sb.Append(TypeNameHelper.GetTypeDisplayName(args[i], fullName: false, includeGenericParameterNames: true));
+
+                if (i >= tupleNames.Count) {
+                    continue;
+                }
+
+                var argName = tupleNames[i];
+                if (argName == null) {
+                    continue;
+                }
+
+                sb.Append(" ");
+                sb.Append(argName);
+            }
+
+            sb.Append(")");
+
+            return new ResolvedParameter(name, sb.ToString(), parameterType, prefix);
+        }
+
+        private static bool TryResolveStateMachineMethod(ref MethodBase method, out Type declaringType) {
+            Debug.Assert(method != null);
+            Debug.Assert(method.DeclaringType != null);
+
+            declaringType = method.DeclaringType;
+
+            var parentType = declaringType.DeclaringType;
+            if (parentType == null) {
+                return false;
+            }
+
+            var methods = parentType.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance | BindingFlags.DeclaredOnly);
+
+            foreach (var candidateMethod in methods) {
+                var attributes = candidateMethod.GetCustomAttributes<StateMachineAttribute>();
+
+                foreach (var asma in attributes) {
+                    if (asma.StateMachineType == declaringType) {
+                        method = candidateMethod;
+                        declaringType = candidateMethod.DeclaringType;
+                        // Mark the iterator as changed; so it gets the + annotation of the original method
+                        // async statemachines resolve directly to their builder methods so aren't marked as changed
+                        return asma is IteratorStateMachineAttribute;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        private enum GeneratedNameKind {
+            None = 0,
+
+            // Used by EE:
+            ThisProxyField = '4',
+            HoistedLocalField = '5',
+            DisplayClassLocalOrField = '8',
+            LambdaMethod = 'b',
+            LambdaDisplayClass = 'c',
+            StateMachineType = 'd',
+            LocalFunction = 'g', // note collision with Deprecated_InitializerLocal, however this one is only used for method names
+
+            // Used by EnC:
+            AwaiterField = 'u',
+            HoistedSynthesizedLocalField = 's',
+
+            // Currently not parsed:
+            StateMachineStateField = '1',
+            IteratorCurrentBackingField = '2',
+            StateMachineParameterProxyField = '3',
+            ReusableHoistedLocalField = '7',
+            LambdaCacheField = '9',
+            FixedBufferField = 'e',
+            AnonymousType = 'f',
+            TransparentIdentifier = 'h',
+            AnonymousTypeField = 'i',
+            AutoPropertyBackingField = 'k',
+            IteratorCurrentThreadIdField = 'l',
+            IteratorFinallyMethod = 'm',
+            BaseMethodWrapper = 'n',
+            AsyncBuilderField = 't',
+            DynamicCallSiteContainerType = 'o',
+            DynamicCallSiteField = 'p'
+        }
+
+        private struct ResolvedMethod {
+            public MethodBase MethodBase { get; set; }
+            public string DeclaringTypeName { get; set; }
+            public bool IsAsync { get; set; }
+            public bool IsLambda { get; set; }
+            public ResolvedParameter ReturnParameter { get; set; }
+            public string Name { get; set; }
+            public int? Ordinal { get; set; }
+            public string GenericArguments { get; set; }
+            public Type[] ResolvedGenericArguments { get; set; }
+            public MethodBase SubMethodBase { get; set; }
+            public string SubMethod { get; set; }
+            public List<ResolvedParameter> Parameters { get; set; }
+            public List<ResolvedParameter> SubMethodParameters { get; set; }
+        }
+
+        private struct ResolvedParameter {
+            public string Name { get; }
+            public string Type { get; }
+            public Type ResolvedType { get; }
+            public string Prefix { get; }
+
+            public ResolvedParameter(string name, string type, Type resolvedType, string prefix) {
+                Name = name;
+                Type = type;
+                ResolvedType = resolvedType;
+                Prefix = prefix;
+            }
+        }
+    }
+}

--- a/Common/Tests/Utilities/Ben.Demystifier/StringBuilderExtensions.cs
+++ b/Common/Tests/Utilities/Ben.Demystifier/StringBuilderExtensions.cs
@@ -32,7 +32,7 @@ using System.Threading;
 using System.Threading.Tasks;
 
 namespace TestUtilities.Ben.Demystifier {
-    internal static class StringBuilderExtensions {
+    public static class StringBuilderExtensions {
         public static StringBuilder AppendException(this StringBuilder stringBuilder, Exception exception) {
             stringBuilder.Append(exception.Message);
 

--- a/Common/Tests/Utilities/Ben.Demystifier/TypeNameHelper.cs
+++ b/Common/Tests/Utilities/Ben.Demystifier/TypeNameHelper.cs
@@ -1,0 +1,147 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+// 
+// Copyright (c) Ben A Adams. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+// 
+// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABLITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace TestUtilities.Ben.Demystifier {
+    // Adapted from https://github.com/aspnet/Common/blob/dev/shared/Microsoft.Extensions.TypeNameHelper.Sources/TypeNameHelper.cs
+    internal sealed class TypeNameHelper {
+        private static readonly Dictionary<Type, string> _builtInTypeNames = new Dictionary<Type, string> {
+            { typeof(void), "void" },
+            { typeof(bool), "bool" },
+            { typeof(byte), "byte" },
+            { typeof(char), "char" },
+            { typeof(decimal), "decimal" },
+            { typeof(double), "double" },
+            { typeof(float), "float" },
+            { typeof(int), "int" },
+            { typeof(long), "long" },
+            { typeof(object), "object" },
+            { typeof(sbyte), "sbyte" },
+            { typeof(short), "short" },
+            { typeof(string), "string" },
+            { typeof(uint), "uint" },
+            { typeof(ulong), "ulong" },
+            { typeof(ushort), "ushort" }
+        };
+
+        /// <summary>
+        /// Pretty print a type name.
+        /// </summary>
+        /// <param name="type">The <see cref="Type"/>.</param>
+        /// <param name="fullName"><c>true</c> to print a fully qualified name.</param>
+        /// <param name="includeGenericParameterNames"><c>true</c> to include generic parameter names.</param>
+        /// <returns>The pretty printed type name.</returns>
+        public static string GetTypeDisplayName(Type type, bool fullName = true, bool includeGenericParameterNames = false) {
+            var builder = new StringBuilder();
+            ProcessType(builder, type, new DisplayNameOptions(fullName, includeGenericParameterNames));
+            return builder.ToString();
+        }
+
+        private static void ProcessType(StringBuilder builder, Type type, DisplayNameOptions options) {
+            if (type.IsGenericType) {
+                var genericArguments = type.GetGenericArguments();
+                ProcessGenericType(builder, type, genericArguments, genericArguments.Length, options);
+            } else if (type.IsArray) {
+                ProcessArrayType(builder, type, options);
+            } else if (_builtInTypeNames.TryGetValue(type, out var builtInName)) {
+                builder.Append(builtInName);
+            } else if (type.Namespace == nameof(System)) {
+                builder.Append(type.Name);
+            } else if (type.IsGenericParameter) {
+                if (options.IncludeGenericParameterNames) {
+                    builder.Append(type.Name);
+                }
+            }
+            else {
+                builder.Append(options.FullName ? type.FullName ?? type.Name : type.Name);
+            }
+        }
+
+        private static void ProcessArrayType(StringBuilder builder, Type type, DisplayNameOptions options) {
+            var innerType = type;
+            while (innerType != null && innerType.IsArray){
+                innerType = innerType.GetElementType();
+            }
+
+            ProcessType(builder, innerType, options);
+
+            while (type != null && type.IsArray) {
+                builder.Append('[');
+                builder.Append(',', type.GetArrayRank() - 1);
+                builder.Append(']');
+                type = type.GetElementType();
+            }
+        }
+
+        private static void ProcessGenericType(StringBuilder builder, Type type, Type[] genericArguments, int length, DisplayNameOptions options) {
+            var offset = 0;
+            if (type.IsNested && type.DeclaringType != null) {
+                offset = type.DeclaringType.GetGenericArguments().Length;
+            }
+
+            if (options.FullName) {
+                if (type.IsNested) {
+                    ProcessGenericType(builder, type.DeclaringType, genericArguments, offset, options);
+                    builder.Append('+');
+                } else if (!string.IsNullOrEmpty(type.Namespace)) {
+                    builder.Append(type.Namespace);
+                    builder.Append('.');
+                }
+            }
+
+            var genericPartIndex = type.Name.IndexOf('`');
+            if (genericPartIndex <= 0) {
+                builder.Append(type.Name);
+                return;
+            }
+
+            builder.Append(type.Name, 0, genericPartIndex);
+
+            builder.Append('<');
+            for (var i = offset; i < length; i++) {
+                ProcessType(builder, genericArguments[i], options);
+                if (i + 1 == length) {
+                    continue;
+                }
+
+                builder.Append(',');
+                if (options.IncludeGenericParameterNames || !genericArguments[i + 1].IsGenericParameter) {
+                    builder.Append(' ');
+                }
+            }
+            builder.Append('>');
+        }
+
+        private struct DisplayNameOptions {
+            public DisplayNameOptions(bool fullName, bool includeGenericParameterNames) {
+                FullName = fullName;
+                IncludeGenericParameterNames = includeGenericParameterNames;
+            }
+
+            public bool FullName { get; }
+            public bool IncludeGenericParameterNames { get; }
+        }
+    }
+}

--- a/Common/Tests/Utilities/Ben.Demystifier/readme.txt
+++ b/Common/Tests/Utilities/Ben.Demystifier/readme.txt
@@ -1,0 +1,1 @@
+﻿The folder contains modified version of the Ben.Demystifier (https://github.com/benaadams/Ben.Demystifier) which makes it easier to read modern .net stack traces

--- a/Common/Tests/Utilities/MSTestEnvironment.cs
+++ b/Common/Tests/Utilities/MSTestEnvironment.cs
@@ -1,0 +1,63 @@
+﻿// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABLITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Common = Microsoft.PythonTools.Infrastructure;
+using Analysis = Microsoft.PythonTools.Analysis.Infrastructure;
+
+namespace TestUtilities {
+    public sealed class MSTestEnvironment : Common.ITestEnvironment, Analysis.ITestEnvironment {
+        private static MSTestEnvironment _instance;
+
+        public static void Initialize() {
+            _instance = new MSTestEnvironment();
+            Analysis.TestEnvironment.Current = _instance;
+            Common.TestEnvironment.Current = _instance;
+        }
+
+        public static void TestInitialize(int secondsTimeout = 30) => _instance.BeforeTestRun(secondsTimeout);
+        public static void TestCleanup() => _instance.AfterTestRun();
+
+        private readonly AsyncLocal<TaskObserver> _taskObserver = new AsyncLocal<TaskObserver>();
+
+        public bool TryAddTaskToWait(Task task) {
+            var taskObserver = _taskObserver.Value;
+            if (taskObserver == null) {
+                return false;
+            }
+            taskObserver.Add(task);
+            return true;
+        }
+        
+        private void BeforeTestRun(int secondsTimeout) {
+            if (_taskObserver.Value != null) {
+                throw new InvalidOperationException("AsyncLocal<TaskObserver> reentrancy");
+            }
+
+            _taskObserver.Value = new TaskObserver(secondsTimeout);
+        }
+
+        private void AfterTestRun() {
+            try {
+                _taskObserver.Value?.WaitForObservedTask();
+            } finally {
+                _taskObserver.Value = null;
+            }
+        }
+    }
+}

--- a/Common/Tests/Utilities/TaskObserver.cs
+++ b/Common/Tests/Utilities/TaskObserver.cs
@@ -22,7 +22,6 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.PythonTools.Analysis.Infrastructure;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using TestUtilities.Ben.Demystifier;
 
@@ -171,14 +170,13 @@ namespace TestUtilities {
             foreach (var frame in stackTrace) {
                 var frameMethod = frame.GetMethod();
                 if (skip) {
-                    if (frameMethod.Name == nameof(Microsoft.PythonTools.Infrastructure.TaskExtensions.DoNotWait) && 
-                        frameMethod.DeclaringType?.Name == nameof(Microsoft.PythonTools.Infrastructure.TaskExtensions)) {
+                    if (frameMethod.Name == "DoNotWait" && frameMethod.DeclaringType?.Name == "TaskExtensions") {
                         skip = false;
                     }
                     continue;
                 }
 
-                if (frameMethod.DeclaringType?.Namespace.StartsWithOrdinal("Microsoft.VisualStudio.TestPlatform.MSTestFramework") ?? false) {
+                if (frameMethod.DeclaringType?.Namespace?.StartsWith("Microsoft.VisualStudio.TestPlatform.MSTestFramework", StringComparison.Ordinal) ?? false) {
                     continue;
                 }
 

--- a/Common/Tests/Utilities/TaskObserver.cs
+++ b/Common/Tests/Utilities/TaskObserver.cs
@@ -1,0 +1,191 @@
+﻿// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABLITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.PythonTools.Analysis.Infrastructure;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using TestUtilities.Ben.Demystifier;
+
+namespace TestUtilities {
+    internal class TaskObserver {
+        private readonly int _secondsTimeout;
+        private readonly Action<Task> _afterTaskCompleted;
+        private readonly TaskCompletionSource<Exception> _tcs;
+        private readonly ConcurrentDictionary<Task, StackFrame[]> _stackTraces;
+        private int _count;
+        private bool _isTestCompleted;
+
+        public TaskObserver(int secondsTimeout) {
+            _secondsTimeout = secondsTimeout;
+            _afterTaskCompleted = AfterTaskCompleted;
+            _tcs = new TaskCompletionSource<Exception>();
+            _stackTraces = new ConcurrentDictionary<Task, StackFrame[]>();
+        }
+
+        public void Add(Task task) {
+            // No reason to watch for task if it is completed already
+            if (task.IsCompleted) {
+                task.GetAwaiter().GetResult();
+            }
+
+            Interlocked.Increment(ref _count);
+            _stackTraces.TryAdd(task, GetFilteredStackTrace());
+            task.ContinueWith(_afterTaskCompleted, CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
+        }
+        
+        public void WaitForObservedTask() {
+            TestCompleted();
+            _tcs.Task.Wait(_secondsTimeout * 1000);
+
+            try {
+                Summarize();
+            } finally {
+                _stackTraces.Clear();
+            }
+        }
+
+        private void Summarize() { 
+            var incompleteTasks = new Queue<StackFrame[]>();
+            var failedTasks = new Queue<KeyValuePair<StackFrame[], Exception>>();
+            foreach (var kvp in _stackTraces) {
+                var task = kvp.Key;
+                if (!task.IsCompleted) {
+                    incompleteTasks.Enqueue(kvp.Value);
+                } else if (task.IsFaulted && task.Exception != null) {
+                    var aggregateException = task.Exception.Flatten();
+                    var exception = aggregateException.InnerExceptions.Count == 1
+                        ? aggregateException.InnerException
+                        : aggregateException;
+
+                    failedTasks.Enqueue(new KeyValuePair<StackFrame[], Exception>(kvp.Value, exception));
+                }
+            }
+
+            if (incompleteTasks.Count == 0 && failedTasks.Count == 0) {
+                return;
+            }
+
+            var message = new StringBuilder();
+            var hasIncompleteTasks = incompleteTasks.Count > 0;
+            var hasFailedTasks = failedTasks.Count > 0;
+            if (hasIncompleteTasks) {
+                if (incompleteTasks.Count > 1) {
+                    message
+                        .Append(incompleteTasks.Count)
+                        .AppendLine(" tasks that have been started during test run are still not completed:")
+                        .AppendLine();
+                } else {
+                    message
+                        .AppendLine("One task that has been started during test run is still not completed:")
+                        .AppendLine();
+                }
+
+                while (incompleteTasks.Count > 0) {
+                    message
+                        .AppendFrames(incompleteTasks.Dequeue())
+                        .AppendLine()
+                        .AppendLine();
+                }
+
+                if (hasFailedTasks) {
+                    message
+                        .Append("Also, ");
+                }
+            }
+
+            if (hasFailedTasks) {
+                if (failedTasks.Count > 1) {
+                    message
+                        .Append(failedTasks.Count)
+                        .AppendLine(" not awaited tasks have failed:")
+                        .AppendLine();
+                } else {
+                    message
+                        .Append(hasIncompleteTasks ? "one" : "One")
+                        .AppendLine(" not awaited tasks has failed:")
+                        .AppendLine();
+                }
+            }
+
+            while (failedTasks.Count > 0) {
+                var kvp = failedTasks.Dequeue();
+                message
+                    .Append(kvp.Value.GetType().Name)
+                    .Append(": ")
+                    .AppendException(kvp.Value)
+                    .AppendLine()
+                    .Append("   --- Task stack trace: ---")
+                    .AppendLine()
+                    .AppendFrames(kvp.Key)
+                    .AppendLine()
+                    .AppendLine();
+            }
+
+            throw new AssertFailedException(message.ToString());
+        }
+
+        private void TestCompleted() {
+            Volatile.Write(ref _isTestCompleted, true);
+            if (_count == 0) {
+                _tcs.TrySetResult(null);
+            }
+        }
+
+        private void AfterTaskCompleted(Task task) {
+            var count = Interlocked.Decrement(ref _count);
+            if (!task.IsFaulted) {
+                _stackTraces.TryRemove(task, out _);
+            } else if (Debugger.IsAttached) {
+                Debugger.Break();
+            }
+
+            if (count == 0 && Volatile.Read(ref _isTestCompleted)) {
+                _tcs.TrySetResult(null);
+            }
+        }
+
+        private static StackFrame[] GetFilteredStackTrace() {
+            var stackTrace = new StackTrace(2, true).GetFrames() ?? new StackFrame[0];
+            var filteredStackTrace = new List<StackFrame>();
+            var skip = true;
+            foreach (var frame in stackTrace) {
+                var frameMethod = frame.GetMethod();
+                if (skip) {
+                    if (frameMethod.Name == nameof(Microsoft.PythonTools.Infrastructure.TaskExtensions.DoNotWait) && 
+                        frameMethod.DeclaringType?.Name == nameof(Microsoft.PythonTools.Infrastructure.TaskExtensions)) {
+                        skip = false;
+                    }
+                    continue;
+                }
+
+                if (frameMethod.DeclaringType?.Namespace.StartsWithOrdinal("Microsoft.VisualStudio.TestPlatform.MSTestFramework") ?? false) {
+                    continue;
+                }
+
+                filteredStackTrace.Add(frame);
+            }
+
+            return filteredStackTrace.ToArray();
+        }
+    }
+}

--- a/Common/Tests/Utilities/TestEnvironment.cs
+++ b/Common/Tests/Utilities/TestEnvironment.cs
@@ -17,21 +17,13 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using Common = Microsoft.PythonTools.Infrastructure;
-using Analysis = Microsoft.PythonTools.Analysis.Infrastructure;
 
 namespace TestUtilities {
-    public sealed class MSTestEnvironment : Common.ITestEnvironment, Analysis.ITestEnvironment {
-        private static MSTestEnvironment _instance;
+    public class TestEnvironment {
+        protected static TestEnvironment Instance { get; set; }
 
-        public static void Initialize() {
-            _instance = new MSTestEnvironment();
-            Analysis.TestEnvironment.Current = _instance;
-            Common.TestEnvironment.Current = _instance;
-        }
-
-        public static void TestInitialize(int secondsTimeout = 30) => _instance.BeforeTestRun(secondsTimeout);
-        public static void TestCleanup() => _instance.AfterTestRun();
+        public static void TestInitialize(int secondsTimeout = 30) => Instance?.BeforeTestRun(secondsTimeout);
+        public static void TestCleanup() => Instance?.AfterTestRun();
 
         private readonly AsyncLocal<TaskObserver> _taskObserver = new AsyncLocal<TaskObserver>();
 

--- a/Common/Tests/Utilities/TestUtilities.csproj
+++ b/Common/Tests/Utilities/TestUtilities.csproj
@@ -88,6 +88,9 @@
   </Choose>
   <ItemGroup>
     <Compile Include="AssertListener.cs" />
+    <Compile Include="Ben.Demystifier\ILReader.cs" />
+    <Compile Include="Ben.Demystifier\StringBuilderExtensions.cs" />
+    <Compile Include="Ben.Demystifier\TypeNameHelper.cs" />
     <Compile Include="FileUtils.cs" />
     <Compile Include="IAddExistingItem.cs" />
     <Compile Include="IAddNewItem.cs" />
@@ -102,9 +105,11 @@
     <Compile Include="Mocks\MockTextViewModel.cs" />
     <Compile Include="Mocks\MockVsShell.cs" />
     <Compile Include="Mocks\TextVersionWorkaround.cs" />
+    <Compile Include="MSTestEnvironment.cs" />
     <Compile Include="ProcessScope.cs" />
     <Compile Include="SessionHolder.cs" />
     <Compile Include="SharedProject\SymbolicLinkItem.cs" />
+    <Compile Include="TaskObserver.cs" />
     <Compile Include="VCCompiler.cs" />
     <Compile Include="VisualStudioPath.cs" />
     <Compile Include="WebDownloadUtility.cs" />
@@ -179,6 +184,16 @@
     <Compile Include="TestExtensions.cs" />
     <Compile Include="TestMethod.cs" />
     <Compile Include="WpfProxy.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Python\Product\Analysis\Analysis.csproj">
+      <Project>{a85d479d-67a9-4bdb-904a-7d86daf68a6f}</Project>
+      <Name>Analysis</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\Python\Product\Common\Common.csproj">
+      <Project>{B3DB0521-D9E3-4F48-9E2E-E5ECAE886049}</Project>
+      <Name>Common</Name>
+    </ProjectReference>
   </ItemGroup>
   <Target Name="BeforeCompile">
     <Exec Command="taskkill /f /im QTAgent32.exe" IgnoreExitCode="true" ContinueOnError="true" IgnoreStandardErrorWarningFormat="true" />

--- a/Common/Tests/Utilities/TestUtilities.csproj
+++ b/Common/Tests/Utilities/TestUtilities.csproj
@@ -105,11 +105,11 @@
     <Compile Include="Mocks\MockTextViewModel.cs" />
     <Compile Include="Mocks\MockVsShell.cs" />
     <Compile Include="Mocks\TextVersionWorkaround.cs" />
-    <Compile Include="MSTestEnvironment.cs" />
     <Compile Include="ProcessScope.cs" />
     <Compile Include="SessionHolder.cs" />
     <Compile Include="SharedProject\SymbolicLinkItem.cs" />
     <Compile Include="TaskObserver.cs" />
+    <Compile Include="TestEnvironment.cs" />
     <Compile Include="VCCompiler.cs" />
     <Compile Include="VisualStudioPath.cs" />
     <Compile Include="WebDownloadUtility.cs" />
@@ -184,16 +184,6 @@
     <Compile Include="TestExtensions.cs" />
     <Compile Include="TestMethod.cs" />
     <Compile Include="WpfProxy.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\Python\Product\Analysis\Analysis.csproj">
-      <Project>{a85d479d-67a9-4bdb-904a-7d86daf68a6f}</Project>
-      <Name>Analysis</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\..\..\Python\Product\Common\Common.csproj">
-      <Project>{B3DB0521-D9E3-4F48-9E2E-E5ECAE886049}</Project>
-      <Name>Common</Name>
-    </ProjectReference>
   </ItemGroup>
   <Target Name="BeforeCompile">
     <Exec Command="taskkill /f /im QTAgent32.exe" IgnoreExitCode="true" ContinueOnError="true" IgnoreStandardErrorWarningFormat="true" />

--- a/Python/Product/Analysis/Analysis.csproj
+++ b/Python/Product/Analysis/Analysis.csproj
@@ -64,11 +64,13 @@
     <Compile Include="Infrastructure\EnumerableExtensions.cs" />
     <Compile Include="Infrastructure\ExceptionExtensions.cs" />
     <Compile Include="Infrastructure\InstallPath.cs" />
+    <Compile Include="Infrastructure\ITestEnvironment.cs" />
     <Compile Include="Infrastructure\PathEqualityComparer.cs" />
     <Compile Include="Infrastructure\PathUtils.cs" />
     <Compile Include="Infrastructure\ProcessHelper.cs" />
     <Compile Include="Infrastructure\StringExtensions.cs" />
     <Compile Include="Infrastructure\TaskExtensions.cs" />
+    <Compile Include="Infrastructure\TestEnvironment.cs" />
     <Compile Include="Infrastructure\UriEqualityComparer.cs" />
     <Compile Include="Intellisense\AnalysisPriority.cs" />
     <Compile Include="Intellisense\AnalysisQueue.cs" />

--- a/Python/Product/Analysis/Infrastructure/ITestEnvironment.cs
+++ b/Python/Product/Analysis/Infrastructure/ITestEnvironment.cs
@@ -1,0 +1,23 @@
+// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABLITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System.Threading.Tasks;
+
+namespace Microsoft.PythonTools.Analysis.Infrastructure {
+    public interface ITestEnvironment {
+        bool TryAddTaskToWait(Task task);
+    }
+}

--- a/Python/Product/Analysis/Infrastructure/TaskExtensions.cs
+++ b/Python/Product/Analysis/Infrastructure/TaskExtensions.cs
@@ -22,9 +22,13 @@ namespace Microsoft.PythonTools.Analysis.Infrastructure {
         /// Suppresses warnings about unawaited tasks and ensures that unhandled
         /// errors will cause the process to terminate.
         /// </summary>
-        public static async void DoNotWait(this Task task) {
-            await task;
+        public static void DoNotWait(this Task task) {
+            if (TestEnvironment.Current == null || !TestEnvironment.Current.TryAddTaskToWait(task)) {
+                DoNotWaitImpl(task);
+            }
         }
+
+        private static async void DoNotWaitImpl(Task task) => await task;
 
         /// <summary>
         /// Waits for a task to complete. If an exception occurs, the exception

--- a/Python/Product/Analysis/Infrastructure/TestEnvironment.cs
+++ b/Python/Product/Analysis/Infrastructure/TestEnvironment.cs
@@ -1,0 +1,34 @@
+﻿// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABLITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System;
+using System.Threading;
+
+namespace Microsoft.PythonTools.Analysis.Infrastructure {
+    public static class TestEnvironment {
+        private static ITestEnvironment _current;
+
+        public static ITestEnvironment Current {
+            get => _current;
+            set {
+                var oldValue = Interlocked.CompareExchange(ref _current, value, null);
+                if (oldValue != null) {
+                    throw new InvalidOperationException("Only one test environment can be set per app domain");
+                }
+            }
+        }
+    }
+}

--- a/Python/Product/Common/Common.csproj
+++ b/Python/Product/Common/Common.csproj
@@ -49,6 +49,7 @@
     <Compile Include="Infrastructure\CancellationTokens.cs" />
     <Compile Include="Infrastructure\COMEnumerator.cs" />
     <Compile Include="Infrastructure\ICatalogLog.cs" />
+    <Compile Include="Infrastructure\ITestEnvironment.cs" />
     <Compile Include="Infrastructure\NativeMethods.cs" />
     <Compile Include="Infrastructure\ObservableCollectionExtensions.cs" />
     <Compile Include="Infrastructure\PathUtils.cs" />
@@ -61,6 +62,7 @@
     <Compile Include="Infrastructure\StringExtensions.cs" />
     <Compile Include="Infrastructure\StringListReader.cs" />
     <Compile Include="Infrastructure\TaskExtensions.cs" />
+    <Compile Include="Infrastructure\TestEnvironment.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Strings.Designer.cs">
       <AutoGen>True</AutoGen>

--- a/Python/Product/Common/Infrastructure/ITestEnvironment.cs
+++ b/Python/Product/Common/Infrastructure/ITestEnvironment.cs
@@ -1,0 +1,23 @@
+// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABLITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System.Threading.Tasks;
+
+namespace Microsoft.PythonTools.Infrastructure {
+    public interface ITestEnvironment {
+        bool TryAddTaskToWait(Task task);
+    }
+}

--- a/Python/Product/Common/Infrastructure/TaskExtensions.cs
+++ b/Python/Product/Common/Infrastructure/TaskExtensions.cs
@@ -26,9 +26,13 @@ namespace Microsoft.PythonTools.Infrastructure {
         /// Suppresses warnings about unawaited tasks and ensures that unhandled
         /// errors will cause the process to terminate.
         /// </summary>
-        public static async void DoNotWait(this Task task) {
-            await task;
+        public static void DoNotWait(this Task task) {
+            if (TestEnvironment.Current == null || !TestEnvironment.Current.TryAddTaskToWait(task)) {
+                DoNotWaitImpl(task);
+            }
         }
+
+        private static async void DoNotWaitImpl(Task task) => await task;
 
         /// <summary>
         /// Waits for a task to complete. If an exception occurs, the exception

--- a/Python/Product/Common/Infrastructure/TestEnvironment.cs
+++ b/Python/Product/Common/Infrastructure/TestEnvironment.cs
@@ -1,0 +1,34 @@
+﻿// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABLITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System;
+using System.Threading;
+
+namespace Microsoft.PythonTools.Infrastructure {
+    public static class TestEnvironment {
+        private static ITestEnvironment _current;
+
+        public static ITestEnvironment Current {
+            get => _current;
+            set {
+                var oldValue = Interlocked.CompareExchange(ref _current, value, null);
+                if (oldValue != null) {
+                    throw new InvalidOperationException("Only one test environment can be set per app domain");
+                }
+            }
+        }
+    }
+}

--- a/Python/Tests/Core.UI/VSPackage.cs
+++ b/Python/Tests/Core.UI/VSPackage.cs
@@ -17,6 +17,7 @@
 using System;
 using Microsoft.VisualStudio.Shell;
 using TestRunnerInterop;
+using TestUtilities.Python;
 using TestUtilities.UI;
 
 namespace PythonToolsUITests {
@@ -25,9 +26,10 @@ namespace PythonToolsUITests {
     public sealed class VSPackage : Package {
         public const string AutomationObject = "Microsoft.PythonTools.Tests.PythonToolsUITests";
 
-        private readonly Lazy<IVsHostedPythonToolsTest> _testRunner = new Lazy<IVsHostedPythonToolsTest>(() =>
-            new HostedPythonToolsTestRunner(typeof(VSPackage).Assembly)
-        );
+        private readonly Lazy<IVsHostedPythonToolsTest> _testRunner = new Lazy<IVsHostedPythonToolsTest>(() => {
+                MSTestEnvironment.Initialize();
+                return new HostedPythonToolsTestRunner(typeof(VSPackage).Assembly);
+            });
 
         protected override object GetAutomationObject(string name) {
             if (name == AutomationObject) {

--- a/Python/Tests/Core/AssemblySetup.cs
+++ b/Python/Tests/Core/AssemblySetup.cs
@@ -1,0 +1,26 @@
+// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABLITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using TestUtilities;
+
+namespace PythonToolsTests {
+    [TestClass]
+    public sealed class AssemblySetup {
+        [AssemblyInitialize]
+        public static void Initialize(TestContext testContext) => MSTestEnvironment.Initialize();
+    }
+}

--- a/Python/Tests/Core/PythonToolsTests.csproj
+++ b/Python/Tests/Core/PythonToolsTests.csproj
@@ -102,6 +102,7 @@
     <Compile Include="..\DebuggerTests\DebugExtensions.cs">
       <Link>DebugExtensions.cs</Link>
     </Compile>
+    <Compile Include="AssemblySetup.cs" />
     <Compile Include="AutoIndentTests.cs" />
     <Compile Include="BuildTasksTests.cs" />
     <Compile Include="CodeCellTests.cs" />

--- a/Python/Tests/DebuggerUITests/VSPackage.cs
+++ b/Python/Tests/DebuggerUITests/VSPackage.cs
@@ -18,6 +18,7 @@ using System;
 using System.Runtime.InteropServices;
 using Microsoft.VisualStudio.Shell;
 using TestRunnerInterop;
+using TestUtilities.Python;
 using TestUtilities.UI;
 
 namespace PythonToolsUITests {
@@ -27,9 +28,10 @@ namespace PythonToolsUITests {
     public sealed class VSPackage : Package {
         public const string AutomationObject = "Microsoft.PythonTools.Tests.DebuggerUITests";
 
-        private readonly Lazy<IVsHostedPythonToolsTest> _testRunner = new Lazy<IVsHostedPythonToolsTest>(() =>
-            new HostedPythonToolsTestRunner(typeof(VSPackage).Assembly)
-        );
+        private readonly Lazy<IVsHostedPythonToolsTest> _testRunner = new Lazy<IVsHostedPythonToolsTest>(() => {
+            MSTestEnvironment.Initialize();
+            return new HostedPythonToolsTestRunner(typeof(VSPackage).Assembly);
+        });
 
         protected override object GetAutomationObject(string name) {
             if (name == AutomationObject) {

--- a/Python/Tests/DjangoUITests/VSPackage.cs
+++ b/Python/Tests/DjangoUITests/VSPackage.cs
@@ -17,6 +17,7 @@
 using System;
 using Microsoft.VisualStudio.Shell;
 using TestRunnerInterop;
+using TestUtilities.Python;
 using TestUtilities.UI;
 
 namespace PythonToolsUITests {
@@ -25,13 +26,14 @@ namespace PythonToolsUITests {
     public sealed class VSPackage : Package {
         public const string AutomationObject = "Microsoft.PythonTools.Tests.DjangoUITests";
 
-        private readonly Lazy<IVsHostedPythonToolsTest> _testRunner = new Lazy<IVsHostedPythonToolsTest>(() =>
-            new HostedPythonToolsTestRunner(
+        private readonly Lazy<IVsHostedPythonToolsTest> _testRunner = new Lazy<IVsHostedPythonToolsTest>(() => {
+            MSTestEnvironment.Initialize();
+            return new HostedPythonToolsTestRunner(
                 typeof(VSPackage).Assembly,
                 new Guid("a8637c34-aa55-46e2-973c-9c3e09afc17b"), // Django
-                new Guid("8b24f93b-b3c8-33b8-8425-3af897ab50a4")  // DebuggerUITests
-            )
-        );
+                new Guid("8b24f93b-b3c8-33b8-8425-3af897ab50a4") // DebuggerUITests
+            );
+        });
 
         protected override object GetAutomationObject(string name) {
             if (name == AutomationObject) {

--- a/Python/Tests/ProfilingUITests/VSPackage.cs
+++ b/Python/Tests/ProfilingUITests/VSPackage.cs
@@ -17,6 +17,7 @@
 using System;
 using Microsoft.VisualStudio.Shell;
 using TestRunnerInterop;
+using TestUtilities.Python;
 using TestUtilities.UI;
 
 namespace ProfilingUITests {
@@ -25,12 +26,13 @@ namespace ProfilingUITests {
     public sealed class VSPackage : Package {
         public const string AutomationObject = "Microsoft.PythonTools.Tests.ProfilingUITests";
 
-        private readonly Lazy<IVsHostedPythonToolsTest> _testRunner = new Lazy<IVsHostedPythonToolsTest>(() =>
-            new HostedPythonToolsTestRunner(
+        private readonly Lazy<IVsHostedPythonToolsTest> _testRunner = new Lazy<IVsHostedPythonToolsTest>(() => {
+            MSTestEnvironment.Initialize();
+            return new HostedPythonToolsTestRunner(
                 typeof(VSPackage).Assembly,
                 new Guid("F4A63B2A-49AB-4b2d-AA59-A10F01026C89") // Profiling
-            )
-        );
+            );
+        });
 
         protected override object GetAutomationObject(string name) {
             if (name == AutomationObject) {

--- a/Python/Tests/ReplWindowUITests/VSPackage.cs
+++ b/Python/Tests/ReplWindowUITests/VSPackage.cs
@@ -17,6 +17,7 @@
 using System;
 using Microsoft.VisualStudio.Shell;
 using TestRunnerInterop;
+using TestUtilities.Python;
 using TestUtilities.UI;
 
 namespace PythonToolsUITests {
@@ -25,9 +26,10 @@ namespace PythonToolsUITests {
     public sealed class VSPackage : Package {
         public const string AutomationObject = "Microsoft.PythonTools.Tests.ReplWindowUITests";
 
-        private readonly Lazy<IVsHostedPythonToolsTest> _testRunner = new Lazy<IVsHostedPythonToolsTest>(() =>
-            new HostedPythonToolsTestRunner(typeof(VSPackage).Assembly)
-        );
+        private readonly Lazy<IVsHostedPythonToolsTest> _testRunner = new Lazy<IVsHostedPythonToolsTest>(() => {
+            MSTestEnvironment.Initialize();
+            return new HostedPythonToolsTestRunner(typeof(VSPackage).Assembly);
+        });
 
         protected override object GetAutomationObject(string name) {
             if (name == AutomationObject) {

--- a/Python/Tests/Utilities.Python.Analysis/MSTestEnvironment.cs
+++ b/Python/Tests/Utilities.Python.Analysis/MSTestEnvironment.cs
@@ -20,10 +20,10 @@ using Analysis = Microsoft.PythonTools.Analysis.Infrastructure;
 namespace TestUtilities.Python {
     public sealed class MSTestEnvironment : TestEnvironment, Common.ITestEnvironment, Analysis.ITestEnvironment {
         public static void Initialize() {
-            var isntance = new MSTestEnvironment();
-            Instance = isntance;
-            Analysis.TestEnvironment.Current = isntance;
-            Common.TestEnvironment.Current = isntance;
+            var instance = new MSTestEnvironment();
+            Instance = instance;
+            Analysis.TestEnvironment.Current = instance;
+            Common.TestEnvironment.Current = instance;
         }
     }
 }

--- a/Python/Tests/Utilities.Python.Analysis/MSTestEnvironment.cs
+++ b/Python/Tests/Utilities.Python.Analysis/MSTestEnvironment.cs
@@ -1,4 +1,4 @@
-// Python Tools for Visual Studio
+﻿// Python Tools for Visual Studio
 // Copyright(c) Microsoft Corporation
 // All rights reserved.
 //
@@ -14,13 +14,16 @@
 // See the Apache Version 2.0 License for specific language governing
 // permissions and limitations under the License.
 
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using TestUtilities.Python;
+using Common = Microsoft.PythonTools.Infrastructure;
+using Analysis = Microsoft.PythonTools.Analysis.Infrastructure;
 
-namespace PythonToolsTests {
-    [TestClass]
-    public sealed class AssemblySetup {
-        [AssemblyInitialize]
-        public static void Initialize(TestContext testContext) => MSTestEnvironment.Initialize();
+namespace TestUtilities.Python {
+    public sealed class MSTestEnvironment : TestEnvironment, Common.ITestEnvironment, Analysis.ITestEnvironment {
+        public static void Initialize() {
+            var isntance = new MSTestEnvironment();
+            Instance = isntance;
+            Analysis.TestEnvironment.Current = isntance;
+            Common.TestEnvironment.Current = isntance;
+        }
     }
 }

--- a/Python/Tests/Utilities.Python.Analysis/TestUtilities.Python.Analysis.csproj
+++ b/Python/Tests/Utilities.Python.Analysis/TestUtilities.Python.Analysis.csproj
@@ -55,6 +55,7 @@
     <Compile Include="MockPythonInterpreterFactory.cs" />
     <Compile Include="MockPythonInterpreterFactoryProvider.cs" />
     <Compile Include="MockPythonProjectEntry.cs" />
+    <Compile Include="MSTestEnvironment.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="PythonAnalysis.cs" />
     <Compile Include="PythonPaths.cs" />


### PR DESCRIPTION
This approach helps tests catch exceptions in tasks that aren't awaited or run too for long.

For example, imagine the following code:
```cs
public void Run() {
    RunThenFailAsync().DoNotWait();
    RunForeverAsync().DoNotWait();
}

private async Task RunThenFailAsync() {
    await Task.Delay(1000);
    throw new InvalidOperationException();
}

private async Task RunForeverAsync() {
    while (true) {
        await Task.Delay(500);
    }
}
```

If we create a simple test for it, it will successfully pass:
```cs
[TestMethod]
public void SomeTypeTest() {
    new SomeType().Run();
}
```
![image](https://user-images.githubusercontent.com/8933858/36044501-bc668e16-0d87-11e8-9b20-9b93c78420f2.png)

But, with `TaskObserver` enabled:
```cs
[TestInitialize]
public void Initialize() => MSTestEnvironment.TestInitialize(5);

[TestCleanup]
public void Cleanup() => MSTestEnvironment.TestCleanup();

[TestMethod]
public void SomeTypeTest() {
    new SomeType().Run();
}
```
we will get both tasks in the output:
```
Test Failed - SomeTypeTest
Message: One task that has been started during test run is still not completed:

   at void SomeType.Run() in C:\Temp\SomeType.cs:line 29
   at void Tests.SomeTypeTest() in C:\Temp\Tests.cs:line 44
   at object RuntimeMethodHandle.InvokeMethod(object target, object[] arguments, Signature sig, bool constructor)
   at object System.Reflection.RuntimeMethodInfo.UnsafeInvokeInternal(object obj, object[] parameters, object[] arguments)
   at object System.Reflection.RuntimeMethodInfo.Invoke(object obj, BindingFlags invokeAttr, Binder binder, object[] parameters, CultureInfo culture)

Also, one not awaited tasks has failed:

InvalidOperationException: Operation is not valid due to the current state of the object.
   at async Task SomeType.RunThenFailAsync() in C:\Temp\SomeType.cs:line 34
   --- Task stack trace: ---
   at void SomeType.Run() in C:\Temp\SomeType.cs:line 28
   at void Tests.SomeTypeTest() in C:\Temp\Tests.cs:line 44
   at object RuntimeMethodHandle.InvokeMethod(object target, object[] arguments, Signature sig, bool constructor)
   at object System.Reflection.RuntimeMethodInfo.UnsafeInvokeInternal(object obj, object[] parameters, object[] arguments)
   at object System.Reflection.RuntimeMethodInfo.Invoke(object obj, BindingFlags invokeAttr, Binder binder, object[] parameters, CultureInfo culture)
```