### PR TITLE
Fixes #3719 and #3720

### DIFF
--- a/Python/Product/Analysis/ProjectEntry.cs
+++ b/Python/Product/Analysis/ProjectEntry.cs
@@ -167,7 +167,7 @@ namespace Microsoft.PythonTools.Analysis {
                 AnalysisVersion++;
 
                 foreach (var aggregate in _aggregates) {
-                    aggregate.BumpVersion();
+                    aggregate?.BumpVersion();
                 }
 
                 Parse(enqueueOnly, cancel);
@@ -299,11 +299,13 @@ namespace Microsoft.PythonTools.Analysis {
         public void RemovedFromProject() {
             lock (this) {
                 AnalysisVersion = -1;
-            }
-            foreach (var aggregatedInto in _aggregates) {
-                if (aggregatedInto.AnalysisVersion != -1) {
-                    ProjectState.ClearAggregate(aggregatedInto);
-                    aggregatedInto.RemovedFromProject();
+
+                var state = ProjectState;
+                foreach (var aggregatedInto in _aggregates) {
+                    if (aggregatedInto != null && aggregatedInto.AnalysisVersion != -1) {
+                        state?.ClearAggregate(aggregatedInto);
+                        aggregatedInto.RemovedFromProject();
+                    }
                 }
             }
         }
@@ -314,7 +316,9 @@ namespace Microsoft.PythonTools.Analysis {
 
         public void AggregatedInto(IVersioned into) {
             if (into is AggregateProjectEntry agg) {
-                _aggregates.Add(agg);
+                lock (this) {
+                    _aggregates.Add(agg);
+                }
             }
         }
 

--- a/Python/Product/PythonTools/PythonTools/Navigation/WaitForCompleteAnalysisDialog.xaml.cs
+++ b/Python/Product/PythonTools/PythonTools/Navigation/WaitForCompleteAnalysisDialog.xaml.cs
@@ -46,21 +46,27 @@ namespace Microsoft.PythonTools.Navigation {
 
         private bool UpdateItemsRemaining(int itemsLeft) {
             if (itemsLeft == 0) {
-                Dispatcher.Invoke((Action)(() => {
-                    this.DialogResult = true;
-                    this.Close();
-                }));
+                try {
+                    Dispatcher.Invoke((Action)(() => {
+                        this.DialogResult = true;
+                        this.Close();
+                    }));
+                } catch (OperationCanceledException) {
+                    // Should only occur if the dialog is closed already, so nothing left to do
+                }
                 return false;
             }
             
             bool? dialogResult = null;
-            Dispatcher.Invoke((Action)(() => {
-                dialogResult = DialogResult;
-                if (dialogResult == null) {
-                    _progress.Maximum = itemsLeft;
-                }
-            }));
-            
+            try {
+                Dispatcher.Invoke((Action)(() => {
+                    dialogResult = DialogResult;
+                    if (dialogResult == null) {
+                        _progress.Maximum = itemsLeft;
+                    }
+                }));
+            } catch (OperationCanceledException) {
+            }
 
             return dialogResult == null;
         }


### PR DESCRIPTION
Fixes #3719 NullReferenceException in ProjectEntry.RemovedFromProject
Protects aggregates hashset under lock and safely handles unexpected null elements

Fixes #3720 Unhandled dispatcher cancellation when waiting for analysis
Handles cancellation error.