### PR TITLE
Add UI test for mixed-mode debugger.

### DIFF
--- a/Python/Tests/DebuggerUITests/DebuggerUITests.csproj
+++ b/Python/Tests/DebuggerUITests/DebuggerUITests.csproj
@@ -88,6 +88,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AttachUITests.cs" />
+    <Compile Include="MixedModeDebugProjectUITests.cs" />
     <Compile Include="DebugProjectUITests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="VSPackage.cs" />

--- a/Python/Tests/DebuggerUITests/MixedModeDebugProjectUITests.cs
+++ b/Python/Tests/DebuggerUITests/MixedModeDebugProjectUITests.cs
@@ -1,0 +1,79 @@
+// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABLITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using EnvDTE;
+using TestUtilities;
+using TestUtilities.UI;
+using TestUtilities.UI.Python;
+using Assert = Microsoft.VisualStudio.TestTools.UnitTesting.Assert;
+using Thread = System.Threading.Thread;
+
+namespace DebuggerUITests {
+    public class MixedModeDebugProjectUITests {
+        #region Test Cases
+
+        /// <summary>
+        /// Verify that debugging starts and a breakpoint is hit.
+        /// </summary>
+        public void DebugPurePythonProject(PythonVisualStudioApp app, string interpreter) {
+            using (app.SelectDefaultInterpreter(FindInterpreter(interpreter))) {
+                StartHelloWorldAndBreak(app);
+
+                app.Dte.Debugger.Go(WaitForBreakOrEnd: true);
+                Assert.AreEqual(dbgDebugMode.dbgDesignMode, app.Dte.Debugger.CurrentMode);
+            }
+        }
+
+        #endregion
+
+        #region Helpers
+
+        private static void StartHelloWorldAndBreak(VisualStudioApp app) {
+            DebugProjectUITests.OpenProjectAndBreak(app, @"TestData\MixedModeHelloWorld.sln", "Program.py", 1);
+        }
+
+        private static bool HasSymbols(PythonVersion interpreter) {
+            if (interpreter == null) {
+                return false;
+            }
+
+            // For simplicity, require the test machine to have the .pdb files
+            // next to their binaries.
+            return File.Exists(Path.ChangeExtension(interpreter.Configuration.InterpreterPath, "pdb"));
+        }
+
+        private static PythonVersion FindInterpreter(string pythonVersion) {
+            // Examples of values for pythonVersion (match field names on PythonPaths):
+            // "Python36"
+            // "Python36|Python36_x64"
+            var interpreter = pythonVersion.Split('|')
+                .Select(v => typeof(PythonPaths).GetField(v, BindingFlags.Static | BindingFlags.Public)?.GetValue(null) as PythonVersion)
+                .Where(HasSymbols)
+                .FirstOrDefault();
+
+            if (interpreter == null) {
+                Assert.Inconclusive($"Interpreter '{pythonVersion}' not installed.");
+            }
+
+            return interpreter;
+        }
+
+        #endregion
+    }
+}

--- a/Python/Tests/DebuggerUITestsRunner/DebuggerUITestsRunner.csproj
+++ b/Python/Tests/DebuggerUITestsRunner/DebuggerUITestsRunner.csproj
@@ -24,6 +24,7 @@
     <Reference Include="System.Core" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="MixedModeDebugProjectUITests.cs" />
     <Compile Include="DebugProjectUITests.cs" />
     <Compile Include="AttachUITests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/Python/Tests/DebuggerUITestsRunner/MixedModeDebugProjectUITests.cs
+++ b/Python/Tests/DebuggerUITestsRunner/MixedModeDebugProjectUITests.cs
@@ -1,0 +1,70 @@
+// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABLITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using TestRunnerInterop;
+
+namespace DebuggerUITestsRunner {
+    [TestClass, Ignore]
+    public abstract class MixedModeDebugProjectUITests {
+        #region UI test boilerplate
+        public VsTestInvoker _vs => new VsTestInvoker(
+            VsTestContext.Instance,
+            // Remote container (DLL) name
+            "Microsoft.PythonTools.Tests.DebuggerUITests",
+            // Remote class name
+            $"DebuggerUITests.{nameof(MixedModeDebugProjectUITests)}"
+        );
+
+        public TestContext TestContext { get; set; }
+
+        protected abstract string Interpreter { get; }
+
+        [TestInitialize]
+        public void TestInitialize() => VsTestContext.Instance.TestInitialize(TestContext.DeploymentDirectory);
+        [TestCleanup]
+        public void TestCleanup() => VsTestContext.Instance.TestCleanup();
+        [ClassCleanup]
+        public static void ClassCleanup() => VsTestContext.Instance.Dispose();
+        #endregion
+
+        [TestMethod, Priority(0)]
+        [TestCategory("Installed")]
+        public void DebugPurePythonProject() {
+            _vs.RunTest(nameof(DebuggerUITests.MixedModeDebugProjectUITests.DebugPurePythonProject), Interpreter);
+        }
+    }
+
+    [TestClass]
+    public class MixedModeDebugProjectUITests2x_32 : MixedModeDebugProjectUITests {
+        protected override string Interpreter => "Python27";
+    }
+
+    [TestClass]
+    public class MixedModeDebugProjectUITests2x_64 : MixedModeDebugProjectUITests {
+        protected override string Interpreter => "Python27_x64";
+    }
+
+    [TestClass]
+    public class MixedModeDebugProjectUITests3x_32 : MixedModeDebugProjectUITests {
+        protected override string Interpreter => "Python35|Python36";
+    }
+
+    [TestClass]
+    public class MixedModeDebugProjectUITests3x_64 : MixedModeDebugProjectUITests {
+        protected override string Interpreter => "Python35_x64|Python36_x64";
+    }
+}

--- a/Python/Tests/TestData/MixedModeHelloWorld.sln
+++ b/Python/Tests/TestData/MixedModeHelloWorld.sln
@@ -1,0 +1,20 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 11.00
+# Visual Studio 2010
+Project("{888888A0-9F3D-457C-B088-3A5042F75D52}") = "MixedModeHelloWorld", "MixedModeHelloWorld\MixedModeHelloWorld.pyproj", "{12535E18-06DA-4F15-B99E-8F492FE721E2}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{12535E18-06DA-4F15-B99E-8F492FE721E2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{12535E18-06DA-4F15-B99E-8F492FE721E2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{12535E18-06DA-4F15-B99E-8F492FE721E2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{12535E18-06DA-4F15-B99E-8F492FE721E2}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/Python/Tests/TestData/MixedModeHelloWorld/MixedModeHelloWorld.pyproj
+++ b/Python/Tests/TestData/MixedModeHelloWorld/MixedModeHelloWorld.pyproj
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{12535e18-06da-4f15-b99e-8f492fe721e2}</ProjectGuid>
+    <ProjectHome>.</ProjectHome>
+    <StartupFile>Program.py</StartupFile>
+    <SearchPath>
+    </SearchPath>
+    <WorkingDirectory>.</WorkingDirectory>
+    <AssemblyName>MixedModeHelloWorld</AssemblyName>
+    <Name>MixedModeHelloWorld</Name>
+    <RootNamespace>MixedModeHelloWorld</RootNamespace>
+    <OutputPath>.</OutputPath>
+    <EnableNativeCodeDebugging>True</EnableNativeCodeDebugging>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
+    <DebugSymbols>true</DebugSymbols>
+    <EnableUnmanagedDebugging>false</EnableUnmanagedDebugging>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+    <DebugSymbols>true</DebugSymbols>
+    <EnableUnmanagedDebugging>false</EnableUnmanagedDebugging>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Program.py" />
+  </ItemGroup>
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\Python Tools\Microsoft.PythonTools.targets" />
+</Project>

--- a/Python/Tests/TestData/MixedModeHelloWorld/Program.py
+++ b/Python/Tests/TestData/MixedModeHelloWorld/Program.py
@@ -1,0 +1,1 @@
+print('hello world')


### PR DESCRIPTION
Fix #3713 

This is sufficient to catch the regression with 64-bit mixed-mode debugging.

We can add more later, for example a test that involves C++ code ;)
