### PR TITLE
Fix #3761 & some more perf turning

### DIFF
--- a/Python/Product/Analysis/Parsing/Parser.cs
+++ b/Python/Product/Analysis/Parsing/Parser.cs
@@ -2036,8 +2036,10 @@ namespace Microsoft.PythonTools.Parsing {
                         NextToken();
                         var ne = new NameExpression(name.RealName);
                         ne.SetLoc(GetStart(), GetEnd());
-                        AddVerbatimName(name, ne);
-                        AddPreceedingWhiteSpace(ne);
+                        if (_verbatim) {
+                            AddVerbatimName(name, ne);
+                            AddPreceedingWhiteSpace(ne);
+                        }
                         p = new Parameter(ne, kind);
                     } else if (kind == ParameterKind.List) {
                         // bare lists are allowed
@@ -2048,7 +2050,7 @@ namespace Microsoft.PythonTools.Parsing {
                     }
                     p.SetLoc(start < 0 ? GetStart() : start, GetEnd());
 
-                    if (preStarWhitespace != null) {
+                    if (_verbatim && preStarWhitespace != null) {
                         AddPreceedingWhiteSpace(p, preStarWhitespace);
                     }
 

--- a/Python/Product/Analysis/Parsing/Tokenizer.cs
+++ b/Python/Product/Analysis/Parsing/Tokenizer.cs
@@ -24,6 +24,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Numerics;
+using System.Runtime.CompilerServices;
 using System.Text;
 using Microsoft.PythonTools.Analysis.Infrastructure;
 
@@ -815,10 +816,21 @@ namespace Microsoft.PythonTools.Parsing {
         public static bool IsIdentifierStartChar(char ch) {
             // Identifiers determined according to PEP 3131
 
-            switch (ch) {
+            // ASCII case
+            if (ch <= 'z') {
                 // Underscore is explicitly allowed to start an identifier
-                case '_':
-                    return true;
+                return ch <= 'Z' ? ch >= 'A' : ch >= 'a' || ch == '_';
+            }
+
+            if (ch < 0xAA) {
+                return false;
+            }
+
+            return IsIdentifierStartCharNonAscii(ch);
+        }
+
+        private static bool IsIdentifierStartCharNonAscii(char ch) {
+            switch (ch) {
                 // Characters with the Other_ID_Start property
                 case '\x1885':
                 case '\x1886':
@@ -846,10 +858,14 @@ namespace Microsoft.PythonTools.Parsing {
 
         public static bool IsIdentifierChar(char ch) {
             // ASCII case
-            if (ch <= 7F) {
+            if (ch <= 'z') {
                 return ch <= 'Z'
                     ? ch >= 'A' || ch >= '0' && ch <= '9'
-                    : ch >= 'a' && ch <= 'z' || ch == '_';
+                    : ch >= 'a' || ch == '_';
+            }
+
+            if (ch < 0xAA) {
+                return false;
             }
 
             switch (ch) {
@@ -869,7 +885,7 @@ namespace Microsoft.PythonTools.Parsing {
                     return true;
             }
 
-            if (IsIdentifierStartChar(ch)) {
+            if (IsIdentifierStartCharNonAscii(ch)) {
                 return true;
             }
 

--- a/Python/Product/Analysis/Parsing/Tokenizer.cs
+++ b/Python/Product/Analysis/Parsing/Tokenizer.cs
@@ -845,15 +845,11 @@ namespace Microsoft.PythonTools.Parsing {
         }
 
         public static bool IsIdentifierChar(char ch) {
-            // Latin1 case
-            if (ch <= byte.MaxValue) {
-                return ch <= 'z'
-                    ? ch <= 'Z'
-                      ? ch >= 'A' || ch >= '0' && ch <= '9'
-                      : ch >= 'a' || ch == '_'
-                    : ch >= 'À'
-                      ? ch != '×' && ch != '÷'
-                      : ch == 'ª' || ch == 'µ' || ch == 'º';
+            // ASCII case
+            if (ch <= 7F) {
+                return ch <= 'Z'
+                    ? ch >= 'A' || ch >= '0' && ch <= '9'
+                    : ch >= 'a' && ch <= 'z' || ch == '_';
             }
 
             switch (ch) {


### PR DESCRIPTION
- Fix #3761: Parser with Verbatim=false throws assert for function definition
- Cache field value in Tokenizer.Peek (+3%)
- Optimize IsIdentifierChar for Latin1 case (+7%)