### PR TITLE
Fix crash in cookiecutter due to unhandled JsonException.

### DIFF
--- a/Python/Product/Cookiecutter/Model/GitHubClient.cs
+++ b/Python/Product/Cookiecutter/Model/GitHubClient.cs
@@ -22,7 +22,7 @@ using Newtonsoft.Json;
 
 namespace Microsoft.CookiecutterTools.Model {
     class GitHubClient : IGitHubClient {
-        // throws WebExceptions (for example, with 403 forbidden)
+        // throws WebException (for example, with 403 forbidden) and JsonException
         public async Task<GitHubRepoSearchResult> SearchRepositoriesAsync(string requestUrl) {
             if (requestUrl == null) {
                 throw new ArgumentNullException(nameof(requestUrl));

--- a/Python/Product/Cookiecutter/Model/GitHubTemplateSource.cs
+++ b/Python/Product/Cookiecutter/Model/GitHubTemplateSource.cs
@@ -18,6 +18,7 @@ using System.Collections.Generic;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
+using Newtonsoft.Json;
 
 namespace Microsoft.CookiecutterTools.Model {
     class GitHubTemplateSource : ITemplateSource {
@@ -63,6 +64,8 @@ namespace Microsoft.CookiecutterTools.Model {
 
                 return new TemplateEnumerationResult(templates, result.Links.Next);
             } catch (WebException ex) {
+                throw new TemplateEnumerationException(Strings.GitHubSearchError, ex);
+            } catch (JsonException ex) {
                 throw new TemplateEnumerationException(Strings.GitHubSearchError, ex);
             }
         }


### PR DESCRIPTION
Fix #3785 cookiecutter crash parsing invalid JSON