### PR TITLE
Change GetProject() to always return null in case of failure

### DIFF
--- a/Common/Product/SharedProject/CommonPackage.cs
+++ b/Common/Product/SharedProject/CommonPackage.cs
@@ -190,7 +190,7 @@ namespace Microsoft.VisualStudioTools {
             var buildMgr = (IVsSolutionBuildManager)serviceProvider.GetService(typeof(IVsSolutionBuildManager));
             IVsHierarchy hierarchy;
             if (buildMgr != null && ErrorHandler.Succeeded(buildMgr.get_StartupProject(out hierarchy)) && hierarchy != null) {
-                return hierarchy.GetProject().GetCommonProject();
+                return hierarchy.GetProject()?.GetCommonProject();
             }
             return null;
         }

--- a/Common/Product/SharedProject/Navigation/LibraryManager.cs
+++ b/Common/Product/SharedProject/Navigation/LibraryManager.cs
@@ -102,8 +102,12 @@ namespace Microsoft.VisualStudioTools.Navigation {
                 return;
             }
 
+            var commonProject = hierarchy.GetProject()?.GetCommonProject();
+            if (commonProject == null) {
+                return;
+            }
+
             RegisterLibrary();
-            var commonProject = hierarchy.GetProject().GetCommonProject();
             HierarchyListener listener = new HierarchyListener(hierarchy, this);
             var node = _hierarchies[hierarchy] = new HierarchyInfo(
                 listener,
@@ -191,7 +195,10 @@ namespace Microsoft.VisualStudioTools.Navigation {
         /// </summary>
         protected void FileParsed(LibraryTask task) {
             try {
-                var project = task.ModuleID.Hierarchy.GetProject().GetCommonProject();
+                var project = task.ModuleID.Hierarchy.GetProject()?.GetCommonProject();
+                if (project == null) {
+                    return;
+                }
 
                 HierarchyNode fileNode = fileNode = project.NodeFromItemId(task.ModuleID.ItemID);
                 HierarchyInfo parent;

--- a/Common/Product/SharedProject/ProjectReferenceNode.cs
+++ b/Common/Product/SharedProject/ProjectReferenceNode.cs
@@ -461,7 +461,7 @@ namespace Microsoft.VisualStudioTools.Project {
             // TODO: This has got to be wrong, it doesn't work w/ other project types.
             IVsHierarchy hierarchy = VsShellUtilities.GetHierarchy(this.ProjectMgr.Site, projectGuid);
 
-            IReferenceContainerProvider provider = hierarchy.GetProject().GetCommonProject() as IReferenceContainerProvider;
+            IReferenceContainerProvider provider = hierarchy.GetProject()?.GetCommonProject() as IReferenceContainerProvider;
             if (provider != null) {
                 IReferenceContainer referenceContainer = provider.GetReferenceContainer();
 

--- a/Common/Product/SharedProject/VsExtensions.cs
+++ b/Common/Product/SharedProject/VsExtensions.cs
@@ -27,14 +27,13 @@ namespace Microsoft.VisualStudioTools {
         internal static EnvDTE.Project GetProject(this IVsHierarchy hierarchy) {
             object project;
 
-            int hr = hierarchy.GetProperty(
+            if (ErrorHandler.Failed(hierarchy.GetProperty(
                 VSConstants.VSITEMID_ROOT,
                 (int)__VSHPROPID.VSHPROPID_ExtObject,
                 out project
-            );
-
-            Debug.Assert(ErrorHandler.Succeeded(hr), string.Format("unexpected HR={0:X08}", hr));
-            ErrorHandler.ThrowOnFailure(hr);
+            ))) {
+                return null;
+            }
 
             return (project as EnvDTE.Project);
         }

--- a/Python/Product/PythonTools/PythonTools/Extensions.cs
+++ b/Python/Product/PythonTools/PythonTools/Extensions.cs
@@ -197,7 +197,7 @@ namespace Microsoft.PythonTools {
         }
 
         public static IPythonInterpreterFactory GetPythonInterpreterFactory(this IVsHierarchy self) {
-            var node = (self.GetProject().GetCommonProject() as PythonProjectNode);
+            var node = (self.GetProject()?.GetCommonProject() as PythonProjectNode);
             if (node != null) {
                 return node.GetInterpreterFactory();
             }
@@ -229,7 +229,7 @@ namespace Microsoft.PythonTools {
 
 
         internal static PythonProjectNode GetPythonProject(this IVsProject project) {
-            return ((IVsHierarchy)project).GetProject().GetCommonProject() as PythonProjectNode;
+            return ((IVsHierarchy)project).GetProject()?.GetCommonProject() as PythonProjectNode;
         }
 
         internal static PythonProjectNode GetPythonProject(this EnvDTE.Project project) {

--- a/Python/Product/PythonTools/PythonTools/Navigation/PythonLibraryManager.cs
+++ b/Python/Product/PythonTools/PythonTools/Navigation/PythonLibraryManager.cs
@@ -58,7 +58,7 @@ namespace Microsoft.PythonTools.Navigation {
         }
 
         public override void RegisterHierarchy(IVsHierarchy hierarchy) {
-            var project = hierarchy.GetProject().GetPythonProject();
+            var project = hierarchy.GetProject()?.GetPythonProject();
             if (project != null) {
                 lock (_handlers) {
                     if (!_handlers.ContainsKey(project)) {
@@ -71,7 +71,7 @@ namespace Microsoft.PythonTools.Navigation {
         }
 
         public override void UnregisterHierarchy(IVsHierarchy hierarchy) {
-            var project = hierarchy.GetProject().GetPythonProject();
+            var project = hierarchy.GetProject()?.GetPythonProject();
             if (project != null) {
                 lock (_handlers) {
                     AnalysisCompleteHandler handler;
@@ -91,7 +91,7 @@ namespace Microsoft.PythonTools.Navigation {
             }
 
             var project = task.ModuleID.Hierarchy
-                    .GetProject()
+                    .GetProject()?
                     .GetPythonProject();
             if (project == null) {
                 return;

--- a/Python/Product/PythonTools/PythonTools/Navigation/PythonLibraryNode.cs
+++ b/Python/Product/PythonTools/PythonTools/Navigation/PythonLibraryNode.cs
@@ -174,7 +174,7 @@ namespace Microsoft.PythonTools.Navigation {
         }
 
         public override IVsSimpleObjectList2 FindReferences() {
-            var analyzer = this.Hierarchy.GetPythonProject().GetAnalyzer();
+            var analyzer = this.Hierarchy.GetPythonProject()?.GetAnalyzer();
 
 
             List<IAnalysisVariable> vars = new List<IAnalysisVariable>();


### PR DESCRIPTION
Fix #2411 Assert clicking on Output in Test Results
Fix #3787 COMException opening XAML editor

Most callers were handling a `null` return value, only one was handling exception and `null`, and some were handling neither. I changed them to all handle `null`. I also removed the assert because in some cases it's normal that there's no project (test explorer output window).