### PR TITLE
Fixes #3793 Migrate hover to server

### DIFF
--- a/Python/Product/Analysis/Analysis.csproj
+++ b/Python/Product/Analysis/Analysis.csproj
@@ -62,6 +62,7 @@
     <Compile Include="Analyzer\ExpressionEvaluatorAnnotationConverter.cs" />
     <Compile Include="DocumentBuffer.cs" />
     <Compile Include="ExpressionFinder.cs" />
+    <Compile Include="IHasQualifiedName.cs" />
     <Compile Include="Infrastructure\EnumerableExtensions.cs" />
     <Compile Include="Infrastructure\ExceptionExtensions.cs" />
     <Compile Include="Infrastructure\InstallPath.cs" />

--- a/Python/Product/Analysis/AnalysisLogWriter.cs
+++ b/Python/Product/Analysis/AnalysisLogWriter.cs
@@ -157,6 +157,10 @@ namespace Microsoft.PythonTools.Analysis {
             }
 
             if (_dumping.CurrentCount == 0) {
+                if (synchronous) {
+                    _dumping.Wait();
+                    _dumping.Release();
+                }
                 return;
             }
 

--- a/Python/Product/Analysis/ExpressionFinder.cs
+++ b/Python/Product/Analysis/ExpressionFinder.cs
@@ -27,8 +27,7 @@ namespace Microsoft.PythonTools.Analysis {
         }
 
         public ExpressionFinder(string expression, PythonLanguageVersion version, GetExpressionOptions options) {
-            var parserOpts = new ParserOptions { Verbatim = true };
-            var parser = Parser.CreateParser(new StringReader(expression), version, parserOpts);
+            var parser = Parser.CreateParser(new StringReader(expression), version, ParserOptions.Default);
             Ast = parser.ParseTopExpression();
             Ast.Body.SetLoc(0, expression.Length);
             Options = options.Clone();

--- a/Python/Product/Analysis/ExpressionFinder.cs
+++ b/Python/Product/Analysis/ExpressionFinder.cs
@@ -167,13 +167,17 @@ namespace Microsoft.PythonTools.Analysis {
 
             public override bool Walk(MemberExpression node) {
                 if (base.Walk(node)) {
-                    if (_options.MemberName && Location >= node.NameHeader && _endLocation <= node.EndIndex) {
-                        var nameNode = new NameExpression(node.Name);
-                        nameNode.SetLoc(node.NameHeader, node.EndIndex);
-                        Expression = nameNode;
-                        return false;
+                    if (Location >= node.NameHeader && _endLocation <= node.EndIndex) {
+                        if (_options.MemberName) {
+                            var nameNode = new NameExpression(node.Name);
+                            nameNode.SetLoc(node.NameHeader, node.EndIndex);
+                            Expression = nameNode;
+                            return false;
+                        } else if (_options.Members) {
+                            Expression = node;
+                        }
                     }
-                    return Save(node, true, _options.Members);
+                    return true;
                 }
                 return false;
             }

--- a/Python/Product/Analysis/IHasQualifiedName.cs
+++ b/Python/Product/Analysis/IHasQualifiedName.cs
@@ -1,0 +1,38 @@
+﻿// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABLITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System.Collections.Generic;
+
+namespace Microsoft.PythonTools.Analysis {
+    interface IHasQualifiedName {
+        /// <summary>
+        /// Gets the fully qualified, dot-separated name of the value.
+        /// This is typically used for displaying to users.
+        /// </summary>
+        string FullyQualifiedName { get; }
+
+        /// <summary>
+        /// Gets the import and lookup names of the value. The first part
+        /// should be importable, and the second is a name that can be
+        /// resolved with getattr().
+        /// These are often seen separated with a colon.
+        /// </summary>
+        /// <exception cref="NotSupportedException">
+        /// The value cannot be resolved (for example, a nested function).
+        /// </exception>
+        KeyValuePair<string, string> FullyQualifiedNamePair { get; }
+    }
+}

--- a/Python/Product/Analysis/Interpreter/Ast/AstPythonModule.cs
+++ b/Python/Product/Analysis/Interpreter/Ast/AstPythonModule.cs
@@ -72,8 +72,7 @@ namespace Microsoft.PythonTools.Interpreter.Ast {
         ) {
             PythonAst ast;
             var parser = Parser.CreateParser(sourceFile, langVersion, new ParserOptions {
-                StubFile = fileName.EndsWithOrdinal(".pyi", ignoreCase: true),
-                Verbatim = true
+                StubFile = fileName.EndsWithOrdinal(".pyi", ignoreCase: true)
             });
             ast = parser.ParseFile();
 

--- a/Python/Product/Analysis/LanguageServer/Server.cs
+++ b/Python/Product/Analysis/LanguageServer/Server.cs
@@ -22,6 +22,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.PythonTools.Analysis.Infrastructure;
@@ -508,6 +509,87 @@ namespace Microsoft.PythonTools.Analysis.LanguageServer {
             }).Concat(extras).ToArray();
         }
 
+        public override async Task<Hover> Hover(TextDocumentPositionParams @params) {
+            var uri = @params.textDocument.uri;
+            GetAnalysis(@params.textDocument, @params.position, @params._version, out var entry, out var tree);
+
+            TraceMessage($"Hover in {uri} at {@params.position}");
+
+            var analysis = entry?.Analysis;
+            if (analysis == null) {
+                TraceMessage($"No analysis found for {uri}");
+                return default(Hover);
+            }
+
+            int? version = null;
+            var parse = entry.WaitForCurrentParse(_clientCaps?.python?.completionsTimeout ?? -1);
+            if (parse != null) {
+                tree = parse.Tree ?? tree;
+                if (parse.Cookie is VersionCookie vc) {
+                    if (vc.Versions.TryGetValue(GetPart(uri), out var bv)) {
+                        tree = bv.Ast ?? tree;
+                        if (bv.Version >= 0) {
+                            version = bv.Version;
+                        }
+                    }
+                }
+            }
+
+            int index = tree.LocationToIndex(@params.position);
+            var w = new ImportedModuleNameWalker(entry.ModuleName, index);
+            tree.Walk(w);
+            ModuleReference modRef;
+            if (!string.IsNullOrEmpty(w.ImportedName) &&
+                _analyzer.Modules.TryImport(w.ImportedName, out modRef)) {
+
+                // Return module information
+                return new Hover { contents = "{0} : module".FormatUI(w.ImportedName) };
+            }
+
+            Expression expr;
+            SourceSpan exprSpan;
+            Analyzer.InterpreterScope scope = null;
+
+            if (!string.IsNullOrEmpty(@params._expr)) {
+                TraceMessage($"Getting hover for {@params._expr}");
+                expr = analysis.GetExpressionForText(@params._expr, @params.position, out scope, out var exprTree);
+                // This span will not be valid within the document, but it will at least
+                // have the correct length. If we have passed "_expr" then we are likely
+                // planning to ignore the returned span anyway.
+                exprSpan = expr.GetSpan(exprTree);
+            } else {
+                var finder = new ExpressionFinder(tree, GetExpressionOptions.Hover);
+                expr = finder.GetExpression(@params.position) as Expression;
+                exprSpan = expr.GetSpan(tree);
+            }
+            if (expr == null) {
+                LogMessage(MessageType.Info, $"No hover info found in {uri} at {@params.position}");
+                return default(Hover);
+            }
+
+            TraceMessage($"Getting hover for {expr.ToCodeString(tree, CodeFormattingOptions.Traditional)}");
+            var values = analysis.GetValues(expr, @params.position, scope).ToList();
+
+            string originalExpr;
+            if (expr is ConstantExpression || expr is ErrorExpression) {
+                originalExpr = null;
+            } else {
+                originalExpr = @params._expr?.Trim();
+                if (string.IsNullOrEmpty(originalExpr)) {
+                    originalExpr = expr.ToCodeString(tree, CodeFormattingOptions.Traditional);
+                }
+            }
+
+            var names = values.Select(GetFullTypeName).Where(n => !string.IsNullOrEmpty(n)).Distinct().ToArray();
+
+            return new Hover {
+                contents = MakeHoverText(values, originalExpr),
+                range = exprSpan,
+                _version = version,
+                _typeNames = names
+            };
+        }
+
         public override async Task<SymbolInformation[]> WorkplaceSymbols(WorkplaceSymbolParams @params) {
             var members = Enumerable.Empty<MemberResult>();
             var opts = GetMemberOptions.ExcludeBuiltins | GetMemberOptions.DeclaredOnly;
@@ -636,6 +718,116 @@ namespace Microsoft.PythonTools.Analysis.LanguageServer {
                 var path = Path.Combine(document.Host, document.AbsolutePath).Trim(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
                 yield return new ModulePath(Path.ChangeExtension(path, null), path, null);
             }
+        }
+
+        private string MakeHoverText(IEnumerable<AnalysisValue> values, string originalExpression) {
+            string firstLongDescription = null;
+            bool multiline = false;
+            var result = new StringBuilder();
+            var descriptions = new HashSet<string>();
+
+            foreach (var v in values) {
+                if (string.IsNullOrEmpty(firstLongDescription)) {
+                    firstLongDescription = v.Description;
+                }
+
+                var description = LimitLines(v.ShortDescription ?? "");
+                if (string.IsNullOrEmpty(description)) {
+                    continue;
+                }
+
+                if (descriptions.Add(description)) {
+                    if (descriptions.Count > 1) {
+                        if (result.Length == 0) {
+                            // Nop
+                        } else if (result[result.Length - 1] != '\n') {
+                            result.Append(", ");
+                        } else {
+                            multiline = true;
+                        }
+                    }
+                    result.Append(description);
+                }
+            }
+
+            if (descriptions.Count == 1 && !string.IsNullOrEmpty(firstLongDescription)) {
+                result.Clear();
+                result.Append(firstLongDescription);
+            }
+
+            if (!string.IsNullOrEmpty(originalExpression)) {
+                if (originalExpression.Length > 4096) {
+                    originalExpression = originalExpression.Substring(0, 4093) + "...";
+                }
+                if (multiline) {
+                    result.Insert(0, originalExpression + ": " + Environment.NewLine);
+                } else if (result.Length > 0) {
+                    result.Insert(0, originalExpression + ": ");
+                } else {
+                    result.Append(originalExpression);
+                    result.Append(": ");
+                    result.Append("<unknown type>");
+                }
+            }
+
+            return result.ToString();
+        }
+
+        internal static string LimitLines(
+            string str,
+            int maxLines = 30,
+            int charsPerLine = 200,
+            bool ellipsisAtEnd = true,
+            bool stopAtFirstBlankLine = false
+        ) {
+            if (string.IsNullOrEmpty(str)) {
+                return str;
+            }
+
+            int lineCount = 0;
+            var prettyPrinted = new StringBuilder();
+            bool wasEmpty = true;
+
+            using (var reader = new StringReader(str)) {
+                for (var line = reader.ReadLine(); line != null && lineCount < maxLines; line = reader.ReadLine()) {
+                    if (string.IsNullOrWhiteSpace(line)) {
+                        if (wasEmpty) {
+                            continue;
+                        }
+                        wasEmpty = true;
+                        if (stopAtFirstBlankLine) {
+                            lineCount = maxLines;
+                            break;
+                        }
+                        lineCount += 1;
+                        prettyPrinted.AppendLine();
+                    } else {
+                        wasEmpty = false;
+                        lineCount += (line.Length / charsPerLine) + 1;
+                        prettyPrinted.AppendLine(line);
+                    }
+                }
+            }
+            if (ellipsisAtEnd && lineCount >= maxLines) {
+                prettyPrinted.AppendLine("...");
+            }
+            return prettyPrinted.ToString().Trim();
+        }
+
+        private static string GetFullTypeName(AnalysisValue value) {
+            if (value is IHasQualifiedName qualName) {
+                return qualName.FullyQualifiedName;
+            }
+
+            if (value is Values.InstanceInfo ii) {
+                return GetFullTypeName(ii.ClassInfo);
+            }
+
+            if (value is Values.BuiltinInstanceInfo bii) {
+                return GetFullTypeName(bii.ClassInfo);
+            }
+
+            return value?.Name;
         }
 
         #endregion

--- a/Python/Product/Analysis/LanguageServer/Server.cs
+++ b/Python/Product/Analysis/LanguageServer/Server.cs
@@ -80,12 +80,6 @@ namespace Microsoft.PythonTools.Analysis.LanguageServer {
             }
         }
 
-        private void TraceMessage(string message) {
-            if (_traceLogging) {
-                LogMessage(MessageType.Log, message);
-            }
-        }
-
         #region Client message handling
 
         public async override Task<InitializeResult> Initialize(InitializeParams @params) {
@@ -323,7 +317,7 @@ namespace Microsoft.PythonTools.Analysis.LanguageServer {
                     TraceMessage($"Completing expression {expr.ToCodeString(tree, CodeFormattingOptions.Traditional)}");
                     members = analysis.GetMembers(expr, @params.position, opts, null);
                 } else {
-                    TraceMessage("Completing all names");
+                    TraceMessage($"Completing all names");
                     members = entry.Analysis.GetAllAvailableMembers(@params.position, opts);
                 }
             }
@@ -613,8 +607,6 @@ namespace Microsoft.PythonTools.Analysis.LanguageServer {
             return _projectFiles.GetOrAdd(documentUri, entry);
         }
 
-        internal IProjectEntry GetEntry(TextDocumentIdentifier document) => GetEntry(document.uri);
-
         internal IProjectEntry GetEntry(Uri documentUri, bool throwIfMissing = true) {
             IProjectEntry entry = null;
             if ((documentUri == null || !_projectFiles.TryGetValue(documentUri, out entry)) && throwIfMissing) {
@@ -834,6 +826,8 @@ namespace Microsoft.PythonTools.Analysis.LanguageServer {
 
         #region Non-LSP public API
 
+        public IProjectEntry GetEntry(TextDocumentIdentifier document) => GetEntry(document.uri);
+
         public Task<IProjectEntry> LoadFileAsync(Uri documentUri) {
             return AddFileAsync(documentUri, null);
         }
@@ -867,13 +861,13 @@ namespace Microsoft.PythonTools.Analysis.LanguageServer {
 
         public async Task WaitForCompleteAnalysisAsync() {
             // Wait for all current parsing to complete
-            TraceMessage("Waiting for parsing to complete");
+            TraceMessage($"Waiting for parsing to complete");
             await _parseQueue.WaitForAllAsync();
-            TraceMessage("Parsing complete. Waiting for analysis entries to enqueue");
+            TraceMessage($"Parsing complete. Waiting for analysis entries to enqueue");
             await _pendingAnalysisEnqueue.WaitForZeroAsync();
-            TraceMessage("Enqueue complete. Waiting for analysis to complete");
+            TraceMessage($"Enqueue complete. Waiting for analysis to complete");
             await _queue.WaitForCompleteAsync();
-            TraceMessage("Analysis complete.");
+            TraceMessage($"Analysis complete.");
         }
 
         public int EstimateRemainingWork() {
@@ -1076,7 +1070,7 @@ namespace Microsoft.PythonTools.Analysis.LanguageServer {
             } catch (BadSourceException) {
             } catch (OperationCanceledException ex) {
                 LogMessage(MessageType.Warning, $"Parsing {doc.DocumentUri} cancelled");
-                TraceMessage(ex.ToString());
+                TraceMessage($"{ex}");
             } catch (Exception ex) {
                 LogMessage(MessageType.Error, ex.ToString());
             }

--- a/Python/Product/Analysis/LanguageServer/Structures.cs
+++ b/Python/Product/Analysis/LanguageServer/Structures.cs
@@ -188,6 +188,8 @@ namespace Microsoft.PythonTools.Analysis.LanguageServer {
     public struct MarkupContent {
         public MarkupKind kind;
         public string value;
+
+        public static implicit operator MarkupContent(string text) => new MarkupContent { kind = MarkupKind.PlainText, value = text };
     }
 
 
@@ -599,6 +601,10 @@ namespace Microsoft.PythonTools.Analysis.LanguageServer {
         /// The document version that range applies to.
         /// </summary>
         public int? _version;
+        /// <summary>
+        /// List of fully qualified type names for the expression
+        /// </summary>
+        public string[] _typeNames;
     }
 
     public struct SignatureHelp {

--- a/Python/Product/Analysis/MemberResult.cs
+++ b/Python/Product/Analysis/MemberResult.cs
@@ -146,17 +146,19 @@ namespace Microsoft.PythonTools.Analysis {
 
                     string typeDisplay = "unknown type";
                     var types = docType.Value.OrderBy(s => s).ToList();
-                    if (types.Count <= 1) {
-                        typeDisplay = "";
+                    if (types.Count == 0) {
+                        continue;
+                    } else if (types.Count == 1) {
+                        typeDisplay = types[0];
                     } else {
                         var orStr = types.Count == 2 ? " or " : ", or ";
-                        typeDisplay = string.Join(", ", types.Take(types.Count - 1)) + orStr + types.Last() + ": ";
+                        typeDisplay = string.Join(", ", types.Take(types.Count - 1)) + orStr + types.Last();
                     }
-                    typeToDoc[typeDisplay] = docType.Key;
+                    typeToDoc[string.Join(",", types)] = typeDisplay + ": " + docType.Key;
                 }
 
                 foreach (var typeDoc in typeToDoc.OrderBy(kv => kv.Key)) {
-                    doc.AppendLine(typeDoc.Key + typeDoc.Value);
+                    doc.AppendLine(typeDoc.Value);
                     doc.AppendLine();
                 }
 

--- a/Python/Product/Analysis/ModuleAnalysis.cs
+++ b/Python/Product/Analysis/ModuleAnalysis.cs
@@ -59,6 +59,13 @@ namespace Microsoft.PythonTools.Analysis {
             return GetValues(exprText, _unit.Tree.IndexToLocation(index));
         }
 
+        internal Expression GetExpressionForText(string exprText, SourceLocation location, out InterpreterScope scope, out PythonAst exprTree) {
+            scope = FindScope(location);
+            var privatePrefix = GetPrivatePrefixClassName(scope);
+            exprTree = GetAstFromText(exprText, privatePrefix);
+            return Statement.GetExpression(exprTree.Body);
+        }
+
         /// <summary>
         /// Evaluates the given expression in at the provided line number and returns the values
         /// that the expression can evaluate to.
@@ -67,10 +74,16 @@ namespace Microsoft.PythonTools.Analysis {
         /// <param name="location">The location in the file where the expression should be evaluated.</param>
         /// <remarks>New in 2.2</remarks>
         public IEnumerable<AnalysisValue> GetValues(string exprText, SourceLocation location) {
-            var scope = FindScope(location);
-            var privatePrefix = GetPrivatePrefixClassName(scope);
-            var expr = Statement.GetExpression(GetAstFromText(exprText, privatePrefix).Body);
+            var expr = GetExpressionForText(exprText, location, out var scope, out _);
+            if (expr == null) {
+                return Enumerable.Empty<AnalysisValue>();
+            }
 
+            return GetValues(expr, location, scope);
+        }
+
+        internal IEnumerable<AnalysisValue> GetValues(Expression expr, SourceLocation location, InterpreterScope scope = null) {
+            scope = scope ?? FindScope(location);
             var unit = GetNearestEnclosingAnalysisUnit(scope);
             var eval = new ExpressionEvaluator(unit.CopyForEval(), scope, mergeScopes: true);
 
@@ -225,20 +238,17 @@ namespace Microsoft.PythonTools.Analysis {
         /// The location in the file where the expression should be evaluated.
         /// </param>
         public IEnumerable<IAnalysisVariable> GetVariables(string exprText, SourceLocation location) {
-            var scope = FindScope(location);
-            string privatePrefix = GetPrivatePrefixClassName(scope);
-            var ast = GetAstFromText(exprText, privatePrefix);
-            var expr = Statement.GetExpression(ast.Body);
+            var expr = GetExpressionForText(exprText, location, out var scope, out var exprTree);
 
             if (expr == null) {
-                return new VariablesResult(Enumerable.Empty<IAnalysisVariable>(), ast);
+                return new VariablesResult(Enumerable.Empty<IAnalysisVariable>(), exprTree);
             }
 
-            return GetVariables(expr, location, exprText);
+            return GetVariables(expr, location, exprText, scope);
         }
 
-        internal VariablesResult GetVariables(Expression expr, SourceLocation location, string originalText = null) {
-            var scope = FindScope(location);
+        internal VariablesResult GetVariables(Expression expr, SourceLocation location, string originalText = null, InterpreterScope scope = null) {
+            scope = scope ?? FindScope(location);
             var unit = GetNearestEnclosingAnalysisUnit(scope);
             var tree = unit.Tree;
 
@@ -387,16 +397,15 @@ namespace Microsoft.PythonTools.Analysis {
             SourceLocation location,
             GetMemberOptions options = GetMemberOptions.IntersectMultipleResults
         ) {
-            if (exprText.Length == 0) {
+            if (string.IsNullOrEmpty(exprText)) {
                 return GetAllAvailableMembers(location, options);
             }
 
-            var scope = FindScope(location);
-            var privatePrefix = GetPrivatePrefixClassName(scope);
+            var expr = GetExpressionForText(exprText, location, out var scope, out var ast);
+            if (expr == null) {
+                return Enumerable.Empty<MemberResult>();
+            }
 
-            var ast = GetAstFromText(exprText, privatePrefix).Body;
-
-            var expr = Statement.GetExpression(ast);
             return GetMembers(expr, location, options, scope);
         }
 
@@ -435,9 +444,7 @@ namespace Microsoft.PythonTools.Analysis {
                 }
             }
 
-            if (scope == null) {
-                scope = FindScope(location);
-            }
+            scope = scope ?? FindScope(location);
 
             if (!lookup.Any()) {
                 var unit = GetNearestEnclosingAnalysisUnit(scope);
@@ -503,23 +510,23 @@ namespace Microsoft.PythonTools.Analysis {
         /// <remarks>New in 2.2</remarks>
         public IEnumerable<IOverloadResult> GetSignatures(string exprText, SourceLocation location) {
             try {
-                var parser = Parser.CreateParser(new StringReader(exprText), _unit.State.LanguageVersion);
-                var expr = GetExpression(parser.ParseTopExpression().Body);
-                if (expr is ListExpression ||
-                    expr is TupleExpression ||
-                    expr is DictionaryExpression) {
-                    return Enumerable.Empty<IOverloadResult>();
-                }
-
-                return GetSignatures(expr, location);
+                var expr = GetExpressionForText(exprText, location, out var scope, out _);
+                return GetSignatures(expr, location, scope);
             } catch (Exception ex) when (!ex.IsCriticalException()) {
                 Debug.Fail(ex.ToString());
                 return GetSignaturesError;
             }
         }
 
-        internal IEnumerable<IOverloadResult> GetSignatures(Expression expr, SourceLocation location) {
-            var scope = FindScope(location);
+        internal IEnumerable<IOverloadResult> GetSignatures(Expression expr, SourceLocation location, InterpreterScope scope = null) {
+            if (expr == null ||
+                expr is ListExpression ||
+                expr is TupleExpression ||
+                expr is DictionaryExpression) {
+                return Enumerable.Empty<IOverloadResult>();
+            }
+
+            scope = scope ?? FindScope(location);
             var unit = GetNearestEnclosingAnalysisUnit(scope);
             var eval = new ExpressionEvaluator(unit.CopyForEval(), scope, mergeScopes: true);
 
@@ -964,7 +971,7 @@ namespace Microsoft.PythonTools.Analysis {
         }
 
         internal PythonAst GetAstFromText(string exprText, string privatePrefix) {
-            var parser = Parser.CreateParser(new StringReader(exprText), _unit.State.LanguageVersion, new ParserOptions() { PrivatePrefix = privatePrefix, Verbatim = true });
+            var parser = Parser.CreateParser(new StringReader(exprText), _unit.State.LanguageVersion, new ParserOptions { PrivatePrefix = privatePrefix });
             return parser.ParseTopExpression();
         }
 

--- a/Python/Product/Analysis/Parsing/Ast/CallExpression.cs
+++ b/Python/Product/Analysis/Parsing/Ast/CallExpression.cs
@@ -180,7 +180,7 @@ namespace Microsoft.PythonTools.Parsing.Ast {
                 }
             }
 
-            if (listWhiteSpace.Length == Args.Count) {
+            if (listWhiteSpace == null || listWhiteSpace.Length == Args.Count) {
                 // Trailing comma, so we are not in any argument
                 argIndex = -1;
                 return true;

--- a/Python/Product/Analysis/Parsing/Ast/FunctionDefinition.cs
+++ b/Python/Product/Analysis/Parsing/Ast/FunctionDefinition.cs
@@ -103,6 +103,8 @@ namespace Microsoft.PythonTools.Parsing.Ast {
             internal set { _decorators = value; }
         }
 
+        internal LambdaExpression LambdaExpression { get; set; }
+
         /// <summary>
         /// True if the function is a generator.  Generators contain at least one yield
         /// expression and instead of returning a value when called they return a generator

--- a/Python/Product/Analysis/Parsing/Ast/LambdaExpression.cs
+++ b/Python/Product/Analysis/Parsing/Ast/LambdaExpression.cs
@@ -48,14 +48,20 @@ namespace Microsoft.PythonTools.Parsing.Ast {
             if (namedOnlyText != null) {
                 res.Append(namedOnlyText);
             }
-            res.Append(this.GetSecondWhiteSpace(ast));
+            format.Append(res, format.SpaceBeforeLambdaColon, " ", "", this.GetSecondWhiteSpace(ast));
             if (!this.IsIncompleteNode(ast)) {
                 res.Append(":");
+                string afterColon = null;
+                if (format.SpaceAfterLambdaColon == true) {
+                    afterColon = " ";
+                } else if (format.SpaceAfterLambdaColon == false) {
+                    afterColon = "";
+                }
                 if (_function.Body is ReturnStatement) {
-                    ((ReturnStatement)_function.Body).Expression.AppendCodeString(res, ast, format);
+                    ((ReturnStatement)_function.Body).Expression.AppendCodeString(res, ast, format, afterColon);
                 } else {
                     Debug.Assert(_function.Body is ExpressionStatement);
-                    ((ExpressionStatement)_function.Body).Expression.AppendCodeString(res, ast, format);
+                    ((ExpressionStatement)_function.Body).Expression.AppendCodeString(res, ast, format, afterColon);
                 }
             }
         }

--- a/Python/Product/Analysis/Parsing/CodeFormattingOptions.cs
+++ b/Python/Product/Analysis/Parsing/CodeFormattingOptions.cs
@@ -47,6 +47,7 @@ namespace Microsoft.PythonTools.Parsing {
         public static CodeFormattingOptions Traditional { get; } = new CodeFormattingOptions {
             SpaceAfterComma = true,
             SpaceAfterDot = false,
+            SpaceAfterLambdaColon = true,
             SpaceAroundAnnotationArrow = true,
             SpaceAroundDefaultValueEquals = true,
             SpaceBeforeCallParen = false,
@@ -55,6 +56,7 @@ namespace Microsoft.PythonTools.Parsing {
             SpaceBeforeFunctionDeclarationParen = false,
             SpaceBeforeIndexBracket = false,
             SpaceBeforeDot = false,
+            SpaceBeforeLambdaColon = false,
             SpacesAroundAssignmentOperator = true,
             SpacesAroundBinaryOperators = true,
             SpacesWithinEmptyListExpression = false,
@@ -233,6 +235,9 @@ namespace Microsoft.PythonTools.Parsing {
 
         public bool? SpaceBeforeDot { get; set; }
         public bool? SpaceAfterDot { get; set; }
+
+        public bool? SpaceBeforeLambdaColon { get; set; }
+        public bool? SpaceAfterLambdaColon { get; set; }
 
         #endregion
 

--- a/Python/Product/Analysis/Parsing/Parser.cs
+++ b/Python/Product/Analysis/Parsing/Parser.cs
@@ -2260,6 +2260,7 @@ namespace Microsoft.PythonTools.Parsing {
             func.EndIndex = GetEnd();
 
             LambdaExpression ret = new LambdaExpression(func);
+            func.LambdaExpression = ret;
             func.SetLoc(func.IndexSpan);
             ret.SetLoc(func.IndexSpan);
             if (_verbatim) {

--- a/Python/Product/Analysis/Parsing/ParserOptions.cs
+++ b/Python/Product/Analysis/Parsing/ParserOptions.cs
@@ -31,7 +31,7 @@ namespace Microsoft.PythonTools.Parsing {
 
         public Severity IndentationInconsistencySeverity { set; get; }
 
-        public bool Verbatim { get; set; } = true;
+        public bool Verbatim { get; set; } = false;
 
         /// <summary>
         /// True if references to variables should be bound in the AST.  The root node must be

--- a/Python/Product/Analysis/PythonAnalyzer.cs
+++ b/Python/Product/Analysis/PythonAnalyzer.cs
@@ -249,10 +249,12 @@ namespace Microsoft.PythonTools.Analysis {
             Contract.EndContractBlock();
 
             ModuleInfo removed;
-            _modulesByFilename.TryRemove(entry.FilePath, out removed);
+            if (!string.IsNullOrEmpty(entry.FilePath)) {
+                _modulesByFilename.TryRemove(entry.FilePath, out removed);
+            }
 
             var pyEntry = entry as IPythonProjectEntry;
-            if (pyEntry != null) {
+            if (pyEntry != null && !string.IsNullOrEmpty(pyEntry.ModuleName)) {
                 ModuleReference modRef;
                 Modules.TryRemove(pyEntry.ModuleName, out modRef);
             }

--- a/Python/Product/Analysis/Values/BoundMethodInfo.cs
+++ b/Python/Product/Analysis/Values/BoundMethodInfo.cs
@@ -21,74 +21,46 @@ using Microsoft.PythonTools.Interpreter;
 using Microsoft.PythonTools.Parsing.Ast;
 
 namespace Microsoft.PythonTools.Analysis.Values {
-    internal class BoundMethodInfo : AnalysisValue, IHasRichDescription {
-        private readonly FunctionInfo _function;
-        private readonly AnalysisValue _instanceInfo;
-
+    internal class BoundMethodInfo : AnalysisValue, IHasRichDescription, IHasQualifiedName {
         public BoundMethodInfo(FunctionInfo function, AnalysisValue instance) {
-            _function = function;
-            _instanceInfo = instance;
+            Function = function;
+            Instance = instance;
         }
 
         public override AnalysisUnit AnalysisUnit {
             get {
-                return _function.AnalysisUnit;
+                return Function.AnalysisUnit;
             }
         }
 
         public override IAnalysisSet Call(Node node, AnalysisUnit unit, IAnalysisSet[] args, NameExpression[] keywordArgNames) {
-            return _function.Call(node, unit, Utils.Concat(_instanceInfo.SelfSet, args), keywordArgNames);
+            return Function.Call(node, unit, Utils.Concat(Instance.SelfSet, args), keywordArgNames);
         }
 
-        public FunctionInfo Function {
-            get {
-                return _function;
-            }
-        }
-
-        public AnalysisValue Instance {
-            get {
-                return _instanceInfo;
-            }
-        }
-
-        public override IPythonProjectEntry DeclaringModule {
-            get {
-                return _function.DeclaringModule;
-            }
-        }
-
-        public override int DeclaringVersion {
-            get {
-                return _function.DeclaringVersion;
-            }
-        }
-
-        public override IEnumerable<LocationInfo> Locations {
-            get {
-                return _function.Locations;
-            }
-        }
+        public FunctionInfo Function { get; }
+        public AnalysisValue Instance { get; }
+        public override IPythonProjectEntry DeclaringModule => Function.DeclaringModule;
+        public override int DeclaringVersion => Function.DeclaringVersion;
+        public override IEnumerable<LocationInfo> Locations => Function.Locations;
 
         public IEnumerable<KeyValuePair<string, string>> GetRichDescription() {
             yield return new KeyValuePair<string, string>(WellKnownRichDescriptionKinds.Misc, "method ");
-            yield return new KeyValuePair<string, string>(WellKnownRichDescriptionKinds.Name, _function.FunctionDefinition.Name);
+            yield return new KeyValuePair<string, string>(WellKnownRichDescriptionKinds.Name, Function.FunctionDefinition.Name);
 
-            var ii = _instanceInfo as InstanceInfo;
-            if (ii != null) {
+            if (Instance is InstanceInfo ii) {
                 yield return new KeyValuePair<string, string>(WellKnownRichDescriptionKinds.Misc, " of ");
-                yield return new KeyValuePair<string, string>(WellKnownRichDescriptionKinds.Name, ii.ClassInfo.ClassDefinition.Name);
+                yield return new KeyValuePair<string, string>(WellKnownRichDescriptionKinds.Name, ii.ClassInfo.FullyQualifiedName);
                 yield return new KeyValuePair<string, string>(WellKnownRichDescriptionKinds.Misc, " objects ");
             }
 
-            foreach (var kv in FunctionInfo.GetReturnTypeString(_function.GetReturnValue)) {
+            foreach (var kv in FunctionInfo.GetReturnTypeString(Function.GetReturnValue)) {
                 yield return kv;
             }
 
             bool needsNl = true;
             var nlKind = WellKnownRichDescriptionKinds.EndOfDeclaration;
 
-            foreach (var kv in FunctionInfo.GetDocumentationString(_function.Documentation)) {
+            foreach (var kv in FunctionInfo.GetDocumentationString(Function.Documentation)) {
                 if (needsNl) {
                     yield return new KeyValuePair<string, string>(nlKind, "\r\n");
                     nlKind = WellKnownRichDescriptionKinds.Misc;
@@ -100,38 +72,31 @@ namespace Microsoft.PythonTools.Analysis.Values {
 
         public override IEnumerable<OverloadResult> Overloads {
             get {
-                foreach (var p in _function.Overloads) {
+                foreach (var p in Function.Overloads) {
                     yield return p.Parameters.Length > 0 ? p.WithNewParameters(p.Parameters.Skip(1).ToArray()) : p;
                 }
             }
         }
 
-        public override string Documentation {
-            get {
-                return _function.Documentation;
-            }
-        }
-
-        public override PythonMemberType MemberType {
-            get {
-                return PythonMemberType.Method;
-            }
-        }
+        public override string Documentation => Function.Documentation;
+        public override PythonMemberType MemberType => PythonMemberType.Method;
+        public string FullyQualifiedName => Function.FullyQualifiedName;
+        public KeyValuePair<string, string> FullyQualifiedNamePair => Function.FullyQualifiedNamePair;
 
         public override string ToString() {
-            var name = _function.FunctionDefinition.Name;
+            var name = Function.FunctionDefinition.Name;
             return "Method" /* + hex(id(self)) */ + " " + name;
         }
 
         internal override AnalysisValue UnionMergeTypes(AnalysisValue ns, int strength) {
             var bmi = ns as BoundMethodInfo;
-            if (bmi == null || (Function.Equals(bmi.Function) && _instanceInfo.Equals(bmi._instanceInfo))) {
+            if (bmi == null || (Function.Equals(bmi.Function) && Instance.Equals(bmi.Instance))) {
                 return this;
             } else {
                 bool changed1, changed2;
                 var cmp = UnionComparer.Instances[strength];
                 var newFunc = cmp.MergeTypes(Function, bmi.Function, out changed1) as FunctionInfo;
-                var newInst = cmp.MergeTypes(_instanceInfo, bmi._instanceInfo, out changed2);
+                var newInst = cmp.MergeTypes(Instance, bmi.Instance, out changed2);
                 if (newFunc != null && newInst != null && (changed1 | changed2)) {
                     return new BoundMethodInfo(newFunc, newInst);
                 }
@@ -141,11 +106,11 @@ namespace Microsoft.PythonTools.Analysis.Values {
 
         internal override bool UnionEquals(AnalysisValue ns, int strength) {
             var bmi = ns as BoundMethodInfo;
-            return bmi != null && _instanceInfo.UnionEquals(bmi._instanceInfo, strength) && Function.UnionEquals(bmi.Function, strength);
+            return bmi != null && Instance.UnionEquals(bmi.Instance, strength) && Function.UnionEquals(bmi.Function, strength);
         }
 
         internal override int UnionHashCode(int strength) {
-            return _instanceInfo.UnionHashCode(strength) ^ Function.UnionHashCode(strength);
+            return Instance.UnionHashCode(strength) ^ Function.UnionHashCode(strength);
         }
     }
 }

--- a/Python/Product/Analysis/Values/BuiltinClassInfo.cs
+++ b/Python/Product/Analysis/Values/BuiltinClassInfo.cs
@@ -22,7 +22,7 @@ using Microsoft.PythonTools.Interpreter;
 using Microsoft.PythonTools.Parsing.Ast;
 
 namespace Microsoft.PythonTools.Analysis.Values {
-    internal class BuiltinClassInfo : BuiltinNamespace<IPythonType>, IReferenceableContainer, IHasRichDescription {
+    internal class BuiltinClassInfo : BuiltinNamespace<IPythonType>, IReferenceableContainer, IHasRichDescription, IHasQualifiedName {
         private BuiltinInstanceInfo _inst;
         private string _doc;
         private readonly MemberReferences _referencedMembers = new MemberReferences();
@@ -80,6 +80,27 @@ namespace Microsoft.PythonTools.Analysis.Values {
         }
 
         public string ShortInstanceDescription => InstanceDescription;
+
+        public string FullyQualifiedName {
+            get {
+                if (_type != null) {
+                    if (_type.IsBuiltin) {
+                        return _type.Name;
+                    }
+                    return _type.DeclaringModule.Name + "." + _type.Name;
+                }
+                return null;
+            }
+        }
+
+        public KeyValuePair<string, string> FullyQualifiedNamePair {
+            get {
+                if (_type != null) {
+                    return new KeyValuePair<string, string>(_type.DeclaringModule.Name, _type.Name);
+                }
+                throw new NotSupportedException();
+            }
+        }
 
         public override IEnumerable<IAnalysisSet> Mro {
             get {

--- a/Python/Product/Analysis/VariablesResult.cs
+++ b/Python/Product/Analysis/VariablesResult.cs
@@ -14,36 +14,21 @@
 // See the Apache Version 2.0 License for specific language governing
 // permissions and limitations under the License.
 
-using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Microsoft.PythonTools.Parsing.Ast;
 
 namespace Microsoft.PythonTools.Analysis {
     sealed class VariablesResult : IEnumerable<IAnalysisVariable> {
         private readonly IEnumerable<IAnalysisVariable> _vars;
-        private readonly PythonAst _ast;
 
         internal VariablesResult(IEnumerable<IAnalysisVariable> variables, PythonAst expr) {
             _vars = variables;
-            _ast = expr;
+            Ast = expr;
         }
 
-        public IEnumerator<IAnalysisVariable> GetEnumerator() {
-            return _vars.GetEnumerator();
-        }
-
-        IEnumerator IEnumerable.GetEnumerator() {
-            return _vars.GetEnumerator();
-        }
-
-        public PythonAst Ast {
-            get {
-                return _ast;
-            }
-        }
+        public IEnumerator<IAnalysisVariable> GetEnumerator() => _vars.GetEnumerator();
+        IEnumerator IEnumerable.GetEnumerator() => _vars.GetEnumerator();
+        public PythonAst Ast { get; }
     }
 }

--- a/Python/Product/PythonTools/PythonTools/Intellisense/ExpressionAtPoint.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/ExpressionAtPoint.cs
@@ -23,13 +23,14 @@ namespace Microsoft.PythonTools.Intellisense {
         public readonly string Text;
         public readonly AnalysisEntry Entry;
         public readonly ITrackingSpan Span;
-        public readonly SourceLocation Location;
+        public readonly SourceSpan SourceSpan;
+        public SourceLocation Location => SourceSpan.Start;
 
-        public ExpressionAtPoint(AnalysisEntry entry, string text, ITrackingSpan span, SourceLocation location) {
+        public ExpressionAtPoint(AnalysisEntry entry, string text, ITrackingSpan span, SourceSpan sourceSpan) {
             Entry = entry;
             Text = text;
             Span = span;
-            Location = location;
+            SourceSpan = sourceSpan;
         }
     }
 

--- a/Python/Product/PythonTools/PythonTools/Intellisense/IntellisenseController.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/IntellisenseController.cs
@@ -434,7 +434,7 @@ namespace Microsoft.PythonTools.Intellisense {
             }
 
             var languageVersion = entry.Analyzer.LanguageVersion;
-            var parser = Parser.CreateParser(new StringReader(text), languageVersion, new ParserOptions { Verbatim = true });
+            var parser = Parser.CreateParser(new StringReader(text), languageVersion, ParserOptions.Default);
             var ast = parser.ParseSingleStatement();
 
             var walker = new ExpressionCompletionWalker(caretPoint.Value.Position - statement.Value.Start.Position);

--- a/Python/Product/PythonTools/PythonTools/Intellisense/ProjectAnalyzer.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/ProjectAnalyzer.cs
@@ -1306,7 +1306,7 @@ namespace Microsoft.PythonTools.Intellisense {
             var analysis = await GetExpressionAtPointAsync(point, purpose, TimeSpan.FromSeconds(1.0)).ConfigureAwait(false);
 
             if (analysis != null) {
-                var location = analysis.Location;
+                var location = analysis.SourceSpan.End;
                 var req = new AP.AnalyzeExpressionRequest() {
                     expr = analysis.Text,
                     column = location.Column,
@@ -2627,7 +2627,7 @@ namespace Microsoft.PythonTools.Intellisense {
                 bi.AnalysisEntry,
                 span.GetText(),
                 span.Snapshot.CreateTrackingSpan(span, SpanTrackingMode.EdgeInclusive),
-                sourceSpan.Value.Start
+                sourceSpan.Value
             );
         }
 

--- a/Python/Product/PythonTools/PythonTools/Navigation/EditFilter.cs
+++ b/Python/Product/PythonTools/PythonTools/Navigation/EditFilter.cs
@@ -124,7 +124,7 @@ namespace Microsoft.PythonTools.Language {
             var caret = _textView.GetPythonCaret();
             var analysis = _textView.GetAnalysisAtCaret(_editorServices.Site);
             if (analysis != null && caret != null) {
-                var defs = await analysis.Analyzer.AnalyzeExpressionAsync(analysis, caret.Value);
+                var defs = await analysis.Analyzer.AnalyzeExpressionAsync(analysis, caret.Value, ExpressionAtPointPurpose.FindDefinition);
                 if (defs == null) {
                     return;
                 }
@@ -202,7 +202,7 @@ namespace Microsoft.PythonTools.Language {
             var caret = _textView.GetPythonCaret();
             var analysis = _textView.GetAnalysisAtCaret(_editorServices.Site);
             if (analysis != null && caret != null) {
-                var references = await analysis.Analyzer.AnalyzeExpressionAsync(analysis, caret.Value);
+                var references = await analysis.Analyzer.AnalyzeExpressionAsync(analysis, caret.Value, ExpressionAtPointPurpose.FindDefinition);
                 if (references == null) {
                     return;
                 }

--- a/Python/Tests/Analysis/AnalysisTest.cs
+++ b/Python/Tests/Analysis/AnalysisTest.cs
@@ -3296,7 +3296,7 @@ a = C()
 b = a.f
             ");
 
-            entry.AssertDescription("b", "method f of C objects \r\ndoc string");
+            entry.AssertDescription("b", "method f of test-module.C objects \r\ndoc string");
 
             entry = ProcessText(@"
 class C(object):
@@ -3307,7 +3307,7 @@ a = C()
 b = a.f
             ");
 
-            entry.AssertDescription("b", "method f of C objects \r\ndoc string");
+            entry.AssertDescription("b", "method f of test-module.C objects \r\ndoc string");
         }
 
         [TestMethod, Priority(0)]
@@ -5768,8 +5768,8 @@ def with_params_default_starargs(*args, **kwargs):
             entry.AssertIsInstance("d", "fob");
             entry.AssertDescription("sys", "built-in module sys");
             entry.AssertDescription("f", "def test-module.f() -> str");
-            entry.AssertDescription("fob.f", "def test-module.fob.f(self)\r\ndeclared in fob");
-            entry.AssertDescription("fob().g", "method g of fob objects ");
+            entry.AssertDescription("fob.f", "def test-module.fob.f(self : fob)\r\ndeclared in fob");
+            entry.AssertDescription("fob().g", "method g of test-module.fob objects ");
             entry.AssertDescription("fob", "class test-module.fob(object)");
             //AssertUtil.ContainsExactly(entry.GetVariableDescriptionsByIndex("System.StringSplitOptions.RemoveEmptyEntries", 1), "field of type StringSplitOptions");
             entry.AssertDescription("g", "def test-module.g()");    // return info could be better
@@ -5780,17 +5780,17 @@ def with_params_default_starargs(*args, **kwargs):
             entry.AssertDescription("docstr_func", "def test-module.docstr_func() -> int\r\nuseful documentation");
 
             entry.AssertDescription("with_params", "def test-module.with_params(a, b, c)");
-            entry.AssertDescription("with_params_default", "def test-module.with_params_default(a, b, c = 100)");
-            entry.AssertDescription("with_params_default_2", "def test-module.with_params_default_2(a, b, c = [])");
-            entry.AssertDescription("with_params_default_3", "def test-module.with_params_default_3(a, b, c = ())");
-            entry.AssertDescription("with_params_default_4", "def test-module.with_params_default_4(a, b, c = {})");
-            entry.AssertDescription("with_params_default_2a", "def test-module.with_params_default_2a(a, b, c = [...])");
-            entry.AssertDescription("with_params_default_3a", "def test-module.with_params_default_3a(a, b, c = (...))");
-            entry.AssertDescription("with_params_default_4a", "def test-module.with_params_default_4a(a, b, c = {...})");
-            entry.AssertDescription("with_params_default_starargs", "def test-module.with_params_default_starargs(*args, **kwargs)");
+            entry.AssertDescription("with_params_default", "def test-module.with_params_default(a, b, c : int = 100)");
+            entry.AssertDescription("with_params_default_2", "def test-module.with_params_default_2(a, b, c : list = [])");
+            entry.AssertDescription("with_params_default_3", "def test-module.with_params_default_3(a, b, c : tuple = ())");
+            entry.AssertDescription("with_params_default_4", "def test-module.with_params_default_4(a, b, c : dict = {})");
+            entry.AssertDescription("with_params_default_2a", "def test-module.with_params_default_2a(a, b, c : list = [...])");
+            entry.AssertDescription("with_params_default_3a", "def test-module.with_params_default_3a(a, b, c : tuple = (...))");
+            entry.AssertDescription("with_params_default_4a", "def test-module.with_params_default_4a(a, b, c : dict = {...})");
+            entry.AssertDescription("with_params_default_starargs", "def test-module.with_params_default_starargs(*args : tuple, **kwargs : dict)");
 
             // method which returns it's self, we shouldn't stack overflow producing the help...
-            entry.AssertDescription("return_func_class().return_func", @"method return_func of return_func_class objects  -> method return_func of return_func_class objects ...
+            entry.AssertDescription("return_func_class().return_func", @"method return_func of test-module.return_func_class objects  -> method return_func of test-module.return_func_class objects ...
 some help");
         }
 
@@ -6443,7 +6443,7 @@ def update_wrapper(wrapper, wrapped, assigned, updated):
             state.AssertConstantEquals("test1.__name__", "test1");
             Assert.AreEqual("doc", state.GetValue<FunctionInfo>("test1").Documentation);
             state.GetValue<FunctionInfo>("test1.__wrapped__");
-            Assert.AreEqual(2, state.GetValue<FunctionInfo>("test1").Overloads.Count());
+            Assert.AreEqual(3, state.GetValue<FunctionInfo>("test1").Overloads.Count());
             state.AssertConstantEquals("test1_result", "decorated");
 
             // __name__ should not have been changed by update_wrapper
@@ -6539,7 +6539,7 @@ def update_wrapper(wrapper, wrapped, assigned, updated):
             var entry = ProcessText(code);
 
             Assert.AreEqual(
-                "def test-module.A.fn(self) -> lambda: 123 -> int\ndeclared in A",
+                "def test-module.A.fn(self : A) -> lambda: 123 -> int\ndeclared in A",
                 entry.GetDescriptions("A.fn", 0).Single().Replace("\r\n", "\n")
             );
         }

--- a/Python/Tests/Analysis/ExpressionFinderTests.cs
+++ b/Python/Tests/Analysis/ExpressionFinderTests.cs
@@ -169,6 +169,62 @@ C().fff", GetExpressionOptions.Complete);
         }
 
         [TestMethod, Priority(0)]
+        public void FindExpressionsForDefinition() {
+            var code = Parse(@"class C(object):
+    def f(a):
+        return a
+
+b = C().f(1)
+", GetExpressionOptions.FindDefinition);
+            var clsCode = code.Source.Substring(0, code.Source.IndexOfEnd("return a"));
+            var funcCode = clsCode.Substring(clsCode.IndexOf("def"));
+
+            AssertNoExpr(code, 1, 1);
+            AssertExpr(code, 1, 7, "C");
+            AssertExpr(code, 1, 8, "C");
+            AssertNoExpr(code, 1, 7, 1, 9);
+            AssertExpr(code, 1, 9, "object");
+            AssertExpr(code, 1, 15, "object");
+            AssertNoExpr(code, 1, 16);
+            AssertNoExpr(code, 1, 15, 1, 16);
+
+            AssertNoExpr(code, 2, 1);
+            AssertNoExpr(code, 2, 5);
+            AssertExpr(code, 2, 9, "f");
+            AssertExpr(code, 2, 10, "f");
+            AssertExpr(code, 2, 11, "a");
+
+            AssertNoExpr(code, 3, 15);
+            AssertExpr(code, 3, 16, "a");
+            AssertExpr(code, 3, 17, "a");
+
+            AssertExpr(code, 5, 1, "b");
+            AssertExpr(code, 5, 5, "C");
+            AssertExpr(code, 5, 6, "C");
+            AssertNoExpr(code, 5, 7);
+            AssertExpr(code, 5, 9, "C().f");
+            AssertExpr(code, 5, 10, "C().f");
+            AssertExpr(code, 5, 9, 5, 10, "C().f");
+            AssertNoExpr(code, 5, 11);
+
+            // Same code as in the GotoDefinition test
+            code = Parse(@"class C:
+    def fff(self, x=a): pass
+i=1+2
+C().fff", GetExpressionOptions.FindDefinition);
+
+            AssertExpr(code, 1, 8, "C");
+            AssertExpr(code, 2, 9, 2, 12, "fff");
+            AssertExpr(code, 2, 13, 2, 17, "self");
+            AssertExpr(code, 2, 22, "a");
+            AssertNoExpr(code, 2, 29);
+            AssertNoExpr(code, 3, 4);
+            AssertNoExpr(code, 3, 6);
+            AssertExpr(code, 4, 1, 4, 2, "C");
+            AssertExpr(code, 4, 6, 4, 8, "C().fff");
+        }
+
+        [TestMethod, Priority(0)]
         public void FindKeywords() {
             var code = Parse(@"a and b
 assert a

--- a/Python/Tests/Analysis/LanguageServerTests.cs
+++ b/Python/Tests/Analysis/LanguageServerTests.cs
@@ -309,8 +309,8 @@ mc";
 
             await AssertCompletion(s, mod1,
                 position: new Position { line = 2, character = 5 },
-                contains: new string[0],
-                excludes: new[] { "value" }
+                contains: new[] { "value" },
+                excludes: new string[0]
             );
 
             await s.UnloadFileAsync(mod2);

--- a/Python/Tests/Analysis/LanguageServerTests.cs
+++ b/Python/Tests/Analysis/LanguageServerTests.cs
@@ -471,6 +471,42 @@ mod1.f(a=D)", "mod2");
         }
 
         [TestMethod, Priority(0)]
+        public async Task Hover() {
+            var s = await CreateServer();
+            var mod = await AddModule(s, @"123
+'abc'
+f()
+def f(): pass
+
+class C:
+    def f(self):
+        def g(self):
+            pass
+        return g
+
+C.f
+c = C()
+c_g = c.f()
+
+x = 123
+x = 3.14
+");
+
+            await AssertHover(s, mod, new SourceLocation(1, 1), "int", new[] { "int" }, new SourceSpan(1, 1, 1, 4));
+            await AssertHover(s, mod, new SourceLocation(2, 1), "str", new[] { "str" }, new SourceSpan(2, 1, 2, 6));
+            await AssertHover(s, mod, new SourceLocation(3, 1), "f: def test-module.f()", new[] { "test-module.f" }, new SourceSpan(3, 1, 3, 2));
+            await AssertHover(s, mod, new SourceLocation(4, 6), "f: def test-module.f()", new[] { "test-module.f" }, new SourceSpan(4, 5, 4, 6));
+
+            await AssertHover(s, mod, new SourceLocation(12, 1), "C: class test-module.C", new[] { "test-module.C" }, new SourceSpan(12, 1, 12, 2));
+            await AssertHover(s, mod, new SourceLocation(13, 1), "c: C", new[] { "test-module.C" }, new SourceSpan(13, 1, 13, 2));
+            await AssertHover(s, mod, new SourceLocation(14, 7), "c: C", new[] { "test-module.C" }, new SourceSpan(14, 7, 14, 8));
+            await AssertHover(s, mod, new SourceLocation(14, 9), "c.f: method f of test-module.C objects*", new[] { "test-module.C.f" }, new SourceSpan(14, 7, 14, 10));
+            await AssertHover(s, mod, new SourceLocation(14, 1), "c_g: def test-module.C.f.g(self)\r\ndeclared in C.f", new[] { "test-module.C.f.g" }, new SourceSpan(14, 1, 14, 4));
+
+            await AssertHover(s, mod, new SourceLocation(16, 1), "x: int, float", new[] { "int", "float" }, new SourceSpan(16, 1, 16, 2));
+        }
+
+        [TestMethod, Priority(0)]
         public async Task MultiPartDocument() {
             var s = await CreateServer();
 
@@ -612,6 +648,29 @@ mod1.f(a=D)", "mod2");
                 contains,
                 excludes
             );
+        }
+
+        public static async Task AssertHover(Server s, TextDocumentIdentifier document, SourceLocation position, string hoverText, IEnumerable<string> typeNames, SourceSpan? range = null, string expr = null) {
+            var hover = await s.Hover(new TextDocumentPositionParams {
+                textDocument = document,
+                position = position,
+                _expr = expr
+            });
+
+            if (hoverText.EndsWith("*")) {
+                // Check prefix first, but then show usual message for mismatched value
+                if (!hover.contents.value.StartsWith(hoverText.Remove(hoverText.Length - 1))) {
+                    Assert.AreEqual(hoverText, hover.contents.value);
+                }
+            } else {
+                Assert.AreEqual(hoverText, hover.contents.value);
+            }
+            if (typeNames != null) {
+                AssertUtil.ContainsExactly(hover._typeNames, typeNames.ToArray());
+            }
+            if (range.HasValue) {
+                Assert.AreEqual(range.Value, (SourceSpan)hover.range);
+            }
         }
 
         public static async Task AssertReferences(Server s, TextDocumentIdentifier document, SourceLocation position, IEnumerable<string> contains, IEnumerable<string> excludes, string expr = null, bool returnDefinition = false) {

--- a/Python/Tests/Analysis/ParserTests.cs
+++ b/Python/Tests/Analysis/ParserTests.cs
@@ -69,10 +69,10 @@ namespace AnalysisTests {
             ParseErrors("MixedWhitespace1.py", PythonLanguageVersion.V27, Severity.Error);
 
             // mixed in the same block, tabs first
-            ParseErrors("MixedWhitespace2.py", PythonLanguageVersion.V27, Severity.Error, new ErrorInfo("inconsistent whitespace", 293, 13, 32, 302, 14, 9));
+            ParseErrors("MixedWhitespace2.py", PythonLanguageVersion.V27, Severity.Error, new ErrorInfo("inconsistent whitespace", 294, 14, 1, 302, 14, 9));
 
             // mixed in same block, spaces first
-            ParseErrors("MixedWhitespace3.py", PythonLanguageVersion.V27, Severity.Error, new ErrorInfo("inconsistent whitespace", 285, 13, 24, 287, 14, 2));
+            ParseErrors("MixedWhitespace3.py", PythonLanguageVersion.V27, Severity.Error, new ErrorInfo("inconsistent whitespace", 286, 14, 1, 287, 14, 2));
 
             // mixed on same line, spaces first
             ParseErrors("MixedWhitespace4.py", PythonLanguageVersion.V27, Severity.Error);
@@ -81,7 +81,7 @@ namespace AnalysisTests {
             ParseErrors("MixedWhitespace5.py", PythonLanguageVersion.V27, Severity.Error);
 
             // mixed on a comment line - should not crash
-            ParseErrors("MixedWhitespace6.py", PythonLanguageVersion.V27, Severity.Error, new ErrorInfo("inconsistent whitespace", 126, 8, 17, 128, 9, 2));
+            ParseErrors("MixedWhitespace6.py", PythonLanguageVersion.V27, Severity.Error, new ErrorInfo("inconsistent whitespace", 127, 9, 1, 128, 9, 2));
         }
 
         [TestMethod, Priority(0)]
@@ -2978,7 +2978,7 @@ namespace AnalysisTests {
         }
 
         private static Action<int, int?> ParseCall(string code) {
-            var parser = Parser.CreateParser(new StringReader(code), PythonLanguageVersion.V36);
+            var parser = Parser.CreateParser(new StringReader(code), PythonLanguageVersion.V36, new ParserOptions { Verbatim = true });
             var tree = parser.ParseTopExpression();
             if (Statement.GetExpression(tree.Body) is CallExpression ce) {
                 return (index, expected) => {


### PR DESCRIPTION
Fixes #3793 Migrate hover to server
Implements the Hover() command on server
Also disables verbatim parsing by default, as it was interfering with tests. Some work for lambda was required to restore the previous behaviour.