### PR TITLE
Small optimizations for conda discovery

### DIFF
--- a/Python/Product/VSInterpreters/Interpreter/CondaEnvironmentFactoryProvider.cs
+++ b/Python/Product/VSInterpreters/Interpreter/CondaEnvironmentFactoryProvider.cs
@@ -292,7 +292,8 @@ namespace Microsoft.PythonTools.Interpreter {
                     .AsParallel()
                     .Where(folder => Directory.Exists(folder))
                     .Select(folder => CreateEnvironmentInfo(folder))
-                    .Where(env => env != null);
+                    .Where(env => env != null)
+                    .ToList();
             }
 
             return Enumerable.Empty<PythonInterpreterInformation>();

--- a/Python/Product/VSInterpreters/Interpreter/CondaEnvironmentFactoryProvider.cs
+++ b/Python/Product/VSInterpreters/Interpreter/CondaEnvironmentFactoryProvider.cs
@@ -220,7 +220,7 @@ namespace Microsoft.PythonTools.Interpreter {
             // Discover the available interpreters...
             bool anyChanged = false;
 
-            List<PythonInterpreterInformation> found = null;
+            IReadOnlyList<PythonInterpreterInformation> found = null;
 
             try {
                 // Try to find an existing root conda installation
@@ -228,7 +228,7 @@ namespace Microsoft.PythonTools.Interpreter {
                 var globalFactories = _globalProvider.GetInterpreterFactories().ToList();
                 var mainCondaExePath = CondaUtils.GetLatestCondaExecutablePath(globalFactories);
                 if (mainCondaExePath != null) {
-                    found = FindCondaEnvironments(mainCondaExePath).ToList();
+                    found = FindCondaEnvironments(mainCondaExePath);
                 }
             } catch (ObjectDisposedException) {
                 // We are aborting, so silently return with no results.
@@ -285,7 +285,7 @@ namespace Microsoft.PythonTools.Interpreter {
             public string[] EnvironmentRootFolders = null;
         }
 
-        private IEnumerable<PythonInterpreterInformation> FindCondaEnvironments(string condaPath) {
+        private IReadOnlyList<PythonInterpreterInformation> FindCondaEnvironments(string condaPath) {
             var condaInfoResult = ExecuteCondaInfo(condaPath);
             if (condaInfoResult != null) {
                 return condaInfoResult.EnvironmentFolders
@@ -296,7 +296,7 @@ namespace Microsoft.PythonTools.Interpreter {
                     .ToList();
             }
 
-            return Enumerable.Empty<PythonInterpreterInformation>();
+            return Enumerable.Empty<PythonInterpreterInformation>().ToList();
         }
 
         private static PythonInterpreterInformation CreateEnvironmentInfo(string prefixPath) {


### PR DESCRIPTION
- Read from .version instead of calling conda -V when trying to determine which global conda.exe is the latest
- Do some parallel environment creation (instead of serially calling python.exe for each environment)

Fix #3540 

Timing of complete discovery of all conda environments varies quite a bit from run to run, but it seems to be slightly better on average (for me by about 1 sec)

As far as fixed cost of finding which global conda.exe to use, I don't know that it's worth doing a lot more than this (like caching results), especially if we plan on having a private conda at some point.