### PR TITLE
Fixes #3786 OOM adding text to the repl

### DIFF
--- a/Common/Product/SharedProject/UIThread.cs
+++ b/Common/Product/SharedProject/UIThread.cs
@@ -15,11 +15,13 @@
 // permissions and limitations under the License.
 
 using System;
+using System.Collections.Generic;
 using System.ComponentModel.Design;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Windows.Forms;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Threading;
 using Task = System.Threading.Tasks.Task;
@@ -211,7 +213,7 @@ namespace Microsoft.VisualStudioTools {
             _factory.RunAsync(async () => {
                 // Convert assertions to exceptions while joining on a task
                 // or the message box will deadlock.
-                using (ThrowOnAssertListener.Push()) {
+                using (NoDeadlockAssertListener.Push()) {
                     await _factory.SwitchToMainThreadAsync(cancellationToken);
                     await func();
                 }
@@ -231,7 +233,7 @@ namespace Microsoft.VisualStudioTools {
             return _factory.RunAsync(async () => {
                 // Convert assertions to exceptions while joining on a task
                 // or the message box will deadlock.
-                using (ThrowOnAssertListener.Push()) {
+                using (NoDeadlockAssertListener.Push()) {
                     await _factory.SwitchToMainThreadAsync(cancellationToken);
                     return await func();
                 }
@@ -240,15 +242,17 @@ namespace Microsoft.VisualStudioTools {
 
         #region ThrowOnAssertListener class
 
-        class ThrowOnAssertListener : TraceListener {
-            TraceListener[] _inner;
+        sealed class AssertException : Exception {
+            public AssertException(string message) : base(message) { }
+        }
 
+        class NoDeadlockAssertListener : TraceListener {
             public static IDisposable Push() {
 #if DEBUG
                 var inner = new TraceListener[Trace.Listeners.Count];
                 Trace.Listeners.CopyTo(inner, 0);
                 Trace.Listeners.Clear();
-                var res = new ThrowOnAssertListener(inner);
+                var res = new NoDeadlockAssertListener(inner);
                 Trace.Listeners.Add(res);
                 return res;
 #else
@@ -256,7 +260,10 @@ namespace Microsoft.VisualStudioTools {
 #endif
             }
 
-            protected ThrowOnAssertListener(TraceListener[] inner) : base(nameof(ThrowOnAssertListener)) {
+#if DEBUG
+            private readonly TraceListener[] _inner;
+
+            protected NoDeadlockAssertListener(TraceListener[] inner) : base(nameof(NoDeadlockAssertListener)) {
                 _inner = inner;
             }
 
@@ -283,14 +290,26 @@ namespace Microsoft.VisualStudioTools {
             }
 
             public override void Fail(string message) {
-                throw new Exception(message);
+                var trace = new StackTrace(true).ToString();
+                var fullMessage = string.IsNullOrEmpty(message) ? trace : (message + Environment.NewLine + trace);
+                switch (MessageBox.Show(fullMessage, "Failed Assertion", MessageBoxButtons.AbortRetryIgnore)) {
+                    case DialogResult.Abort:
+                        Environment.FailFast(string.IsNullOrEmpty(message) ? fullMessage : message);
+                        break;
+                    case DialogResult.Retry:
+                        Debugger.Launch();
+                        break;
+                    case DialogResult.Ignore:
+                        break;
+                }
             }
 
             public override void Fail(string message, string detailMessage) {
-                throw new Exception(message + Environment.NewLine + detailMessage);
+                Fail(message + Environment.NewLine + detailMessage);
             }
         }
+#endif
 
-#endregion
+        #endregion
     }
 }

--- a/Python/Product/PythonTools/PythonTools/Repl/PythonCommonInteractiveEvaluator.cs
+++ b/Python/Product/PythonTools/PythonTools/Repl/PythonCommonInteractiveEvaluator.cs
@@ -637,8 +637,11 @@ namespace Microsoft.PythonTools.Repl {
 
             Span span;
             var write = isError ? (Func<string, Span>)window.WriteError : window.Write;
+            int lastEscape = -1;
 
-            while (escape >= 0) {
+            while (escape > lastEscape) {
+                lastEscape = escape;
+
                 span = write(text.Substring(start, escape - start));
                 if (span.Length > 0) {
                     colors.Add(new ColoredSpan(span, color));
@@ -646,7 +649,10 @@ namespace Microsoft.PythonTools.Repl {
 
                 start = escape + 2;
                 color = GetColorFromEscape(text, ref start);
+                Debug.Assert(start >= escape + 2);
+
                 escape = text.IndexOfOrdinal("\x1b[", start);
+                Debug.Assert(escape < 0 || escape > lastEscape);
             }
 
             var rest = text.Substring(start);


### PR DESCRIPTION
Fixes #3786 OOM adding text to the repl
Ensures our search for color codes always makes forward progress.
Improves handling of debug assertions when in a context that doesn't handle dialogs well.