### PR TITLE
Fixes #3791 Error adding WPF event handler using XAML designer

### DIFF
--- a/Common/Product/SharedProject/CommonFileNode.cs
+++ b/Common/Product/SharedProject/CommonFileNode.cs
@@ -187,9 +187,6 @@ namespace Microsoft.VisualStudioTools.Project {
         }
 
         private ITextBuffer GetTextBufferOnUIThread(bool create) {
-            IVsTextManager textMgr = (IVsTextManager)GetService(typeof(SVsTextManager));
-            var model = GetService(typeof(SComponentModel)) as IComponentModel;
-            var adapter = model.GetService<IVsEditorAdaptersFactoryService>();
             uint itemid;
 
             IVsRunningDocumentTable rdt = ProjectMgr.GetService(typeof(SVsRunningDocumentTable)) as IVsRunningDocumentTable;
@@ -236,7 +233,12 @@ namespace Microsoft.VisualStudioTools.Project {
                 }
 
                 if (srpTextLines != null) {
-                    return adapter.GetDocumentBuffer(srpTextLines);
+                    var model = GetService(typeof(SComponentModel)) as IComponentModel;
+                    var adapter = model.GetService<IVsEditorAdaptersFactoryService>();
+                    var buffer = adapter.GetDocumentBuffer(srpTextLines);
+                    if (buffer != null) {
+                        return buffer;
+                    }
                 }
             }
 

--- a/Python/Product/PythonTools/PythonTools/Intellisense/ProjectAnalyzer.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/ProjectAnalyzer.cs
@@ -2061,9 +2061,12 @@ namespace Microsoft.PythonTools.Intellisense {
             return res?.names ?? Array.Empty<string>();
         }
 
-        internal async Task<InsertionPoint> GetInsertionPointAsync(ITextSnapshot textSnapshot, string className) {
+        internal async Task<InsertionPoint> GetInsertionPointAsync(ITextSnapshot textSnapshot, string className, AnalysisEntry entry = null) {
+            if (textSnapshot == null) {
+                return null;
+            }
             var bi = _services.GetBufferInfo(textSnapshot.TextBuffer);
-            var entry = bi?.AnalysisEntry;
+            entry = entry ?? bi?.AnalysisEntry;
             if (entry == null) {
                 return null;
             }

--- a/Python/Product/VSCommon/Infrastructure/IXamlDesignerSupport.cs
+++ b/Python/Product/VSCommon/Infrastructure/IXamlDesignerSupport.cs
@@ -37,6 +37,7 @@ namespace Microsoft.PythonTools.Infrastructure {
             get;
         }
 
+        bool EnsureDocumentIsOpen();
         InsertionPoint GetInsertionPoint(string className);
 
         string[] FindMethods(string className, int? paramCount);

--- a/Python/Product/XamlDesignerSupport/WpfEventBindingProvider.cs
+++ b/Python/Product/XamlDesignerSupport/WpfEventBindingProvider.cs
@@ -49,6 +49,10 @@ namespace Microsoft.PythonTools.XamlDesignerSupport {
         }
 
         public override bool CreateMethod(EventDescription eventDescription, string methodName, string initialStatements) {
+            if (!_callback.EnsureDocumentIsOpen()) {
+                return false;
+            }
+
             // build the new method handler
             var insertPoint = _callback.GetInsertionPoint(null);
 


### PR DESCRIPTION
Fixes #3791 Error adding WPF event handler using XAML designer
Ensures document is open before adding handler
Skip finding AnalysisEntry on newly opened buffer