### PR TITLE
Fixes #3816 Deleting conda environment output has too many newlines

### DIFF
--- a/Python/Product/PythonTools/PythonTools/InterpreterList/InterpreterListToolWindow.cs
+++ b/Python/Product/PythonTools/PythonTools/InterpreterList/InterpreterListToolWindow.cs
@@ -479,7 +479,7 @@ namespace Microsoft.PythonTools.InterpreterList {
             }
 
             public void OnErrorTextReceived(ICondaEnvironmentManager sender, string text) {
-                _window.WriteErrorLine(text);
+                _window.WriteErrorLine(text.TrimEndNewline());
             }
 
             public void OnOperationFinished(ICondaEnvironmentManager sender, string operation, bool success) {
@@ -490,7 +490,7 @@ namespace Microsoft.PythonTools.InterpreterList {
             }
 
             public void OnOutputTextReceived(ICondaEnvironmentManager sender, string text) {
-                _window.WriteLine(text);
+                _window.WriteLine(text.TrimEndNewline());
             }
         }
 


### PR DESCRIPTION
Fixes #3816 Deleting conda environment output has too many newlines
Adds trim code like we use elsewhere