### PR TITLE
Fixes #3841 15.6 broke mixed mode debugging.

### DIFF
--- a/Python/Product/VCDebugLauncher/source.extension.vsixmanifest
+++ b/Python/Product/VCDebugLauncher/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="PythonVCDebugLauncher.5AF7E179-1406-4804-9267-93F3BD7C7422" Version="3.2" Language="en-US" Publisher="Microsoft Corporation" />
+        <Identity Id="PythonVCDebugLauncher.5AF7E179-1406-4804-9267-93F3BD7C7422" Version="3.2.1" Language="en-US" Publisher="Microsoft Corporation" />
         <DisplayName>Python - C++ project debugging support</DisplayName>
         <Description xml:space="preserve">Adds a debug launcher for C++ projects that launches with Python debugging enabled.</Description>
         <MoreInfo>http://aka.ms/ptvs</MoreInfo>


### PR DESCRIPTION
Fixes #3841 15.6 broke mixed mode debugging
Updates version of the VCDebugLauncher package to ensure the newer build is installed.

For the forward-port we should update all VSIX versions to 15.7