### PR TITLE
Prevent crash in MessageProcessingThreadAsync.

### DIFF
--- a/Python/Product/Debugger/Debugger/DebugConnection.cs
+++ b/Python/Product/Debugger/Debugger/DebugConnection.cs
@@ -171,6 +171,8 @@ namespace Microsoft.PythonTools.Debugger {
                     ex.ObjectName == typeof(Socket).FullName,
                     "Accidentally handled ObjectDisposedException(" + ex.ObjectName + ")"
                 );
+            } catch (Exception ex) when (!ex.IsCriticalException()) {
+                Debug.Fail(ex.ToUnhandledExceptionMessage(typeof(DebugConnection)));
             } finally {
                 lock (_isListeningLock) {
                     // Exit out of the event handling thread


### PR DESCRIPTION
Fix #3788 

Ideally we'd have a more localized fix where the InvalidOperationException is thrown, but we don't know where that is.

The other thread proc (EventHandlingThread) also catches all and asserts, so I guess it's not so bad to do here too.

Fortunately this whole class will go away soon enough.