### PR TITLE
Hide the Automatically generate completion DB on first use option

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Options/PythonGeneralOptionsControl.cs
+++ b/Python/Product/PythonTools/PythonTools/Options/PythonGeneralOptionsControl.cs
@@ -66,6 +66,8 @@ namespace Microsoft.PythonTools.Options {
             _invalidEncodingWarning.Checked = pyService.GeneralOptions.InvalidEncodingWarning;
             _clearGlobalPythonPath.Checked = pyService.GeneralOptions.ClearGlobalPythonPath;
             IndentationInconsistencySeverity = pyService.GeneralOptions.IndentationInconsistencySeverity;
+
+            _autoAnalysis.Visible = !pyService.ExperimentalOptions.NoDatabaseFactory;
         }
 
         internal void SyncPageWithControlSettings(PythonToolsService pyService) {


### PR DESCRIPTION
Fix #3784 

Hiding the control is sufficient, the table is smart enough to move everything up so there's no gap.