### PR TITLE
Fixes #3835 Start and End must be well ordered

### DIFF
--- a/Python/Product/Analyzer/Intellisense/OutOfProcProjectAnalyzer.cs
+++ b/Python/Product/Analyzer/Intellisense/OutOfProcProjectAnalyzer.cs
@@ -1078,6 +1078,10 @@ namespace Microsoft.PythonTools.Intellisense {
 
                     var startLoc = classDef.GetStart(bufferVersion.Ast);
                     var endLoc = classDef.GetEnd(bufferVersion.Ast);
+                    if (startLoc >= endLoc) {
+                        Debug.Fail($"Invalid span on AST node {classDef}");
+                        endLoc = bufferVersion.Ast.IndexToLocation(classDef.StartIndex + 1);
+                    }
 
                     navs.Add(new AP.Navigation() {
                         type = "class",
@@ -1127,7 +1131,12 @@ namespace Microsoft.PythonTools.Intellisense {
                 type = "class";
             }
             var startLoc = stmt.GetStart(ast);
-            var endLoc = stmt.GetStart(ast);
+            var endLoc = stmt.GetEnd(ast);
+            if (startLoc >= endLoc) {
+                Debug.Fail($"Invalid span on AST node {stmt}");
+                endLoc = ast.IndexToLocation(stmt.StartIndex + 1);
+            }
+
             return new AP.Navigation {
                 type = type,
                 name = name,


### PR DESCRIPTION
Fixes #3835 Start and End must be well ordered
Verifies AST spans are at least one character long before returning as navigation locations.