### PR TITLE
Fixes #3536 VS code debugger installation

### DIFF
--- a/Python/Product/Debugger/DebugAdapterProcess.cs
+++ b/Python/Product/Debugger/DebugAdapterProcess.cs
@@ -91,8 +91,7 @@ namespace Microsoft.PythonTools.Debugger {
                 cwd.Trim('\\'),
                 $"{_listenerPort}",
                 $"{_processGuid}",
-                $"{_debugOptions}",
-                "-g"
+                $"{_debugOptions}"
             };
             var launcherArgs = string.Join(" ", argsList.Where(a => !string.IsNullOrWhiteSpace(a)).Select(ProcessOutput.QuoteSingleArgument));
             var arguments = $"{launcherArgs} {scriptAndScriptArgs}";

--- a/Python/Product/Debugger/DebugAdapterProcess.cs
+++ b/Python/Product/Debugger/DebugAdapterProcess.cs
@@ -91,7 +91,8 @@ namespace Microsoft.PythonTools.Debugger {
                 cwd.Trim('\\'),
                 $"{_listenerPort}",
                 $"{_processGuid}",
-                $"{_debugOptions}"
+                $"{_debugOptions}",
+                "-g"
             };
             var launcherArgs = string.Join(" ", argsList.Where(a => !string.IsNullOrWhiteSpace(a)).Select(ProcessOutput.QuoteSingleArgument));
             var arguments = $"{launcherArgs} {scriptAndScriptArgs}";

--- a/Python/Product/Debugger/Debugger.csproj
+++ b/Python/Product/Debugger/Debugger.csproj
@@ -190,4 +190,24 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="..\ProjectAfter.settings" />
+  <Target Name="_GatherPtvsd" BeforeTargets="_IncludePtvsd" Condition="!Exists('$(IntermediateOutputPath)Packages\ptvsd')">
+    <PropertyGroup>
+      <PipCommand>"$(PackagesPath)python\tools\python.exe" -m pip install ptvsd</PipCommand>
+      <PipCommand>$(PipCommand) --pre --no-compile --upgrade --target "$(IntermediateOutputPath)Packages"</PipCommand>
+    </PropertyGroup>
+    <Exec Command="$(PipCommand)" />
+  </Target>
+  <Target Name="_IncludePtvsd" BeforeTargets="AssignTargetPaths;GetVSIXSourceItems">
+    <ItemGroup>
+      <PtvsdFiles Include="$(IntermediateOutputPath)Packages\ptvsd\**\*" />
+      <PtvsdFiles>
+        <IncludeInVSIX>true</IncludeInVSIX>
+        <Link>Packages\ptvsd\%(RecursiveDir)%(Filename)%(Extension)</Link>
+        <VSIXSubPath>Packages\ptvsd\%(RecursiveDir)</VSIXSubPath>
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </PtvsdFiles>
+      <Content Include="@(PtvsdFiles)" />
+      <FileWrites Include="@(PtvsdFiles)" />
+    </ItemGroup>
+  </Target>
 </Project>

--- a/Python/Product/Debugger/Debugger.csproj
+++ b/Python/Product/Debugger/Debugger.csproj
@@ -190,7 +190,7 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="..\ProjectAfter.settings" />
-  <Target Name="_GatherPtvsd" BeforeTargets="_IncludePtvsd" Condition="!Exists('$(IntermediateOutputPath)Packages\ptvsd')">
+  <Target Name="_GatherPtvsd" BeforeTargets="_IncludePtvsd" Condition="!Exists('$(IntermediateOutputPath)Packages\ptvsd\__init__.py')">
     <PropertyGroup>
       <PipCommand>"$(PackagesPath)python\tools\python.exe" -m pip install ptvsd</PipCommand>
       <PipCommand>$(PipCommand) --pre --no-compile --upgrade --target "$(IntermediateOutputPath)Packages"</PipCommand>

--- a/Python/Product/PythonTools/ptvsd_launcher.py
+++ b/Python/Product/PythonTools/ptvsd_launcher.py
@@ -71,6 +71,9 @@ sys.path[0] = ''
 # Load the debugger package
 try:
     if bundled_ptvsd:
+        ptvs_lib_path = os.path.dirname(__file__)
+        sys.path.insert(0, ptvs_lib_path)
+    else:
         ptvs_lib_path = os.path.join(os.path.dirname(__file__), 'Packages')
         sys.path.append(ptvs_lib_path)
     try:

--- a/Python/Product/PythonTools/ptvsd_launcher.py
+++ b/Python/Product/PythonTools/ptvsd_launcher.py
@@ -71,8 +71,8 @@ sys.path[0] = ''
 # Load the debugger package
 try:
     if bundled_ptvsd:
-        ptvs_lib_path = os.path.dirname(__file__)
-        sys.path.insert(0, ptvs_lib_path)
+        ptvs_lib_path = os.path.join(os.path.dirname(__file__), 'Packages')
+        sys.path.append(ptvs_lib_path)
     try:
         import ptvsd
         import ptvsd.debugger as vspd

--- a/Python/Product/PythonTools/ptvsd_launcher.py
+++ b/Python/Product/PythonTools/ptvsd_launcher.py
@@ -70,6 +70,7 @@ sys.path[0] = ''
 
 # Load the debugger package
 try:
+    ptvs_lib_path = None
     if bundled_ptvsd:
         ptvs_lib_path = os.path.dirname(__file__)
         sys.path.insert(0, ptvs_lib_path)
@@ -103,7 +104,7 @@ Press Enter to close. . .''')
         input()
     sys.exit(1)
 finally:
-    if bundled_ptvsd:
+    if ptvs_lib_path:
         sys.path.remove(ptvs_lib_path)
 
 # and start debugging

--- a/Python/Product/VSInterpreters/Interpreter/ExperimentalOptions.cs
+++ b/Python/Product/VSInterpreters/Interpreter/ExperimentalOptions.cs
@@ -30,8 +30,8 @@ namespace Microsoft.PythonTools.Interpreter {
         internal static readonly Lazy<bool> _useVsCodeDebugger = new Lazy<bool>(GetUseVsCodeDebugger);
 
         public static bool GetNoDatabaseFactory() => GetBooleanFlag(NoDatabaseFactoryKey, defaultVal: true);
-        public static bool GetAutoDetectCondaEnvironments() => GetBooleanFlag(AutoDetectCondaEnvironmentsKey, defaultVal: false);
-        public static bool GetUseCondaPackageManager() => GetBooleanFlag(UseCondaPackageManagerKey, defaultVal: false);
+        public static bool GetAutoDetectCondaEnvironments() => GetBooleanFlag(AutoDetectCondaEnvironmentsKey, defaultVal: true);
+        public static bool GetUseCondaPackageManager() => GetBooleanFlag(UseCondaPackageManagerKey, defaultVal: true);
         public static bool GetUseVsCodeDebugger() => GetBooleanFlag(UseVsCodeDebuggerKey, defaultVal: true);
 
         private static bool GetBooleanFlag(string keyName, bool defaultVal) {

--- a/Python/Product/VSInterpreters/Interpreter/ExperimentalOptions.cs
+++ b/Python/Product/VSInterpreters/Interpreter/ExperimentalOptions.cs
@@ -32,7 +32,7 @@ namespace Microsoft.PythonTools.Interpreter {
         public static bool GetNoDatabaseFactory() => GetBooleanFlag(NoDatabaseFactoryKey, defaultVal: true);
         public static bool GetAutoDetectCondaEnvironments() => GetBooleanFlag(AutoDetectCondaEnvironmentsKey, defaultVal: false);
         public static bool GetUseCondaPackageManager() => GetBooleanFlag(UseCondaPackageManagerKey, defaultVal: false);
-        public static bool GetUseVsCodeDebugger() => GetBooleanFlag(UseVsCodeDebuggerKey, defaultVal: false);
+        public static bool GetUseVsCodeDebugger() => GetBooleanFlag(UseVsCodeDebuggerKey, defaultVal: true);
 
         private static bool GetBooleanFlag(string keyName, bool defaultVal) {
             using (var root = Registry.CurrentUser.OpenSubKey(ExperimentSubkey, false)) {


### PR DESCRIPTION
Fixes #3536 VS code debugger installation
Embeds the latest release of ptvsd into the bundle.

This needs to be changed at some point to lock to a specific release, but as the only available release right now is not suitable for embedding.