### PR TITLE
Fixes #3919 Imported modules do not allow go to definition

### DIFF
--- a/Python/Product/Analysis/Infrastructure/EnumerableExtensions.cs
+++ b/Python/Product/Analysis/Infrastructure/EnumerableExtensions.cs
@@ -39,5 +39,11 @@ namespace Microsoft.PythonTools.Analysis.Infrastructure {
         public static IEnumerable<T> Ordered<T>(this IEnumerable<T> source) {
             return source.OrderBy(Identity);
         }
+
+        private static bool NotNull<T>(T obj) where T : class => obj != null;
+
+        public static IEnumerable<T> WhereNotNull<T>(this IEnumerable<T> source) where T : class {
+            return source.Where(NotNull);
+        }
     }
 }

--- a/Python/Product/PythonTools/PythonTools/Intellisense/ProjectAnalyzer.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/ProjectAnalyzer.cs
@@ -1291,8 +1291,8 @@ namespace Microsoft.PythonTools.Intellisense {
                     expr,
                     null,
                     definitions.variables
-                        .Where(x => x.file != null)
                         .Select(ToAnalysisVariable)
+                        .Where(v => v != null)
                         .ToArray(),
                     definitions.privatePrefix
                 );
@@ -1321,8 +1321,8 @@ namespace Microsoft.PythonTools.Intellisense {
                         analysis.Text,
                         analysis.Span,
                         definitions.variables
-                            .Where(x => x.file != null)
                             .Select(ToAnalysisVariable)
+                            .Where(x => x != null)
                             .ToArray(),
                         definitions.privatePrefix
                     );
@@ -2566,8 +2566,19 @@ namespace Microsoft.PythonTools.Intellisense {
                 case "value": type = VariableType.Value; break;
             }
 
+            var file = arg.file;
+            if (string.IsNullOrEmpty(file)) {
+                try {
+                    file = arg.documentUri?.LocalPath;
+                } catch (InvalidOperationException) {
+                }
+                if (!File.Exists(file)) {
+                    return null;
+                }
+            }
+
             var location = new LocationInfo(
-                arg.file,
+                file,
                 arg.documentUri,
                 arg.startLine,
                 arg.startColumn,
@@ -2576,7 +2587,7 @@ namespace Microsoft.PythonTools.Intellisense {
             );
 
             var defLocation = new LocationInfo(
-                arg.file,
+                file,
                 arg.documentUri,
                 arg.definitionStartLine ?? arg.startLine,
                 arg.definitionStartColumn ?? arg.startColumn,

--- a/Python/Product/PythonTools/PythonTools/Navigation/Navigable/NavigableSymbolSource.cs
+++ b/Python/Product/PythonTools/PythonTools/Navigation/Navigable/NavigableSymbolSource.cs
@@ -112,7 +112,11 @@ namespace Microsoft.PythonTools.Navigation.Navigable {
                 }
             }
 
-            return list.ToArray();
+            return list
+                .OrderBy(v => v.Location.DocumentUri?.AbsoluteUri ?? "")
+                .ThenBy(v => v.Location.StartLine)
+                .ThenBy(v => v.Location.StartColumn)
+                .ToArray();
         }
     }
 }

--- a/Python/Tests/Analysis/AnalysisTest.cs
+++ b/Python/Tests/Analysis/AnalysisTest.cs
@@ -2953,9 +2953,7 @@ from baz import abc2 as abc";
                 new VariableLocation(2, 25, VariableType.Reference)
             );
             state.AssertReferences(fobMod, "abc", 0,
-                new VariableLocation(1, 7, VariableType.Value),         // possible value
-                                                                        //new VariableLocation(1, 7, VariableType.Value),
-                                                                        // appears twice for two modules, but cannot test that
+                new VariableLocation(1, 7, VariableType.Definition),
                 new VariableLocation(1, 25, VariableType.Reference),
                 new VariableLocation(2, 20, VariableType.Reference),    // import
                 new VariableLocation(2, 25, VariableType.Reference),    // as
@@ -5651,7 +5649,7 @@ n1 = g(1)";
             );
 
             entry.AssertReferences("g",
-                new VariableLocation(5, 9, VariableType.Value),
+                new VariableLocation(5, 9, VariableType.Definition),
                 new VariableLocation(10, 5, VariableType.Definition),
                 new VariableLocation(13, 6, VariableType.Reference)
             );
@@ -5679,7 +5677,7 @@ n1 = g(1)";
             entry.AssertReferences("g",
                 new VariableLocation(7, 5, VariableType.Definition),
                 new VariableLocation(10, 6, VariableType.Reference),
-                new VariableLocation(2, 9, VariableType.Value)
+                new VariableLocation(2, 9, VariableType.Definition)
             );
         }
 

--- a/Python/Tests/Analysis/LanguageServerTests.cs
+++ b/Python/Tests/Analysis/LanguageServerTests.cs
@@ -390,7 +390,7 @@ mod1.f(a=D)", "mod2");
             // f
             var expected = new[] {
                 "Definition;(2, 5) - (2, 6)",
-                "Value;(2, 5) - (3, 11)",
+                "Definition;(2, 5) - (3, 11)",
                 "Reference;(5, 1) - (5, 2)",
                 "Reference;(10, 1) - (10, 2)",
                 "Reference;(17, 6) - (17, 7)"

--- a/Python/Tests/PythonToolsMockTests/NavigableTests.cs
+++ b/Python/Tests/PythonToolsMockTests/NavigableTests.cs
@@ -56,7 +56,7 @@ namespace PythonToolsMockTests {
 ";
             using (var helper = new NavigableHelper(code, Version)) {
                 // os
-                await helper.CheckDefinitionLocations(7, 2, ExternalLocation(1, 1, "os.py"));
+                await helper.CheckDefinitionLocations(7, 2, ExternalLocation(1, 1, "os.py"), Location(1, 8));
             }
         }
 
@@ -186,8 +186,8 @@ print(obj._my_attr_val)
                 await helper.CheckDefinitionLocations(71, 7, Location(9, 9));
                 await helper.CheckDefinitionLocations(128, 7, Location(9, 9));
                 await helper.CheckDefinitionLocations(152, 7, Location(9, 9));
-                await helper.CheckDefinitionLocations(229, 7, Location(13, 5), Location(9, 9));
-                await helper.CheckDefinitionLocations(252, 7, Location(13, 5), Location(9, 9));
+                await helper.CheckDefinitionLocations(229, 7, Location(9, 9), Location(13, 5));
+                await helper.CheckDefinitionLocations(252, 7, Location(9, 9), Location(13, 5));
 
                 // val
                 await helper.CheckDefinitionLocations(166, 3, Location(9, 23));
@@ -195,9 +195,9 @@ print(obj._my_attr_val)
 
                 // _my_attr_val
                 await helper.CheckDefinitionLocations(28, 12, Location(2, 5));
-                await helper.CheckDefinitionLocations(107, 12, Location(10, 14), Location(2, 5));
-                await helper.CheckDefinitionLocations(186, 12, Location(10, 14), Location(2, 5));
-                await helper.CheckDefinitionLocations(272, 12, Location(10, 14), Location(2, 5));
+                await helper.CheckDefinitionLocations(107, 12, Location(2, 5), Location(10, 14));
+                await helper.CheckDefinitionLocations(186, 12, Location(2, 5), Location(10, 14));
+                await helper.CheckDefinitionLocations(272, 12, Location(2, 5), Location(10, 14));
 
                 // self
                 await helper.CheckDefinitionLocations(79, 4, Location(5, 17));
@@ -253,7 +253,7 @@ res = my_var * 10
 
                     Console.WriteLine($"Actual locations for pos={pos}, length={length}:");
                     foreach (var actualLocation in actualLocations) {
-                        Console.WriteLine($"line={actualLocation.Location.StartLine},col={actualLocation.Location.StartColumn}");
+                        Console.WriteLine($"file={actualLocation.Location.DocumentUri},line={actualLocation.Location.StartLine},col={actualLocation.Location.StartColumn}");
                     }
 
                     Assert.AreEqual(expectedLocations.Length, actualLocations.Length, "incorrect number of locations");


### PR DESCRIPTION
Fixes #3919 Imported modules do not allow go to definition
Attempt to read local path from documentUri if file path is missing
Return class/function and external values as definitions rather than values