### PR TITLE
Fixes #3915 IndexOutOfRangeException from BraceMatcher

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Editor/BraceMatcher.cs
+++ b/Python/Product/PythonTools/PythonTools/Editor/BraceMatcher.cs
@@ -188,6 +188,9 @@ namespace Microsoft.PythonTools.Editor {
         }
 
         private static BraceKind GetBraceKind(string brace) {
+            if (string.IsNullOrEmpty(brace)) {
+                throw new InvalidOperationException();
+            }
             switch (brace[0]) {
                 case '[':
                 case ']': return BraceKind.Bracket;


### PR DESCRIPTION
Fixes #3915 IndexOutOfRangeException from BraceMatcher
Raise correct error when `brace` string is empty.