### PR TITLE
Improve environments window startup time

### DIFF
--- a/Python/Product/EnvironmentsList/EnvironmentView.cs
+++ b/Python/Product/EnvironmentsList/EnvironmentView.cs
@@ -62,6 +62,7 @@ namespace Microsoft.PythonTools.EnvironmentsList {
         public string LocalizedDisplayName { get; }
         public string LocalizedHelpText { get; }
         public string BrokenEnvironmentHelpUrl { get; }
+        public bool ExtensionsCreated { get; set; }
 
         private EnvironmentView(string id, string localizedName, string localizedHelpText) {
             Configuration = new InterpreterConfiguration(id, id);

--- a/Python/Product/EnvironmentsList/PipExtension.xaml.cs
+++ b/Python/Product/EnvironmentsList/PipExtension.xaml.cs
@@ -116,7 +116,11 @@ namespace Microsoft.PythonTools.EnvironmentsList {
             e.Handled = true;
         }
 
-        private async void UninstallPackage_Executed(object sender, ExecutedRoutedEventArgs e) {
+        private void UninstallPackage_Executed(object sender, ExecutedRoutedEventArgs e) {
+            UninstallPackage_ExecutedAsync(sender, e).DoNotWait();
+        }
+
+        private async Task UninstallPackage_ExecutedAsync(object sender, ExecutedRoutedEventArgs e) {
             try {
                 var view = (PipPackageView)e.Parameter;
                 await _provider.UninstallPackage(view.Package);
@@ -143,7 +147,11 @@ namespace Microsoft.PythonTools.EnvironmentsList {
             e.CanExecute = !view.UpgradeVersion.IsEmpty && view.UpgradeVersion.CompareTo(view.Version) > 0;
         }
 
-        private async void UpgradePackage_Executed(object sender, ExecutedRoutedEventArgs e) {
+        private void UpgradePackage_Executed(object sender, ExecutedRoutedEventArgs e) {
+            UpgradePackage_ExecutedAsync(sender, e).DoNotWait();
+        }
+
+        private async Task UpgradePackage_ExecutedAsync(object sender, ExecutedRoutedEventArgs e) {
             try {
                 var view = (PipPackageView)e.Parameter;
                 // Construct a PackageSpec with the upgraded version.
@@ -161,7 +169,11 @@ namespace Microsoft.PythonTools.EnvironmentsList {
             e.Handled = true;
         }
 
-        private async void InstallPackage_Executed(object sender, ExecutedRoutedEventArgs e) {
+        private void InstallPackage_Executed(object sender, ExecutedRoutedEventArgs e) {
+            InstallPackage_ExecutedAsync(sender, e).DoNotWait();
+        }
+
+        private async Task InstallPackage_ExecutedAsync(object sender, ExecutedRoutedEventArgs e) {
             try {
                 await _provider.InstallPackage(new PackageSpec((string)e.Parameter));
             } catch (OperationCanceledException) {
@@ -175,7 +187,11 @@ namespace Microsoft.PythonTools.EnvironmentsList {
             e.Handled = true;
         }
 
-        private async void InstallPip_Executed(object sender, ExecutedRoutedEventArgs e) {
+        private void InstallPip_Executed(object sender, ExecutedRoutedEventArgs e) {
+            InstallPip_ExecutedAsync(sender, e).DoNotWait();
+        }
+
+        private async Task InstallPip_ExecutedAsync(object sender, ExecutedRoutedEventArgs e) {
             try {
                 await _provider.InstallPip();
             } catch (OperationCanceledException) {
@@ -251,11 +267,16 @@ namespace Microsoft.PythonTools.EnvironmentsList {
             _installableView.View.CurrentChanged += InstallableView_CurrentChanged;
             _installableViewRefreshTimer = new Timer(InstallablePackages_Refresh);
 
-            FinishInitialization();
+            FinishInitialization().DoNotWait();
         }
 
-        private async void PipExtensionProvider_IsPipInstalledChanged(object sender, EventArgs e) {
+        private void PipExtensionProvider_IsPipInstalledChanged(object sender, EventArgs e) {
+            PipExtensionProvider_IsPipInstalledChangedAsync(sender, e).DoNotWait();
+        }
+
+        private async Task PipExtensionProvider_IsPipInstalledChangedAsync(object sender, EventArgs e) {
             await Dispatcher.InvokeAsync(() => { IsPipInstalled = _provider.IsPipInstalled ?? true; });
+            await RefreshPackages();
         }
 
         private void InstalledView_CurrentChanged(object sender, EventArgs e) {
@@ -270,7 +291,7 @@ namespace Microsoft.PythonTools.EnvironmentsList {
             }
         }
 
-        private async void FinishInitialization() {
+        private async Task FinishInitialization() {
             try {
                 await RefreshPackages();
             } catch (OperationCanceledException) {
@@ -295,7 +316,11 @@ namespace Microsoft.PythonTools.EnvironmentsList {
             get { return _installCommandView; }
         }
 
-        private async void PipExtensionProvider_UpdateStarted(object sender, EventArgs e) {
+        private void PipExtensionProvider_UpdateStarted(object sender, EventArgs e) {
+            PipExtensionProvider_UpdateStartedAsync(sender, e).DoNotWait();
+        }
+
+        private async Task PipExtensionProvider_UpdateStartedAsync(object sender, EventArgs e) {
             try {
                 await Dispatcher.InvokeAsync(() => { IsListRefreshing = true; });
             } catch (Exception ex) when (!ex.IsCriticalException()) {
@@ -303,7 +328,11 @@ namespace Microsoft.PythonTools.EnvironmentsList {
             }
         }
 
-        private async void PipExtensionProvider_UpdateComplete(object sender, EventArgs e) {
+        private void PipExtensionProvider_UpdateComplete(object sender, EventArgs e) {
+            PipExtensionProvider_UpdateCompleteAsync(sender, e).DoNotWait();
+        }
+
+        private async Task PipExtensionProvider_UpdateCompleteAsync(object sender, EventArgs e) {
             try {
                 await RefreshPackages();
             } catch (Exception ex) when (!ex.IsCriticalException()) {
@@ -311,7 +340,11 @@ namespace Microsoft.PythonTools.EnvironmentsList {
             }
         }
 
-        private async void PipExtensionProvider_InstalledPackagesChanged(object sender, EventArgs e) {
+        private void PipExtensionProvider_InstalledPackagesChanged(object sender, EventArgs e) {
+            PipExtensionProvider_InstalledPackagesChangedAsync(sender, e).DoNotWait();
+        }
+
+        private async Task PipExtensionProvider_InstalledPackagesChangedAsync(object sender, EventArgs e) {
             try {
                 await RefreshPackages();
             } catch (Exception ex) when (!ex.IsCriticalException()) {
@@ -373,7 +406,11 @@ namespace Microsoft.PythonTools.EnvironmentsList {
             }
         }
 
-        private async void InstallablePackages_Refresh(object state) {
+        private void InstallablePackages_Refresh(object state) {
+            InstallablePackages_RefreshAsync(state).DoNotWait();
+        }
+
+        private async Task InstallablePackages_RefreshAsync(object state) {
             string query = null;
             try {
                 query = await Dispatcher.InvokeAsync(() => SearchQuery);

--- a/Python/Product/EnvironmentsList/ToolWindow.xaml.cs
+++ b/Python/Product/EnvironmentsList/ToolWindow.xaml.cs
@@ -86,6 +86,7 @@ namespace Microsoft.PythonTools.EnvironmentsList {
                 }
                 return;
             }
+            OnViewSelected(item);
             var oldSelect = _extensionsView.View.CurrentItem?.GetType();
             var newSelect = oldSelect == null ? null :
                 item.Extensions?.FirstOrDefault(ext => ext != null && ext.GetType().IsEquivalentTo(oldSelect));
@@ -444,11 +445,16 @@ namespace Microsoft.PythonTools.EnvironmentsList {
             ViewCreated?.Invoke(this, new EnvironmentViewEventArgs(view));
         }
 
+        internal void OnViewSelected(EnvironmentView view) {
+            ViewSelected?.Invoke(this, new EnvironmentViewEventArgs(view));
+        }
+
         private void OnProviderCreated(CondaExtensionProvider provider) {
             CondaProviderCreated?.Invoke(this, new CondaProviderEventArgs(provider));
         }
 
         public event EventHandler<EnvironmentViewEventArgs> ViewCreated;
+        public event EventHandler<EnvironmentViewEventArgs> ViewSelected;
 
         internal event EventHandler<CondaProviderEventArgs> CondaProviderCreated;
 


### PR DESCRIPTION
Fix https://github.com/Microsoft/PTVS/issues/3905

Stop initializing all extensions for all environments on window startup. Extensions are now initialized as needed, when an environment is selected the first time.

There were 2 difficulties, which have been resolved.

A. Install package from solution explorer brings up the package manager extension and sets focus to the search box. Before when everything was initialized early, that worked fine but now that everything is delayed it was trying to focus on the text box before the package manager was 'ready' ie the textbox was disabled.

B. When pip extension was selected from drop down and you clicked a different environment, it was skipping the refresh packages because its state wasn't ready yet, so no packages appeared and it never attempted to refresh once it became ready.

I discovered another performance issue while testing B where we refresh packages of the previous environment AND refresh packages of the new environment when you change selection in environment list. There's no point in refreshing packages for the old environment, that only takes away CPU/IO from the refresh of the new environment. I'll file a bug for it. This PR doesn't change that behavior.

On my machine with:
2 anaconda,
5 conda envs
2 ironpython
15 cpython

I only tested debug build (NOT running under debugger). Timing of `ToolWindow.UpdateEnvironments` function. Window does not become responsive until that method has finished executing. That's pretty bad if the tool window is visible when VS starts.

Before: 5735ms
After: 147ms

There's a very slight delay when you select an environment in the list as it creates the extensions for that environment (only once per env of course), but it's much better than the initial delay where we created all of them!