### PR TITLE
Avoid pending analysis of the same file multiple times during test discovery

### DIFF
--- a/Python/Product/TestAdapter/TestContainerDiscoverer.cs
+++ b/Python/Product/TestAdapter/TestContainerDiscoverer.cs
@@ -234,7 +234,9 @@ namespace Microsoft.PythonTools.TestAdapter {
                 int originalCount;
                 lock (_containersLock) {
                     pendingRequests = _pendingRequests;
-                    _pendingRequests.Add(path);
+                    if (!_pendingRequests.Contains(path)) {
+                        _pendingRequests.Add(path);
+                    }
                     originalCount = _pendingRequests.Count;
 
                     if (originalCount > 50) {


### PR DESCRIPTION
Fix #3637 A test with the same name already exists warning 