### PR TITLE
Fix duplicate test discovery again 

### DIFF
--- a/Python/Product/TestAdapter/TestContainerDiscoverer.cs
+++ b/Python/Product/TestAdapter/TestContainerDiscoverer.cs
@@ -234,9 +234,7 @@ namespace Microsoft.PythonTools.TestAdapter {
                 int originalCount;
                 lock (_containersLock) {
                     pendingRequests = _pendingRequests;
-                    if (!_pendingRequests.Contains(path)) {
-                        _pendingRequests.Add(path);
-                    }
+                    _pendingRequests.Add(path);
                     originalCount = _pendingRequests.Count;
 
                     if (originalCount > 50) {
@@ -267,7 +265,7 @@ namespace Microsoft.PythonTools.TestAdapter {
                 var testCaseData = await analyzer.SendExtensionCommandAsync(
                     TestAnalyzer.Name,
                     TestAnalyzer.GetTestCasesCommand,
-                    string.Join(";", paths)
+                    string.Join(";", paths.Distinct())
                 );
 
                 if (testCaseData == null) {

--- a/Python/Product/TestAdapter/TestContainerDiscoverer.cs
+++ b/Python/Product/TestAdapter/TestContainerDiscoverer.cs
@@ -265,7 +265,7 @@ namespace Microsoft.PythonTools.TestAdapter {
                 var testCaseData = await analyzer.SendExtensionCommandAsync(
                     TestAnalyzer.Name,
                     TestAnalyzer.GetTestCasesCommand,
-                    string.Join(";", paths.Distinct())
+                    string.Join(";", paths.Distinct(Analysis.Infrastructure.PathEqualityComparer.Instance))
                 );
 
                 if (testCaseData == null) {


### PR DESCRIPTION
Previous fix (https://github.com/Microsoft/PTVS/pull/3979) was breaking the pending/submit mechanism.

Fix #3992 Too many test discoveries
