### PR TITLE
Force use of the old debugger for unit test debugging.

### DIFF
--- a/Python/Product/Debugger/Debugger/DebugEngine/Remote/PythonRemoteDebugProgram.cs
+++ b/Python/Product/Debugger/Debugger/DebugEngine/Remote/PythonRemoteDebugProgram.cs
@@ -86,11 +86,15 @@ namespace Microsoft.PythonTools.Debugger.Remote {
         }
 
         public int GetEngineInfo(out string pbstrEngine, out Guid pguidEngine) {
-            pguidEngine = ExperimentalOptions.UseVsCodeDebugger ? 
+            pguidEngine = ExperimentalOptions.UseVsCodeDebugger && !IsUnitTest() ? 
                 DebugAdapterLauncher.VSCodeDebugEngine : 
                 AD7Engine.DebugEngineGuid;
             pbstrEngine = null;
             return 0;
+        }
+
+        private bool IsUnitTest() {
+            return _process.DebugPort.Uri.Query.Contains("legacyUnitTest");
         }
 
         public int GetMemoryBytes(out IDebugMemoryBytes2 ppMemoryBytes) {

--- a/Python/Product/TestAdapter.Executor/TestExecutor.cs
+++ b/Python/Product/TestAdapter.Executor/TestExecutor.cs
@@ -566,7 +566,7 @@ namespace Microsoft.PythonTools.TestAdapter {
                         if (!killed && _debugMode != PythonDebugMode.None) {
                             try {
                                 if (_debugMode == PythonDebugMode.PythonOnly) {
-                                    string qualifierUri = string.Format("tcp://{0}@localhost:{1}", _debugSecret, _debugPort);
+                                    string qualifierUri = string.Format("tcp://{0}@localhost:{1}?legacyUnitTest", _debugSecret, _debugPort);
                                     while (!_app.AttachToProcess(proc, PythonRemoteDebugPortSupplierUnsecuredId, qualifierUri)) {
                                         if (proc.Wait(TimeSpan.FromMilliseconds(500))) {
                                             break;


### PR DESCRIPTION
Right now debug unit test is completely broken with the experimental debugger.

This is a workaround that makes the debug unit test feature work until we can properly use the new debugger.