### PR TITLE
Fix rename folder to save relative path in .pyproj, instead of absolute.

### DIFF
--- a/Common/Product/SharedProject/FolderNode.cs
+++ b/Common/Product/SharedProject/FolderNode.cs
@@ -487,7 +487,12 @@ namespace Microsoft.VisualStudioTools.Project {
             try {
                 ProjectMgr.OnItemDeleted(this);
 
-                ItemNode.Rename(newPath);
+                var relativePath = CommonUtils.GetRelativeDirectoryPath(
+                    ProjectMgr.ProjectHome,
+                    newPath
+                );
+
+                ItemNode.Rename(relativePath);
 
                 ProjectMgr.OnItemAdded(newParent, this);
 

--- a/Python/Tests/Core.UI/BasicProjectTests.cs
+++ b/Python/Tests/Core.UI/BasicProjectTests.cs
@@ -350,6 +350,20 @@ namespace PythonToolsUITests {
             Assert.IsTrue(Directory.Exists(expectedC));
         }
 
+        public void ProjectRenameFolder(VisualStudioApp app) {
+            var sln = app.CopyProjectForTest(@"TestData\HelloWorld.sln");
+            var project = app.OpenProject(sln);
+
+            var folder = project.ProjectItems.AddFolder("Test\\Folder\\Name");
+            folder.Name = "Renamed";
+
+            project.Save();
+
+            // Verify that after rename, the path in .pyproj is relative
+            var projText = File.ReadAllText(project.FullName);
+            AssertUtil.Contains(projText, "Folder Include=\"Test\\Folder\\Renamed\\\"");
+        }
+
         public void AddExistingFolder(VisualStudioApp app) {
             var sln = app.CopyProjectForTest(@"TestData\AddExistingFolder.sln");
             var project = app.OpenProject(sln);

--- a/Python/Tests/PythonToolsUITestsRunner/BasicProjectTests.cs
+++ b/Python/Tests/PythonToolsUITestsRunner/BasicProjectTests.cs
@@ -100,6 +100,12 @@ namespace PythonToolsUITestsRunner {
             _vs.RunTest(nameof(PythonToolsUITests.BasicProjectTests.ProjectAddFolderThroughUI));
         }
 
+        [TestMethod, Priority(0)]
+        [TestCategory("Installed")]
+        public void ProjectRenameFolder() {
+            _vs.RunTest(nameof(PythonToolsUITests.BasicProjectTests.ProjectRenameFolder));
+        }
+
         [TestMethod, Priority(2)]
         [TestCategory("Installed")]
         public void AddExistingFolder() {


### PR DESCRIPTION
Fix #4011

I ran all of our project system related tests that could potentially be affected. There are some failures, but nothing related to this change.