### PR TITLE
Prevent crash in conda package manager

### DIFF
--- a/Python/Product/VSInterpreters/PackageManager/CondaPackageManager.cs
+++ b/Python/Product/VSInterpreters/PackageManager/CondaPackageManager.cs
@@ -422,6 +422,9 @@ namespace Microsoft.PythonTools.Interpreter {
                                         .Where(p => p.IsValid)
                                         .OrderBy(p => p.Name)
                                         .ToList();
+                                } catch (InvalidOperationException ex) {
+                                    Debug.WriteLine("Failed to parse: {0}".FormatInvariant(ex.Message));
+                                    Debug.WriteLine(json);
                                 } catch (Newtonsoft.Json.JsonException ex) {
                                     Debug.WriteLine("Failed to parse: {0}".FormatInvariant(ex.Message));
                                     Debug.WriteLine(json);
@@ -532,6 +535,9 @@ namespace Microsoft.PythonTools.Interpreter {
                                 .Where(p => p.IsValid)
                                 .OrderBy(p => p.Name)
                                 .ToList();
+                        } catch (InvalidOperationException ex) {
+                            Debug.WriteLine("Failed to parse: {0}".FormatInvariant(ex.Message));
+                            Debug.WriteLine(json);
                         } catch (JsonException ex) {
                             Debug.WriteLine("Failed to parse: {0}".FormatInvariant(ex.Message));
                             Debug.WriteLine(json);


### PR DESCRIPTION
Fix #4047 "An unexpected error occurred" when trying to install a python package

Minimal fix that I'll also want to backport to 15.7

I'm looking into ways we can inform the user to update their conda if they have an old unsupported version (perhaps using our existing `IsReady` API), but I will submit that separately so we can pick and choose for 15.7.