### PR TITLE
Fixes #3866 Endlessly analyzing sympy

### DIFF
--- a/Python/Product/Analysis/Values/BuiltinInstanceInfo.cs
+++ b/Python/Product/Analysis/Values/BuiltinInstanceInfo.cs
@@ -248,20 +248,20 @@ namespace Microsoft.PythonTools.Analysis.Values {
                     return TypeId == BuiltinTypeId.NoneType && ns.TypeId == BuiltinTypeId.NoneType;
                 }
 
+                var type = ProjectState.ClassInfos[BuiltinTypeId.Type];
+                if (ClassInfo == type) {
+                    // CI + BII(type) => BII(type)
+                    // BCI + BII(type) => BII(type)
+                    return ns is ClassInfo || ns is BuiltinClassInfo || ns == type.Instance;
+                } else if (ns == type.Instance) {
+                    return false;
+                }
+
                 if (TypeId == BuiltinTypeId.Function) {
                     // FI + BII(function) => BII(function)
                     return ns is FunctionInfo || ns is BuiltinFunctionInfo ||
                         (ns is BuiltinInstanceInfo && ns.TypeId == BuiltinTypeId.Function);
                 } else if (ns.TypeId == BuiltinTypeId.Function) {
-                    return false;
-                }
-
-                var type = ProjectState.ClassInfos[BuiltinTypeId.Type];
-                if (this == type.Instance) {
-                    // CI + BII(type) => BII(type)
-                    // BCI + BII(type) => BII(type)
-                    return ns is ClassInfo || ns is BuiltinClassInfo || ns == type.Instance;
-                } else if (ns == type.Instance) {
                     return false;
                 }
 
@@ -290,6 +290,10 @@ namespace Microsoft.PythonTools.Analysis.Values {
 
         internal override int UnionHashCode(int strength) {
             if (strength >= MergeStrength.ToObject) {
+                var type = ProjectState.ClassInfos[BuiltinTypeId.Type];
+                if (ClassInfo == type) {
+                    return type.UnionHashCode(strength);
+                }
                 return ProjectState.ClassInfos[BuiltinTypeId.Object].GetHashCode();
             }
             return ClassInfo.UnionHashCode(strength);
@@ -303,6 +307,10 @@ namespace Microsoft.PythonTools.Analysis.Values {
                     // combinations of BuiltinInstanceInfo or ConstantInfo that
                     // need to be merged.
                     return ProjectState.ClassInfos[BuiltinTypeId.NoneType].Instance;
+                }
+
+                if (ClassInfo == ProjectState.ClassInfos[BuiltinTypeId.Type]) {
+                    return this;
                 }
 
                 var func = ProjectState.ClassInfos[BuiltinTypeId.Function];

--- a/Python/Product/Analysis/Values/FunctionInfo.cs
+++ b/Python/Product/Analysis/Values/FunctionInfo.cs
@@ -52,12 +52,22 @@ namespace Microsoft.PythonTools.Analysis.Values {
                 _callDepthLimit = declUnit.State.Limits.CallDepth;
             }
 
-            if (node.Parameters.Any() && node.ContainsNestedFreeVariables || node.IsGenerator) {
+            if (!CanBeClosure(ProjectState, ProjectEntry)) {
+                _analysisUnit = new FunctionAnalysisUnit(this, declUnit, declScope, ProjectEntry, true);
+            } else if ((node.Parameters.Any() && node.ContainsNestedFreeVariables || node.IsGenerator)) {
                 _analysisUnit = new FunctionAnalysisUnit(this, declUnit, declScope, ProjectEntry, true);
                 _callsWithClosure = new CallChainSet();
             } else {
                 _analysisUnit = new FunctionAnalysisUnit(this, declUnit, declScope, ProjectEntry, false);
             }
+        }
+
+        private static bool CanBeClosure(PythonAnalyzer state, IPythonProjectEntry entry) {
+            int limit = state.Limits.CallDepth;
+            if (entry.Properties.TryGetValue(AnalysisLimits.CallDepthKey, out object o) && o is int i) {
+                limit = i;
+            }
+            return limit > 0;
         }
 
         public ProjectEntry ProjectEntry { get; }

--- a/Python/Product/Analysis/VariableDef.cs
+++ b/Python/Product/Analysis/VariableDef.cs
@@ -18,7 +18,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Runtime.CompilerServices;
-using System.Threading;
 using Microsoft.PythonTools.Analysis.Analyzer;
 using Microsoft.PythonTools.Analysis.Infrastructure;
 using Microsoft.PythonTools.Parsing.Ast;

--- a/Python/Product/Analysis/VariableDef.cs
+++ b/Python/Product/Analysis/VariableDef.cs
@@ -18,6 +18,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Threading;
 using Microsoft.PythonTools.Analysis.Analyzer;
 using Microsoft.PythonTools.Analysis.Infrastructure;
 using Microsoft.PythonTools.Parsing.Ast;
@@ -159,6 +160,7 @@ namespace Microsoft.PythonTools.Analysis {
         static readonly object LockedVariableDefsValue = new object();
 
         protected IAnalysisSet _emptySet = AnalysisSet.Empty;
+        private IAnalysisSet _cache;
 
         /// <summary>
         /// Marks the current VariableDef as exceeding the limit and not to be
@@ -263,6 +265,9 @@ namespace Microsoft.PythonTools.Analysis {
                 }
             }
 
+            if (added) {
+                _cache = null;
+            }
             if (added && enqueue) {
                 EnqueueDependents(projectEntry, declaringScope);
             }
@@ -322,6 +327,10 @@ namespace Microsoft.PythonTools.Analysis {
                 if (_dependencies.Count == 0) {
                     return false;
                 }
+                if (_cache?.Count > 0) {
+                    return true;
+                }
+
                 T oneDependency;
                 if (_dependencies.TryGetSingleValue(out oneDependency)) {
                     return oneDependency.Types.Count > 0;
@@ -344,7 +353,11 @@ namespace Microsoft.PythonTools.Analysis {
         /// </summary>
         public IAnalysisSet TypesNoCopy {
             get {
-                var res = _emptySet;
+                var res = _cache;
+                if (res != null) {
+                    return res;
+                }
+                res = _emptySet;
                 if (_dependencies.Count != 0) {
                     T oneDependency;
                     if (_dependencies.TryGetSingleValue(out oneDependency)) {
@@ -363,7 +376,7 @@ namespace Microsoft.PythonTools.Analysis {
                     ExceedsTypeLimit();
                 }
 
-                return res;
+                return _cache = res;
             }
         }
 
@@ -372,17 +385,9 @@ namespace Microsoft.PythonTools.Analysis {
         /// resulting set will not mutate in the future even if the types in the VariableDef
         /// change in the future.
         /// </summary>
-        public IAnalysisSet Types {
-            get {
-                return TypesNoCopy.Clone();
-            }
-        }
+        public IAnalysisSet Types => TypesNoCopy;
 
-        public virtual bool IsEphemeral {
-            get {
-                return false;
-            }
-        }    
+        public virtual bool IsEphemeral => false;
 
         /// <summary>
         /// If the number of types associated with this variable exceeds a
@@ -419,6 +424,7 @@ namespace Microsoft.PythonTools.Analysis {
                 }
 
                 if (anyChanged) {
+                    _cache = null;
                     EnqueueDependents();
                     return true;
                 }


### PR DESCRIPTION
Fixes #3866 Endlessly analyzing sympy
Fixes 'type' comparison
Reduces analysis when merging all function calls
Adds simple cache for VariableDef to improve performance when a function has many callers