### PR TITLE
Fix memory leaks

### DIFF
--- a/Python/Product/Analysis/Analyzer/DDG.cs
+++ b/Python/Product/Analysis/Analyzer/DDG.cs
@@ -288,7 +288,7 @@ namespace Microsoft.PythonTools.Analysis.Analyzer {
                 return false;
             }
 
-            modRef.AddReference(_unit.DeclaringModule);
+            _unit.DeclaringModule.AddModuleReference(modRef);
 
             Debug.Assert(modRef.Module != null);
             var userMod = modRef.Module;
@@ -490,7 +490,7 @@ namespace Microsoft.PythonTools.Analysis.Analyzer {
                     continue;
                 }
 
-                modRef.AddReference(_unit.DeclaringModule);
+                _unit.DeclaringModule.AddModuleReference(modRef);
 
                 var userMod = modRef.Module;
                 Debug.Assert(userMod != null);

--- a/Python/Product/Analysis/EncodedLocation.cs
+++ b/Python/Product/Analysis/EncodedLocation.cs
@@ -53,7 +53,7 @@ namespace Microsoft.PythonTools.Analysis {
             Location = location;
         }
 
-        bool ICanExpire.IsAlive => (Resolver as ICanExpire)?.IsAlive ?? true;
+        public bool IsAlive => (Resolver as ICanExpire)?.IsAlive ?? true;
 
         public override int GetHashCode() {
             return (Resolver?.GetHashCode() ?? 0) ^ (Location?.GetHashCode() ?? 0);

--- a/Python/Product/Analysis/LanguageServer/ParseQueue.cs
+++ b/Python/Product/Analysis/LanguageServer/ParseQueue.cs
@@ -32,12 +32,12 @@ namespace Microsoft.PythonTools.Analysis.LanguageServer {
         public const string PythonParserSource = "Python";
         private const string TaskCommentSource = "Task comment";
 
-        private readonly ConcurrentDictionary<IDocument, ParseTask> _parsing;
+        private readonly ConcurrentDictionary<Uri, ParseTask> _parsing;
         private readonly VolatileCounter _parsingInProgress;
 
         public ParseQueue() {
             _parsingInProgress = new VolatileCounter();
-            _parsing = new ConcurrentDictionary<IDocument, ParseTask>();
+            _parsing = new ConcurrentDictionary<Uri, ParseTask>();
         }
 
         public int Count => _parsingInProgress.Count;
@@ -51,7 +51,7 @@ namespace Microsoft.PythonTools.Analysis.LanguageServer {
 
             var task = new ParseTask(this, doc, languageVersion);
             try {
-                return _parsing.AddOrUpdate(doc, task, (d, prev) => task.ContinueAfter(prev)).Start();
+                return _parsing.AddOrUpdate(doc.DocumentUri, task, (d, prev) => task.ContinueAfter(prev)).Start();
             } finally {
                 task.DisposeIfNotStarted();
             }

--- a/Python/Product/Analysis/ModuleReference.cs
+++ b/Python/Product/Analysis/ModuleReference.cs
@@ -43,15 +43,9 @@ namespace Microsoft.PythonTools.Analysis {
             return _references.Value.Add(module);
         }
 
-        public bool RemoveReference(ModuleInfo module) {
-            return _references.IsValueCreated && _references.Value.Remove(module);
-        }
+        public bool RemoveReference(ModuleInfo module) => _references.IsValueCreated && _references.Value.Remove(module);
 
-        public bool HasReferences {
-            get {
-                return _references.IsValueCreated && _references.Value.Any();
-            }
-        }
+        public bool HasReferences => _references.IsValueCreated && _references.Value.Any();
 
         public IEnumerable<ModuleInfo> References {
             get {

--- a/Python/Product/Analysis/ProjectEntry.cs
+++ b/Python/Product/Analysis/ProjectEntry.cs
@@ -15,6 +15,7 @@
 // permissions and limitations under the License.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
@@ -42,10 +43,8 @@ namespace Microsoft.PythonTools.Analysis {
     internal sealed class ProjectEntry : IPythonProjectEntry, IAggregateableProjectEntry, IDocument {
         private AnalysisUnit _unit;
         private readonly SortedDictionary<int, DocumentBuffer> _buffers;
+        private readonly ConcurrentQueue<WeakReference<ReferenceDict>> _backReferences = new ConcurrentQueue<WeakReference<ReferenceDict>>();
         internal readonly HashSet<AggregateProjectEntry> _aggregates = new HashSet<AggregateProjectEntry>();
-
-        // we expect to have at most 1 waiter on updated project entries, so we attempt to share the event.
-        private static ManualResetEventSlim _sharedWaitEvent = new ManualResetEventSlim(false);
 
         internal ProjectEntry(
             PythonAnalyzer state,
@@ -312,6 +311,18 @@ namespace Microsoft.PythonTools.Analysis {
                         aggregatedInto.RemovedFromProject();
                     }
                 }
+
+                while (_backReferences.TryDequeue(out var reference)) {
+                    if (reference.TryGetTarget(out var referenceDict)) {
+                        lock (referenceDict) {
+                            referenceDict.Remove(this);
+                        }
+                    }
+                }
+
+                foreach (var moduleReference in MyScope.ModuleReferences.ToList()) {
+                    MyScope.RemoveModuleReference(moduleReference);
+                }
             }
         }
 
@@ -432,6 +443,10 @@ namespace Microsoft.PythonTools.Analysis {
                 _buffers[0].Reset(version, content);
                 SetCurrentParse(Tree, null, false);
             }
+        }
+
+        internal void AddBackReference(ReferenceDict referenceDict) {
+            _backReferences.Enqueue(new WeakReference<ReferenceDict>(referenceDict));
         }
     }
 

--- a/Python/Product/Analysis/PythonAnalyzer.cs
+++ b/Python/Product/Analysis/PythonAnalyzer.cs
@@ -52,7 +52,6 @@ namespace Microsoft.PythonTools.Analysis {
         private readonly ConcurrentDictionary<string, XamlProjectEntry> _xamlByFilename = new ConcurrentDictionary<string, XamlProjectEntry>();
 #endif
         internal ConstantInfo _noneInst;
-        private readonly Deque<AnalysisUnit> _queue;
         private Action<int> _reportQueueSize;
         private int _reportQueueInterval;
         internal readonly IModuleContext _defaultContext;
@@ -125,7 +124,7 @@ namespace Microsoft.PythonTools.Analysis {
 
             Limits = AnalysisLimits.GetDefaultLimits();
 
-            _queue = new Deque<AnalysisUnit>();
+            Queue = new Deque<AnalysisUnit>();
 
             _defaultContext = _interpreter.CreateModuleContext();
 
@@ -156,11 +155,6 @@ namespace Microsoft.PythonTools.Analysis {
                 _nullKey,
                 () => new ConstantInfo(ClassInfos[BuiltinTypeId.NoneType], null, PythonMemberType.Constant)
             );
-
-            DoNotUnionInMro = AnalysisSet.Create(new AnalysisValue[] {
-                ClassInfos[BuiltinTypeId.Object],
-                ClassInfos[BuiltinTypeId.Type]
-            });
 
             AddBuiltInSpecializations();
         }
@@ -247,21 +241,22 @@ namespace Microsoft.PythonTools.Analysis {
         /// </summary>
         public void RemoveModule(IProjectEntry entry) {
             if (entry == null) {
-                throw new ArgumentNullException("entry");
+                throw new ArgumentNullException(nameof(entry));
             }
             Contract.EndContractBlock();
 
-            ModuleInfo removed;
-            if (!string.IsNullOrEmpty(entry.FilePath)) {
-                _modulesByFilename.TryRemove(entry.FilePath, out removed);
+            if (!string.IsNullOrEmpty(entry.FilePath) && _modulesByFilename.TryRemove(entry.FilePath, out var moduleInfo)) {
+                lock (_modulesWithUnresolvedImportsLock) {
+                    _modulesWithUnresolvedImports.Remove(moduleInfo);
+                }
             }
 
-            var pyEntry = entry as IPythonProjectEntry;
-            if (pyEntry != null && !string.IsNullOrEmpty(pyEntry.ModuleName)) {
-                ModuleReference modRef;
-                Modules.TryRemove(pyEntry.ModuleName, out modRef);
+            if (entry is IPythonProjectEntry pyEntry && !string.IsNullOrEmpty(pyEntry.ModuleName)) {
+                Modules.TryRemove(pyEntry.ModuleName, out var _);
             }
+
             entry.RemovedFromProject();
+            ClearDiagnostics(entry);
         }
 #if DESKTOP
         /// <summary>
@@ -808,16 +803,7 @@ namespace Microsoft.PythonTools.Analysis {
             }
         }
 
-        internal IAnalysisSet DoNotUnionInMro {
-            get;
-            private set;
-        }
-
-        internal Deque<AnalysisUnit> Queue {
-            get {
-                return _queue;
-            }
-        }
+        internal Deque<AnalysisUnit> Queue { get; }
 
         /// <summary>
         /// Returns the cached value for the provided key, creating it with

--- a/Python/Product/Analysis/Values/MemberReferences.cs
+++ b/Python/Product/Analysis/Values/MemberReferences.cs
@@ -73,11 +73,16 @@ namespace Microsoft.PythonTools.Analysis.Values {
     /// A collection of references which are keyd off of project entry.
     /// </summary>
     class ReferenceDict : Dictionary<IProjectEntry, ReferenceList> {
-        public ReferenceList GetReferences(ProjectEntry project) {
+        public ReferenceList GetReferences(ProjectEntry projectEntry) {
             ReferenceList builtinRef;
             lock (this) {
-                if (!TryGetValue(project, out builtinRef) || builtinRef.Version != project.AnalysisVersion) {
-                    this[project] = builtinRef = new ReferenceList(project);
+                var isReferenced = TryGetValue(projectEntry, out builtinRef);
+                if (!isReferenced || builtinRef.Version != projectEntry.AnalysisVersion) {
+                    this[projectEntry] = builtinRef = new ReferenceList(projectEntry);
+                }
+
+                if (!isReferenced) {
+                    projectEntry.AddBackReference(this);
                 }
             }
             return builtinRef;

--- a/Python/Product/Analysis/Values/ModuleInfo.cs
+++ b/Python/Product/Analysis/Values/ModuleInfo.cs
@@ -179,7 +179,7 @@ namespace Microsoft.PythonTools.Analysis.Values {
         public void AddModuleReference(ModuleReference moduleRef) {
             if (moduleRef == null) {
                 Debug.Fail("moduleRef should never be null");
-                throw new ArgumentNullException("moduleRef");
+                throw new ArgumentNullException(nameof(moduleRef));
             }
             _referencedModules.Add(moduleRef);
             moduleRef.AddReference(this);
@@ -191,11 +191,7 @@ namespace Microsoft.PythonTools.Analysis.Values {
             }
         }
 
-        public IEnumerable<ModuleReference> ModuleReferences {
-            get {
-                return _referencedModules;
-            }
-        }
+        public IEnumerable<ModuleReference> ModuleReferences => _referencedModules;
 
         public void SpecializeFunction(string name, CallDelegate callable, bool mergeOriginalAnalysis) {
             lock (this) {


### PR DESCRIPTION
Fixes two cases of memory leaks:
- `LocatedVariableDef` held a link to the outdated `PythonAst`. This could also lead to the invalid calculation of span. Now it is updated to the latest one. 
- `ProjectEntry` of a closed file was held by `ReferenceDict`, `ParseQueue` and `PythonAnalyzer` instances.

Before the fix, 10 closing/reopening of the `test_io.py` file with 10 atomic changes of the `import` statements for each reopening resulted in a 200MB leak.

Also, some dead code is cleaned up.