### PR TITLE
Fixes #4096 Add test that default analyzer is used for non project file

### DIFF
--- a/Common/Tests/Utilities.UI/UI/VisualStudioApp.cs
+++ b/Common/Tests/Utilities.UI/UI/VisualStudioApp.cs
@@ -29,6 +29,7 @@ using EnvDTE;
 using EnvDTE80;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.ComponentModelHost;
+using Microsoft.VisualStudio.Editor;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -294,6 +295,11 @@ namespace TestUtilities.UI {
 
         public SaveDialog SaveAs() {
             return SaveDialog.FromDte(this);
+        }
+
+        public EditorWindow OpenDocument(string filename) {
+            VsShellUtilities.OpenDocument(ServiceProvider, filename);
+            return GetDocument(filename);
         }
 
         /// <summary>

--- a/Python/Product/Analysis/LanguageServer/ParseQueue.cs
+++ b/Python/Product/Analysis/LanguageServer/ParseQueue.cs
@@ -235,7 +235,8 @@ namespace Microsoft.PythonTools.Analysis.LanguageServer {
         ) {
             var opts = new ParserOptions {
                 BindReferences = true,
-                IndentationInconsistencySeverity = DiagnosticsErrorSink.GetSeverity(InconsistentIndentation)
+                IndentationInconsistencySeverity = DiagnosticsErrorSink.GetSeverity(InconsistentIndentation),
+                StubFile = entry.DocumentUri.AbsolutePath.EndsWithOrdinal(".pyi", ignoreCase: true)
             };
 
             List<Diagnostic> diags = null;

--- a/Python/Product/PythonTools/PythonTools/Editor/PythonTextBufferInfo.cs
+++ b/Python/Product/PythonTools/PythonTools/Editor/PythonTextBufferInfo.cs
@@ -854,7 +854,7 @@ namespace Microsoft.PythonTools.Editor {
         }
 
         private static async Task<IReadOnlyList<ProjectAnalyzer>> FindAllAnalyzersForFile(this IServiceProvider site, string filename, bool firstOnly) {
-                if (string.IsNullOrEmpty(filename)) {
+            if (string.IsNullOrEmpty(filename)) {
                 throw new ArgumentNullException(nameof(filename));
             }
 

--- a/Python/Product/PythonTools/PythonTools/Intellisense/ProjectAnalyzer.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/ProjectAnalyzer.cs
@@ -238,7 +238,7 @@ namespace Microsoft.PythonTools.Intellisense {
                 Trace.TraceInformation($"Connection log: {_conn.LogFilename}");
             }
 
-            Task.Run(() => _conn.ProcessMessages()).DoNotWait();
+            _conn.StartProcessing();
 
             _toString = $"<{GetType().Name}:{_interpreterFactory.Configuration.Id}:{_analysisProcess}:{comment.IfNullOrEmpty(DefaultComment)}>";
             _userCount = 1;

--- a/Python/Product/PythonTools/PythonTools/Intellisense/ProjectAnalyzer.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/ProjectAnalyzer.cs
@@ -1004,6 +1004,10 @@ namespace Microsoft.PythonTools.Intellisense {
                 return;
             }
 
+            if (oldEntry.Properties.ContainsKey(IntellisenseController.FollowDefaultEnvironment)) {
+                entry.Properties[IntellisenseController.FollowDefaultEnvironment] = true;
+            }
+
             var bufferParser = entry.GetOrCreateBufferParser(_services);
 
             if (oldSnapshots != null && oldSnapshots.Length > 0) {

--- a/Python/Tests/Core.UI/EditorTests.cs
+++ b/Python/Tests/Core.UI/EditorTests.cs
@@ -23,29 +23,28 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
-using EnvDTE;
-using analysis::Microsoft.PythonTools;
-using pythontools::Microsoft.PythonTools;
-using pythontools::Microsoft.PythonTools.Editor;
-using Microsoft.PythonTools.Infrastructure;
-using pythontools::Microsoft.PythonTools.Intellisense;
 using analysis::Microsoft.PythonTools.Parsing;
+using EnvDTE;
+using Microsoft.PythonTools.Infrastructure;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Language.Intellisense;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Classification;
+using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Text.Tagging;
 using Microsoft.VisualStudio.TextManager.Interop;
 using Microsoft.VisualStudioTools;
+using pythontools::Microsoft.PythonTools;
+using pythontools::Microsoft.PythonTools.Editor;
+using pythontools::Microsoft.PythonTools.Intellisense;
 using TestUtilities;
-using util::TestUtilities.UI;
 using TestUtilities.UI.Python;
-using Microsoft.VisualStudio.Text.Editor;
-using System.Threading;
+using util::TestUtilities.UI;
 
 namespace PythonToolsUITests {
     public class EditorTests {

--- a/Python/Tests/Core.UI/ErrorListTaskListTests.cs
+++ b/Python/Tests/Core.UI/ErrorListTaskListTests.cs
@@ -220,5 +220,18 @@ namespace PythonToolsUITests {
             app.WaitForTaskListItems(typeof(SVsErrorList), 0);
             app.WaitForTaskListItems(typeof(SVsTaskList), 0);
         }
+
+        /// <summary>
+        /// Make sure *.pyi files ignore the active Python version
+        /// </summary>
+        public void ErrorListEmptyForValidTypingFile(VisualStudioApp app) {
+            var project = app.OpenProject(@"TestData\Typings.sln");
+            project.ProjectItems.Item("mymod.pyi").Open();
+
+            var actual = app.WaitForTaskListItems(typeof(SVsErrorList), 1);
+            Assert.AreEqual(1, actual.Count);
+            ErrorHandler.ThrowOnFailure(actual[0].Document(out var doc));
+            Assert.AreEqual("usermod.py", Path.GetFileName(doc));
+        }
     }
 }

--- a/Python/Tests/PythonToolsUITestsRunner/EditorTests.cs
+++ b/Python/Tests/PythonToolsUITestsRunner/EditorTests.cs
@@ -179,5 +179,11 @@ namespace PythonToolsUITestsRunner {
         public void ImportPresentThenAddThenRemoveReference() {
             _vs.RunTest(nameof(PythonToolsUITests.EditorTests.ImportPresentThenAddThenRemoveReference));
         }
+
+        [TestMethod, Priority(0)]
+        [TestCategory("Installed")]
+        public void DefaultAnalyzerForNonProjectFile() {
+            _vs.RunTest(nameof(PythonToolsUITests.EditorTests.DefaultAnalyzerForNonProjectFile));
+        }
     }
 }

--- a/Python/Tests/PythonToolsUITestsRunner/ErrorListTaskListTests.cs
+++ b/Python/Tests/PythonToolsUITestsRunner/ErrorListTaskListTests.cs
@@ -74,5 +74,11 @@ namespace PythonToolsUITestsRunner {
         public void ErrorListAndTaskListAreClearedWhenFileIsDeleted() {
             _vs.RunTest(nameof(PythonToolsUITests.ErrorListTaskListTests.ErrorListAndTaskListAreClearedWhenFileIsDeleted));
         }
+
+        [TestMethod, Priority(0)]
+        [TestCategory("Installed")]
+        public void ErrorListEmptyForValidTypingFile() {
+            _vs.RunTest(nameof(PythonToolsUITests.ErrorListTaskListTests.ErrorListEmptyForValidTypingFile));
+        }
     }
 }

--- a/Python/Tests/TestData/Typings.sln
+++ b/Python/Tests/TestData/Typings.sln
@@ -1,0 +1,23 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.27617.1
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{888888A0-9F3D-457C-B088-3A5042F75D52}") = "Typings", "Typings\Typings.pyproj", "{F1A63273-AC10-4598-9B45-0F42494C5DDE}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{F1A63273-AC10-4598-9B45-0F42494C5DDE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F1A63273-AC10-4598-9B45-0F42494C5DDE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {F4F26A6C-C110-46EF-9D43-4C8194B2BC43}
+	EndGlobalSection
+EndGlobal

--- a/Python/Tests/TestData/Typings/Typings.pyproj
+++ b/Python/Tests/TestData/Typings/Typings.pyproj
@@ -1,0 +1,42 @@
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>f1a63273-ac10-4598-9b45-0f42494c5dde</ProjectGuid>
+    <ProjectHome>.</ProjectHome>
+    <StartupFile>usermod.py</StartupFile>
+    <SearchPath>..\Typings</SearchPath>
+    <WorkingDirectory>.</WorkingDirectory>
+    <OutputPath>.</OutputPath>
+    <Name>Typings</Name>
+    <RootNamespace>Typings</RootNamespace>
+    <InterpreterId>Global|PythonCore|2.7-32</InterpreterId>
+    <_InProcessPythonAnalyzer>true</_InProcessPythonAnalyzer>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
+    <DebugSymbols>true</DebugSymbols>
+    <EnableUnmanagedDebugging>false</EnableUnmanagedDebugging>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+    <DebugSymbols>true</DebugSymbols>
+    <EnableUnmanagedDebugging>false</EnableUnmanagedDebugging>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="mymod.pyi" />
+    <Compile Include="usermod.py">
+      <SubType>Code</SubType>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <InterpreterReference Include="Global|PythonCore|2.7-32" />
+  </ItemGroup>
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\Python Tools\Microsoft.PythonTools.targets" />
+  <!-- Uncomment the CoreCompile target to enable the Build command in
+       Visual Studio and specify your pre- and post-build commands in
+       the BeforeBuild and AfterBuild targets below. -->
+  <!--<Target Name="CoreCompile" />-->
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+</Project>

--- a/Python/Tests/TestData/Typings/mymod.pyi
+++ b/Python/Tests/TestData/Typings/mymod.pyi
@@ -1,0 +1,6 @@
+
+class MyClass(metaclass=type):
+    Instance : MyClass = ...
+    def f(self, a : int, b : float) -> MyClass: ...
+
+

--- a/Python/Tests/TestData/Typings/usermod.py
+++ b/Python/Tests/TestData/Typings/usermod.py
@@ -1,0 +1,4 @@
+
+from mymod import MyClass
+
+x : MyClass = MyClass()


### PR DESCRIPTION
Fixes #4096 Add test that default analyzer is used for non project file
Make default analyzer files follow environment changes
Ensures stub files are always parsed correctly.