### PR TITLE
Fixes #4115: Completions dropdown shouldn't appear after def and class

### DIFF
--- a/Python/Product/Analysis/Analyzer/OverviewWalker.cs
+++ b/Python/Product/Analysis/Analyzer/OverviewWalker.cs
@@ -440,7 +440,7 @@ namespace Microsoft.PythonTools.Analysis.Analyzer {
                     if (nameNode.Name == "*") {
                         _scope.ContainsImportStar = true;
                     } else {
-                        var v = CreateVariableInDeclaredScope(nameNode, isLocated: true);
+                        var v = CreateVariableInDeclaredScope(nameNode, isLocated: false);
                         v.AddReference(nameNode, _curUnit);
                     }
                 }
@@ -486,7 +486,7 @@ namespace Microsoft.PythonTools.Analysis.Analyzer {
                 }
 
                 if (name != null) {
-                    CreateVariableInDeclaredScope(name, isLocated: true);
+                    CreateVariableInDeclaredScope(name, isLocated: false);
                 }
             }
 

--- a/Python/Product/Analysis/LanguageServer/CompletionAnalysis.cs
+++ b/Python/Product/Analysis/LanguageServer/CompletionAnalysis.cs
@@ -41,7 +41,6 @@ namespace Microsoft.PythonTools.Analysis.LanguageServer {
             Options = opts;
             _textBuilder = textBuilder;
             _log = log;
-            ShouldCommitByDefault = true;
 
             var finder = new ExpressionFinder(Tree, new GetExpressionOptions {
                 Names = true,
@@ -61,7 +60,7 @@ namespace Microsoft.PythonTools.Analysis.LanguageServer {
         public SourceLocation Position { get; }
         public int Index { get; }
         public GetMemberOptions Options { get; set; }
-        public bool ShouldCommitByDefault { get; set; }
+        public bool? ShouldCommitByDefault { get; set; }
 
         public Node Node => _node;
         public Node Statement => _statement;

--- a/Python/Product/Analysis/LanguageServer/CompletionAnalysis.cs
+++ b/Python/Product/Analysis/LanguageServer/CompletionAnalysis.cs
@@ -41,6 +41,7 @@ namespace Microsoft.PythonTools.Analysis.LanguageServer {
             Options = opts;
             _textBuilder = textBuilder;
             _log = log;
+            ShouldCommitByDefault = true;
 
             var finder = new ExpressionFinder(Tree, new GetExpressionOptions {
                 Names = true,
@@ -60,6 +61,7 @@ namespace Microsoft.PythonTools.Analysis.LanguageServer {
         public SourceLocation Position { get; }
         public int Index { get; }
         public GetMemberOptions Options { get; set; }
+        public bool ShouldCommitByDefault { get; set; }
 
         public Node Node => _node;
         public Node Statement => _statement;
@@ -95,6 +97,10 @@ namespace Microsoft.PythonTools.Analysis.LanguageServer {
 
             if (additional != null) {
                 res = res.Concat(additional);
+            }
+
+            if (ReferenceEquals(res, Empty)) {
+                return null;
             }
 
             return res;
@@ -247,6 +253,7 @@ namespace Microsoft.PythonTools.Analysis.LanguageServer {
                     return null;
                 }
                 var loc = fd.GetStart(Tree);
+                ShouldCommitByDefault = false;
                 return Analysis.GetOverrideable(loc)
                     .Select(o => new CompletionItem {
                         label = o.Name,
@@ -263,7 +270,7 @@ namespace Microsoft.PythonTools.Analysis.LanguageServer {
             // completions 
 
             if (Statement is FunctionDefinition fd) {
-                if (Index > fd.HeaderIndex) {
+                if (fd.HeaderIndex > fd.StartIndex && Index > fd.HeaderIndex) {
                     return null;
                 } else if (Index == fd.HeaderIndex) {
                     return Empty;
@@ -296,7 +303,7 @@ namespace Microsoft.PythonTools.Analysis.LanguageServer {
                 return null;
 
             } else if (Statement is ClassDefinition cd) {
-                if (Index > cd.HeaderIndex) {
+                if (cd.HeaderIndex > cd.StartIndex && Index > cd.HeaderIndex) {
                     return null;
                 } else if (Index == cd.HeaderIndex) {
                     return Empty;

--- a/Python/Product/Analysis/LanguageServer/Server.Completion.cs
+++ b/Python/Product/Analysis/LanguageServer/Server.Completion.cs
@@ -41,6 +41,10 @@ namespace Microsoft.PythonTools.Analysis.LanguageServer {
             var opts = GetOptions(@params.context);
             var ctxt = new CompletionAnalysis(analysis, tree, @params.position, opts, _displayTextBuilder, this);
             var members = ctxt.GetCompletionsFromString(@params._expr) ?? ctxt.GetCompletions();
+            if (members == null) {
+                TraceMessage($"Do not trigger at {@params.position} in {uri}");
+                return new CompletionList();
+            }
 
             if (_settings.SuppressAdvancedMembers) {
                 members = members.Where(m => !m.label.StartsWith("__"));
@@ -55,7 +59,8 @@ namespace Microsoft.PythonTools.Analysis.LanguageServer {
             var res = new CompletionList {
                 items = members.ToArray(),
                 _applicableSpan = ctxt.Node?.GetSpan(tree),
-                _expr = ctxt.ParentExpression?.ToCodeString(tree, CodeFormattingOptions.Traditional)
+                _expr = ctxt.ParentExpression?.ToCodeString(tree, CodeFormattingOptions.Traditional),
+                _commitByDefault = ctxt.ShouldCommitByDefault
             };
             LogMessage(MessageType.Info, $"Found {res.items.Length} completions for {uri} at {@params.position} after filtering");
             return res;

--- a/Python/Product/Analysis/LanguageServer/Structures.cs
+++ b/Python/Product/Analysis/LanguageServer/Structures.cs
@@ -658,7 +658,8 @@ namespace Microsoft.PythonTools.Analysis.LanguageServer {
         /// </summary>
         public string _expr;
         /// <summary>
-        /// When true, completions should commit by default.
+        /// When true, completions should commit by default. When false, completions
+        /// should not commit. If unspecified the client may decide.
         /// </summary>
         public bool? _commitByDefault;
     }

--- a/Python/Product/Analysis/LanguageServer/Structures.cs
+++ b/Python/Product/Analysis/LanguageServer/Structures.cs
@@ -657,6 +657,10 @@ namespace Microsoft.PythonTools.Analysis.LanguageServer {
         /// The expression that members are being displayed for.
         /// </summary>
         public string _expr;
+        /// <summary>
+        /// When true, completions should commit by default.
+        /// </summary>
+        public bool? _commitByDefault;
     }
 
     [Serializable]

--- a/Python/Product/Analysis/Parsing/Ast/EmptyStatement.cs
+++ b/Python/Product/Analysis/Parsing/Ast/EmptyStatement.cs
@@ -22,6 +22,8 @@ namespace Microsoft.PythonTools.Parsing.Ast {
         public EmptyStatement() {
         }
 
+        public override int KeywordLength => 4;
+
         public override void Walk(PythonWalker walker) {
             if (walker.Walk(this)) {
             }

--- a/Python/Product/Analysis/Parsing/Parser.cs
+++ b/Python/Product/Analysis/Parsing/Parser.cs
@@ -1687,11 +1687,6 @@ namespace Microsoft.PythonTools.Parsing {
             var nameExpr = MakeName(name);
             string nameWhiteSpace = _tokenWhiteSpace;
 
-            if (name.RealName == null) {
-                // no name, assume there's no class.
-                return ErrorStmt(_verbatim ? (classWhiteSpace + "class") : null);
-            }
-
             bool isParenFree = false;
             string leftParenWhiteSpace = null, rightParenWhiteSpace = null;
             List<string> commaWhiteSpace = null;

--- a/Python/Product/Analyzer/Intellisense/OutOfProcProjectAnalyzer.cs
+++ b/Python/Product/Analyzer/Intellisense/OutOfProcProjectAnalyzer.cs
@@ -1330,7 +1330,7 @@ namespace Microsoft.PythonTools.Intellisense {
             }
 
             return new AP.SignaturesResponse {
-                sigs = sigs.signatures.Select(
+                sigs = sigs?.signatures?.Select(
                     s => new AP.Signature {
                         name = s.label,
                         doc = s.documentation?.value,

--- a/Python/Product/PythonTools/PythonTools/Intellisense/NormalCompletionAnalysis.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/NormalCompletionAnalysis.cs
@@ -200,6 +200,7 @@ namespace Microsoft.PythonTools.Intellisense {
                 CompletionComparer.UnderscoresLast,
                 matchInsertionText: true
             );
+            result.CommitByDefault = completions._commitByDefault ?? true;
 
             end = _stopwatch.ElapsedMilliseconds;
 

--- a/Python/Product/PythonTools/PythonTools/Intellisense/ProjectAnalyzer.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/ProjectAnalyzer.cs
@@ -1441,7 +1441,7 @@ namespace Microsoft.PythonTools.Intellisense {
             }
 
             if (sigs != null) {
-                foreach (var sig in sigs.sigs) {
+                foreach (var sig in sigs.sigs.MaybeEnumerate()) {
                     result.Add(new PythonSignature(this, applicableSpan, sig, paramIndex, lastKeywordArg));
                 }
             }

--- a/Python/Tests/Analysis/ExpressionFinderTests.cs
+++ b/Python/Tests/Analysis/ExpressionFinderTests.cs
@@ -116,14 +116,26 @@ C().fff", GetExpressionOptions.Evaluate);
 
         [TestMethod, Priority(0)]
         public void FindExpressionsForComplete() {
-            var code = Parse(@"class C(object):
+            PythonAstAndSource code;
+
+            code = Parse(@"class 
+
+pass", GetExpressionOptions.Complete);
+            AssertExpr(code, 1, 6, "class");
+            AssertNoExpr(code, 1, 7);
+
+            code = Parse(@"def 
+
+pass", GetExpressionOptions.Complete);
+            AssertExpr(code, 1, 4, "def");
+            AssertNoExpr(code, 1, 5);
+
+            code = Parse(@"class C(object):
     def f(a):
         return a
 
 b = C().f(1)
 ", GetExpressionOptions.Complete);
-            var clsCode = code.Source.Substring(0, code.Source.IndexOfEnd("return a"));
-            var funcCode = clsCode.Substring(clsCode.IndexOf("def"));
 
             AssertExpr(code, 1, 1, "class");
             AssertNoExpr(code, 1, 7);


### PR DESCRIPTION
Fixes #4115: Completions dropdown shouldn't appear after def and class
Fixes handling of incomplete def and class statements
Fixes default commit of overrides
Fixes references to import names