### PR TITLE
Fixes 4120, 4123

### DIFF
--- a/Python/Product/Analysis/LanguageServer/CompletionAnalysis.cs
+++ b/Python/Product/Analysis/LanguageServer/CompletionAnalysis.cs
@@ -461,11 +461,14 @@ namespace Microsoft.PythonTools.Analysis.LanguageServer {
                     // matching comment before this point
                     match = ~match - 1;
                 }
-                Debug.Assert(0 <= match && match < Tree._commentLocations.Length);
+                if (match < 0 || match >= Tree._commentLocations.Length) {
+                    Debug.Fail("Failed to find nearest preceding comment in AST");
+                    return null;
+                }
 
                 if (Tree._commentLocations[match].Line == Position.Line &&
                     Tree._commentLocations[match].Column < Position.Column) {
-                    // We are inside a comment, but not right at the start
+                    // We are inside a comment
                     return Empty;
                 }
             }

--- a/Python/Product/Analysis/LanguageServer/CompletionAnalysis.cs
+++ b/Python/Product/Analysis/LanguageServer/CompletionAnalysis.cs
@@ -504,7 +504,7 @@ namespace Microsoft.PythonTools.Analysis.LanguageServer {
                 }
             }
 
-            return members.Select(ToCompletionItem);
+            return members.Select(ToCompletionItem).Where(c => !string.IsNullOrEmpty(c.insertText));
         }
 
 
@@ -523,16 +523,23 @@ namespace Microsoft.PythonTools.Analysis.LanguageServer {
         };
 
         private CompletionItem ToCompletionItem(MemberResult m) {
+            var completion = m.Completion;
+            if (string.IsNullOrEmpty(completion)) {
+                completion = m.Name;
+            }
+            if (string.IsNullOrEmpty(completion)) {
+                return default(CompletionItem);
+            }
             var doc = _textBuilder.GetDocumentation(m.Values, string.Empty);
             var res = new CompletionItem {
                 label = m.Name,
-                insertText = m.Completion,
+                insertText = completion,
                 documentation = string.IsNullOrWhiteSpace(doc) ? null : new MarkupContent {
                     kind = _textBuilder.DisplayOptions.preferredFormat,
                     value = doc
                 },
                 // Place regular items first, advanced entries last
-                sortText = char.IsLetter(m.Completion, 0) ? "1" : "2",
+                sortText = char.IsLetter(completion, 0) ? "1" : "2",
                 kind = ToCompletionItemKind(m.MemberType),
                 _kind = m.MemberType.ToString().ToLowerInvariant()
             };

--- a/Python/Product/Analysis/LanguageServer/Server.Completion.cs
+++ b/Python/Product/Analysis/LanguageServer/Server.Completion.cs
@@ -58,10 +58,23 @@ namespace Microsoft.PythonTools.Analysis.LanguageServer {
 
             var res = new CompletionList {
                 items = members.ToArray(),
-                _applicableSpan = ctxt.Node?.GetSpan(tree),
                 _expr = ctxt.ParentExpression?.ToCodeString(tree, CodeFormattingOptions.Traditional),
                 _commitByDefault = ctxt.ShouldCommitByDefault
             };
+
+            if (ctxt.Node != null) {
+                var span = ctxt.Node.GetSpan(tree);
+                if (@params.context?.triggerKind == CompletionTriggerKind.TriggerCharacter) {
+                    SourceLocation trigger = @params.position;
+                    if (span.End > trigger) {
+                        span = new SourceSpan(span.Start, trigger);
+                    }
+                }
+                if (span.End != span.Start) {
+                    res._applicableSpan = span;
+                }
+            }
+
             LogMessage(MessageType.Info, $"Found {res.items.Length} completions for {uri} at {@params.position} after filtering");
             return res;
         }

--- a/Python/Product/Analysis/Parsing/Parser.cs
+++ b/Python/Product/Analysis/Parsing/Parser.cs
@@ -204,7 +204,7 @@ namespace Microsoft.PythonTools.Parsing {
         }
 
         private PythonAst CreateAst(Statement ret) {
-            var ast = new PythonAst(ret, _tokenizer.GetLineLocations(), _tokenizer.LanguageVersion);
+            var ast = new PythonAst(ret, _tokenizer.GetLineLocations(), _tokenizer.LanguageVersion, _tokenizer.GetCommentLocations());
             ast.HasVerbatim = _verbatim;
             ast.PrivatePrefix = _privatePrefix;
             if (_token.Token != null) {

--- a/Python/Product/Analysis/Parsing/Tokenizer.cs
+++ b/Python/Product/Analysis/Parsing/Tokenizer.cs
@@ -43,6 +43,7 @@ namespace Microsoft.PythonTools.Parsing {
         private Severity _indentationInconsistencySeverity;
         private bool _endContinues, _printFunction, _unicodeLiterals, _withStatement;
         private List<NewLineLocation> _newLineLocations;
+        private List<SourceLocation> _commentLocations;
         private SourceLocation _initialLocation;
         private TextReader _reader;
         private char[] _buffer;
@@ -215,6 +216,7 @@ namespace Microsoft.PythonTools.Parsing {
             }
 
             _newLineLocations = new List<NewLineLocation>();
+            _commentLocations = new List<SourceLocation>();
             _tokenEnd = -1;
             _multiEolns = !_disableLineFeedLineSeparator;
             _initialLocation = initialLocation;
@@ -488,6 +490,7 @@ namespace Microsoft.PythonTools.Parsing {
                         break;
 
                     case '#':
+                        _commentLocations.Add(CurrentPosition.AddColumns(-1));
                         if ((_options & (TokenizerOptions.VerbatimCommentsAndLineJoins | TokenizerOptions.Verbatim)) != 0) {
                             var commentRes = ReadSingleLineComment(out ch);
                             if ((_options & TokenizerOptions.VerbatimCommentsAndLineJoins) == 0) {
@@ -2015,6 +2018,7 @@ namespace Microsoft.PythonTools.Parsing {
                         sb.Append('\f');
                         break;
                     case '#':
+                        _commentLocations.Add(CurrentPosition.AddColumns(-1));
                         if ((_options & TokenizerOptions.VerbatimCommentsAndLineJoins) != 0) {
                             BufferBack();
                             MarkTokenEnd();
@@ -2231,9 +2235,8 @@ namespace Microsoft.PythonTools.Parsing {
             Console.WriteLine("{0} `{1}`", token.Kind, token.Image.Replace("\r", "\\r").Replace("\n", "\\n").Replace("\t", "\\t"));
         }
 
-        internal NewLineLocation[] GetLineLocations() {
-            return _newLineLocations.ToArray();
-        }
+        internal NewLineLocation[] GetLineLocations() => _newLineLocations.ToArray();
+        internal SourceLocation[] GetCommentLocations() => _commentLocations.ToArray();
 
         [Serializable]
         class IncompleteString : IEquatable<IncompleteString> {

--- a/Python/Product/PythonTools/PythonTools/Extensions.cs
+++ b/Python/Product/PythonTools/PythonTools/Extensions.cs
@@ -142,9 +142,11 @@ namespace Microsoft.PythonTools {
             }
 
             var spanLength = position - line.Start.Position;
-            // Increase position by one to include 'fob' in: "abc.|fob"
-            if (spanLength < line.Length) {
-                spanLength += 1;
+            if (completeWord) {
+                // Increase position by one to include 'fob' in: "abc.|fob"
+                if (spanLength < line.Length) {
+                    spanLength += 1;
+                }
             }
 
             var classifications = classifier.GetClassificationSpans(new SnapshotSpan(line.Start, spanLength));

--- a/Python/Product/PythonTools/PythonTools/Intellisense/NormalCompletionAnalysis.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/NormalCompletionAnalysis.cs
@@ -40,73 +40,6 @@ namespace Microsoft.PythonTools.Intellisense {
             _snapshot = snapshot;
         }
 
-        internal bool GetPrecedingExpression(out string parentExpression, out SnapshotSpan expressionExtent) {
-            parentExpression = string.Empty;
-            expressionExtent = default(SnapshotSpan);
-
-            // We never want normal completions on space
-            if (Session.GetTriggerCharacter() == ' ' && !Session.IsCompleteWordMode()) {
-                return false;
-            }
-
-            var bi = PythonTextBufferInfo.TryGetForBuffer(_snapshot.TextBuffer);
-            if (bi == null) {
-                return false;
-            }
-            var span = Span.GetSpan(_snapshot);
-            var expr = bi.GetExpressionAtPoint(span, GetExpressionOptions.EvaluateMembers);
-            if (expr != null) {
-                parentExpression = expr.Value.GetText() ?? "";
-                expressionExtent = new SnapshotSpan(expr.Value.Start, span.End);
-                return true;
-            }
-
-            expr = bi.GetExpressionAtPoint(span, GetExpressionOptions.Complete);
-            if (expr != null) {
-                expressionExtent = expr.Value;
-                return true;
-            }
-
-            var tok = bi.GetTokenAtPoint(span.End);
-            if (tok == null) {
-                expressionExtent = span;
-                return true;
-            }
-
-            switch (tok.Value.Category) {
-                case TokenCategory.Comment:
-                    return false;
-                case TokenCategory.Delimiter:
-                case TokenCategory.Grouping:
-                case TokenCategory.Operator:
-                case TokenCategory.WhiteSpace:
-                    // Expect top-level completions after these
-                    expressionExtent = span;
-                    return true;
-                //case TokenCategory.BuiltinIdentifier:
-                case TokenCategory.Keyword:
-                    // Expect filtered top-level completions here
-                    // (but the return value is no different)
-                    expressionExtent = span;
-                    return true;
-                case TokenCategory.Identifier:
-                    // When preceded by a delimiter, grouping, or operator
-                    var tok2 = bi.GetTokensInReverseFromPoint(span.End).Where(t => t.Category != TokenCategory.WhiteSpace && t.Category != TokenCategory.Comment).Take(2).ToArray();
-                    if (tok2.Length == 2 && tok2[0].Category == tok.Value.Category) {
-                        switch (tok2[1].Category) {
-                            case TokenCategory.Delimiter:
-                            case TokenCategory.Grouping:
-                            case TokenCategory.Operator:
-                                expressionExtent = span;
-                                return true;
-                        }
-                    }
-                    break;
-            }
-
-            return false;
-        }
-
         public override CompletionSet GetCompletions(IGlyphService glyphService) {
             var start1 = _stopwatch.ElapsedMilliseconds;
 
@@ -132,7 +65,14 @@ namespace Microsoft.PythonTools.Intellisense {
                 analysis
             );
 
-            var completions = analyzer.WaitForRequest(analyzer.GetCompletionsAsync(analysis, location, _options.MemberOptions), "GetCompletions.GetMembers");
+            var triggerChar = Session.GetTriggerCharacter();
+            var completions = analyzer.WaitForRequest(analyzer.GetCompletionsAsync(
+                analysis,
+                location,
+                _options.MemberOptions,
+                triggerChar == '\0' ? Analysis.LanguageServer.CompletionTriggerKind.Invoked : Analysis.LanguageServer.CompletionTriggerKind.TriggerCharacter,
+                triggerChar == '\0' ? null : triggerChar.ToString()
+            ), "GetCompletions.GetMembers");
 
             if (completions.items == null) {
                 return null;

--- a/Python/Product/PythonTools/PythonTools/Intellisense/ProjectAnalyzer.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/ProjectAnalyzer.cs
@@ -1353,8 +1353,7 @@ namespace Microsoft.PythonTools.Intellisense {
         /// Gets a CompletionList providing a list of possible members the user can dot through.
         /// </summary>
         internal static CompletionAnalysis GetCompletions(PythonEditorServices services, ICompletionSession session, ITextView view, ITextSnapshot snapshot, ITrackingSpan span, ITrackingPoint point, CompletionOptions options) {
-            return //TrySpecialCompletions(services, session, view, snapshot, span, point, options) ??
-                   GetNormalCompletionContext(services, session, view, snapshot, span, point, options);
+            return GetNormalCompletionContext(services, session, view, snapshot, span, point, options);
         }
 
         //internal async Task<CompletionSet> GetCompletionsAsync(AnalysisEntry entry, ITextView view, ITextSnapshot snapshot, ITrackingPoint point, CompletionOptions options) {
@@ -1987,14 +1986,16 @@ namespace Microsoft.PythonTools.Intellisense {
             }
         }
 
-        internal async Task<LS.CompletionList> GetCompletionsAsync(AnalysisEntry entry, SourceLocation location, GetMemberOptions options) {
+        internal async Task<LS.CompletionList> GetCompletionsAsync(AnalysisEntry entry, SourceLocation location, GetMemberOptions options, LS.CompletionTriggerKind triggerKind, string triggerChar) {
             return await SendLanguageServerRequestAsync<LS.CompletionParams, LS.CompletionList>(
                 "textDocument/completion",
                 new LS.CompletionParams {
                     textDocument = new Uri(entry.DocumentUri.AbsoluteUri),
                     position = location,
                     context = new LS.CompletionContext {
-                        _intersection = options.Intersect()
+                        _intersection = options.Intersect(),
+                        triggerKind = triggerKind,
+                        triggerCharacter = triggerChar
                     }
                 }
             ).ConfigureAwait(false);

--- a/Python/Product/PythonTools/PythonTools/Intellisense/PythonSignature.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/PythonSignature.cs
@@ -154,7 +154,6 @@ namespace Microsoft.PythonTools.Intellisense {
             }
 
             if (index < 0 || index >= _parameters.Count) {
-                Debug.Assert(_parameters.Count == 0 || index == int.MaxValue, $"Failed to select parameter {index}//'{name ?? "(null)"}'");
                 SetCurrentParameter(null);
                 return -1;
             }

--- a/Python/Tests/Analysis/ParserTests.cs
+++ b/Python/Tests/Analysis/ParserTests.cs
@@ -2974,6 +2974,35 @@ namespace AnalysisTests {
             return null;
         }
 
+        [TestMethod, Priority(0)]
+        public void CommentLocations() {
+            var parser = Parser.CreateParser(new StringReader(@"# line 1
+
+# line 3
+pass
+  # line 4"), PythonLanguageVersion.V36);
+            var tree = parser.ParseFile();
+
+            AssertUtil.AreEqual(tree._commentLocations,
+                new SourceLocation(1, 1),
+                new SourceLocation(3, 1),
+                new SourceLocation(5, 3)
+            );
+
+            parser = Parser.CreateParser(new StringReader(@"# line 1
+"), PythonLanguageVersion.V36);
+            var tree1 = parser.ParseFile();
+            parser = Parser.CreateParser(new StringReader(@"# line 3
+pass
+  # line 4"), PythonLanguageVersion.V36);
+            tree = new PythonAst(new[] { tree1, parser.ParseFile() });
+            AssertUtil.AreEqual(tree._commentLocations,
+                new SourceLocation(1, 1),
+                new SourceLocation(3, 1),
+                new SourceLocation(5, 3)
+            );
+        }
+
         #endregion
 
         #region Checker Factories / Helpers

--- a/Python/Tests/PythonToolsMockTests/CompletionTests.cs
+++ b/Python/Tests/PythonToolsMockTests/CompletionTests.cs
@@ -1168,30 +1168,6 @@ async def g():
             }
         }
 
-        private static void TestMemberCompletion(PythonEditor view, int index, string expectedExpression) {
-            var snapshot = view.CurrentSnapshot;
-            if (index < 0) {
-                index += snapshot.Length + 1;
-            }
-
-            var context = view.VS.Invoke(() => view.VS.GetPyService().GetCompletions(
-                null,
-                view.View.TextView,
-                snapshot,
-                snapshot.GetApplicableSpan(index, completeWord: true) ?? snapshot.CreateTrackingSpan(index, 0, SpanTrackingMode.EdgeInclusive),
-                snapshot.CreateTrackingPoint(index, PointTrackingMode.Negative),
-                new CompletionOptions()
-            ));
-
-            Assert.IsInstanceOfType(context, typeof(NormalCompletionAnalysis));
-            var normalContext = (NormalCompletionAnalysis)context;
-
-            string text;
-            SnapshotSpan statementExtent;
-            Assert.IsTrue(normalContext.GetPrecedingExpression(out text, out statementExtent));
-            Assert.AreEqual(expectedExpression, text);
-        }
-
         private static SignatureAnalysis GetSignatureAnalysis(PythonEditor view, int index) {
             var snapshot = view.CurrentSnapshot;
 


### PR DESCRIPTION
Fixes #4120 Editing in comments should not bring up completions
Tracks comment locations in AST so we can easily suppress completions

Fixes #4123 Completion or formatting mangles string
Fixes applicable span calculation to avoid triggering completion on wrong word

Removes unnecessary assertion in invalid signatures.