### PR TITLE
Fix refactor rename of function or class

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Refactoring/VariableRenamer.cs
+++ b/Python/Product/PythonTools/PythonTools/Refactoring/VariableRenamer.cs
@@ -64,6 +64,7 @@ namespace Microsoft.PythonTools.Refactoring {
 
             string privatePrefix = analysis.PrivatePrefix;
             var originalName = analysis.Variables
+                .Where(r => r.Type == VariableType.Definition)
                 .Where(r => r.Location.DocumentUri == buffer.DocumentUri && buffer.LocationTracker.CanTranslateFrom(r.Version ?? -1))
                 .Select(r => {
                     var snapshot = buffer.CurrentSnapshot;


### PR DESCRIPTION
Fix #4169 

Ensure that we get the old name from one of the definitions (it doesn't matter which one if there are more than one, they will all have the same name).

Already covered by RefactorRenameTests. The following tests were failing and are now passing:
NestedFunctions
SanityRenameClass
SanityRenameFunction
