### PR TITLE
Prevent crash due to ArgumentNullException when parsing search paths.

### DIFF
--- a/Python/Product/Analysis/Interpreter/PythonLibraryPath.cs
+++ b/Python/Product/Analysis/Interpreter/PythonLibraryPath.cs
@@ -194,6 +194,9 @@ namespace Microsoft.PythonTools.Analysis {
                 }
                 try {
                     return Parse(s);
+                } catch (ArgumentException) {
+                    Debug.Fail("Invalid search path: " + (s ?? "<null>"));
+                    return null;
                 } catch (FormatException) {
                     Debug.Fail("Invalid format for search path: " + s);
                     return null;
@@ -219,8 +222,10 @@ namespace Microsoft.PythonTools.Analysis {
                     while ((line = file.ReadLine()) != null) {
                         try {
                             result.Add(Parse(line));
+                        } catch (ArgumentException) {
+                            Debug.Fail("Invalid search path: " + (line ?? "<null>"));
                         } catch (FormatException) {
-                            Debug.Fail("Invalid format: " + line);
+                            Debug.Fail("Invalid format for search path: " + line);
                         }
                     }
                 }


### PR DESCRIPTION
Fix #4150