### PR TITLE
Fix navigation in Go To All

### DIFF
--- a/Python/Product/Analyzer/Intellisense/OutOfProcProjectAnalyzer.cs
+++ b/Python/Product/Analyzer/Intellisense/OutOfProcProjectAnalyzer.cs
@@ -1421,7 +1421,8 @@ namespace Microsoft.PythonTools.Intellisense {
                                     startLine = s.location.range.start.line + 1,
                                     startColumn = s.location.range.start.character + 1,
                                     endLine = s.location.range.end.line + 1,
-                                    endColumn = s.location.range.end.character + 1
+                                    endColumn = s.location.range.end.character + 1,
+                                    kind = "definition",
                                 }
                             }
                         }


### PR DESCRIPTION
Fix #4193 

`kind` was `null`, and `PythonNavigateToItemDisplay` was only initializing the item location if one of the results had `loc.kind == "definition"`.

Don't know if that's too simplistic or not. The function I'm changing is called only from `GetAllMembers`, so presumably it's only definitions that we are getting.