### PR TITLE
Skip static file collection when STATIC_ROOT is not defined

### DIFF
--- a/Python/Product/Django/Microsoft.PythonTools.Django.targets
+++ b/Python/Product/Django/Microsoft.PythonTools.Django.targets
@@ -70,7 +70,7 @@ permissions and limitations under the License.
        user has provided their own value.
   -->
   <Target Name="DetectStaticRootPath">
-    <RunPythonCommand Target="import $(DjangoSettingsModule) as settings; print(settings.STATIC_ROOT or '')"
+    <RunPythonCommand Target="import $(DjangoSettingsModule) as settings; print(getattr(settings, 'STATIC_ROOT', '') or '')"
                       TargetType="code"
                       ExecuteIn="none"
                       WorkingDirectory="$(WorkingDirectory)"


### PR DESCRIPTION
Fix #4184 

Our Django templates define `STATIC_ROOT`, but when you import from existing code a project created using `django-admin startproject`, settings.py doesn't have `STATIC_ROOT` defined.

People are starting to `startproject` templates rather than our own since our templates don't target Django 2.0.
