### PR TITLE
Fix failing tests

### DIFF
--- a/Python/Product/Analysis/LanguageServer/DocumentationBuilder.cs
+++ b/Python/Product/Analysis/LanguageServer/DocumentationBuilder.cs
@@ -66,15 +66,17 @@ namespace Microsoft.PythonTools.Analysis.LanguageServer {
             foreach (var v in values) {
                 var d = v.Description;
                 string doc = null;
-                if (!string.IsNullOrEmpty(d) && v.PythonType?.IsBuiltin != true) {
-                    doc = v.Documentation;
-                    if (DisplayOptions.trimDocumentationLines) {
-                        doc = LimitLines(doc);
+                if (!string.IsNullOrEmpty(d)) {
+                    if (v.PythonType?.IsBuiltin != true) {
+                        doc = v.Documentation;
+                        if (DisplayOptions.trimDocumentationLines) {
+                            doc = LimitLines(doc);
+                        }
+                        haveDocs |= !string.IsNullOrEmpty(doc);
                     }
+                    multiline |= d.IndexOf('\n') >= 0;
+                    descriptions[d] = doc ?? string.Empty;
                 }
-                haveDocs |= !string.IsNullOrEmpty(doc);
-                multiline |= d.IndexOf('\n') >= 0;
-                descriptions[d] = doc ?? string.Empty;
             }
 
             if (descriptions.Count == 0) {

--- a/Python/Product/Analysis/LanguageServer/DocumentationBuilder.cs
+++ b/Python/Product/Analysis/LanguageServer/DocumentationBuilder.cs
@@ -67,7 +67,7 @@ namespace Microsoft.PythonTools.Analysis.LanguageServer {
                 var d = v.Description;
                 string doc = null;
                 if (!string.IsNullOrEmpty(d)) {
-                    if (v.PythonType?.IsBuiltin != true) {
+                    if (!IsBasicType(v.PythonType)) {
                         doc = v.Documentation;
                         if (DisplayOptions.trimDocumentationLines) {
                             doc = LimitLines(doc);
@@ -153,7 +153,6 @@ namespace Microsoft.PythonTools.Analysis.LanguageServer {
         protected abstract string MakeFunctionDocumentation(AnalysisValue value);
         protected abstract string MakeClassDocumentation(AnalysisValue value);
 
-
         protected string LimitLines(
             string str,
             bool ellipsisAtEnd = true,
@@ -198,5 +197,24 @@ namespace Microsoft.PythonTools.Analysis.LanguageServer {
         }
 
         protected virtual string SoftWrap(string s) => s;
+
+        private static bool IsBasicType(IPythonType type) {
+            if (type == null || !type.IsBuiltin) {
+                return false;
+            }
+
+            switch(type.TypeId) {
+                case BuiltinTypeId.Bool:
+                case BuiltinTypeId.Bytes:
+                case BuiltinTypeId.Complex:
+                case BuiltinTypeId.Dict:
+                case BuiltinTypeId.Float:
+                case BuiltinTypeId.Int:
+                case BuiltinTypeId.Str:
+                case BuiltinTypeId.Unicode:
+                    return true;
+            }
+            return false;
+        }
     }
 }

--- a/Python/Product/Analysis/LanguageServer/DocumentationBuilder.cs
+++ b/Python/Product/Analysis/LanguageServer/DocumentationBuilder.cs
@@ -59,16 +59,22 @@ namespace Microsoft.PythonTools.Analysis.LanguageServer {
 
         private string MakeGeneralDocumentation(AnalysisValue[] values, string originalExpression) {
             var descriptions = new Dictionary<string, string>();
+            var haveDocs = false;
+            var multiline = false;
+            var descPrefix = string.Empty;
 
             foreach (var v in values) {
                 var d = v.Description;
-                if (!string.IsNullOrEmpty(d)) {
-                    var doc = v.Documentation;
+                string doc = null;
+                if (!string.IsNullOrEmpty(d) && v.PythonType?.IsBuiltin != true) {
+                    doc = v.Documentation;
                     if (DisplayOptions.trimDocumentationLines) {
                         doc = LimitLines(doc);
                     }
-                    descriptions[d] = doc ?? string.Empty;
                 }
+                haveDocs |= !string.IsNullOrEmpty(doc);
+                multiline |= d.IndexOf('\n') >= 0;
+                descriptions[d] = doc ?? string.Empty;
             }
 
             if (descriptions.Count == 0) {
@@ -76,46 +82,51 @@ namespace Microsoft.PythonTools.Analysis.LanguageServer {
             }
 
             var result = new StringBuilder();
-            var descPrefix = DisplayOptions.preferredFormat == MarkupKind.Markdown ? $"```python{Environment.NewLine}" : string.Empty;
-            var descSuffix = DisplayOptions.preferredFormat == MarkupKind.Markdown ? $"```{Environment.NewLine}" : string.Empty;
-            var multiline = descriptions.Count > 1;
+            if (!haveDocs && !multiline) {
+                // No documentation, simply description, just concatenate
+                result.Append(string.Join(", ", descriptions.Keys));
+            } else {
+                descPrefix = DisplayOptions.preferredFormat == MarkupKind.Markdown ? $"```python{Environment.NewLine}" : string.Empty;
+                var descSuffix = DisplayOptions.preferredFormat == MarkupKind.Markdown ? $"```{Environment.NewLine}" : string.Empty;
+                multiline = descriptions.Count > 1;
 
-            foreach (var kvp in descriptions) {
-                var desc = kvp.Key;
-                var doc = kvp.Value;
+                foreach (var kvp in descriptions) {
+                    var desc = kvp.Key;
+                    var doc = kvp.Value;
 
-                if(result.Length > 0) {
-                    result.AppendLine();
-                    result.AppendLine();
-                }
-                result.Append(descPrefix);
-                result.AppendLine(desc);
-                result.Append(descSuffix);
+                    if (result.Length > 0) {
+                        result.AppendLine();
+                        result.AppendLine();
+                    }
+                    result.Append(descPrefix);
+                    result.AppendLine(desc);
+                    result.Append(descSuffix);
 
-                if (!string.IsNullOrEmpty(doc)) {
-                    result.AppendLine(SoftWrap(doc));
-                    multiline |= doc.IndexOf('\n') >= 0;
-                }
+                    if (!string.IsNullOrEmpty(doc)) {
+                        result.AppendLine(SoftWrap(doc));
+                        multiline |= doc.IndexOf('\n') >= 0;
+                    }
 
-                if (DisplayOptions.trimDocumentationText && result.Length > DisplayOptions.maxDocumentationTextLength) {
-                    result.Length = Math.Max(0, DisplayOptions.maxDocumentationTextLength - 3);
-                    result.Append(_ellipsis);
-                    break;
-                } else if (DisplayOptions.trimDocumentationLines) {
-                    using (var sr = new StringReader(result.ToString())) {
-                        result.Clear();
-                        int lines = DisplayOptions.maxDocumentationLineLength;
-                        for (var line = sr.ReadLine(); line != null; line = sr.ReadLine()) {
-                            if (--lines < 0) {
-                                result.Append(_ellipsis);
-                                break;
+                    if (DisplayOptions.trimDocumentationText && result.Length > DisplayOptions.maxDocumentationTextLength) {
+                        result.Length = Math.Max(0, DisplayOptions.maxDocumentationTextLength - 3);
+                        result.Append(_ellipsis);
+                        break;
+                    } else if (DisplayOptions.trimDocumentationLines) {
+                        using (var sr = new StringReader(result.ToString())) {
+                            result.Clear();
+                            int lines = DisplayOptions.maxDocumentationLineLength;
+                            for (var line = sr.ReadLine(); line != null; line = sr.ReadLine()) {
+                                if (--lines < 0) {
+                                    result.Append(_ellipsis);
+                                    break;
+                                }
+                                result.AppendLine(line);
                             }
-                            result.AppendLine(line);
                         }
                     }
-                }
 
-                result.TrimEnd();
+                    result.TrimEnd();
+                }
             }
 
             if (!string.IsNullOrEmpty(originalExpression)) {

--- a/Python/Product/Analysis/LanguageServer/Server.Hover.cs
+++ b/Python/Product/Analysis/LanguageServer/Server.Hover.cs
@@ -57,18 +57,10 @@ namespace Microsoft.PythonTools.Analysis.LanguageServer {
             SourceSpan? exprSpan;
             Analyzer.InterpreterScope scope = null;
 
-            if (!string.IsNullOrEmpty(@params._expr)) {
-                TraceMessage($"Getting hover for {@params._expr}");
-                expr = analysis.GetExpressionForText(@params._expr, @params.position, out scope, out var exprTree);
-                // This span will not be valid within the document, but it will at least
-                // have the correct length. If we have passed "_expr" then we are likely
-                // planning to ignore the returned span anyway.
-                exprSpan = expr?.GetSpan(exprTree);
-            } else {
-                var finder = new ExpressionFinder(tree, GetExpressionOptions.Hover);
-                expr = finder.GetExpression(@params.position) as Expression;
-                exprSpan = expr?.GetSpan(tree);
-            }
+            var finder = new ExpressionFinder(tree, GetExpressionOptions.Hover);
+            expr = finder.GetExpression(@params.position) as Expression;
+            exprSpan = expr?.GetSpan(tree);
+
             if (expr == null) {
                 TraceMessage($"No hover info found in {uri} at {@params.position}");
                 return EmptyHover;

--- a/Python/Product/Analysis/Values/TypingTypeInfo.cs
+++ b/Python/Product/Analysis/Values/TypingTypeInfo.cs
@@ -46,7 +46,7 @@ namespace Microsoft.PythonTools.Analysis.Values {
         public override IAnalysisSet GetInstanceType() => this;
 
         public override IAnalysisSet Call(Node node, AnalysisUnit unit, IAnalysisSet[] args, NameExpression[] keywordArgNames) {
-            if (_args == null && node is CallExpression ce) {
+            if ((_args == null || !_args.Any()) && node is CallExpression ce) {
                 return unit.Scope.GetOrMakeNodeValue(node, NodeValueKind.TypeAnnotation, n => {
                     // Use annotation converter and reparse the arguments
                     var newArgs = new List<IAnalysisSet>();
@@ -152,9 +152,8 @@ namespace Microsoft.PythonTools.Analysis.Values {
             }
         }
 
-        public override string Description => _innerValue?.Description ?? base.Description; 
-        public override string Documentation => _innerValue?.Documentation ?? base.Documentation;
-        public override PythonMemberType MemberType => _innerValue != null ? _innerValue.MemberType : base.MemberType;
+        public override string Description => base.Description ?? _innerValue?.Description; 
+        public override string Documentation => base.Documentation ?? _innerValue?.Documentation;
 
         public override bool Equals(object obj) {
             if (obj is TypingTypeInfo other) {

--- a/Python/Tests/Analysis/AnalysisSaveTest.cs
+++ b/Python/Tests/Analysis/AnalysisSaveTest.cs
@@ -116,7 +116,7 @@ Aliased = test.Aliased
                 AssertUtil.ContainsExactly(newMod.Analysis.GetShortDescriptionsByIndex("list_of_int", pos), "list of int");
                 AssertUtil.ContainsExactly(newMod.Analysis.GetShortDescriptionsByIndex("tuple_of_str", pos), "tuple of str");
 
-                AssertUtil.ContainsExactly(newMod.Analysis.GetShortDescriptionsByIndex("fob", pos), "int");
+                AssertUtil.ContainsExactly(newMod.Analysis.GetShortDescriptionsByIndex("fob", pos), "type int");
 
                 var result = newMod.Analysis.GetSignaturesByIndex("f1", pos).ToArray();
                 Assert.AreEqual(1, result.Length);
@@ -175,7 +175,7 @@ Overloaded = test.Overloaded
                 var allMembers = newMod.Analysis.GetAllAvailableMembersByIndex(pos, GetMemberOptions.None);
 
                 Assert.AreEqual(
-                    "test.Aliased\r\nclass doc\r\n\r\nAliased(fob)\r\nfunction doc",
+                    "class test.Aliased\r\nclass doc\r\n\r\nAliased(fob)\r\nfunction doc",
                     allMembers.First(x => x.Name == "Aliased").Documentation
                 );
                 newPs.Analyzer.AssertHasParameters("FunctionNoRetType", "value");

--- a/Python/Tests/Analysis/AnalysisSaveTest.cs
+++ b/Python/Tests/Analysis/AnalysisSaveTest.cs
@@ -335,8 +335,8 @@ baz_Fob = baz.Fob
 ";
                 newPs.NewModule("fez", code);
 
-                newPs.Analyzer.AssertDescription("oar_Fob", "fob.Fob");
-                newPs.Analyzer.AssertDescription("baz_Fob", "fob.Fob");
+                newPs.Analyzer.AssertDescription("oar_Fob", "class fob.Fob");
+                newPs.Analyzer.AssertDescription("baz_Fob", "class fob.Fob");
             }
         }
 

--- a/Python/Tests/Analysis/AnalysisTest.cs
+++ b/Python/Tests/Analysis/AnalysisTest.cs
@@ -3425,8 +3425,8 @@ class cls(cls):
             entry.AssertIsInstance("cls.abc", BuiltinTypeId.Int);
 
             AssertUtil.Contains(string.Join(Environment.NewLine, entry.GetCompletionDocumentation("","cls")),
-                "The most base type",
-                "cls"
+                "cls",
+                "type object"
             );
         }
 

--- a/Python/Tests/Analysis/LanguageServerTests.cs
+++ b/Python/Tests/Analysis/LanguageServerTests.cs
@@ -617,16 +617,16 @@ x = 3.14
 
             await AssertHover(s, mod, new SourceLocation(1, 1), "int", new[] { "int" }, new SourceSpan(1, 1, 1, 4));
             await AssertHover(s, mod, new SourceLocation(2, 1), "str", new[] { "str" }, new SourceSpan(2, 1, 2, 6));
-            await AssertHover(s, mod, new SourceLocation(3, 1), "f: test-module.f()", new[] { "test-module.f" }, new SourceSpan(3, 1, 3, 2));
-            await AssertHover(s, mod, new SourceLocation(4, 6), "f: test-module.f()", new[] { "test-module.f" }, new SourceSpan(4, 5, 4, 6));
+            await AssertHover(s, mod, new SourceLocation(3, 1), "built-in function test-module.f()", new[] { "test-module.f" }, new SourceSpan(3, 1, 3, 2));
+            await AssertHover(s, mod, new SourceLocation(4, 6), "built-in function test-module.f()", new[] { "test-module.f" }, new SourceSpan(4, 5, 4, 6));
 
-            await AssertHover(s, mod, new SourceLocation(12, 1), "C: class test-module.C", new[] { "test-module.C" }, new SourceSpan(12, 1, 12, 2));
+            await AssertHover(s, mod, new SourceLocation(12, 1), "class test-module.C", new[] { "test-module.C" }, new SourceSpan(12, 1, 12, 2));
             await AssertHover(s, mod, new SourceLocation(13, 1), "c: C", new[] { "test-module.C" }, new SourceSpan(13, 1, 13, 2));
             await AssertHover(s, mod, new SourceLocation(14, 7), "c: C", new[] { "test-module.C" }, new SourceSpan(14, 7, 14, 8));
             await AssertHover(s, mod, new SourceLocation(14, 9), "c.f: method f of test-module.C objects*", new[] { "test-module.C.f" }, new SourceSpan(14, 7, 14, 10));
-            await AssertHover(s, mod, new SourceLocation(14, 1), $"c_g:{Environment.NewLine}test-module.C.f.g(self){Environment.NewLine}declared in C.f", new[] { "test-module.C.f.g" }, new SourceSpan(14, 1, 14, 4));
+            await AssertHover(s, mod, new SourceLocation(14, 1), $"built-in function test-module.C.f.g(self)  {Environment.NewLine}declared in C.f", new[] { "test-module.C.f.g" }, new SourceSpan(14, 1, 14, 4));
 
-            await AssertHover(s, mod, new SourceLocation(16, 1), "x: float, int", new[] { "int", "float" }, new SourceSpan(16, 1, 16, 2));
+            await AssertHover(s, mod, new SourceLocation(16, 1), "x: int, float", new[] { "int", "float" }, new SourceSpan(16, 1, 16, 2));
         }
 
         [TestMethod, Priority(0)]


### PR DESCRIPTION
- Update baselines 
- Don't display long class doc for built-in types (i.e. display just 'int' for the int constant)
- Minor tweak in the tooltip to match the test for simple types.
- Fix fetching arg types for named tuple (looks like `_args` can now be empty and not always null)