### PR TITLE
Specify correct encoding in WebClient when calling into GitHub API.

### DIFF
--- a/Python/Product/Cookiecutter/Model/GitHubClient.cs
+++ b/Python/Product/Cookiecutter/Model/GitHubClient.cs
@@ -16,10 +16,10 @@
 
 using System;
 using System.Net;
-using System.Threading.Tasks;
-using static System.FormattableString;
-using Newtonsoft.Json;
 using System.Text;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using static System.FormattableString;
 
 namespace Microsoft.CookiecutterTools.Model {
     class GitHubClient : IGitHubClient {

--- a/Python/Product/Cookiecutter/Model/GitHubClient.cs
+++ b/Python/Product/Cookiecutter/Model/GitHubClient.cs
@@ -23,6 +23,8 @@ using static System.FormattableString;
 
 namespace Microsoft.CookiecutterTools.Model {
     class GitHubClient : IGitHubClient {
+        private const string UserAgent = "PythonToolsForVisualStudio/" + AssemblyVersionInfo.Version;
+
         // throws WebException (for example, with 403 forbidden) and JsonException
         public async Task<GitHubRepoSearchResult> SearchRepositoriesAsync(string requestUrl) {
             if (requestUrl == null) {
@@ -78,7 +80,7 @@ namespace Microsoft.CookiecutterTools.Model {
         private static WebClient CreateClient() {
             var wc = new WebClient();
             wc.Encoding = Encoding.UTF8;
-            wc.Headers.Add(HttpRequestHeader.UserAgent, "PTVS");
+            wc.Headers.Add(HttpRequestHeader.UserAgent, UserAgent);
             return wc;
         }
 

--- a/Python/Product/Cookiecutter/Model/GitHubClient.cs
+++ b/Python/Product/Cookiecutter/Model/GitHubClient.cs
@@ -19,6 +19,7 @@ using System.Net;
 using System.Threading.Tasks;
 using static System.FormattableString;
 using Newtonsoft.Json;
+using System.Text;
 
 namespace Microsoft.CookiecutterTools.Model {
     class GitHubClient : IGitHubClient {
@@ -76,6 +77,7 @@ namespace Microsoft.CookiecutterTools.Model {
 
         private static WebClient CreateClient() {
             var wc = new WebClient();
+            wc.Encoding = Encoding.UTF8;
             wc.Headers.Add(HttpRequestHeader.UserAgent, "PTVS");
             return wc;
         }

--- a/Python/Tests/CookiecutterTests/CookiecutterTests.csproj
+++ b/Python/Tests/CookiecutterTests/CookiecutterTests.csproj
@@ -80,6 +80,7 @@
   </Choose>
   <ItemGroup>
     <Compile Include="ContextItemViewModelComparer.cs" />
+    <Compile Include="GitHubClientTests.cs" />
     <Compile Include="GitClientTests.cs" />
     <Compile Include="GitHubDiscoveryTests.cs" />
     <Compile Include="ITelemetryTestSupport.cs" />

--- a/Python/Tests/CookiecutterTests/GitHubClientTests.cs
+++ b/Python/Tests/CookiecutterTests/GitHubClientTests.cs
@@ -1,0 +1,33 @@
+﻿// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABLITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System.Threading.Tasks;
+using Microsoft.CookiecutterTools.Model;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using TestUtilities;
+
+namespace CookiecutterTests {
+    [TestClass]
+    public class GitHubClientTests {
+       [TestMethod]
+        public async Task CheckEncoding() {
+            // Use a repository with a description in Chinese to check UTF-8 decoding
+            var client = new GitHubClient();
+            var details = await client.GetRepositoryDetails("chenyinxin", "cookiecutter-bitadmin-core");
+            AssertUtil.Contains(details.Description, "BitAdminCore是基于net core的管理应用快速开发框架");
+        }
+    }
+}


### PR DESCRIPTION
Fix #4240