### PR TITLE
Fixes #4145 AD7 debugger can't attach to Python 3.7

### DIFF
--- a/Common/Tests/Utilities/VCCompiler.cs
+++ b/Common/Tests/Utilities/VCCompiler.cs
@@ -34,11 +34,13 @@ namespace TestUtilities {
         public static VCCompiler VC11_X86 { get { return FindVC("11.0", ProcessorArchitecture.X86); } }
         public static VCCompiler VC12_X86 { get { return FindVC("12.0", ProcessorArchitecture.X86); } }
         public static VCCompiler VC14_X86 { get { return FindVC("14.0", ProcessorArchitecture.X86); } }
+        public static VCCompiler VC15_X86 { get { return FindVC("15.0", ProcessorArchitecture.X86); } }
         public static VCCompiler VC9_X64 { get { return FindVC("9.0", ProcessorArchitecture.Amd64); } }
         public static VCCompiler VC10_X64 { get { return FindVC("10.0", ProcessorArchitecture.Amd64); } }
         public static VCCompiler VC11_X64 { get { return FindVC("11.0", ProcessorArchitecture.Amd64); } }
         public static VCCompiler VC12_X64 { get { return FindVC("12.0", ProcessorArchitecture.Amd64); } }
         public static VCCompiler VC14_X64 { get { return FindVC("14.0", ProcessorArchitecture.Amd64); } }
+        public static VCCompiler VC15_X64 { get { return FindVC("15.0", ProcessorArchitecture.Amd64); } }
 
         private VCCompiler(string bin, string bins, string include, string lib) {
             BinPath = bin ?? string.Empty;

--- a/Python/Product/Profiling/vspyprof.py
+++ b/Python/Product/Profiling/vspyprof.py
@@ -69,7 +69,7 @@ def profile(file, globals_obj, locals_obj, profdll):
     pyprofdll.InitProfiler.argtypes = [ctypes.c_void_p]
     pyprofdll.InitProfiler.restype = ctypes.c_void_p
 
-    profiler = pyprofdll.CreateProfiler(sys.dllhandle)
+    profiler = pyprofdll.CreateProfiler(ctypes.c_void_p(sys.dllhandle))
     if not profiler:
         raise NotImplementedError("Profiling is currently not supported for " + sys.version)
     handle = None

--- a/Python/Product/PyDebugAttach/PyDebugAttach.cpp
+++ b/Python/Product/PyDebugAttach/PyDebugAttach.cpp
@@ -36,6 +36,7 @@ typedef PyInterpreterState* (PyInterpreterState_Head)();
 typedef PyThreadState* (PyInterpreterState_ThreadHead)(PyInterpreterState* interp);
 typedef PyThreadState* (PyThreadState_Next)(PyThreadState *tstate);
 typedef PyThreadState* (PyThreadState_Swap)(PyThreadState *tstate);
+typedef PyThreadState* (_PyThreadState_UncheckedGet)();
 typedef PyObject* (PyDict_New)();
 typedef PyObject* (PyModule_New)(const char *name);
 typedef PyObject* (PyModule_GetDict)(PyObject *module);
@@ -654,7 +655,7 @@ ConnectionInfo GetConnectionInfo() {
     char* pBuf;
 
     wchar_t fullMappingName[1024];
-    _snwprintf_s(fullMappingName, _countof(fullMappingName), L"PythonDebuggerMemory%d", GetCurrentProcessId());
+    _snwprintf_s(fullMappingName, sizeof(fullMappingName) / sizeof(fullMappingName[0]), L"PythonDebuggerMemory%d", GetCurrentProcessId());
 
     hMapFile = OpenFileMapping(
         FILE_MAP_ALL_ACCESS,   // read/write access
@@ -807,7 +808,6 @@ bool DoAttach(HMODULE module, ConnectionInfo& connInfo, bool isDebug) {
 
         // found initialized Python runtime, gather and check the APIs we need for a successful attach...
         auto addPendingCall = (Py_AddPendingCall*)GetProcAddress(module, "Py_AddPendingCall");
-        auto curPythonThread = (PyThreadState**)(void*)GetProcAddress(module, "_PyThreadState_Current");
         auto interpHead = (PyInterpreterState_Head*)GetProcAddress(module, "PyInterpreterState_Head");
         auto gilEnsure = (PyGILState_Ensure*)GetProcAddress(module, "PyGILState_Ensure");
         auto gilRelease = (PyGILState_Release*)GetProcAddress(module, "PyGILState_Release");
@@ -843,7 +843,6 @@ bool DoAttach(HMODULE module, ConnectionInfo& connInfo, bool isDebug) {
             strFromString = (PyString_FromString*)GetProcAddress(module, "PyString_FromString");
             intFromSizeT = (PyInt_FromSize_t*)GetProcAddress(module, "PyInt_FromSize_t");
         }
-        auto intervalCheck = (int*)GetProcAddress(module, "_Py_CheckInterval");
         auto errOccurred = (PyErr_Occurred*)GetProcAddress(module, "PyErr_Occurred");
         auto pyErrFetch = (PyErr_Fetch*)GetProcAddress(module, "PyErr_Fetch");
         auto pyErrRestore = (PyErr_Restore*)GetProcAddress(module, "PyErr_Restore");
@@ -852,8 +851,7 @@ bool DoAttach(HMODULE module, ConnectionInfo& connInfo, bool isDebug) {
         auto pyGetAttr = (PyObject_GetAttrString*)GetProcAddress(module, "PyObject_GetAttrString");
         auto pySetAttr = (PyObject_SetAttrString*)GetProcAddress(module, "PyObject_SetAttrString");
         auto pyNone = (PyObject*)GetProcAddress(module, "_Py_NoneStruct");
-        auto getSwitchInterval = (_PyEval_GetSwitchInterval*)GetProcAddress(module, "_PyEval_GetSwitchInterval");
-        auto setSwitchInterval = (_PyEval_SetSwitchInterval*)GetProcAddress(module, "_PyEval_SetSwitchInterval");
+
         auto boolFromLong = (PyBool_FromLong*)GetProcAddress(module, "PyBool_FromLong");
         auto getThreadTls = (PyThread_get_key_value*)GetProcAddress(module, "PyThread_get_key_value");
         auto setThreadTls = (PyThread_set_key_value*)GetProcAddress(module, "PyThread_set_key_value");
@@ -863,12 +861,22 @@ bool DoAttach(HMODULE module, ConnectionInfo& connInfo, bool isDebug) {
         auto pyUnicodeAsWideChar = (PyUnicode_AsWideChar*)GetProcAddress(module,
             version < PythonVersion_33 ? "PyUnicodeUCS2_AsWideChar" : "PyUnicode_AsWideChar");
 
-        if (addPendingCall == nullptr || curPythonThread == nullptr || interpHead == nullptr || gilEnsure == nullptr || gilRelease == nullptr || threadHead == nullptr ||
+        // Either _PyThreadState_Current or _PyThreadState_UncheckedGet are required
+        auto curPythonThread = (PyThreadState**)(void*)GetProcAddress(module, "_PyThreadState_Current");
+        auto getPythonThread = (_PyThreadState_UncheckedGet*)GetProcAddress(module, "_PyThreadState_UncheckedGet");
+
+        // Either _Py_CheckInterval or _PyEval_[GS]etSwitchInterval are useful, but not required
+        auto intervalCheck = (int*)GetProcAddress(module, "_Py_CheckInterval");
+        auto getSwitchInterval = (_PyEval_GetSwitchInterval*)GetProcAddress(module, "_PyEval_GetSwitchInterval");
+        auto setSwitchInterval = (_PyEval_SetSwitchInterval*)GetProcAddress(module, "_PyEval_SetSwitchInterval");
+
+        if (addPendingCall == nullptr || interpHead == nullptr || gilEnsure == nullptr || gilRelease == nullptr || threadHead == nullptr ||
             initThreads == nullptr || releaseLock == nullptr || threadsInited == nullptr || threadNext == nullptr || threadSwap == nullptr ||
             pyDictNew == nullptr || pyCompileString == nullptr || pyEvalCode == nullptr || getDictItem == nullptr || call == nullptr ||
             getBuiltins == nullptr || dictSetItem == nullptr || intFromLong == nullptr || pyErrRestore == nullptr || pyErrFetch == nullptr ||
             errOccurred == nullptr || pyImportMod == nullptr || pyGetAttr == nullptr || pyNone == nullptr || pySetAttr == nullptr || boolFromLong == nullptr ||
-            getThreadTls == nullptr || setThreadTls == nullptr || delThreadTls == nullptr || pyObjectRepr == nullptr || pyUnicodeAsWideChar == nullptr) {
+            getThreadTls == nullptr || setThreadTls == nullptr || delThreadTls == nullptr || pyObjectRepr == nullptr || pyUnicodeAsWideChar == nullptr ||
+            (curPythonThread == nullptr && getPythonThread == nullptr)) {
                 // we're missing some APIs, we cannot attach.
                 connInfo.ReportError(ConnError_PythonNotFound);
                 return false;
@@ -957,7 +965,9 @@ bool DoAttach(HMODULE module, ConnectionInfo& connInfo, bool isDebug) {
                 SuspendThreads(suspendedThreads, addPendingCall, threadsInited);
 
                 if (!threadsInited()) {
-                    if (*curPythonThread == nullptr) {
+                    auto curPyThread = getPythonThread ? getPythonThread() : *curPythonThread;
+                    
+                    if (curPyThread == nullptr) {
                         // no threads are currently running, it is safe to initialize multi threading.
                         PyGILState_STATE gilState;
                         if (version >= PythonVersion_34) {
@@ -1081,7 +1091,7 @@ bool DoAttach(HMODULE module, ConnectionInfo& connInfo, bool isDebug) {
 
             auto repr = PyObjectHolder(isDebug, pyObjectRepr(value));
             wchar_t reprText[0x1000] = {};
-            pyUnicodeAsWideChar(repr.ToPython(), reprText, _countof(reprText) - 1);
+            pyUnicodeAsWideChar(repr.ToPython(), reprText, sizeof(reprText) / sizeof(reprText[0]) - 1);
             fputws(reprText, stderr);
 
             connInfo.ReportErrorAfterAttachDone(ConnError_LoadDebuggerFailed);
@@ -1115,7 +1125,7 @@ bool DoAttach(HMODULE module, ConnectionInfo& connInfo, bool isDebug) {
         unordered_set<PyThreadState*> seenThreads;
         {
             // find what index is holding onto the thread state...
-            auto curPyThread = *curPythonThread;
+            auto curPyThread = getPythonThread ? getPythonThread() : *curPythonThread;
             int threadStateIndex = -1;
             for (int i = 0; i < 100000; i++) {
                 void* value = getThreadTls(i);

--- a/Python/Product/VsPyProf/PythonApi.cpp
+++ b/Python/Product/VsPyProf/PythonApi.cpp
@@ -88,7 +88,7 @@ VsPyProf* VsPyProf::Create(HMODULE pythonModule) {
                 }
 
                 if ((major == 2 && (minor >= 4 && minor <= 7)) ||
-                    (major == 3 && (minor >= 0 && minor <= 6))) {
+                    (major == 3 && (minor >= 0 && minor <= 7))) {
                         return new VsPyProf(pythonModule,
                             major,
                             minor,
@@ -217,6 +217,9 @@ bool VsPyProf::GetUserToken(PyFrameObject* frameObj, DWORD_PTR& func, DWORD_PTR&
             } else if (PyCodeObject36::IsFor(MajorVersion, MinorVersion)) {
                 RegisterName(func, ((PyCodeObject36*)codeObj)->co_name, &moduleName);
                 lineno = ((PyCodeObject36*)codeObj)->co_firstlineno;
+            } else if (PyCodeObject37::IsFor(MajorVersion, MinorVersion)) {
+                RegisterName(func, ((PyCodeObject37*)codeObj)->co_name, &moduleName);
+                lineno = ((PyCodeObject37*)codeObj)->co_firstlineno;
             }
 
             // give the profiler the line number of this function
@@ -265,8 +268,10 @@ wstring VsPyProf::GetClassNameFromFrame(PyFrameObject* frameObj, PyObject *codeO
                 PyObject* self = nullptr;
                 if (PyFrameObject25_33::IsFor(MajorVersion, MinorVersion)) {
                     self = ((PyFrameObject25_33*)frameObj)->f_localsplus[0];
-                } else if (PyFrameObject34_37::IsFor(MajorVersion, MinorVersion)) {
-                    self = ((PyFrameObject34_37*)frameObj)->f_localsplus[0];
+                } else if (PyFrameObject34_36::IsFor(MajorVersion, MinorVersion)) {
+                    self = ((PyFrameObject34_36*)frameObj)->f_localsplus[0];
+                } else if (PyFrameObject37::IsFor(MajorVersion, MinorVersion)) {
+                    self = ((PyFrameObject37*)frameObj)->f_localsplus[0];
                 }
                 return GetClassNameFromSelf(self, codeObj);
             }
@@ -296,6 +301,8 @@ wstring VsPyProf::GetClassNameFromSelf(PyObject* self, PyObject *codeObj) {
             nameObj = ((PyCodeObject33_35*)codeObj)->co_name;
         } else if (PyCodeObject36::IsFor(MajorVersion, MinorVersion)) {
             nameObj = ((PyCodeObject36*)codeObj)->co_name;
+        } else if (PyCodeObject37::IsFor(MajorVersion, MinorVersion)) {
+            nameObj = ((PyCodeObject37*)codeObj)->co_name;
         }
         GetNameAscii(nameObj, codeName);
 


### PR DESCRIPTION
Fixes #4145 AD7 debugger can't attach to Python 3.7
Corrects structures for Python 3.7
Allows profiling on 3.7