### PR TITLE
Fix #4075: TaskCanceledException in Microsoft.PythonTools.Repl.PythonInteractiveEvaluator.ExecuteCodeAsync

### DIFF
--- a/Python/Product/Analysis/Infrastructure/TaskExtensions.cs
+++ b/Python/Product/Analysis/Infrastructure/TaskExtensions.cs
@@ -14,21 +14,52 @@
 // See the Apache Version 2.0 License for specific language governing
 // permissions and limitations under the License.
 
+using System;
+using System.Runtime.ExceptionServices;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.PythonTools.Analysis.Infrastructure {
     internal static class TaskExtensions {
         /// <summary>
-        /// Suppresses warnings about unawaited tasks and ensures that unhandled
-        /// errors will cause the process to terminate.
+        /// Suppresses warnings about unawaited tasks and rethrows task exceptions back to the callers synchronization context if it is possible
         /// </summary>
+        /// <remarks>
+        /// <see cref="OperationCanceledException"/> is always ignored.
+        /// </remarks>
         public static void DoNotWait(this Task task) {
-            if (TestEnvironment.Current == null || !TestEnvironment.Current.TryAddTaskToWait(task)) {
-                DoNotWaitImpl(task);
+            if (task.IsCompleted) {
+                ReThrowTaskException(task);
+                return;
+            }
+
+            var synchronizationContext = SynchronizationContext.Current;
+            if (synchronizationContext != null && synchronizationContext.GetType() != typeof (SynchronizationContext)) {
+                task.ContinueWith(DoNotWaitSynchronizationContextContinuation, synchronizationContext, CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
+            } else {
+                task.ContinueWith(DoNotWaitThreadContinuation, TaskContinuationOptions.ExecuteSynchronously);
             }
         }
 
-        private static async void DoNotWaitImpl(Task task) => await task;
+        private static void ReThrowTaskException(object state) {
+            var task = (Task)state;
+            if (task.IsFaulted && task.Exception != null) {
+                var exception = task.Exception.InnerException;
+                ExceptionDispatchInfo.Capture(exception).Throw();
+            }
+        }
+
+        private static void DoNotWaitThreadContinuation(Task task) {
+            if (task.IsFaulted && task.Exception != null) {
+                var exception = task.Exception.InnerException;
+                ThreadPool.QueueUserWorkItem(s => ((ExceptionDispatchInfo)s).Throw(), ExceptionDispatchInfo.Capture(exception));
+            }
+        }
+
+        private static void DoNotWaitSynchronizationContextContinuation(Task task, object state) {
+            var context = (SynchronizationContext) state;
+            context.Post(ReThrowTaskException, task);
+        }
 
         /// <summary>
         /// Waits for a task to complete. If an exception occurs, the exception

--- a/Python/Product/Common/Strings.Designer.cs
+++ b/Python/Product/Common/Strings.Designer.cs
@@ -1120,6 +1120,15 @@ namespace Microsoft.PythonTools {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Command {0} has been canceled.
+        /// </summary>
+        public static string CustomCommandCanceled {
+            get {
+                return ResourceManager.GetString("CustomCommandCanceled", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Executing -m {0} {1}.
         /// </summary>
         public static string CustomCommandExecutingModule {
@@ -2920,7 +2929,7 @@ namespace Microsoft.PythonTools {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Please &apos;pip install ptvsd --pre&apos; in your Python environment to use the experimental debugger.
+        ///   Looks up a localized string similar to Please run &apos;pip install --upgrade ptvsd --pre&apos; in your Python environment to use the experimental debugger.
         /// </summary>
         public static string ImportPtvsdFailedMessage {
             get {

--- a/Python/Product/Common/Strings.resx
+++ b/Python/Product/Common/Strings.resx
@@ -252,6 +252,9 @@ Continue?</value>
   <data name="SearchPathContainerProperties" xml:space="preserve">
     <value>Search Paths Properties</value>
   </data>
+  <data name="CustomCommandCanceled" xml:space="preserve">
+    <value>Command {0} has been canceled</value>
+  </data>
   <data name="ErrorRunningCustomCommand" xml:space="preserve">
     <value>An error occurred while running {0}.
 

--- a/Python/Product/Cookiecutter/Shared/Infrastructure/TaskExtensions.cs
+++ b/Python/Product/Cookiecutter/Shared/Infrastructure/TaskExtensions.cs
@@ -15,18 +15,50 @@
 // permissions and limitations under the License.
 
 using System;
-using System.Diagnostics;
+using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.CookiecutterTools.Infrastructure {
     public static class TaskExtensions {
         /// <summary>
-        /// Suppresses warnings about unawaited tasks and ensures that unhandled
-        /// errors will cause the process to terminate.
+        /// Suppresses warnings about unawaited tasks and rethrows task exceptions back to the callers synchronization context if it is possible
         /// </summary>
-        public static async void DoNotWait(this Task task) {
-            await task;
+        /// <remarks>
+        /// <see cref="OperationCanceledException"/> is always ignored.
+        /// </remarks>
+        public static void DoNotWait(this Task task) {
+            if (task.IsCompleted) {
+                ReThrowTaskException(task);
+                return;
+            }
+
+            var synchronizationContext = SynchronizationContext.Current;
+            if (synchronizationContext != null && synchronizationContext.GetType() != typeof (SynchronizationContext)) {
+                task.ContinueWith(DoNotWaitSynchronizationContextContinuation, synchronizationContext, CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
+            } else {
+                task.ContinueWith(DoNotWaitThreadContinuation, TaskContinuationOptions.ExecuteSynchronously);
+            }
+        }
+
+        private static void ReThrowTaskException(object state) {
+            var task = (Task)state;
+            if (task.IsFaulted && task.Exception != null) {
+                var exception = task.Exception.InnerException;
+                ExceptionDispatchInfo.Capture(exception).Throw();
+            }
+        }
+
+        private static void DoNotWaitThreadContinuation(Task task) {
+            if (task.IsFaulted && task.Exception != null) {
+                var exception = task.Exception.InnerException;
+                ThreadPool.QueueUserWorkItem(s => ((ExceptionDispatchInfo)s).Throw(), ExceptionDispatchInfo.Capture(exception));
+            }
+        }
+
+        private static void DoNotWaitSynchronizationContextContinuation(Task task, object state) {
+            var context = (SynchronizationContext) state;
+            context.Post(ReThrowTaskException, task);
         }
 
         public static T WaitOrDefault<T>(this Task<T> task, int milliseconds) {

--- a/Python/Product/ProjectWizards/CookiecutterWizard.cs
+++ b/Python/Product/ProjectWizards/CookiecutterWizard.cs
@@ -44,10 +44,6 @@ namespace Microsoft.PythonTools.ProjectWizards {
         public void ProjectItemFinishedGenerating(EnvDTE.ProjectItem projectItem) { }
         public void RunFinished() { }
 
-        private static async void DoNotWait(Task task) {
-            await task;
-        }
-
         public void RunStarted(object automationObject, Dictionary<string, string> replacementsDictionary, WizardRunKind runKind, object[] customParams) {
             try {
                 Directory.Delete(replacementsDictionary["$destinationdirectory$"]);

--- a/Python/Product/ProjectWizards/ImportWizard.cs
+++ b/Python/Product/ProjectWizards/ImportWizard.cs
@@ -37,10 +37,6 @@ namespace Microsoft.PythonTools.ProjectWizards {
         public void ProjectItemFinishedGenerating(EnvDTE.ProjectItem projectItem) { }
         public void RunFinished() { }
 
-        private static async void DoNotWait(Task task) {
-            await task;
-        }
-
         public void RunStarted(object automationObject, Dictionary<string, string> replacementsDictionary, WizardRunKind runKind, object[] customParams) {
             try {
                 Directory.Delete(replacementsDictionary["$destinationdirectory$"]);

--- a/Python/Product/PythonTools/PythonTools/Project/CustomCommand.cs
+++ b/Python/Product/PythonTools/PythonTools/Project/CustomCommand.cs
@@ -679,6 +679,9 @@ namespace Microsoft.PythonTools.Project {
                         // We really close the backend, rather than resetting.
                         pyEvaluator.Dispose();
                     }
+                } catch (OperationCanceledException) {
+                    // Swallow OperationCanceledException, it is normal for async operation to be cancelled
+                    ActivityLog.LogInformation(Strings.ProductTitle, Strings.CustomCommandCanceled.FormatUI(_label));
                 } catch (Exception ex) {
                     ActivityLog.LogError(Strings.ProductTitle, Strings.ErrorRunningCustomCommand.FormatUI(_label, ex));
                     var outWindow = OutputWindowRedirector.GetGeneral(project.Site);

--- a/Python/Tests/Core/PythonToolsTests.csproj
+++ b/Python/Tests/Core/PythonToolsTests.csproj
@@ -140,6 +140,7 @@
     <Compile Include="PythonProjectTests.cs" />
     <Compile Include="RegistryWatcherTest.cs" />
     <Compile Include="ReplEvaluatorTests.cs" />
+    <Compile Include="TaskExtensionsTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Product\Analysis\Analysis.csproj">

--- a/Python/Tests/Core/TaskExtensionsTests.cs
+++ b/Python/Tests/Core/TaskExtensionsTests.cs
@@ -1,0 +1,137 @@
+// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABLITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System;
+using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.PythonTools.Infrastructure;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace PythonToolsTests {
+    [TestClass]
+    public class TaskExtensionsTests {
+        [TestMethod]
+        public async Task DoNotWait() {
+            var expected1 = new InvalidOperationException();
+            var expected2 = new InvalidOperationException();
+            var actions = new BlockingCollection<Action>();
+            var exceptions = new ConcurrentQueue<Exception>();
+
+            var thread = new Thread(ConsumerThread);
+            thread.Start();
+
+            actions.Add(() => ThrowCanceledFromConsumerThread(thread.ManagedThreadId).DoNotWait());
+            actions.Add(() => ThrowCanceledFromBackgroundThread(thread.ManagedThreadId).DoNotWait());
+            actions.Add(() => ThrowExceptionFromConsumerThread(thread.ManagedThreadId, expected1).DoNotWait());
+            actions.Add(() => ThrowExceptionFromBackgroundThread(thread.ManagedThreadId, expected2).DoNotWait());
+
+            await Task.Delay(3_000);
+
+            actions.CompleteAdding();
+            thread.Join(3_000);
+
+            Assert.IsTrue(thread.ThreadState == ThreadState.Stopped);
+            Assert.IsTrue(exceptions.Count == 2, $"{nameof(exceptions)} should contain exactly two exceptions");
+            CollectionAssert.AreEquivalent(exceptions, new [] {expected1, expected2});
+
+            void ConsumerThread() {
+                SynchronizationContext.SetSynchronizationContext(new BlockingCollectionSynchronizationContext(actions));
+                foreach (var action in actions.GetConsumingEnumerable()) {
+                    try {
+                        action();
+                    } catch (Exception ex) {
+                        exceptions.Enqueue(ex);
+                    }
+                }
+            }
+        }
+
+        private static async Task ThrowCanceledFromConsumerThread(int managedThreadId) {
+            try {
+                Assert.AreEqual(managedThreadId, Thread.CurrentThread.ManagedThreadId);
+                throw new CustomOperationCanceledException();
+            } finally {
+                Assert.AreEqual(managedThreadId, Thread.CurrentThread.ManagedThreadId);
+            }
+        }
+
+        private static async Task ThrowCanceledFromBackgroundThread(int managedThreadId) {
+            try {
+                Assert.AreEqual(managedThreadId, Thread.CurrentThread.ManagedThreadId);
+                await BackgroundThreadThrowCanceled();
+            } finally {
+                Assert.AreEqual(managedThreadId, Thread.CurrentThread.ManagedThreadId);
+            }
+        }
+
+        private static async Task BackgroundThreadThrowCanceled() {
+            await new BackgroundThreadAwaitable();
+            throw new CustomOperationCanceledException();
+        }
+
+        private static async Task ThrowExceptionFromConsumerThread(int managedThreadId, Exception exception) {
+            try {
+                Assert.AreEqual(managedThreadId, Thread.CurrentThread.ManagedThreadId);
+                throw exception;
+            } finally {
+                Assert.AreEqual(managedThreadId, Thread.CurrentThread.ManagedThreadId);
+            }
+        }
+
+        private static async Task ThrowExceptionFromBackgroundThread(int managedThreadId, Exception exception) {
+            try {
+                Assert.AreEqual(managedThreadId, Thread.CurrentThread.ManagedThreadId);
+                await BackgroundThreadThrowException(exception);
+            } finally {
+                Assert.AreEqual(managedThreadId, Thread.CurrentThread.ManagedThreadId);
+            }
+        }
+
+        private static async Task BackgroundThreadThrowException(Exception exception) {
+            await new BackgroundThreadAwaitable();
+            throw exception;
+        }
+
+        private class CustomOperationCanceledException : OperationCanceledException {}
+
+        private class BlockingCollectionSynchronizationContext : SynchronizationContext {
+            private readonly BlockingCollection<Action> _queue;
+
+            public BlockingCollectionSynchronizationContext(BlockingCollection<Action> queue) {
+                _queue = queue;
+            }
+
+            public override void Send(SendOrPostCallback d, object state) => throw new NotSupportedException();
+            public override void Post(SendOrPostCallback d, object state) => _queue.Add(() => d(state));
+            public override int Wait(IntPtr[] waitHandles, bool waitAll, int millisecondsTimeout) => WaitHelper(waitHandles, waitAll, millisecondsTimeout);
+            public override SynchronizationContext CreateCopy() => new BlockingCollectionSynchronizationContext(_queue);
+        }
+
+        private struct BackgroundThreadAwaitable {
+            public BackgroundThreadAwaiter GetAwaiter() => new BackgroundThreadAwaiter();
+        }
+
+        private struct BackgroundThreadAwaiter : ICriticalNotifyCompletion {
+            private static readonly WaitCallback WaitCallback = state => ((Action)state)();
+            public bool IsCompleted => TaskScheduler.Current == TaskScheduler.Default && Thread.CurrentThread.IsThreadPoolThread;
+            public void OnCompleted(Action continuation) => ThreadPool.QueueUserWorkItem(WaitCallback, continuation);
+            public void UnsafeOnCompleted(Action continuation) => ThreadPool.UnsafeQueueUserWorkItem(WaitCallback, continuation);
+            public void GetResult() {}
+        }
+    }
+}


### PR DESCRIPTION
- Log OperationCanceledException as information instead of error in CustomCommand.RunInRepl
- Switch DoNotWait to explicit implementation to ensure that OperationCanceledException is ignored
- Add test for DoNotWait