### PR TITLE
pip fixes

### DIFF
--- a/Common/Product/SharedProject/Wpf/Controls.cs
+++ b/Common/Product/SharedProject/Wpf/Controls.cs
@@ -43,6 +43,11 @@ namespace Microsoft.VisualStudioTools.Wpf {
         public static readonly object TooltipTextKey = new ThemeResourceKey(EnvCategory, "ToolTip", ThemeResourceKeyType.ForegroundBrush);
         public static readonly object TooltipTextColorKey = new ThemeResourceKey(EnvCategory, "ToolTip", ThemeResourceKeyType.ForegroundColor);
 
+        public static readonly object InfoBackgroundKey = new ThemeResourceKey(EnvCategory, "InfoBackground", ThemeResourceKeyType.BackgroundBrush);
+        public static readonly object InfoBackgroundColorKey = new ThemeResourceKey(EnvCategory, "InfoBackground", ThemeResourceKeyType.BackgroundColor);
+        public static readonly object InfoTextKey = new ThemeResourceKey(EnvCategory, "InfoText", ThemeResourceKeyType.ForegroundBrush);
+        public static readonly object InfoTextColorKey = new ThemeResourceKey(EnvCategory, "InfoText", ThemeResourceKeyType.ForegroundColor);
+
         public static readonly object HyperlinkKey = VsBrushes.ControlLinkTextKey;
         public static readonly object HyperlinkHoverKey = VsBrushes.ControlLinkTextHoverKey;
 

--- a/Common/Product/SharedProject/Wpf/Controls.xaml
+++ b/Common/Product/SharedProject/Wpf/Controls.xaml
@@ -220,6 +220,12 @@
         </Setter>
     </Style>
 
+    <Style x:Key="InfoPanel" TargetType="{x:Type Panel}">
+        <Setter Property="Background" Value="{DynamicResource {x:Static wpf:Controls.InfoBackgroundKey}}" />
+        <Setter Property="TextElement.Foreground" Value="{DynamicResource {x:Static wpf:Controls.InfoTextKey}}" />
+        <Setter Property="img:ImageThemingUtilities.ImageBackgroundColor" Value="{DynamicResource {x:Static wpf:Controls.InfoBackgroundColorKey}}" />
+    </Style>
+
     <Style TargetType="{x:Type GroupBox}">
         <Setter Property="Margin" Value="6" />
         <Setter Property="Padding" Value="6 3" />

--- a/Python/Product/Common/Strings.Designer.cs
+++ b/Python/Product/Common/Strings.Designer.cs
@@ -2920,7 +2920,7 @@ namespace Microsoft.PythonTools {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Please &apos;pip install ptvsd --pre&apos; in your Python environment to use the experimental debugger.
+        ///   Looks up a localized string similar to Please run &apos;pip install --upgrade ptvsd --pre&apos; in your Python environment to use the experimental debugger.
         /// </summary>
         public static string ImportPtvsdFailedMessage {
             get {
@@ -3506,6 +3506,15 @@ namespace Microsoft.PythonTools {
         public static string MisconfiguredEnvironment {
             get {
                 return ResourceManager.GetString("MisconfiguredEnvironment", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Operation cannot be started because pip is not installed in the environment at &apos;{0}&apos;..
+        /// </summary>
+        public static string MisconfiguredPip {
+            get {
+                return ResourceManager.GetString("MisconfiguredPip", resourceCulture);
             }
         }
         

--- a/Python/Product/Common/Strings.resx
+++ b/Python/Product/Common/Strings.resx
@@ -1317,6 +1317,10 @@ modified from these scripts.</value>
     <value>Operation cannot be started because the environment is not configured.</value>
     <comment>Used as exception text</comment>
   </data>
+  <data name="MisconfiguredPip" xml:space="preserve">
+    <value>Operation cannot be started because pip is not installed in the environment at '{0}'.</value>
+    <comment>Used as exception text</comment>
+  </data>
   <data name="ExecutingCommandFailed" xml:space="preserve">
     <value>----- Failed to run '{0}' -----
 

--- a/Python/Product/Cookiecutter/Shared/Wpf/Controls.cs
+++ b/Python/Product/Cookiecutter/Shared/Wpf/Controls.cs
@@ -43,6 +43,11 @@ namespace Microsoft.VisualStudioTools.Wpf {
         public static readonly object TooltipTextKey = new ThemeResourceKey(EnvCategory, "ToolTip", ThemeResourceKeyType.ForegroundBrush);
         public static readonly object TooltipTextColorKey = new ThemeResourceKey(EnvCategory, "ToolTip", ThemeResourceKeyType.ForegroundColor);
 
+        public static readonly object InfoBackgroundKey = new ThemeResourceKey(EnvCategory, "InfoBackground", ThemeResourceKeyType.BackgroundBrush);
+        public static readonly object InfoBackgroundColorKey = new ThemeResourceKey(EnvCategory, "InfoBackground", ThemeResourceKeyType.BackgroundColor);
+        public static readonly object InfoTextKey = new ThemeResourceKey(EnvCategory, "InfoText", ThemeResourceKeyType.ForegroundBrush);
+        public static readonly object InfoTextColorKey = new ThemeResourceKey(EnvCategory, "InfoText", ThemeResourceKeyType.ForegroundColor);
+
         public static readonly object HyperlinkKey = VsBrushes.ControlLinkTextKey;
         public static readonly object HyperlinkHoverKey = VsBrushes.ControlLinkTextHoverKey;
 

--- a/Python/Product/Cookiecutter/Shared/Wpf/Controls.xaml
+++ b/Python/Product/Cookiecutter/Shared/Wpf/Controls.xaml
@@ -220,6 +220,12 @@
         </Setter>
     </Style>
 
+    <Style x:Key="InfoPanel" TargetType="{x:Type Panel}">
+        <Setter Property="Background" Value="{DynamicResource {x:Static wpf:Controls.InfoBackgroundKey}}" />
+        <Setter Property="TextElement.Foreground" Value="{DynamicResource {x:Static wpf:Controls.InfoTextKey}}" />
+        <Setter Property="img:ImageThemingUtilities.ImageBackgroundColor" Value="{DynamicResource {x:Static wpf:Controls.InfoBackgroundColorKey}}" />
+    </Style>
+
     <Style TargetType="{x:Type GroupBox}">
         <Setter Property="Margin" Value="6" />
         <Setter Property="Padding" Value="6 3" />

--- a/Python/Product/EnvironmentsList/PipExtension.xaml
+++ b/Python/Product/EnvironmentsList/PipExtension.xaml
@@ -168,6 +168,9 @@
         <CommandBinding Command="{x:Static l:PipExtension.UpgradePackage}"
                         CanExecute="UpgradePackage_CanExecute"
                         Executed="UpgradePackage_Executed" />
+        <CommandBinding Command="{x:Static l:PipExtension.PipSecurityLearnMore}"
+                        CanExecute="PipSecurityLearnMore_CanExecute"
+                        Executed="PipSecurityLearnMore_Executed" />
         <CommandBinding Command="ApplicationCommands.Delete"
                         CanExecute="Delete_CanExecute"
                         Executed="Delete_Executed" />
@@ -175,6 +178,7 @@
     
     <Grid x:Name="Subcontext">
         <Grid.RowDefinitions>
+            <RowDefinition Height="auto" />
             <RowDefinition Height="auto" />
             <RowDefinition Height="auto" />
             <RowDefinition Height="auto" />
@@ -263,15 +267,37 @@
 
         <TextBox x:Name="SearchQueryText" Style="{StaticResource SearchBox}" />
 
-        <ProgressBar Grid.Row="1"
+        <Grid Grid.Row="1" 
+              Style="{StaticResource InfoPanel}"
+              Visibility="{Binding ShowSecurityWarning,Converter={StaticResource Visibility}}">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="auto"/>
+            </Grid.ColumnDefinitions>
+            <TextBlock
+                Grid.Column="0"
+                Margin="6"
+                HorizontalAlignment="Left"
+                VerticalAlignment="Top"
+                Text="{x:Static l:Resources.PipExtensionSecurityWarning}"/>
+            <Button Style="{StaticResource NavigationButton}"
+                Grid.Column="1"
+                Margin="3"
+                HorizontalAlignment="Left"
+                VerticalAlignment="Center"
+                Command="{x:Static l:PipExtension.PipSecurityLearnMore}"
+                Content="{x:Static l:Resources.PipExtensionSecurityLearnMore}"/>
+        </Grid>
+
+        <ProgressBar Grid.Row="2"
                      IsIndeterminate="True"
                      HorizontalAlignment="Stretch"
                      Height="3"
                      Focusable="False"
                      Visibility="{Binding IsListRefreshing,Converter={StaticResource VisibilityOrHidden}}" />
-        
-        <Button Grid.Row="2"
-                Style="{StaticResource NavigationButton}"
+
+        <Button Style="{StaticResource NavigationButton}"
+                Grid.Row="3"
                 Margin="3"
                 HorizontalAlignment="Left"
                 VerticalAlignment="Top"
@@ -285,7 +311,7 @@
                       CanContentScroll="False"
                       HorizontalScrollBarVisibility="Disabled"
                       VerticalScrollBarVisibility="Auto"
-                      Grid.Row="3"
+                      Grid.Row="4"
                       BorderThickness="0">
             <StackPanel Orientation="Vertical">
                 <StackPanel.Resources>

--- a/Python/Product/EnvironmentsList/PipExtension.xaml.cs
+++ b/Python/Product/EnvironmentsList/PipExtension.xaml.cs
@@ -18,6 +18,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using System.Runtime.ExceptionServices;
@@ -38,6 +39,7 @@ namespace Microsoft.PythonTools.EnvironmentsList {
         public static readonly ICommand UpgradePackage = new RoutedCommand();
         public static readonly ICommand UninstallPackage = new RoutedCommand();
         public static readonly ICommand InstallPip = new RoutedCommand();
+        public static readonly ICommand PipSecurityLearnMore = new RoutedCommand();
 
         private readonly PipExtensionProvider _provider;
         private readonly Timer _focusTimer;
@@ -182,6 +184,15 @@ namespace Microsoft.PythonTools.EnvironmentsList {
             }
         }
 
+        private void PipSecurityLearnMore_CanExecute(object sender, CanExecuteRoutedEventArgs e) {
+            e.CanExecute = true;
+            e.Handled = true;
+        }
+
+        private void PipSecurityLearnMore_Executed(object sender, ExecutedRoutedEventArgs e) {
+            Process.Start("https://go.microsoft.com/fwlink/?linkid=874576");
+        }
+
         private void InstallPip_CanExecute(object sender, CanExecuteRoutedEventArgs e) {
             e.CanExecute = _provider.CanExecute;
             e.Handled = true;
@@ -252,6 +263,10 @@ namespace Microsoft.PythonTools.EnvironmentsList {
             _provider.InstalledPackagesChanged += PipExtensionProvider_InstalledPackagesChanged;
 
             IsPipInstalled = _provider.IsPipInstalled ?? true;
+            ShowSecurityWarning =
+                provider._packageManager.UniqueKey == "pip" &&
+                view.Configuration.Version != new Version(2, 7) &&
+                view.Configuration.Version < new Version(3, 3);
 
             _installCommandView = new InstallPackageView(this);
 
@@ -352,7 +367,6 @@ namespace Microsoft.PythonTools.EnvironmentsList {
             }
         }
 
-
         public bool IsPipInstalled {
             get { return (bool)GetValue(IsPipInstalledProperty); }
             private set { SetValue(IsPipInstalledPropertyKey, value); }
@@ -367,6 +381,19 @@ namespace Microsoft.PythonTools.EnvironmentsList {
 
         public static readonly DependencyProperty IsPipInstalledProperty = IsPipInstalledPropertyKey.DependencyProperty;
 
+        public bool ShowSecurityWarning {
+            get { return (bool)GetValue(ShowSecurityWarningProperty); }
+            private set { SetValue(ShowSecurityWarningPropertyKey, value); }
+        }
+
+        private static readonly DependencyPropertyKey ShowSecurityWarningPropertyKey = DependencyProperty.RegisterReadOnly(
+            "IsPotentialOldSSL",
+            typeof(bool),
+            typeof(PipEnvironmentView),
+            new PropertyMetadata(true)
+        );
+
+        public static readonly DependencyProperty ShowSecurityWarningProperty = ShowSecurityWarningPropertyKey.DependencyProperty;
 
         public string SearchQuery {
             get { return (string)GetValue(SearchQueryProperty); }

--- a/Python/Product/EnvironmentsList/Resources.Designer.cs
+++ b/Python/Product/EnvironmentsList/Resources.Designer.cs
@@ -1014,6 +1014,24 @@ namespace Microsoft.PythonTools.EnvironmentsList {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Learn more.
+        /// </summary>
+        public static string PipExtensionSecurityLearnMore {
+            get {
+                return ResourceManager.GetString("PipExtensionSecurityLearnMore", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Due to security issues, pip may no longer work on this version of Python..
+        /// </summary>
+        public static string PipExtensionSecurityWarning {
+            get {
+                return ResourceManager.GetString("PipExtensionSecurityWarning", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to (unknown).
         /// </summary>
         public static string PipPackageUnknownPackageSpec {

--- a/Python/Product/EnvironmentsList/Resources.Designer.cs
+++ b/Python/Product/EnvironmentsList/Resources.Designer.cs
@@ -1023,7 +1023,7 @@ namespace Microsoft.PythonTools.EnvironmentsList {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Due to security issues, pip may no longer work on this version of Python..
+        ///   Looks up a localized string similar to Due to new security restrictions, installing from the internet may not work on this version of Python..
         /// </summary>
         public static string PipExtensionSecurityWarning {
             get {

--- a/Python/Product/EnvironmentsList/Resources.resx
+++ b/Python/Product/EnvironmentsList/Resources.resx
@@ -423,7 +423,7 @@ The folder will be deleted from disk. This operation cannot be undone.</value>
     <value>Clear search filter</value>
   </data>
   <data name="PipExtensionSecurityWarning" xml:space="preserve">
-    <value>Due to security issues, pip may no longer work on this version of Python.</value>
+    <value>Due to new security restrictions, installing from the internet may not work on this version of Python.</value>
   </data>
   <data name="PipExtensionSecurityLearnMore" xml:space="preserve">
     <value>Learn more</value>

--- a/Python/Product/EnvironmentsList/Resources.resx
+++ b/Python/Product/EnvironmentsList/Resources.resx
@@ -422,6 +422,12 @@ The folder will be deleted from disk. This operation cannot be undone.</value>
   <data name="PipExtensionClearSearchToolTip" xml:space="preserve">
     <value>Clear search filter</value>
   </data>
+  <data name="PipExtensionSecurityWarning" xml:space="preserve">
+    <value>Due to security issues, pip may no longer work on this version of Python.</value>
+  </data>
+  <data name="PipExtensionSecurityLearnMore" xml:space="preserve">
+    <value>Learn more</value>
+  </data>
   <data name="PipExtensionInstallPipToolTip" xml:space="preserve">
     <value>Install the setuptools and pip packages from PyPI. These packages are required to use this panel.</value>
   </data>

--- a/Python/Product/PythonTools/PythonTools/Project/AddVirtualEnvironmentOperation.cs
+++ b/Python/Product/PythonTools/PythonTools/Project/AddVirtualEnvironmentOperation.cs
@@ -106,11 +106,17 @@ namespace Microsoft.PythonTools.Project {
             WriteOutput(Strings.RequirementsTxtInstalling.FormatUI(txt));
             bool success = false;
             try {
+                var ui = new VsPackageManagerUI(_project.Site);
+                if (!pm.IsReady) {
+                    await pm.PrepareAsync(ui, CancellationToken.None);
+                }
                 success = await pm.InstallAsync(
                     PackageSpec.FromArguments("-r " + ProcessOutput.QuoteSingleArgument(txt)),
-                    new VsPackageManagerUI(_project.Site),
+                    ui,
                     CancellationToken.None
                 );
+            } catch (InvalidOperationException ex) {
+                WriteOutput(ex.Message);
             } catch (Exception ex) when (!ex.IsCriticalException()) {
                 WriteOutput(ex.Message);
                 Debug.Fail(ex.ToUnhandledExceptionMessage(GetType()));

--- a/Python/Product/PythonTools/pip_downloader.py
+++ b/Python/Product/PythonTools/pip_downloader.py
@@ -149,9 +149,11 @@ def install_from_ensurepip(ensurepip):
     # We can bootstrap with ensurepip, but then have to upgrade to the latest
     ensurepip.bootstrap(upgrade=True, default_pip=True)
 
-    subprocess.check_call(
-        EXECUTABLE + ["-m", "pip", "install", "-U", "pip", "setuptools", "wheel"]
-    )
+    # Latest version doesn't work on IronPython, so don't upgrade
+    if sys.platform != 'cli':
+        subprocess.check_call(
+            EXECUTABLE + ["-m", "pip", "install", "-U", "pip", "setuptools", "wheel"]
+        )
 
     print('\nInstallation Complete')
     sys.stdout.flush()
@@ -189,6 +191,10 @@ def main():
             'https://go.microsoft.com/fwlink/?LinkId=317602',
             'https://go.microsoft.com/fwlink/?LinkId=313647',
         )
+        return
+
+    if MAJOR_VERSION == (2, 6):
+        install_from_pip('https://go.microsoft.com/fwlink/?linkid=874551')
         return
 
     if MAJOR_VERSION == (3, 1):

--- a/Python/Product/VSInterpreters/PackageManager/CPythonPipPackageManagerProvider.cs
+++ b/Python/Product/VSInterpreters/PackageManager/CPythonPipPackageManagerProvider.cs
@@ -22,22 +22,23 @@ using Microsoft.PythonTools.Infrastructure;
 namespace Microsoft.PythonTools.Interpreter {
     [Export(typeof(IPackageManagerProvider))]
     sealed class CPythonPipPackageManagerProvider : IPackageManagerProvider {
-        class PipCommandsV2 : PipPackageManagerCommands {
+        class PipCommandsV26 : PipPackageManagerCommands {
             public override IEnumerable<string> Base() => new[] { "-c", ProcessOutput.QuoteSingleArgument("import pip; pip.main()") };
             public override IEnumerable<string> Prepare() => new[] { PythonToolsInstallPath.GetFile("pip_downloader.py", typeof(PipPackageManager).Assembly) };
         }
 
-        class PipCommandsV3 : PipPackageManagerCommands {
+        class PipCommandsV27AndLater : PipPackageManagerCommands {
             public override IEnumerable<string> Prepare() => new[] { PythonToolsInstallPath.GetFile("pip_downloader.py", typeof(PipPackageManager).Assembly) };
         }
 
-        private static readonly PipPackageManagerCommands CommandsV2 = new PipCommandsV2();
-        private static readonly PipPackageManagerCommands CommandsV3 = new PipCommandsV3();
+        private static readonly PipPackageManagerCommands CommandsV26 = new PipCommandsV26();
+        private static readonly PipPackageManagerCommands CommandsV27AndLater = new PipCommandsV27AndLater();
 
         public IEnumerable<IPackageManager> GetPackageManagers(IPythonInterpreterFactory factory) {
             IPackageManager pm = null;
             try {
-                pm = new PipPackageManager(factory, factory.Configuration.Version.Major >= 3 ? CommandsV3 : CommandsV2, 1000);
+                var cmds = factory.Configuration.Version >= new Version(2, 6) ? CommandsV27AndLater : CommandsV26;
+                pm = new PipPackageManager(factory, cmds, 1000);
             } catch (NotSupportedException) {
             }
             

--- a/Python/Product/VSInterpreters/PackageManager/CPythonPipPackageManagerProvider.cs
+++ b/Python/Product/VSInterpreters/PackageManager/CPythonPipPackageManagerProvider.cs
@@ -37,7 +37,10 @@ namespace Microsoft.PythonTools.Interpreter {
         public IEnumerable<IPackageManager> GetPackageManagers(IPythonInterpreterFactory factory) {
             IPackageManager pm = null;
             try {
-                var cmds = factory.Configuration.Version >= new Version(2, 6) ? CommandsV27AndLater : CommandsV26;
+                // 'python -m pip', causes this error on Python 2.6: pip is a package and cannot be directly executed
+                // We have to use 'python -m pip' on pip v10, because pip.main() no longer exists
+                // pip v10 is not supported on Python 2.6, so pip.main() is fine there
+                var cmds = factory.Configuration.Version > new Version(2, 6) ? CommandsV27AndLater : CommandsV26;
                 pm = new PipPackageManager(factory, cmds, 1000);
             } catch (NotSupportedException) {
             }

--- a/Python/Product/VSInterpreters/PackageManager/PipPackageManager.cs
+++ b/Python/Product/VSInterpreters/PackageManager/PipPackageManager.cs
@@ -105,7 +105,7 @@ namespace Microsoft.PythonTools.Interpreter {
             if (!IsReady) {
                 await UpdateIsReadyAsync(false, cancellationToken);
                 if (!IsReady) {
-                    throw new InvalidOperationException(Strings.MisconfiguredEnvironment);
+                    throw new InvalidOperationException(Strings.MisconfiguredPip.FormatUI(_factory?.Configuration?.PrefixPath ?? "<null>"));
                 }
             }
         }


### PR DESCRIPTION
Fix #4194 Package management broken on pip v10
Fix #4246 Crash with InvalidOperationException when installing requirements on Python 3.3 venv

On 2.7 and up, use `python -m pip` instead of `python -c 'import pip;pip.main()'` because that's needed for pip v10.

Change pip_downloader so that it fetches the appropriate get_pip.py, since the main one is v10 and doesn't work on 2.6.

Also change pip_downloader to not force upgrade pip on IronPython, because those newer versions of pip don't work for it.

I verified that we still need to use `pip.main()` on 2.6, but that's ok since pip v10 is not supported on that anyway.

The InvalidOperationException crashes were due to pip not being installed, and no one caught the exception. It now ensures that the package manager is 'prepared', before trying to install.

Add an info bar in the package manager to let the user know that pip likely won't work for Python 2.6, 3.1, 3.2. Click learn more to go to https://go.microsoft.com/fwlink/?linkid=874576 which is the packages tab documentation. I'll email Kraig to add a note on this to the docs.

Updated screenshot:
![image](https://user-images.githubusercontent.com/1696845/40450058-4ed843e0-5e8f-11e8-947a-c01b33569bcf.png)
