### PR TITLE
Fixes #4146 Mixed-mode debugger fails on Python 3.7

### DIFF
--- a/Python/Product/Debugger.Concord/Debugger.Concord.csproj
+++ b/Python/Product/Debugger.Concord/Debugger.Concord.csproj
@@ -120,6 +120,7 @@
     <Compile Include="Proxies\DataProxy.cs" />
     <Compile Include="ExpressionEvaluator.cs" />
     <Compile Include="LocalStackWalkingComponent.cs" />
+    <Compile Include="Proxies\Structs\PyRuntimeState.cs" />
     <Compile Include="Proxies\Structs\PyDictObject27.cs" />
     <Compile Include="Proxies\Structs\PyDictObject36.cs" />
     <Compile Include="Proxies\Structs\PyDictObject33.cs" />

--- a/Python/Product/Debugger.Concord/LocalComponent.cs
+++ b/Python/Product/Debugger.Concord/LocalComponent.cs
@@ -171,7 +171,9 @@ namespace Microsoft.PythonTools.Debugger.Concord {
                 var moduleInstance = process.GetNativeRuntimeInstance().GetNativeModuleInstances().Single(mi => mi.UniqueId == ModuleInstanceId);
 
                 if (pyrtInfo.DLLs.CTypes == null && PythonDLLs.CTypesNames.Contains(moduleInstance.Name)) {
-                    moduleInstance.TryLoadSymbols();
+                    if (!moduleInstance.HasSymbols()) {
+                        moduleInstance.TryLoadSymbols();
+                    }
                     if (moduleInstance.HasSymbols()) {
                         pyrtInfo.DLLs.CTypes = moduleInstance;
 
@@ -204,13 +206,17 @@ namespace Microsoft.PythonTools.Debugger.Concord {
                             return;
                         }
 
-                        moduleInstance.TryLoadSymbols();
+                        if (!moduleInstance.HasSymbols()) {
+                            moduleInstance.TryLoadSymbols();
+                        }
                     }
 
                     var symWarnMsg = DkmCustomMessage.Create(process.Connection, process, Guid.Empty, (int)VsPackageMessage.WarnAboutPythonSymbols, moduleInstance.Name, null);
                     symWarnMsg.SendToVsService(Guids.CustomDebuggerEventHandlerGuid, IsBlocking: true);
                 } else if (PythonDLLs.DebuggerHelperNames.Contains(moduleInstance.Name)) {
-                    moduleInstance.TryLoadSymbols();
+                    if (!moduleInstance.HasSymbols()) {
+                        moduleInstance.TryLoadSymbols();
+                    }
 
                     // When the module is reported is loaded, it is not necessarily fully initialized yet - it is possible to get into a state
                     // where its import table is not processed yet. If we register TraceFunc and it gets called by Python when in that state,

--- a/Python/Product/Debugger.Concord/Proxies/Structs/PyInterpreterState.cs
+++ b/Python/Product/Debugger.Concord/Proxies/Structs/PyInterpreterState.cs
@@ -63,7 +63,9 @@ namespace Microsoft.PythonTools.Debugger.Concord.Proxies.Structs {
             public readonly PointerProxy<PyInterpreterState> Proxy;
 
             public InterpHeadHolder(DkmProcess process) {
-                Proxy = process.GetPythonRuntimeInfo().DLLs.Python.GetStaticVariable<PointerProxy<PyInterpreterState>>("interp_head");
+                var pyrtInfo = process.GetPythonRuntimeInfo();
+                Proxy = pyrtInfo.GetRuntimeState()?.interpreters.head
+                    ?? pyrtInfo.DLLs.Python.GetStaticVariable<PointerProxy<PyInterpreterState>>("interp_head");
             }
         }
 

--- a/Python/Product/Debugger.Concord/Proxies/Structs/PyRuntimeState.cs
+++ b/Python/Product/Debugger.Concord/Proxies/Structs/PyRuntimeState.cs
@@ -1,0 +1,88 @@
+﻿// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABLITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.PythonTools.Parsing;
+using Microsoft.VisualStudio.Debugger;
+
+namespace Microsoft.PythonTools.Debugger.Concord.Proxies.Structs {
+    /// <summary>
+    /// In Python 3.7, many global variables were combined into the _PyRuntime struct.
+    /// </summary>
+    [StructProxy(MinVersion = PythonLanguageVersion.V37, StructName = "_PyRuntimeState")]
+    internal class PyRuntimeState : StructProxy {
+        private class Fields {
+            public StructField<BoolProxy> core_initialized;
+            public StructField<BoolProxy> initialized;
+            public StructField<pyinterpreters> interpreters;
+            public StructField<ceval_runtime_state> ceval;
+        }
+
+        private readonly Fields _fields;
+
+        public PyRuntimeState(DkmProcess process, ulong address)
+            : base(process, address) {
+            InitializeStruct(this, out _fields);
+        }
+
+        public BoolProxy core_initialized => GetFieldProxy(_fields.core_initialized);
+        public BoolProxy initialized => GetFieldProxy(_fields.initialized);
+        public pyinterpreters interpreters => GetFieldProxy(_fields.interpreters);
+        public ceval_runtime_state ceval => GetFieldProxy(_fields.ceval);
+
+
+        [StructProxy(MinVersion = PythonLanguageVersion.V37, StructName = "pyinterpreters")]
+        public class pyinterpreters : StructProxy {
+            private class Fields {
+                public StructField<PointerProxy<PyInterpreterState>> head;
+                public StructField<PointerProxy<PyInterpreterState>> main;
+            }
+
+            private readonly Fields _fields;
+
+            public pyinterpreters(DkmProcess process, ulong address)
+                : base(process, address) {
+                InitializeStruct(this, out _fields);
+            }
+
+            public PointerProxy<PyInterpreterState> head => GetFieldProxy(_fields.head);
+            public PointerProxy<PyInterpreterState> main => GetFieldProxy(_fields.main);
+        }
+
+        [StructProxy(MinVersion = PythonLanguageVersion.V37, StructName = "_ceval_runtime_state")]
+        public class ceval_runtime_state : StructProxy {
+            private class Fields {
+                public StructField<Int32Proxy> recursion_limit;
+                public StructField<Int32Proxy> tracing_possible;
+            }
+
+            private readonly Fields _fields;
+
+            public ceval_runtime_state(DkmProcess process, ulong address)
+                : base(process, address) {
+                InitializeStruct(this, out _fields);
+            }
+
+            public Int32Proxy recursion_limit => GetFieldProxy(_fields.recursion_limit);
+            public Int32Proxy tracing_possible => GetFieldProxy(_fields.tracing_possible);
+        }
+    }
+
+}

--- a/Python/Product/Debugger.Concord/PythonRuntimeInfo.cs
+++ b/Python/Product/Debugger.Concord/PythonRuntimeInfo.cs
@@ -16,6 +16,7 @@
 
 using System.Diagnostics;
 using System.Text.RegularExpressions;
+using Microsoft.PythonTools.Debugger.Concord.Proxies.Structs;
 using Microsoft.PythonTools.Parsing;
 using Microsoft.VisualStudio.Debugger;
 using Microsoft.VisualStudio.Debugger.Native;
@@ -84,6 +85,13 @@ namespace Microsoft.PythonTools.Debugger.Concord {
 
         public PythonRuntimeInfo() {
             DLLs = new PythonDLLs(this);
+        }
+
+        public PyRuntimeState GetRuntimeState() {
+            if (LanguageVersion < PythonLanguageVersion.V37) {
+                return null;
+            }
+            return DLLs.Python.GetStaticVariable<PyRuntimeState>("_PyRuntime");
         }
     }
 


### PR DESCRIPTION
Fixes #4146 Mixed-mode debugger fails on Python 3.7
Updates data structures to enable Python 3.7 debugging