### PR TITLE
Fixes IronPython intellisense

### DIFF
--- a/Python/Product/Analysis/Interpreter/Ast/AstPythonInterpreter.cs
+++ b/Python/Product/Analysis/Interpreter/Ast/AstPythonInterpreter.cs
@@ -57,7 +57,6 @@ namespace Microsoft.PythonTools.Interpreter.Ast {
             _factory.ImportableModulesChanged += Factory_ImportableModulesChanged;
             _modules = new ConcurrentDictionary<string, IPythonModule>();
             _builtinTypes = new Dictionary<BuiltinTypeId, IPythonType>();
-            BuiltinModuleName = BuiltinTypeId.Unknown.GetModuleName(_factory.LanguageVersion);
             _noneType = new AstPythonBuiltinType("NoneType", BuiltinTypeId.NoneType);
             _builtinTypes[BuiltinTypeId.NoneType] = _noneType;
             _builtinTypes[BuiltinTypeId.Unknown] = new AstPythonBuiltinType("Unknown", BuiltinTypeId.Unknown);
@@ -85,7 +84,7 @@ namespace Microsoft.PythonTools.Interpreter.Ast {
 
         public IModuleContext CreateModuleContext() => this;
         public IPythonInterpreterFactory Factory => _factory;
-        public string BuiltinModuleName { get; }
+        public string BuiltinModuleName => _factory.BuiltinModuleName;
 
         public IPythonType GetBuiltinType(BuiltinTypeId id) {
             if (id < 0 || id > BuiltinTypeIdExtensions.LastTypeId) {
@@ -142,6 +141,46 @@ namespace Microsoft.PythonTools.Interpreter.Ast {
             return ussp;
         }
 
+        private void ImportedFromUserSearchPath(string name) {
+            lock (_userSearchPathsLock) {
+                if (_userSearchPathImported == null) {
+                    _userSearchPathImported = new HashSet<string>();
+                }
+                _userSearchPathImported.Add(name);
+            }
+        }
+
+        private async Task<ModulePath?> FindModuleInUserSearchPathAsync(string name) {
+            var searchPaths = _userSearchPaths;
+            var packages = await GetUserSearchPathPackagesAsync();
+
+            if (searchPaths == null) {
+                return null;
+            }
+
+            int i = name.IndexOf('.');
+            var firstBit = i < 0 ? name : name.Remove(i);
+            string searchPath;
+
+            ModulePath mp;
+
+            if (packages != null && packages.TryGetValue(firstBit, out searchPath) && !string.IsNullOrEmpty(searchPath)) {
+                if (ModulePath.FromBasePathAndName_NoThrow(searchPath, name, out mp)) {
+                    ImportedFromUserSearchPath(name);
+                    return mp;
+                }
+            }
+
+            foreach (var sp in searchPaths.MaybeEnumerate()) {
+                if (ModulePath.FromBasePathAndName_NoThrow(sp, name, out mp)) {
+                    ImportedFromUserSearchPath(name);
+                    return mp;
+                }
+            }
+
+            return null;
+        }
+
         public IList<string> GetModuleNames() {
             var ussp = GetUserSearchPathPackagesAsync().WaitAndUnwrapExceptions();
             var ssp = _factory.GetImportableModulesAsync().WaitAndUnwrapExceptions();
@@ -161,64 +200,7 @@ namespace Microsoft.PythonTools.Interpreter.Ast {
             return names.MaybeEnumerate().ToArray();
         }
 
-        private ModulePath? FindModuleInSearchPath(
-            IEnumerable<string> searchPaths,
-            IReadOnlyDictionary<string, string> packages,
-            string name
-        ) {
-            if (searchPaths == null) {
-                return null;
-            }
-
-            try {
-                int i = name.IndexOf('.');
-                var firstBit = i < 0 ? name : name.Remove(i);
-                string searchPath;
-
-                ModulePath mp;
-
-                if (packages != null && packages.TryGetValue(firstBit, out searchPath) && !string.IsNullOrEmpty(searchPath)) {
-                    if (ModulePath.FromBasePathAndName_NoThrow(searchPath, name, out mp)) {
-                        return mp;
-                    }
-                }
-
-                foreach (var sp in searchPaths.MaybeEnumerate()) {
-                    if (ModulePath.FromBasePathAndName_NoThrow(sp, name, out mp)) {
-                        return mp;
-                    }
-                }
-            } catch (Exception ex) {
-                _log?.Log(TraceLevel.Error, "Exception", ex.ToString());
-                _log?.Flush();
-            }
-
-            return null;
-        }
-
         public IPythonModule ImportModule(string name) {
-            IPythonModule module = null;
-            bool needRetry = true;
-            for (int retries = 5; retries > 0 && needRetry; --retries) {
-                module = ImportModuleOrRetry(name, out needRetry);
-            }
-            if (needRetry) {
-                // Never succeeded, so just log the error and fail
-                _log?.Log(TraceLevel.Error, "RetryImport", name);
-                return null;
-            }
-            return module;
-        }
-
-        private IPythonModule ImportModuleOrRetry(string name, out bool retry) {
-            retry = false;
-            if (string.IsNullOrEmpty(name)) {
-                return null;
-            }
-
-            Debug.Assert(!name.EndsWithOrdinal("."), $"{name} should not end with '.'");
-
-            // Handle builtins explicitly
             if (name == BuiltinModuleName) {
                 if (_builtinModule == null) {
                     _modules[BuiltinModuleName] = _builtinModule = new AstBuiltinsPythonModule(_factory.LanguageVersion);
@@ -227,176 +209,34 @@ namespace Microsoft.PythonTools.Interpreter.Ast {
                 return _builtinModule;
             }
 
-            IPythonModule mod;
-            // Return any existing module
-            if (_modules.TryGetValue(name, out mod) && mod != null) {
-                if (mod is SentinelModule smod) {
-                    // If we are importing this module on another thread, allow
-                    // time for it to complete. This does not block if we are
-                    // importing on the current thread or the module is not
-                    // really being imported.
-                    var newMod = smod.WaitForImport(5000);
-                    if (newMod is SentinelModule) {
-                        _log?.Log(TraceLevel.Warning, "RecursiveImport", name);
-                        mod = newMod;
-                    } else if (newMod == null) {
-                        _log?.Log(TraceLevel.Warning, "ImportTimeout", name);
-                    } else {
-                        mod = newMod;
-                    }
+            IPythonModule module = null;
+            var ctxt = new AstPythonInterpreterFactory.TryImportModuleContext {
+                Interpreter = this,
+                ModuleCache = _modules,
+                BuiltinModule = _builtinModule,
+                FindModuleInUserSearchPathAsync = FindModuleInUserSearchPathAsync
+            };
+
+            for (int retries = 5; retries > 0; --retries) {
+                switch (_factory.TryImportModule(name, out module, ctxt)) {
+                    case AstPythonInterpreterFactory.TryImportModuleResult.Success:
+                        return module;
+                    case AstPythonInterpreterFactory.TryImportModuleResult.ModuleNotFound:
+                        _log?.Log(TraceLevel.Info, "ImportNotFound", name);
+                        return null;
+                    case AstPythonInterpreterFactory.TryImportModuleResult.NeedRetry:
+                    case AstPythonInterpreterFactory.TryImportModuleResult.Timeout:
+                        break;
+                    case AstPythonInterpreterFactory.TryImportModuleResult.NotSupported:
+                        _log?.Log(TraceLevel.Error, "ImportNotSupported", name);
+                        return null;
                 }
-                return mod;
             }
-
-            // Set up a sentinel so we can detect recursive imports
-            var sentinalValue = new SentinelModule(name, true);
-            if (!_modules.TryAdd(name, sentinalValue)) {
-                // Try to get the new module, in case we raced with a .Clear()
-                if (_modules.TryGetValue(name, out mod) && !(mod is SentinelModule)) {
-                    return mod;
-                }
-                // If we reach here, the race is too complicated to recover
-                // from. Signal the caller to try importing again.
-                _log?.Log(TraceLevel.Warning, "RetryImport", name);
-                retry = true;
-                return null;
-            }
-
-            // Do normal searches
-            if (!string.IsNullOrEmpty(Factory.Configuration?.InterpreterPath)) {
-                var importTask = ImportFromSearchPathsAsync(name);
-                if (importTask.Wait(2000)) {
-                    mod = importTask.Result;
-                } else {
-                    _log?.Log(TraceLevel.Error, "ImportTimeout", name, "ImportFromSearchPaths");
-                    mod = null;
-                }
-                mod = mod ?? ImportFromBuiltins(name);
-            }
-            if (mod == null) {
-                mod = ImportFromCache(name);
-            }
-
-            // Replace our sentinel, or if we raced, get the current
-            // value and abandon the one we just created.
-            if (!_modules.TryUpdate(name, mod, sentinalValue)) {
-                // Try to get the new module, in case we raced
-                if (_modules.TryGetValue(name, out mod) && !(mod is SentinelModule)) {
-                    return mod;
-                }
-                // If we reach here, the race is too complicated to recover
-                // from. Signal the caller to try importing again.
-                _log?.Log(TraceLevel.Warning, "RetryImport", name);
-                retry = true;
-                return null;
-            }
-
-            sentinalValue.Complete(mod);
-            sentinalValue.Dispose();
-            return mod;
-        }
-
-        private IPythonModule ImportFromCache(string name) {
-            if (string.IsNullOrEmpty(_factory.CreationOptions.DatabasePath)) {
-                return null;
-            }
-
-            if (File.Exists(_factory.GetCacheFilePath("python.{0}.pyi".FormatInvariant(name)))) {
-                return new AstCachedPythonModule(name, "python.{0}".FormatInvariant(name));
-            } 
-            if (File.Exists(_factory.GetCacheFilePath("python._{0}.pyi".FormatInvariant(name)))) {
-                return new AstCachedPythonModule(name, "python._{0}".FormatInvariant(name));
-            } 
-            if (File.Exists(_factory.GetCacheFilePath("{0}.pyi".FormatInvariant(name)))) {
-                return new AstCachedPythonModule(name, name);
-            } 
-
+            // Never succeeded, so just log the error and fail
+            _log?.Log(TraceLevel.Error, "RetryImport", name);
             return null;
         }
 
-        private IPythonModule ImportFromBuiltins(string name) {
-            if (_builtinModuleNames == null && _builtinModule != null) {
-                var bmn = (_builtinModule as AstBuiltinsPythonModule).GetAnyMember("__builtin_module_names__") as AstPythonStringLiteral;
-                _builtinModuleNames = bmn?.Value?.Split(',');
-            }
-            if (_builtinModuleNames == null || !_builtinModuleNames.Contains(name)) {
-                return null;
-            }
-
-            _log?.Log(TraceLevel.Info, "ImportBuiltins", name, _factory.FastRelativePath(Factory.Configuration.InterpreterPath));
-
-            try {
-                return new AstBuiltinPythonModule(name, Factory.Configuration.InterpreterPath);
-            } catch (ArgumentNullException) {
-                Debug.Fail("No factory means cannot import builtin modules");
-                return null;
-            }
-        }
-
-        private async Task<IPythonModule> ImportFromSearchPathsAsync(string name) {
-            try {
-                return await ImportFromSearchPathsAsyncWorker(name).ConfigureAwait(false);
-            } catch (Exception ex) {
-                _log?.Log(TraceLevel.Error, "ImportFromSearchPathsAsync", ex.ToString());
-                throw;
-            }
-        }
-        private async Task<IPythonModule> ImportFromSearchPathsAsyncWorker(string name) {
-            var mmp = FindModuleInSearchPath(
-                _userSearchPaths,
-                await GetUserSearchPathPackagesAsync().ConfigureAwait(false),
-                name
-            );
-
-            if (mmp.HasValue) {
-                lock (_userSearchPathsLock) {
-                    if (_userSearchPathImported == null) {
-                        _userSearchPathImported = new HashSet<string>();
-                    }
-                    _userSearchPathImported.Add(name);
-                }
-            } else {
-                _log?.Log(TraceLevel.Verbose, "FindModule", name, "system");
-                var sp = await _factory.GetSearchPathsAsync().ConfigureAwait(false);
-                _log?.Log(TraceLevel.Verbose, "FindModule", name, "system", string.Join(", ", sp));
-                var mods = await _factory.GetImportableModulesAsync().ConfigureAwait(false);
-                mmp = FindModuleInSearchPath(sp, mods, name);
-            }
-
-            if (!mmp.HasValue) {
-                _log?.Log(TraceLevel.Verbose, "ImportNotFound", name);
-                return null;
-            }
-
-            var mp = mmp.Value;
-
-#if USE_TYPESHED
-            lock (_typeShedPathsLock) {
-                if (_typeShedPaths == null) {
-                    var typeshed = FindModuleInSearchPath(_factory.GetSearchPaths(), _factory.GetImportableModules(), "typeshed");
-                    if (typeshed.HasValue) {
-                        _typeShedPaths = GetTypeShedPaths(PathUtils.GetParent(typeshed.Value.SourceFile)).ToArray();
-                    } else {
-                        _typeShedPaths = Array.Empty<string>();
-                    }
-                }
-                if (_typeShedPaths.Any()) {
-                    var mtsp = FindModuleInSearchPath(_typeShedPaths, null, mp.FullName);
-                    if (mtsp.HasValue) {
-                        mp = mtsp.Value;
-                    }
-                }
-            }
-#endif
-
-            if (mp.IsCompiled) {
-                _log?.Log(TraceLevel.Verbose, "ImportScraped", mp.FullName, _factory.FastRelativePath(mp.SourceFile));
-                return new AstScrapedPythonModule(mp.FullName, mp.SourceFile);
-            }
-
-            _log?.Log(TraceLevel.Verbose, "Import", mp.FullName, _factory.FastRelativePath(mp.SourceFile));
-            return AstPythonModule.FromFile(this, mp.SourceFile, _factory.LanguageVersion, mp.FullName);
-        }
 
         public void Initialize(PythonAnalyzer state) {
             if (_analyzer != null) {
@@ -459,26 +299,5 @@ namespace Microsoft.PythonTools.Interpreter.Ast {
 
             yield break;
         }
-
-        private IEnumerable<string> GetTypeShedPaths(string path) {
-            var version = _factory.Configuration.Version;
-            var stdlib = Path.Combine(path, "stdlib");
-            var thirdParty = Path.Combine(path, "third_party");
-
-            foreach (var subdir in new[] { version.ToString(), version.Major.ToString(), "2and3" }) {
-                var candidate = Path.Combine(stdlib, subdir);
-                if (Directory.Exists(candidate)) {
-                    yield return candidate;
-                }
-            }
-
-            foreach (var subdir in new[] { version.ToString(), version.Major.ToString(), "2and3" }) {
-                var candidate = Path.Combine(thirdParty, subdir);
-                if (Directory.Exists(candidate)) {
-                    yield return candidate;
-                }
-            }
-        }
-
     }
 }

--- a/Python/Product/Analysis/Interpreter/Ast/AstPythonModule.cs
+++ b/Python/Product/Analysis/Interpreter/Ast/AstPythonModule.cs
@@ -26,19 +26,14 @@ using Microsoft.PythonTools.Parsing;
 using Microsoft.PythonTools.Parsing.Ast;
 
 namespace Microsoft.PythonTools.Interpreter.Ast {
-    sealed class AstPythonModule : IPythonModule, IProjectEntry, ILocatedMember {
-        private readonly IPythonInterpreter _interpreter;
-        private readonly Dictionary<object, object> _properties;
-        private readonly List<string> _childModules;
-        private readonly Dictionary<string, IMember> _members;
-        private bool _foundChildModules;
-        private string _documentation = string.Empty;
-
+    public static class PythonModuleLoader {
         public static IPythonModule FromFile(
             IPythonInterpreter interpreter,
             string sourceFile,
             PythonLanguageVersion langVersion
-        ) => FromFile(interpreter, sourceFile, langVersion, null);
+        ) {
+            return FromFile(interpreter, sourceFile, langVersion, null);
+        }
 
         public static IPythonModule FromFile(
             IPythonInterpreter interpreter,
@@ -51,19 +46,14 @@ namespace Microsoft.PythonTools.Interpreter.Ast {
             }
         }
 
-        // Avoid hitting the filesystem, but exclude non-importable
-        // paths. Ideally, we'd stop at the first path that's a known
-        // search path, except we don't know search paths here.
-        private static bool IsPackageCheck(string path) {
-            return ModulePath.IsImportable(PathUtils.GetFileName(path.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)));
-        }
-
         public static IPythonModule FromStream(
             IPythonInterpreter interpreter,
             Stream sourceFile,
             string fileName,
             PythonLanguageVersion langVersion
-        ) => FromStream(interpreter, sourceFile, fileName, langVersion, null);
+        ) {
+            return FromStream(interpreter, sourceFile, fileName, langVersion, null);
+        }
 
         public static IPythonModule FromStream(
             IPythonInterpreter interpreter,
@@ -85,6 +75,22 @@ namespace Microsoft.PythonTools.Interpreter.Ast {
                 fileName
             );
         }
+
+        // Avoid hitting the filesystem, but exclude non-importable
+        // paths. Ideally, we'd stop at the first path that's a known
+        // search path, except we don't know search paths here.
+        private static bool IsPackageCheck(string path) {
+            return ModulePath.IsImportable(PathUtils.GetFileName(path.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)));
+        }
+    }
+
+    sealed class AstPythonModule : IPythonModule, IProjectEntry, ILocatedMember {
+        private readonly IPythonInterpreter _interpreter;
+        private readonly Dictionary<object, object> _properties;
+        private readonly List<string> _childModules;
+        private readonly Dictionary<string, IMember> _members;
+        private bool _foundChildModules;
+        private string _documentation = string.Empty;
 
         internal AstPythonModule() {
             Name = string.Empty;
@@ -154,7 +160,7 @@ namespace Microsoft.PythonTools.Interpreter.Ast {
         public bool IsAnalyzed => true;
         public void Analyze(CancellationToken cancel) { }
 
-        private static IEnumerable<string> GetChildModules(string filePath, string prefix, AstPythonInterpreter interpreter) {
+        private static IEnumerable<string> GetChildModules(string filePath, string prefix, IPythonInterpreter interpreter) {
             if (interpreter == null || string.IsNullOrEmpty(filePath)) {
                 yield break;
             }
@@ -178,7 +184,7 @@ namespace Microsoft.PythonTools.Interpreter.Ast {
                     // We've already checked whether this module may have children
                     // so don't worry about checking again here.
                     _foundChildModules = true;
-                    foreach (var m in GetChildModules(FilePath, Name, _interpreter as AstPythonInterpreter)) {
+                    foreach (var m in GetChildModules(FilePath, Name, _interpreter)) {
                         _members[m] = new AstNestedPythonModule(_interpreter, m, new[] { Name + "." + m });
                         _childModules.Add(m);
                     }

--- a/Python/Product/Analyzer/Interpreter/LegacyDB/CPythonInterpreter.cs
+++ b/Python/Product/Analyzer/Interpreter/LegacyDB/CPythonInterpreter.cs
@@ -222,7 +222,7 @@ namespace Microsoft.PythonTools.Interpreter.LegacyDB {
             if (package.IsNativeExtension || package.IsCompiled) {
                 db.LoadExtensionModule(package);
             } else {
-                db.AddModule(package.FullName, AstPythonModule.FromFile(
+                db.AddModule(package.FullName, PythonModuleLoader.FromFile(
                     this,
                     package.SourceFile,
                     _factory.GetLanguageVersion(),
@@ -319,7 +319,7 @@ namespace Microsoft.PythonTools.Interpreter.LegacyDB {
                 if (sourceStream == null) {
                     return null;
                 }
-                return AstPythonModule.FromStream(
+                return PythonModuleLoader.FromStream(
                     this,
                     sourceStream,
                     PathUtils.GetAbsoluteFilePath(zipFile, name.SourceFile),

--- a/Python/Product/IronPython/Interpreter/IronPythonModule.cs
+++ b/Python/Product/IronPython/Interpreter/IronPythonModule.cs
@@ -48,7 +48,7 @@ namespace Microsoft.IronPythonTools.Interpreter {
         public void Imported(IModuleContext context) {
             if (Name == "clr") {
                 ((IronPythonModuleContext)context).ShowClr = true;
-            } else if (Name == "wpf") {
+            } else if (Name == "_wpf") {
                 AddWpfReferences();
             }
         }

--- a/Python/Product/IronPython/Interpreter/RemoteInterpreterProxy.cs
+++ b/Python/Product/IronPython/Interpreter/RemoteInterpreterProxy.cs
@@ -29,8 +29,8 @@ namespace Microsoft.IronPythonTools.Interpreter {
         private readonly RemoteInterpreter _remoteInterpreter;
 
         public RemoteInterpreterProxy() {
-            AppDomain.CurrentDomain.AssemblyResolve += new ResolveEventHandler(CurrentDomain_AssemblyResolve);
-            AppDomain.CurrentDomain.TypeResolve += new ResolveEventHandler(CurrentDomain_AssemblyResolve);
+            //AppDomain.CurrentDomain.AssemblyResolve += new ResolveEventHandler(CurrentDomain_AssemblyResolve);
+            //AppDomain.CurrentDomain.TypeResolve += new ResolveEventHandler(CurrentDomain_AssemblyResolve);
             _remoteInterpreter = new RemoteInterpreter();
         }
 

--- a/Python/Product/IronPython/Interpreter/RemoteInterpreterProxy.cs
+++ b/Python/Product/IronPython/Interpreter/RemoteInterpreterProxy.cs
@@ -29,16 +29,8 @@ namespace Microsoft.IronPythonTools.Interpreter {
         private readonly RemoteInterpreter _remoteInterpreter;
 
         public RemoteInterpreterProxy() {
-            //AppDomain.CurrentDomain.AssemblyResolve += new ResolveEventHandler(CurrentDomain_AssemblyResolve);
-            //AppDomain.CurrentDomain.TypeResolve += new ResolveEventHandler(CurrentDomain_AssemblyResolve);
             _remoteInterpreter = new RemoteInterpreter();
         }
-
-        System.Reflection.Assembly CurrentDomain_AssemblyResolve(object sender, ResolveEventArgs args) {
-            Debug.WriteLine("AssemblyResolve");
-            return null;
-        }
-
 
         internal IEnumerable<string> GetBuiltinModuleNames() {
             return _remoteInterpreter.GetBuiltinModuleNames();

--- a/Python/Product/IronPythonResolver/Resolver.cs
+++ b/Python/Product/IronPythonResolver/Resolver.cs
@@ -37,15 +37,10 @@ namespace Microsoft.IronPythonTools.Interpreter {
             return null;
         }
 
-        private Assembly domain_TypeResolve(object sender, ResolveEventArgs args) {
-            return domain_AssemblyResolve(sender, args);
-        }
-
         internal static void Initialize(string[] args) {
             if (args.Length > 0 && Directory.Exists(args[0])) {
                 var resolver = new IronPythonResolver(args[0]);
                 AppDomain.CurrentDomain.AssemblyResolve += resolver.domain_AssemblyResolve;
-                AppDomain.CurrentDomain.TypeResolve += resolver.domain_TypeResolve;
             }
         }
 

--- a/Python/Product/TestAdapter.Analysis/TestAnalysisExtension.cs
+++ b/Python/Product/TestAdapter.Analysis/TestAnalysisExtension.cs
@@ -254,7 +254,7 @@ namespace Microsoft.PythonTools.TestAdapter {
         public IEnumerable<TestCaseInfo> GetTestCasesFromAst(string path) {
             IPythonModule module;
             try {
-                module = AstPythonModule.FromFile(_analyzer.Interpreter, path, _analyzer.LanguageVersion);
+                module = PythonModuleLoader.FromFile(_analyzer.Interpreter, path, _analyzer.LanguageVersion);
             } catch (Exception ex) when (!ex.IsCriticalException()) {
                 return Enumerable.Empty<TestCaseInfo>();
             }

--- a/Python/Tests/Analysis/AnalysisTest.Perf.cs
+++ b/Python/Tests/Analysis/AnalysisTest.Perf.cs
@@ -18,17 +18,13 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.Linq;
 using System.Text;
 using System.Threading;
 using Microsoft.PythonTools.Analysis;
 using Microsoft.PythonTools.Infrastructure;
-using Microsoft.PythonTools.Intellisense;
 using Microsoft.PythonTools.Interpreter;
 using Microsoft.PythonTools.Parsing;
 using Microsoft.PythonTools.Parsing.Ast;
-using Microsoft.Scripting;
-using Microsoft.VisualStudioTools;
 using TestUtilities;
 
 namespace AnalysisTests {
@@ -289,39 +285,6 @@ import System
             Trace.TraceInformation("Analyze: {0} ms", start4 - start3);
             return projectState;
         }
-
-        internal sealed class FileTextContentProvider : TextContentProvider {
-            private readonly FileStreamContentProvider _provider;
-
-            public FileTextContentProvider(FileStreamContentProvider fileStreamContentProvider) {
-                _provider = fileStreamContentProvider;
-            }
-
-            public override SourceCodeReader GetReader() {
-                return new SourceCodeReader(new StreamReader(_provider.GetStream(), Encoding.ASCII), Encoding.ASCII);
-            }
-        }
-
-        internal sealed class FileStreamContentProvider : StreamContentProvider {
-            private readonly string _path;
-
-            internal string Path {
-                get { return _path; }
-            }
-
-            #region Construction
-
-            internal FileStreamContentProvider(string path) {
-                _path = path;
-            }
-
-            #endregion
-
-            public override Stream GetStream() {
-                return new FileStream(_path, FileMode.Open, FileAccess.Read, FileShare.Read);
-            }
-        }
-
 
         private static void CollectFiles(string dir, List<string> files, ISet<string> excludeDirectories = null) {
             foreach (string file in Directory.GetFiles(dir)) {

--- a/Python/Tests/Analysis/AnalysisTest.cs
+++ b/Python/Tests/Analysis/AnalysisTest.cs
@@ -32,7 +32,6 @@ using Microsoft.PythonTools.Intellisense;
 using Microsoft.PythonTools.Interpreter;
 using Microsoft.PythonTools.Parsing;
 using Microsoft.PythonTools.Parsing.Ast;
-using Microsoft.Scripting.Utils;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using TestUtilities;
 using TestUtilities.Python;

--- a/Python/Tests/Analysis/AnalysisTests.csproj
+++ b/Python/Tests/Analysis/AnalysisTests.csproj
@@ -42,15 +42,6 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Microsoft.Dynamic">
-      <Private>true</Private>
-    </Reference>
-    <Reference Include="Microsoft.Scripting">
-      <Private>true</Private>
-    </Reference>
-    <Reference Include="Microsoft.Scripting.Metadata">
-      <Private>true</Private>
-    </Reference>
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="System" />
     <Reference Include="System.Core">

--- a/Python/Tests/Analysis/AstAnalysisTests.cs
+++ b/Python/Tests/Analysis/AstAnalysisTests.cs
@@ -386,7 +386,7 @@ R_A3 = R_A1.r_A()");
             if (!Path.IsPathRooted(path)) {
                 path = TestData.GetPath(Path.Combine("TestData", "AstAnalysis", path));
             }
-            return AstPythonModule.FromFile(interpreter, path, version);
+            return PythonModuleLoader.FromFile(interpreter, path, version);
         }
 
         [TestMethod, Priority(0)]

--- a/Python/Tests/Core/PythonToolsTests.csproj
+++ b/Python/Tests/Core/PythonToolsTests.csproj
@@ -41,27 +41,12 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="IronPython">
-      <Private>true</Private>
-    </Reference>
-    <Reference Include="IronPython.Modules">
-      <Private>true</Private>
-    </Reference>
     <Reference Include="Microsoft.Build, Version=$(MicrosoftBuildAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
     <Reference Include="Microsoft.Build.Framework, Version=$(MicrosoftBuildAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Microsoft.Dynamic">
-      <Private>true</Private>
-    </Reference>
     <Reference Include="Microsoft.VisualStudio.InteractiveWindow" />
     <Reference Include="Microsoft.VisualStudio.Utilities.Internal, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.VisualStudio.VsInteractiveWindow" />
-    <Reference Include="Microsoft.Scripting">
-      <Private>true</Private>
-    </Reference>
-    <Reference Include="Microsoft.Scripting.Metadata">
-      <Private>true</Private>
-    </Reference>
     <Reference Include="Microsoft.VisualStudio.ComponentModelHost, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.VisualStudio.Composition, Version=15.6.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.VisualStudio.CoreUtility, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" Private="True" />

--- a/Python/Tests/IronPython/IronPythonAnalysis.cs
+++ b/Python/Tests/IronPython/IronPythonAnalysis.cs
@@ -15,9 +15,9 @@
 // permissions and limitations under the License.
 
 using System.Runtime.Remoting;
-using Microsoft.PythonTools.Parsing;
 using Microsoft.IronPythonTools.Interpreter;
 using Microsoft.PythonTools.Interpreter;
+using Microsoft.PythonTools.Parsing;
 using TestUtilities.Python;
 
 namespace IronPythonTests {

--- a/Python/Tests/IronPython/IronPythonAnalysisTest.cs
+++ b/Python/Tests/IronPython/IronPythonAnalysisTest.cs
@@ -23,7 +23,6 @@ using System.Reflection;
 using System.Runtime.Remoting;
 using System.Threading;
 using AnalysisTests;
-using IronPython.Runtime;
 using Microsoft.IronPythonTools.Interpreter;
 using Microsoft.PythonTools.Analysis;
 using Microsoft.PythonTools.Analysis.Values;
@@ -409,7 +408,7 @@ def g():
 ";
             var entry = ProcessText(text);
 
-            AssertUtil.ContainsExactly(entry.GetDescriptions("System", 1), "built-in module System");
+            AssertUtil.ContainsExactly(entry.GetDescriptions("System", 1), "System");
             AssertUtil.ContainsExactly(entry.GetDescriptions("System.String.Length", 1), "property of type int");
             AssertUtil.ContainsExactly(entry.GetDescriptions("System.Environment.CurrentDirectory", 1), "str");
             AssertUtil.ContainsExactly(entry.GetDescriptions("e", 1), "ArrayList");
@@ -420,7 +419,7 @@ def g():
             //AssertUtil.ContainsExactly(entry.GetVariableDescriptionsByIndex("\"abc\".Length", 1), "int");
             //AssertUtil.ContainsExactly(entry.GetVariableDescriptionsByIndex("c.Length", 1), "int");
             //AssertUtil.ContainsExactly(entry.GetVariableDescriptionsByIndex("System.StringSplitOptions.RemoveEmptyEntries", 0), "field of type StringSplitOptions");
-            AssertUtil.ContainsExactly(entry.GetDescriptions("g", 1), "def test-module.g() -> built-in module System");    // return info could be better
+            AssertUtil.ContainsExactly(entry.GetDescriptions("g", 1), "test-module.g() -> System");    // return info could be better
             //AssertUtil.ContainsExactly(entry.GetVariableDescriptionsByIndex("System.AppDomain.DomainUnload", 1), "event of type System.EventHandler");
         }
 
@@ -452,7 +451,7 @@ w = Window()
 w.Activate
 ");
 
-            var result = entry.GetValue<AnalysisValue>("w.Activate", 1);
+            var result = entry.GetValue<AnalysisValue>("w.Activate", 0);
             Console.WriteLine("Docstring was: <{0}>", result.Documentation);
             Assert.IsFalse(string.IsNullOrWhiteSpace(result.Documentation));
         }
@@ -510,17 +509,5 @@ from System.Windows.Media import Colors
                 pyEntry.Analyze(CancellationToken.None);
             }
         }
-
-        private static string[] GetMembers(object obj, bool showClr) {
-            var dir = showClr ? ClrModule.DirClr(obj) : ClrModule.Dir(obj);
-            int len = dir.__len__();
-            string[] result = new string[len];
-            for (int i = 0; i < len; i++) {
-                Assert.IsTrue(dir[i] is string);
-                result[i] = dir[i] as string;
-            }
-            return result;
-        }
-
     }
 }

--- a/Python/Tests/IronPython/IronPythonDatabaseTest.cs
+++ b/Python/Tests/IronPython/IronPythonDatabaseTest.cs
@@ -22,7 +22,6 @@ using Microsoft.PythonTools.Parsing;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using TestUtilities;
 using TestUtilities.Mocks;
-using TestUtilities.Python;
 
 namespace IronPythonTests {
     [TestClass]
@@ -32,7 +31,7 @@ namespace IronPythonTests {
             AssertListener.Initialize();
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(2)]
         public void InvalidIronPythonDatabase() {
             using (var db = MockCompletionDB.Create(PythonLanguageVersion.V27,
                 // __bad_builtin__ is missing str

--- a/Python/Tests/IronPython/IronPythonTests.csproj
+++ b/Python/Tests/IronPython/IronPythonTests.csproj
@@ -41,26 +41,11 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="IronPython">
-      <Private>true</Private>
-    </Reference>
-    <Reference Include="IronPython.Modules">
-      <Private>true</Private>
-    </Reference>
     <Reference Include="Microsoft.Build, Version=$(MicrosoftBuildAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
     <Reference Include="Microsoft.Build.Framework, Version=$(MicrosoftBuildAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Microsoft.Dynamic">
-      <Private>true</Private>
-    </Reference>
     <Reference Include="Microsoft.VisualStudio.InteractiveWindow" />
     <Reference Include="Microsoft.VisualStudio.VsInteractiveWindow" />
-    <Reference Include="Microsoft.Scripting">
-      <Private>true</Private>
-    </Reference>
-    <Reference Include="Microsoft.Scripting.Metadata">
-      <Private>true</Private>
-    </Reference>
     <Reference Include="Microsoft.VisualStudio.CoreUtility, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.VisualStudio.Language.Intellisense, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.VisualStudio.Language.StandardClassification, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />

--- a/Python/Tests/IronPython/ReplEvaluatorTests.cs
+++ b/Python/Tests/IronPython/ReplEvaluatorTests.cs
@@ -15,19 +15,13 @@
 // permissions and limitations under the License.
 
 using System.Diagnostics;
-using System.Linq;
-using System.Text.RegularExpressions;
 using System.Threading.Tasks;
-using Microsoft.IronPythonTools.Interpreter;
-using Microsoft.PythonTools.Analysis;
 using Microsoft.PythonTools.Intellisense;
 using Microsoft.PythonTools.Interpreter;
-using Microsoft.PythonTools.Parsing;
 using Microsoft.PythonTools.Repl;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.VisualStudio.Text.Classification;
 using TestUtilities;
-using TestUtilities.Mocks;
 using TestUtilities.Python;
 
 namespace IronPythonTests {

--- a/Python/Tests/PythonToolsMockTests/PythonToolsMockTests.csproj
+++ b/Python/Tests/PythonToolsMockTests/PythonToolsMockTests.csproj
@@ -44,24 +44,9 @@
     <Reference Include="EnvDTE, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <EmbedInteropTypes>False</EmbedInteropTypes>
     </Reference>
-    <Reference Include="IronPython">
-      <Private>true</Private>
-    </Reference>
-    <Reference Include="IronPython.Modules">
-      <Private>true</Private>
-    </Reference>
     <Reference Include="Microsoft.Build, Version=$(MicrosoftBuildAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
     <Reference Include="Microsoft.Build.Framework, Version=$(MicrosoftBuildAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Microsoft.Dynamic">
-      <Private>true</Private>
-    </Reference>
-    <Reference Include="Microsoft.Scripting">
-      <Private>true</Private>
-    </Reference>
-    <Reference Include="Microsoft.Scripting.Metadata">
-      <Private>true</Private>
-    </Reference>
     <Reference Include="Microsoft.VisualStudio.ComponentModelHost, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.VisualStudio.CoreUtility, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.VisualStudio.Language.Intellisense, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />

--- a/Python/Tests/PythonToolsMockTests/SquiggleTests.cs
+++ b/Python/Tests/PythonToolsMockTests/SquiggleTests.cs
@@ -18,19 +18,13 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
-using System.Threading.Tasks;
-using IronPython.Hosting;
 using Microsoft.PythonTools;
 using Microsoft.PythonTools.Intellisense;
-using Microsoft.PythonTools.Interpreter;
-using Microsoft.PythonTools.Parsing;
-using Microsoft.Scripting.Hosting;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Adornments;
 using Microsoft.VisualStudio.Text.Tagging;
 using Microsoft.VisualStudio.Utilities;
-using Microsoft.VisualStudioTools.MockVsTests;
 using TestUtilities;
 using TestUtilities.Mocks;
 using TestUtilities.Python;
@@ -39,7 +33,6 @@ namespace PythonToolsMockTests {
     [TestClass]
     public class SquiggleTests {
         public static IContentType PythonContentType = new MockContentType("Python", new IContentType[0]);
-        public static ScriptEngine PythonEngine = Python.CreateEngine();
 
         [ClassInitialize]
         public static void DoDeployment(TestContext context) {

--- a/Python/Tests/TestAdapterTests/TestDiscovererTests.cs
+++ b/Python/Tests/TestAdapterTests/TestDiscovererTests.cs
@@ -94,7 +94,7 @@ namespace TestAdapterTests {
 
         private static IEnumerable<TestCaseInfo> GetTestCasesFromAst(string code, PythonAnalyzer analyzer) {
             var codeStream = new MemoryStream(Encoding.UTF8.GetBytes(code));
-            var m = AstPythonModule.FromStream(analyzer.Interpreter, codeStream, "<string>", analyzer.LanguageVersion, "__main__");
+            var m = PythonModuleLoader.FromStream(analyzer.Interpreter, codeStream, "<string>", analyzer.LanguageVersion, "__main__");
             return TestAnalyzer.GetTestCasesFromAst(m, null);
         }
 


### PR DESCRIPTION
Fixes IronPython intellisense
Fixes IronPython tests
Removes unnecessary IronPython dependencies from test projects
Makes Ast.PythonModuleLoader public API

This is a prerequisite for #2943, though it's not a fix for it. Feel free to make architectural suggestions - I've gone for minimum top-level public APIs, but if you really hate the nested classes/enums then let me know why and I'll reconsider :)