### PR TITLE
Handle single-line module documentation better

### DIFF
--- a/Python/Product/Analysis/Interpreter/Ast/AstPythonModule.cs
+++ b/Python/Product/Analysis/Interpreter/Ast/AstPythonModule.cs
@@ -218,8 +218,9 @@ namespace Microsoft.PythonTools.Interpreter.Ast {
             try {
                 using (var sr = new StreamReader(filePath)) {
                     string quote = null;
+                    string line;
                     while (true) {
-                        var line = sr.ReadLine();
+                        line = sr.ReadLine().Trim();
                         if (line == null) {
                             break;
                         }
@@ -235,9 +236,13 @@ namespace Microsoft.PythonTools.Interpreter.Ast {
                     }
 
                     if (quote != null) {
+                        // Check if it is a single-liner
+                        if (line.EndsWithOrdinal(quote) && line.IndexOf(quote) < line.LastIndexOf(quote)) {
+                            return line.Substring(quote.Length, line.Length - 2 * quote.Length).Trim();
+                        }
                         var sb = new StringBuilder();
                         while (true) {
-                            var line = sr.ReadLine();
+                            line = sr.ReadLine();
                             if (line == null || line.EndsWithOrdinal(quote)) {
                                 break;
                             }
@@ -246,7 +251,7 @@ namespace Microsoft.PythonTools.Interpreter.Ast {
                         return sb.ToString();
                     }
                 }
-            } catch (IOException) { } catch(UnauthorizedAccessException) { }
+            } catch (IOException) { } catch (UnauthorizedAccessException) { }
             return string.Empty;
         }
     }

--- a/Python/Product/Analysis/LanguageServer/DocumentationBuilder.cs
+++ b/Python/Product/Analysis/LanguageServer/DocumentationBuilder.cs
@@ -52,6 +52,8 @@ namespace Microsoft.PythonTools.Analysis.LanguageServer {
                         return MakeClassDocumentation(v);
                     case PythonMemberType.Module:
                         return MakeModuleDocumentation(v);
+                    case PythonMemberType.Constant:
+                        return MakeConstantDocumentation(v);
                 }
             }
             return MakeGeneralDocumentation(array, originalExpression);
@@ -152,6 +154,7 @@ namespace Microsoft.PythonTools.Analysis.LanguageServer {
         protected abstract string MakeModuleDocumentation(AnalysisValue value);
         protected abstract string MakeFunctionDocumentation(AnalysisValue value);
         protected abstract string MakeClassDocumentation(AnalysisValue value);
+        protected abstract string MakeConstantDocumentation(AnalysisValue value);
 
         protected string LimitLines(
             string str,

--- a/Python/Product/Analysis/LanguageServer/MarkdownDocumentationBuilder.cs
+++ b/Python/Product/Analysis/LanguageServer/MarkdownDocumentationBuilder.cs
@@ -35,6 +35,7 @@ namespace Microsoft.PythonTools.Analysis.LanguageServer {
         protected override string MakeFunctionDocumentation(AnalysisValue value) => FromDocAndDescription(value);
         protected override string MakeModuleDocumentation(AnalysisValue value) => FromDocAndDescription(value);
         protected override string MakeClassDocumentation(AnalysisValue value) => FromDocAndDescription(value);
+        protected override string MakeConstantDocumentation(AnalysisValue value) => $"```python\n{value.Description}\n```";
 
         private string FromDocAndDescription(AnalysisValue value) {
             var sb = new StringBuilder();

--- a/Python/Product/Analysis/LanguageServer/PlainTextDocumentationBuilder.cs
+++ b/Python/Product/Analysis/LanguageServer/PlainTextDocumentationBuilder.cs
@@ -41,6 +41,7 @@ namespace Microsoft.PythonTools.Analysis.LanguageServer {
             return FromDocAndDescription(value, prefix);
         }
         protected override string MakeClassDocumentation(AnalysisValue value) => FromDocAndDescription(value, string.Empty);
+        protected override string MakeConstantDocumentation(AnalysisValue value) => value.Description;
 
         private string FromDocAndDescription(AnalysisValue value, string prefix) {
             var sb = new StringBuilder();


### PR DESCRIPTION
- Handle documentation that is one-liner like `""" comment """`
- Make separate tooltip for constants to avoid extra empty lines