### PR TITLE
Fix WPF dependency property name.

### DIFF
--- a/Python/Product/EnvironmentsList/PipExtension.xaml.cs
+++ b/Python/Product/EnvironmentsList/PipExtension.xaml.cs
@@ -387,7 +387,7 @@ namespace Microsoft.PythonTools.EnvironmentsList {
         }
 
         private static readonly DependencyPropertyKey ShowSecurityWarningPropertyKey = DependencyProperty.RegisterReadOnly(
-            "IsPotentialOldSSL",
+            "ShowSecurityWarning",
             typeof(bool),
             typeof(PipEnvironmentView),
             new PropertyMetadata(true)


### PR DESCRIPTION
Fix an oversight from my pip changes last week (it still worked, but I'd rather have the good name there).