### PR TITLE
Update the code that sets test explorer grouping to namespace.

### DIFF
--- a/Python/Tests/Utilities.Python/PythonTestExplorer.cs
+++ b/Python/Tests/Utilities.Python/PythonTestExplorer.cs
@@ -28,6 +28,7 @@ namespace TestUtilities.UI {
         private static class TestCommands {
             public const string ToggleShowTestHierarchy = "TestExplorer.ToggleShowTestHierarchy";
             public const string GroupBy = "TestExplorer.GroupBy";
+            public const string NextGroupBy = "TestExplorer.NextGroupBy";
             public const string RunAllTests = "TestExplorer.RunAllTests";
         }
 
@@ -101,8 +102,9 @@ namespace TestUtilities.UI {
                 _app.WaitForCommandAvailable(groupCommand, TimeSpan.FromSeconds(5));
             }
 
-            // This groups by namespace
-            _app.ExecuteCommand(TestCommands.GroupBy);
+            _app.ExecuteCommand(TestCommands.GroupBy); // by class
+            _app.ExecuteCommand(TestCommands.NextGroupBy); // by duration
+            _app.ExecuteCommand(TestCommands.NextGroupBy); // by namespace
 
             // Wait for the test list to be created
             int retry = 5;


### PR DESCRIPTION
partial fix for #4290 

In 15.8, behavior of the commands has changed, and they added a new NextGroupBy command to cycle through all. The default grouping for GroupBy is now Class, and previously it was Namespace.

There's an additional UI automation problem with their tree view that prevents the test from passing (tree nodes fail to expand via automation)