### PR TITLE
Fix colors used for info tip in package manager.

### DIFF
--- a/Common/Product/SharedProject/Wpf/Controls.cs
+++ b/Common/Product/SharedProject/Wpf/Controls.cs
@@ -43,10 +43,10 @@ namespace Microsoft.VisualStudioTools.Wpf {
         public static readonly object TooltipTextKey = new ThemeResourceKey(EnvCategory, "ToolTip", ThemeResourceKeyType.ForegroundBrush);
         public static readonly object TooltipTextColorKey = new ThemeResourceKey(EnvCategory, "ToolTip", ThemeResourceKeyType.ForegroundColor);
 
-        public static readonly object InfoBackgroundKey = new ThemeResourceKey(EnvCategory, "InfoBackground", ThemeResourceKeyType.BackgroundBrush);
-        public static readonly object InfoBackgroundColorKey = new ThemeResourceKey(EnvCategory, "InfoBackground", ThemeResourceKeyType.BackgroundColor);
-        public static readonly object InfoTextKey = new ThemeResourceKey(EnvCategory, "InfoText", ThemeResourceKeyType.ForegroundBrush);
-        public static readonly object InfoTextColorKey = new ThemeResourceKey(EnvCategory, "InfoText", ThemeResourceKeyType.ForegroundColor);
+        public static readonly object InfoBackgroundKey = VsBrushes.InfoBackgroundKey;
+        public static readonly object InfoBackgroundColorKey = VsColors.InfoBackgroundKey;
+        public static readonly object InfoTextKey = VsBrushes.InfoTextKey;
+        public static readonly object InfoTextColorKey = VsColors.InfoTextKey;
 
         public static readonly object HyperlinkKey = VsBrushes.ControlLinkTextKey;
         public static readonly object HyperlinkHoverKey = VsBrushes.ControlLinkTextHoverKey;

--- a/Common/Product/SharedProject/Wpf/Controls.xaml
+++ b/Common/Product/SharedProject/Wpf/Controls.xaml
@@ -226,6 +226,10 @@
         <Setter Property="img:ImageThemingUtilities.ImageBackgroundColor" Value="{DynamicResource {x:Static wpf:Controls.InfoBackgroundColorKey}}" />
     </Style>
 
+    <Style x:Key="InfoText" TargetType="{x:Type TextBlock}" BasedOn="{StaticResource {x:Type TextBlock}}">
+        <Setter Property="Foreground" Value="{DynamicResource {x:Static wpf:Controls.InfoTextKey}}" />
+    </Style>
+
     <Style TargetType="{x:Type GroupBox}">
         <Setter Property="Margin" Value="6" />
         <Setter Property="Padding" Value="6 3" />

--- a/Python/Product/Cookiecutter/Shared/Wpf/Controls.cs
+++ b/Python/Product/Cookiecutter/Shared/Wpf/Controls.cs
@@ -43,10 +43,10 @@ namespace Microsoft.VisualStudioTools.Wpf {
         public static readonly object TooltipTextKey = new ThemeResourceKey(EnvCategory, "ToolTip", ThemeResourceKeyType.ForegroundBrush);
         public static readonly object TooltipTextColorKey = new ThemeResourceKey(EnvCategory, "ToolTip", ThemeResourceKeyType.ForegroundColor);
 
-        public static readonly object InfoBackgroundKey = new ThemeResourceKey(EnvCategory, "InfoBackground", ThemeResourceKeyType.BackgroundBrush);
-        public static readonly object InfoBackgroundColorKey = new ThemeResourceKey(EnvCategory, "InfoBackground", ThemeResourceKeyType.BackgroundColor);
-        public static readonly object InfoTextKey = new ThemeResourceKey(EnvCategory, "InfoText", ThemeResourceKeyType.ForegroundBrush);
-        public static readonly object InfoTextColorKey = new ThemeResourceKey(EnvCategory, "InfoText", ThemeResourceKeyType.ForegroundColor);
+        public static readonly object InfoBackgroundKey = VsBrushes.InfoBackgroundKey;
+        public static readonly object InfoBackgroundColorKey = VsColors.InfoBackgroundKey;
+        public static readonly object InfoTextKey = VsBrushes.InfoTextKey;
+        public static readonly object InfoTextColorKey = VsColors.InfoTextKey;
 
         public static readonly object HyperlinkKey = VsBrushes.ControlLinkTextKey;
         public static readonly object HyperlinkHoverKey = VsBrushes.ControlLinkTextHoverKey;

--- a/Python/Product/Cookiecutter/Shared/Wpf/Controls.xaml
+++ b/Python/Product/Cookiecutter/Shared/Wpf/Controls.xaml
@@ -226,6 +226,10 @@
         <Setter Property="img:ImageThemingUtilities.ImageBackgroundColor" Value="{DynamicResource {x:Static wpf:Controls.InfoBackgroundColorKey}}" />
     </Style>
 
+    <Style x:Key="InfoText" TargetType="{x:Type TextBlock}" BasedOn="{StaticResource {x:Type TextBlock}}">
+        <Setter Property="Foreground" Value="{DynamicResource {x:Static wpf:Controls.InfoTextKey}}" />
+    </Style>
+
     <Style TargetType="{x:Type GroupBox}">
         <Setter Property="Margin" Value="6" />
         <Setter Property="Padding" Value="6 3" />

--- a/Python/Product/EnvironmentsList/PipExtension.xaml
+++ b/Python/Product/EnvironmentsList/PipExtension.xaml
@@ -275,6 +275,7 @@
                 <ColumnDefinition Width="auto"/>
             </Grid.ColumnDefinitions>
             <TextBlock
+                Style="{StaticResource InfoText}"
                 Grid.Column="0"
                 Margin="6"
                 HorizontalAlignment="Left"


### PR DESCRIPTION
Fix #4325

We already had a style definition for TextBlock which forced window text color, so I define a new style to use within info tip.

Also, it turned out that while ThemeResourceKey for InfoBackground was working fine, InfoText wasn't. I changed both to use VsBrushes/VsColors for consistency.

I checked all 4 themes + high contrast (black) + high contrast (white), and they're all fine.