### PR TITLE
Fixes #4247 Crash when saving diagnostics to file

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Options/PythonDiagnosticsOptionsPage.cs
+++ b/Python/Product/PythonTools/PythonTools/Options/PythonDiagnosticsOptionsPage.cs
@@ -78,13 +78,20 @@ namespace Microsoft.PythonTools.Options {
         }
 
         private void SaveToFile(bool includeAnalysisLogs) {
-            var path = Site.BrowseForFileSave(
-                _window.Handle,
-                Strings.DiagnosticsWindow_TextFileFilter,
-                PathUtils.GetAbsoluteFilePath(
+            string initialPath = null;
+            try {
+                initialPath = PathUtils.GetAbsoluteFilePath(
                     Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments),
                     Strings.DiagnosticsWindow_DefaultFileName.FormatUI(DateTime.Now)
-                )
+                );
+            } catch (Exception ex) when (!ex.IsCriticalException()) {
+                Debug.Fail(ex.ToUnhandledExceptionMessage(GetType()));
+            }
+
+            var path = Site.BrowseForFileSave(
+                _window?.Handle ?? IntPtr.Zero,
+                Strings.DiagnosticsWindow_TextFileFilter,
+                initialPath
             );
 
             if (string.IsNullOrEmpty(path)) {
@@ -109,8 +116,7 @@ namespace Microsoft.PythonTools.Options {
                     );
 
                     if (File.Exists(path)) {
-                        var process = Process.Start("explorer.exe", "/select," + ProcessOutput.QuoteSingleArgument(path));
-                        process?.Dispose();
+                        Process.Start("explorer.exe", "/select," + ProcessOutput.QuoteSingleArgument(path))?.Dispose();
                     }
                 } catch (OperationCanceledException) {
                 }

--- a/Python/Product/PythonTools/PythonTools/Options/PythonDiagnosticsOptionsPage.cs
+++ b/Python/Product/PythonTools/PythonTools/Options/PythonDiagnosticsOptionsPage.cs
@@ -89,7 +89,7 @@ namespace Microsoft.PythonTools.Options {
             }
 
             var path = Site.BrowseForFileSave(
-                _window?.Handle ?? IntPtr.Zero,
+                _window.Handle,
                 Strings.DiagnosticsWindow_TextFileFilter,
                 initialPath
             );


### PR DESCRIPTION
Fixes #4274 Crash when saving diagnostics to file
Ensures no null-reference errors can emerge from SaveToFile.