### PR TITLE
Fix #4352: An unexpected error occurred

### DIFF
--- a/Python/Product/PythonTools/PythonToolsService.cs
+++ b/Python/Product/PythonTools/PythonToolsService.cs
@@ -110,6 +110,7 @@ namespace Microsoft.PythonTools {
 
             _idleManager.OnIdle += OnIdleInitialization;
 
+            EditorServices = ComponentModel.GetService<PythonEditorServices>();
             EditorServices.SetPythonToolsService(this);
         }
 
@@ -179,7 +180,7 @@ namespace Microsoft.PythonTools {
             }
         }
 
-        internal PythonEditorServices EditorServices => ComponentModel.GetService<PythonEditorServices>();
+        internal PythonEditorServices EditorServices { get; }
 
         internal void GetDiagnosticsLog(TextWriter writer, bool includeAnalysisLogs) {
             _diagnosticsProvider.WriteLog(writer, includeAnalysisLogs);

--- a/Python/Product/TestAdapter/TestContainerDiscoverer.cs
+++ b/Python/Product/TestAdapter/TestContainerDiscoverer.cs
@@ -210,10 +210,10 @@ namespace Microsoft.PythonTools.TestAdapter {
                 }
             }
 
-            private async void AnalysisComplete(object sender, AnalysisCompleteEventArgs e) {
-                await PendOrSubmitRequests((ProjectAnalyzer)sender, e.Path)
+            private void AnalysisComplete(object sender, AnalysisCompleteEventArgs e) {
+                PendOrSubmitRequests((ProjectAnalyzer)sender, e.Path)
                     .HandleAllExceptions(_discoverer._serviceProvider, GetType())
-                    .ConfigureAwait(false);
+                    .DoNotWait();
             }
 
             private async Task PendOrSubmitRequests(ProjectAnalyzer analyzer, string path) {


### PR DESCRIPTION
Fixes both the symptom and the bug:
- Reference to `PythonEditorServices` is saved before its first use instead of resolving it every time
- `UpdateTestCasesAsync` uses analyzer that raised `AnalysisComplete`. If analyzer is disposed, `SendExtensionCommandAsync` request will be canceled.