### PR TITLE
Fixes #4373 socket completions are not correct

### DIFF
--- a/Python/Product/Analysis/Interpreter/Ast/AstPythonInterpreterFactory.cs
+++ b/Python/Product/Analysis/Interpreter/Ast/AstPythonInterpreterFactory.cs
@@ -194,6 +194,10 @@ namespace Microsoft.PythonTools.Interpreter.Ast {
 
             var hash = SHA256.Create();
             var dir = Path.GetDirectoryName(filePath);
+            if (IsWindows()) {
+                dir = dir.ToLowerInvariant();
+            }
+
             var dirHash = Convert.ToBase64String(hash.ComputeHash(new UTF8Encoding(false).GetBytes(dir)))
                 .Replace('/', '_').Replace('+', '-');
 
@@ -201,6 +205,15 @@ namespace Microsoft.PythonTools.Interpreter.Ast {
                 _databasePath,
                 Path.Combine(dirHash, name)
             ), ".pyi");
+        }
+
+        private static bool IsWindows() {
+#if DESKTOP
+            return true;
+#else
+            return System.Runtime.InteropServices.RuntimeInformation
+                .IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows);
+#endif
         }
 
         #region Cache File Management

--- a/Python/Product/Analysis/ModuleAnalysis.cs
+++ b/Python/Product/Analysis/ModuleAnalysis.cs
@@ -519,7 +519,7 @@ namespace Microsoft.PythonTools.Analysis {
             var specific = new List<OverloadResult>();
             var generic = new List<OverloadResult>();
             foreach (var overload in result.GroupBy(o => o, OverloadResultComparer.WeakInstance).Select(OverloadResult.Merge)) {
-                if (overload.Parameters.All(p => p.Name.StartsWithOrdinal("*"))) {
+                if (overload.Parameters.Any() && overload.Parameters.All(p => p.Name.StartsWithOrdinal("*"))) {
                     generic.Add(overload);
                 } else {
                     specific.Add(overload);

--- a/Python/Product/Analysis/ModulePath.cs
+++ b/Python/Product/Analysis/ModulePath.cs
@@ -109,6 +109,30 @@ namespace Microsoft.PythonTools.Analysis {
         public bool IsStub => PythonStubRegex.IsMatch(PathUtils.GetFileName(SourceFile));
 
         /// <summary>
+        /// True if the module can only be used in debug builds of the interpreter.
+        /// </summary>
+        public bool IsDebug {
+            get {
+                var m = PythonBinaryRegex.Match(PathUtils.GetFileName(SourceFile));
+                // Only binaries require debug builds
+                if (!m.Success) {
+                    return false;
+                }
+
+                if (m.Groups["windebug"].Success) {
+                    return true;
+                }
+
+                var abiTag = PythonAbiTagRegex.Match(m.Groups["abitag"].Value);
+                if (abiTag.Groups["flags"].Value?.Contains("d") == true) {
+                    return true;
+                }
+
+                return false;
+            }
+        }
+
+        /// <summary>
         /// Creates a new ModulePath item.
         /// </summary>
         /// <param name="fullname">The full name of the module.</param>
@@ -131,10 +155,16 @@ namespace Microsoft.PythonTools.Analysis {
             RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
         private static readonly Regex PythonStubRegex = new Regex(@"^(?!\d)(?<name>(\w|_)+)\.pyi$",
             RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
-        private static readonly Regex PythonBinaryRegex = new Regex(@"^(?!\d)(?<name>(\w|_)+)\.((\w|_|-)+?\.)?(pyd|so|dylib)$",
+        private static readonly Regex PythonBinaryRegex = new Regex(@"^(?!\d)(?<name>(\w|_)+?(?<windebug>_d)?)\.((?<abitag>(\w|_|-)+?)\.)?(pyd|so|dylib)$",
             RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
         private static readonly Regex PythonCompiledRegex = new Regex(@"^(?!\d)(?<name>(\w|_)+)\.((\w|_|-)+?\.)?(pyd|py[co]|so|dylib)$",
             RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
+        private static readonly Regex PythonAbiTagRegex = new Regex(@"^(
+              (?<implementation>\w+)-(?<version>\d+)(?<flags>[dmu]+)?   # SOABI style
+            | (?<abi>abi\d+)                                            # Stable ABI style
+            | (?<version>\w+)-(?<platform>(\w|_)+)                      # Windows style
+            )$",
+            RegexOptions.CultureInvariant | RegexOptions.IgnoreCase | RegexOptions.IgnorePatternWhitespace);
 
         private static IEnumerable<ModulePath> GetModuleNamesFromPathHelper(
             string libPath,

--- a/Python/Product/Analysis/scrape_module.py
+++ b/Python/Product/Analysis/scrape_module.py
@@ -88,8 +88,10 @@ LIES_ABOUT_MODULE = frozenset([
     builtins.__name__ + ".weakcallableproxy",
     builtins.__name__ + ".weakproxy",
     builtins.__name__ + ".weakref",
+    "ctypes.ArgumentError",
     "os.stat_result",
     "os.statvfs_result",
+    "xml.parsers.expat.ExpatError",
 
     "numpy.broadcast",
     "numpy.busdaycalendar",
@@ -98,6 +100,17 @@ LIES_ABOUT_MODULE = frozenset([
     "numpy.flatiter",
     "numpy.ndarray",
     "numpy.nditer",
+
+    # These modules contain multiple members that lie about their
+    # module. Always write out all members of these in full.
+    "_asyncio.*",
+    "_bsddb.*",
+    "_decimal.*",
+    "_elementtree.*",
+    "_socket.*",
+    "_sqlite3.*",
+    "_ssl.*",
+    "_testmultiphase.*",
 ])
 
 # These type names cause conflicts with their values, so
@@ -728,7 +741,7 @@ class MemberInfo(object):
 
                 fullname = module + '.' + type_name
 
-                if fullname in LIES_ABOUT_MODULE:
+                if fullname in LIES_ABOUT_MODULE or (in_module + '.*') in LIES_ABOUT_MODULE:
                     # Treat the type as if it came from the current module
                     return (in_module,), type_name
 

--- a/Python/Tests/Analysis/ModulePathTests.cs
+++ b/Python/Tests/Analysis/ModulePathTests.cs
@@ -85,6 +85,27 @@ namespace AnalysisTests {
             }
         }
 
+        [TestMethod, Priority(0)]
+        public void IsDebug() {
+            foreach (var test in new[] {
+                new { SourceFile = @"spam\abc.py", Expected = false },
+                new { SourceFile = @"spam\abc.pyd", Expected = false },
+                new { SourceFile = @"spam\abc.cp35-win32.pyd", Expected = false },
+                new { SourceFile = @"spam\abc.cpython-35d.pyd", Expected = true },  // not a real filename, but should match the tag still
+                new { SourceFile = @"spam\abc_d.pyd", Expected = true },
+                new { SourceFile = @"spam\abc_d.cp3-win_amd64.pyd", Expected = true },
+                new { SourceFile = @"spam\abc.cpython-35.so", Expected = false },
+                new { SourceFile = @"spam\abc.cpython-35u.so", Expected = false },
+                new { SourceFile = @"spam\abc.pypy-35m.so", Expected = false },
+                new { SourceFile = @"spam\abc.cpython-35d.so", Expected = true },
+                new { SourceFile = @"spam\abc.cpython-35dmu.so", Expected = true },
+                new { SourceFile = @"spam\abc.jython-35udm.dylib", Expected = true },
+                new { SourceFile = @"spam\abc.cpython-35umd.dylib", Expected = true },
+            }) {
+                Assert.AreEqual(test.Expected, new ModulePath("abc", test.SourceFile, null).IsDebug, test.SourceFile);
+            }
+        }
+
         /// <summary>
         /// Verify that the analyzer has the proper algorithm for turning a filename into a package name
         /// </summary>


### PR DESCRIPTION
Fixes #4373 socket completions are not correct
Updates list of modules/types that lie about where they are defined
Adds test to verify standard library extension modules have no external dependencies
Adds ability to detect whether ModulePath represents a debug module
Removes typing members from type stubs
Fixes case sensitivity of generated cache paths.
Stops returning very generic overloads when more specific ones are available.