### PR TITLE
Fixes #4378 Crash due to UriFormatException when editing condition on breakpoint

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Editor/PythonTextBufferInfo.cs
+++ b/Python/Product/PythonTools/PythonTools/Editor/PythonTextBufferInfo.cs
@@ -190,7 +190,12 @@ namespace Microsoft.PythonTools.Editor {
 
             var path = Filename;
             if (!string.IsNullOrEmpty(path)) {
-                return new Uri(path);
+                try {
+                    return new Uri(path);
+                } catch (UriFormatException ex) {
+                    Debug.Fail("{0} is not a valid URI.{1}{2}".FormatInvariant(path, Environment.NewLine, ex.ToUnhandledExceptionMessage(GetType())));
+                    return null;
+                }
             }
 
             var replEval = Buffer.GetInteractiveWindow()?.Evaluator as IPythonInteractiveIntellisense;

--- a/Python/Product/PythonTools/PythonTools/Intellisense/IntellisenseControllerProvider.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/IntellisenseControllerProvider.cs
@@ -47,6 +47,11 @@ namespace Microsoft.PythonTools.Intellisense {
             new Dictionary<ITextView, Tuple<BufferParser, VsProjectAnalyzer>>();
 
         public IIntellisenseController TryCreateIntellisenseController(ITextView textView, IList<ITextBuffer> subjectBuffers) {
+            if (textView.Roles.Contains("DEBUGVIEW")) {
+                // TODO: Determine the context for this view and attach to the correct analyzer
+                return null;
+            }
+
             IntellisenseController controller;
             if (!textView.Properties.TryGetProperty(typeof(IntellisenseController), out controller)) {
                 controller = new IntellisenseController(this, textView);


### PR DESCRIPTION
Fixes #4378 Crash due to UriFormatException when editing condition on breakpoint
Prevent crash
Avoid trying to analyze debug view elements.