### PR TITLE
Update to ptvsd==4.1.1a7

### DIFF
--- a/Python/Product/Debugger/Debugger.csproj
+++ b/Python/Product/Debugger/Debugger.csproj
@@ -204,7 +204,7 @@
   </ItemGroup>
   <Import Project="..\ProjectAfter.settings" />
   <PropertyGroup>
-    <BundledPTVSDVersion>4.1.1a1</BundledPTVSDVersion>
+    <BundledPTVSDVersion>4.1.1a7</BundledPTVSDVersion>
   </PropertyGroup>
   <Target Name="_GatherPtvsd" BeforeTargets="_IncludePtvsd" Condition="!Exists('$(IntermediateOutputPath)Packages\ptvsd\__init__.py')">
     <PropertyGroup>


### PR DESCRIPTION
Visible known regressions:
https://github.com/Microsoft/ptvsd/issues/491 Same breakpoint hit multiple times (2.7 only)
https://github.com/Microsoft/ptvsd/issues/459 Break on normal exit is not respected

Our test run has a lot of failures due to that first bug, but the rest looks okay (when running on 3.6).

I'm not convinced myself I want to take this, but getting it ready in case we do want to take it.