### PR TITLE
Fixes #4387 unittest.skip missing from completions

### DIFF
--- a/Python/Product/Analysis/LanguageServer/CompletionAnalysis.cs
+++ b/Python/Product/Analysis/LanguageServer/CompletionAnalysis.cs
@@ -552,6 +552,11 @@ namespace Microsoft.PythonTools.Analysis.LanguageServer {
             if (!(Node is ErrorExpression)) {
                 return null;
             }
+
+            if (Statement is AssignmentStatement assign && Node == assign.Right) {
+                return null;
+            }
+
             var reader = _openDocument?.Invoke();
             if (reader == null) {
                 _log.TraceMessage($"Cannot get completions at error node without sources");

--- a/Python/Product/Analysis/LanguageServer/CompletionAnalysis.cs
+++ b/Python/Product/Analysis/LanguageServer/CompletionAnalysis.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -32,6 +33,7 @@ namespace Microsoft.PythonTools.Analysis.LanguageServer {
         private readonly ScopeStatement _scope;
         private readonly ILogger _log;
         private readonly DocumentationBuilder _textBuilder;
+        private readonly Func<TextReader> _openDocument;
 
         public CompletionAnalysis(
             ModuleAnalysis analysis,
@@ -39,7 +41,8 @@ namespace Microsoft.PythonTools.Analysis.LanguageServer {
             SourceLocation position,
             GetMemberOptions opts,
             DocumentationBuilder textBuilder,
-            ILogger log
+            ILogger log,
+            Func<TextReader> openDocument
         ) {
             Analysis = analysis ?? throw new ArgumentNullException(nameof(analysis));
             Tree = tree ?? throw new ArgumentNullException(nameof(tree));
@@ -48,6 +51,7 @@ namespace Microsoft.PythonTools.Analysis.LanguageServer {
             Options = opts;
             _textBuilder = textBuilder;
             _log = log;
+            _openDocument = openDocument;
 
             var finder = new ExpressionFinder(Tree, new GetExpressionOptions {
                 Names = true,
@@ -56,6 +60,7 @@ namespace Microsoft.PythonTools.Analysis.LanguageServer {
                 ImportNames = true,
                 ImportAsNames = true,
                 Literals = true,
+                Errors = true
             });
             finder.Get(Index, Index, out _node, out _statement, out _scope);
 
@@ -136,6 +141,7 @@ namespace Microsoft.PythonTools.Analysis.LanguageServer {
                 GetCompletionsInWithStatement() ??
                 GetCompletionsInRaiseStatement(ref allowArguments, ref opts) ??
                 GetCompletionsInExceptStatement(ref allowKeywords, ref opts) ??
+                GetCompletionsFromError() ??
                 GetCompletionsFromTopLevel(allowKeywords, allowArguments, opts);
 
             if (additional != null) {
@@ -297,14 +303,17 @@ namespace Microsoft.PythonTools.Analysis.LanguageServer {
                 }
                 var loc = fd.GetStart(Tree);
                 ShouldCommitByDefault = false;
-                return Analysis.GetOverrideable(loc)
-                    .Select(o => new CompletionItem {
-                        label = o.Name,
-                        insertText = MakeCompletionString(new string(' ', loc.Column - 1), o, cd.Name),
-                        kind = CompletionItemKind.Method
-                    });
+                return Analysis.GetOverrideable(loc).Select(o => ToOverrideCompletionItem(o, cd, new string(' ', loc.Column - 1)));
             }
             return null;
+        }
+
+        private CompletionItem ToOverrideCompletionItem(IOverloadResult o, ClassDefinition cd, string indent) {
+            return new CompletionItem {
+                label = o.Name,
+                insertText = MakeOverrideCompletionString(indent, o, cd.Name),
+                kind = CompletionItemKind.Method
+            };
         }
 
         private IEnumerable<CompletionItem> GetCompletionsInDefinition(ref bool allowKeywords, ref List<CompletionItem> additional) {
@@ -539,6 +548,71 @@ namespace Microsoft.PythonTools.Analysis.LanguageServer {
             return null;
         }
 
+        private IEnumerable<CompletionItem> GetCompletionsFromError() {
+            if (!(Node is ErrorExpression)) {
+                return null;
+            }
+            var reader = _openDocument?.Invoke();
+            if (reader == null) {
+                _log.TraceMessage($"Cannot get completions at error node without sources");
+                return Empty;
+            }
+            var tokens = new Stack<KeyValuePair<IndexSpan, Token>>();
+            Tokenizer tokenizer;
+            using (reader) {
+                tokenizer = new Tokenizer(Tree.LanguageVersion, options: TokenizerOptions.GroupingRecovery);
+                tokenizer.Initialize(reader);
+                for (var t = tokenizer.GetNextToken(); !tokenizer.IsEndOfFile && tokenizer.TokenSpan.Start < Index; t = tokenizer.GetNextToken()) {
+                    tokens.Push(new KeyValuePair<IndexSpan, Token>(tokenizer.TokenSpan, t));
+                }
+            }
+
+            if (tokens.Count == 0) {
+                return Empty;
+            }
+
+            string exprString;
+            var lastToken = tokens.Pop();
+            switch (lastToken.Value.Kind) {
+                case TokenKind.Dot:
+                    exprString = ReadExpression(tokens, tokenizer);
+                    if (exprString != null) {
+                        ApplicableSpan = new SourceSpan(Position, Position);
+                        return Analysis.GetMembers(exprString, Position, Options).Select(ToCompletionItem);
+                    }
+                    break;
+                case TokenKind.Name:
+                    if (tokens.Count >= 2 && tokens.Pop().Value.Kind == TokenKind.Dot) {
+                        exprString = ReadExpression(tokens, tokenizer);
+                        if (exprString != null) {
+                            ApplicableSpan = new SourceSpan(tokenizer.IndexToLocation(lastToken.Key.Start), Position);
+                            return Analysis.GetMembers(exprString, Position, Options).Select(ToCompletionItem);
+                        }
+                    }
+                    break;
+                case TokenKind.KeywordDef:
+                    if (lastToken.Key.End < Index) {
+                        var cd = Scope as ClassDefinition ?? ((Scope as FunctionDefinition)?.Parent as ClassDefinition);
+                        if (cd == null) {
+                            return null;
+                        }
+
+                        var loc = tokenizer.IndexToLocation(lastToken.Key.Start);
+                        ShouldCommitByDefault = false;
+                        return Analysis.GetOverrideable(loc).Select(o => ToOverrideCompletionItem(o, cd, new string(' ', loc.Column - 1)));
+                    }
+                    return null;
+                default:
+                    if (lastToken.Value.Kind >= TokenKind.FirstKeyword && lastToken.Value.Kind <= TokenKind.LastKeyword) {
+                        return null;
+                    }
+                    break;
+            }
+
+            _log.TraceMessage($"Unhandled completions from error.\nTokens were: ({lastToken.Value.Image}:{lastToken.Value.Kind}), {string.Join(", ", tokens.AsEnumerable().Take(10).Select(t => $"({t.Value.Image}:{t.Value.Kind})"))}");
+            return Empty;
+        }
+
         private IEnumerable<CompletionItem> GetCompletionsFromTopLevel(bool allowKeywords, bool allowArguments, GetMemberOptions opts) {
             if (Node?.EndIndex < Index) {
                 return Empty;
@@ -675,7 +749,7 @@ namespace Microsoft.PythonTools.Analysis.LanguageServer {
             }
         }
 
-        private string MakeCompletionString(string indentation, IOverloadResult result, string className) {
+        private string MakeOverrideCompletionString(string indentation, IOverloadResult result, string className) {
             var sb = new StringBuilder();
 
             sb.AppendLine(result.Name + "(" + string.Join(", ", result.Parameters.Select((p, i) => GetSafeParameterName(p, i))) + "):");
@@ -704,6 +778,76 @@ namespace Microsoft.PythonTools.Analysis.LanguageServer {
             }
 
             return sb.ToString();
+        }
+
+        private static string ReadExpression(Stack<KeyValuePair<IndexSpan, Token>> tokens, Tokenizer tokenizer) {
+            var expr = ReadExpressionTokens(tokens, tokenizer);
+
+            return string.Join("", expr.Select(e => e.VerbatimImage ?? e.Image));
+        }
+
+        private static IEnumerable<Token> ReadExpressionTokens(Stack<KeyValuePair<IndexSpan, Token>> tokens, Tokenizer tokenizer) {
+            int nesting = 0;
+            var exprTokens = new Stack<Token>();
+            int currentLine = -1;
+
+            while (tokens.Any()) {
+                var t = tokens.Pop();
+                var p = tokenizer.IndexToLocation(t.Key.Start);
+                if (p.Line > currentLine) {
+                    currentLine = p.Line;
+                } else if (p.Line < currentLine && nesting == 0) {
+                    break;
+                }
+
+                exprTokens.Push(t.Value);
+
+                switch (t.Value.Kind) {
+                    case TokenKind.RightParenthesis:
+                    case TokenKind.RightBracket:
+                    case TokenKind.RightBrace:
+                        nesting += 1;
+                        break;
+                    case TokenKind.LeftParenthesis:
+                    case TokenKind.LeftBracket:
+                    case TokenKind.LeftBrace:
+                        if (--nesting < 0) {
+                            exprTokens.Pop();
+                            return exprTokens;
+                        }
+                        break;
+
+                    case TokenKind.Comment:
+                        exprTokens.Pop();
+                        break;
+
+                    case TokenKind.Name:
+                    case TokenKind.Constant:
+                    case TokenKind.Dot:
+                    case TokenKind.Ellipsis:
+                    case TokenKind.MatMultiply:
+                    case TokenKind.KeywordAwait:
+                        break;
+
+                    case TokenKind.Assign:
+                    case TokenKind.LeftShiftEqual:
+                    case TokenKind.RightShiftEqual:
+                    case TokenKind.BitwiseAndEqual:
+                    case TokenKind.BitwiseOrEqual:
+                    case TokenKind.ExclusiveOrEqual:
+                        exprTokens.Pop();
+                        return exprTokens;
+
+                    default:
+                        if (t.Value.Kind >= TokenKind.FirstKeyword || nesting == 0) {
+                            exprTokens.Pop();
+                            return exprTokens;
+                        }
+                        break;
+                }
+            }
+
+            return exprTokens;
         }
     }
 }

--- a/Python/Product/Analysis/LanguageServer/Server.Completion.cs
+++ b/Python/Product/Analysis/LanguageServer/Server.Completion.cs
@@ -38,7 +38,8 @@ namespace Microsoft.PythonTools.Analysis.LanguageServer {
             }
 
             var opts = GetOptions(@params.context);
-            var ctxt = new CompletionAnalysis(analysis, tree, @params.position, opts, _displayTextBuilder, this);
+            var ctxt = new CompletionAnalysis(analysis, tree, @params.position, opts, _displayTextBuilder, this,
+                () => entry.ReadDocument(_projectFiles.GetPart(uri), out _));
             var members = ctxt.GetCompletionsFromString(@params._expr) ?? ctxt.GetCompletions();
             if (members == null) {
                 TraceMessage($"Do not trigger at {@params.position} in {uri}");
@@ -61,12 +62,12 @@ namespace Microsoft.PythonTools.Analysis.LanguageServer {
                 _commitByDefault = ctxt.ShouldCommitByDefault
             };
 
+            SourceLocation trigger = @params.position;
             if (ctxt.ApplicableSpan.HasValue) {
                 res._applicableSpan = ctxt.ApplicableSpan;
             } else if (ctxt.Node != null) {
                 var span = ctxt.Node.GetSpan(tree);
                 if (@params.context?.triggerKind == CompletionTriggerKind.TriggerCharacter) {
-                    SourceLocation trigger = @params.position;
                     if (span.End > trigger) {
                         span = new SourceSpan(span.Start, trigger);
                     }
@@ -74,6 +75,13 @@ namespace Microsoft.PythonTools.Analysis.LanguageServer {
                 if (span.End != span.Start) {
                     res._applicableSpan = span;
                 }
+            } else if (@params.context?.triggerKind == CompletionTriggerKind.TriggerCharacter) {
+                res._applicableSpan = new SourceSpan(
+                    trigger.Line,
+                    Math.Max(1, trigger.Column - 1),
+                    trigger.Line,
+                    trigger.Column
+                );
             }
 
             LogMessage(MessageType.Info, $"Found {res.items.Length} completions for {uri} at {@params.position} after filtering");

--- a/Python/Product/Analysis/LanguageServer/Server.Completion.cs
+++ b/Python/Product/Analysis/LanguageServer/Server.Completion.cs
@@ -76,9 +76,10 @@ namespace Microsoft.PythonTools.Analysis.LanguageServer {
                     res._applicableSpan = span;
                 }
             } else if (@params.context?.triggerKind == CompletionTriggerKind.TriggerCharacter) {
+                var ch = @params.context?.triggerCharacter.FirstOrDefault() ?? '\0';
                 res._applicableSpan = new SourceSpan(
                     trigger.Line,
-                    Math.Max(1, trigger.Column - 1),
+                    Tokenizer.IsIdentifierStartChar(ch) ? Math.Max(1, trigger.Column - 1) : trigger.Column,
                     trigger.Line,
                     trigger.Column
                 );

--- a/Python/Tests/Analysis/LanguageServerTests.cs
+++ b/Python/Tests/Analysis/LanguageServerTests.cs
@@ -362,6 +362,12 @@ namespace AnalysisTests {
 
             u = await AddModule(s, "@");
             await AssertAnyCompletion(s, u, new SourceLocation(1, 2));
+
+            u = await AddModule(s, "import unittest\n\n@unittest.\n");
+            await AssertCompletion(s, u, new[] { "TestCase", "skip", "skipUnless" }, new[] { "abs", "def" }, new SourceLocation(3, 11));
+
+            u = await AddModule(s, "import unittest\n\n@unittest.\ndef f(): pass");
+            await AssertCompletion(s, u, new[] { "TestCase", "skip", "skipUnless" }, new[] { "abs", "def" }, new SourceLocation(3, 11));
         }
 
         [TestMethod, Priority(0)]

--- a/Python/Tests/Analysis/LanguageServerTests.cs
+++ b/Python/Tests/Analysis/LanguageServerTests.cs
@@ -420,6 +420,16 @@ namespace AnalysisTests {
         }
 
         [TestMethod, Priority(0)]
+        public async Task CompletionAfterAssign() {
+            var s = await CreateServer();
+            Uri u;
+
+            u = await AddModule(s, "x = x\ny = ");
+            await AssertCompletion(s, u, new[] { "x", "abs" }, null, new SourceLocation(1, 5));
+            await AssertCompletion(s, u, new[] { "x", "abs" }, null, new SourceLocation(2, 5));
+        }
+
+        [TestMethod, Priority(0)]
         public async Task CompletionWithNewDot() {
             // LSP assumes that the text buffer is up to date with typing,
             // which means the language server must know about dot for a


### PR DESCRIPTION
Fixes #4387 unittest.skip missing from completions
Adds fallback to tokens and reparsing when showing completions in an error node
Fixes applicable span when starting to type