### PR TITLE
Duplicate experimental debugger ui tests into separate 2.7 and 3.6 tests

### DIFF
--- a/Python/Product/Debugger/Debugger.csproj
+++ b/Python/Product/Debugger/Debugger.csproj
@@ -204,7 +204,7 @@
   </ItemGroup>
   <Import Project="..\ProjectAfter.settings" />
   <PropertyGroup>
-    <BundledPTVSDVersion>4.1.1a7</BundledPTVSDVersion>
+    <BundledPTVSDVersion>4.1.1a8</BundledPTVSDVersion>
   </PropertyGroup>
   <Target Name="_GatherPtvsd" BeforeTargets="_IncludePtvsd" Condition="!Exists('$(IntermediateOutputPath)Packages\ptvsd\__init__.py')">
     <PropertyGroup>

--- a/Python/Tests/DebuggerUITests/DebugProjectUITests.cs
+++ b/Python/Tests/DebuggerUITests/DebugProjectUITests.cs
@@ -1040,6 +1040,7 @@ namespace DebuggerUITests {
 
         private static IDisposable SelectDefaultInterpreter(PythonVisualStudioApp app, string pythonVersion) {
             if (string.IsNullOrEmpty(pythonVersion)) {
+                // Test wants to use the existing global default
                 return new EmptyDisposable();
             }
 

--- a/Python/Tests/DebuggerUITests/DebugProjectUITests.cs
+++ b/Python/Tests/DebuggerUITests/DebugProjectUITests.cs
@@ -20,7 +20,6 @@ using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading;
-using System.Threading.Tasks;
 using EnvDTE;
 using EnvDTE90;
 using EnvDTE90a;
@@ -41,8 +40,9 @@ namespace DebuggerUITests {
         /// <summary>
         /// Loads the simple project and then unloads it, ensuring that the solution is created with a single project.
         /// </summary>
-        public void DebugPythonProject(VisualStudioApp app, bool useVsCodeDebugger, DotNotWaitOnNormalExit optionSetter) {
+        public void DebugPythonProject(PythonVisualStudioApp app, bool useVsCodeDebugger, string interpreter, DotNotWaitOnNormalExit optionSetter) {
             var pyService = app.ServiceProvider.GetUIThread().Invoke(() => app.ServiceProvider.GetPythonToolsService());
+            using (SelectDefaultInterpreter(app, interpreter))
             using (new PythonExperimentalGeneralOptionsSetter(pyService, useVsCodeDebugger: useVsCodeDebugger)) {
                 StartHelloWorldAndBreak(app);
 
@@ -54,8 +54,9 @@ namespace DebuggerUITests {
         /// <summary>
         /// Loads a project with the startup file in a subdirectory, ensuring that syspath is correct when debugging.
         /// </summary>
-        public void DebugPythonProjectSubFolderStartupFileSysPath(VisualStudioApp app, bool useVsCodeDebugger, DotNotWaitOnNormalExit optionSetter) {
+        public void DebugPythonProjectSubFolderStartupFileSysPath(PythonVisualStudioApp app, bool useVsCodeDebugger, string interpreter, DotNotWaitOnNormalExit optionSetter) {
             var pyService = app.ServiceProvider.GetUIThread().Invoke(() => app.ServiceProvider.GetPythonToolsService());
+            using (SelectDefaultInterpreter(app, interpreter))
             using (new PythonExperimentalGeneralOptionsSetter(pyService, useVsCodeDebugger: useVsCodeDebugger)) {
                 var sln = app.CopyProjectForTest(@"TestData\SysPath.sln");
                 var project = app.OpenProject(sln);
@@ -77,8 +78,9 @@ namespace DebuggerUITests {
         /// If <see cref="DebugPythonProjectSubFolderStartupFileSysPath"/> fails
         /// this test may also fail.
         /// </summary>
-        public void DebugPythonProjectWithAndWithoutClearingPythonPath(VisualStudioApp app, bool useVsCodeDebugger, DotNotWaitOnNormalExit optionSetter) {
+        public void DebugPythonProjectWithAndWithoutClearingPythonPath(PythonVisualStudioApp app, bool useVsCodeDebugger, string interpreter, DotNotWaitOnNormalExit optionSetter) {
             var pyService = app.ServiceProvider.GetUIThread().Invoke(() => app.ServiceProvider.GetPythonToolsService());
+            using (SelectDefaultInterpreter(app, interpreter))
             using (new PythonExperimentalGeneralOptionsSetter(pyService, useVsCodeDebugger: useVsCodeDebugger)) {
                 var sysPathSln = app.CopyProjectForTest(@"TestData\SysPath.sln");
                 var helloWorldSln = app.CopyProjectForTest(@"TestData\HelloWorld.sln");
@@ -108,7 +110,7 @@ namespace DebuggerUITests {
         /// <summary>
         /// Tests using a custom interpreter path that is relative
         /// </summary>
-        public void DebugPythonCustomInterpreter(VisualStudioApp app, bool useVsCodeDebugger, DotNotWaitOnNormalExit optionSetter) {
+        public void DebugPythonCustomInterpreter(PythonVisualStudioApp app, bool useVsCodeDebugger, DotNotWaitOnNormalExit optionSetter) {
             var pyService = app.ServiceProvider.GetUIThread().Invoke(() => app.ServiceProvider.GetPythonToolsService());
             using (new PythonExperimentalGeneralOptionsSetter(pyService, useVsCodeDebugger: useVsCodeDebugger)) {
                 var interpreter = PythonPaths.Python27 ?? PythonPaths.Python27_x64;
@@ -136,8 +138,9 @@ namespace DebuggerUITests {
         /// <summary>
         /// Tests using a custom interpreter path that doesn't exist
         /// </summary>
-        public void DebugPythonCustomInterpreterMissing(VisualStudioApp app, bool useVsCodeDebugger, DotNotWaitOnNormalExit optionSetter) {
+        public void DebugPythonCustomInterpreterMissing(PythonVisualStudioApp app, bool useVsCodeDebugger, string interpreter, DotNotWaitOnNormalExit optionSetter) {
             var pyService = app.ServiceProvider.GetUIThread().Invoke(() => app.ServiceProvider.GetPythonToolsService());
+            using (SelectDefaultInterpreter(app, interpreter))
             using (new PythonExperimentalGeneralOptionsSetter(pyService, useVsCodeDebugger: useVsCodeDebugger)) {
                 var sln = app.CopyProjectForTest(@"TestData\RelativeInterpreterPath.sln");
                 var project = app.OpenProject(sln, "Program.py");
@@ -154,8 +157,9 @@ namespace DebuggerUITests {
             }
         }
 
-        public void PendingBreakPointLocation(VisualStudioApp app, bool useVsCodeDebugger, DotNotWaitOnNormalExit optionSetter) {
+        public void PendingBreakPointLocation(PythonVisualStudioApp app, bool useVsCodeDebugger, string interpreter, DotNotWaitOnNormalExit optionSetter) {
             var pyService = app.ServiceProvider.GetUIThread().Invoke(() => app.ServiceProvider.GetPythonToolsService());
+            using (SelectDefaultInterpreter(app, interpreter))
             using (new PythonExperimentalGeneralOptionsSetter(pyService, useVsCodeDebugger: useVsCodeDebugger)) {
                 var sln = app.CopyProjectForTest(@"TestData\DebuggerProject.sln");
                 var project = app.OpenProject(sln, "BreakpointInfo.py");
@@ -182,8 +186,9 @@ namespace DebuggerUITests {
             }
         }
 
-        public void BoundBreakpoint(VisualStudioApp app, bool useVsCodeDebugger, DotNotWaitOnNormalExit optionSetter) {
+        public void BoundBreakpoint(PythonVisualStudioApp app, bool useVsCodeDebugger, string interpreter, DotNotWaitOnNormalExit optionSetter) {
             var pyService = app.ServiceProvider.GetUIThread().Invoke(() => app.ServiceProvider.GetPythonToolsService());
+            using (SelectDefaultInterpreter(app, interpreter))
             using (new PythonExperimentalGeneralOptionsSetter(pyService, useVsCodeDebugger: useVsCodeDebugger)) {
                 var project = OpenDebuggerProjectAndBreak(app, "BreakpointInfo.py", 2);
 
@@ -214,8 +219,9 @@ namespace DebuggerUITests {
             }
         }
 
-        public void Step(VisualStudioApp app, bool useVsCodeDebugger, DotNotWaitOnNormalExit optionSetter) {
+        public void Step(PythonVisualStudioApp app, bool useVsCodeDebugger, string interpreter, DotNotWaitOnNormalExit optionSetter) {
             var pyService = app.ServiceProvider.GetUIThread().Invoke(() => app.ServiceProvider.GetPythonToolsService());
+            using (SelectDefaultInterpreter(app, interpreter))
             using (new PythonExperimentalGeneralOptionsSetter(pyService, useVsCodeDebugger: useVsCodeDebugger)) {
                 var project = OpenDebuggerProjectAndBreak(app, "SteppingTest.py", 1);
                 app.Dte.Debugger.StepOver(true);
@@ -229,8 +235,9 @@ namespace DebuggerUITests {
             }
         }
 
-        public void ShowCallStackOnCodeMap(VisualStudioApp app, bool useVsCodeDebugger, DotNotWaitOnNormalExit optionSetter) {
+        public void ShowCallStackOnCodeMap(PythonVisualStudioApp app, bool useVsCodeDebugger, string interpreter, DotNotWaitOnNormalExit optionSetter) {
             var pyService = app.ServiceProvider.GetUIThread().Invoke(() => app.ServiceProvider.GetPythonToolsService());
+            using (SelectDefaultInterpreter(app, interpreter))
             using (new PythonExperimentalGeneralOptionsSetter(pyService, useVsCodeDebugger: useVsCodeDebugger)) {
                 var project = OpenDebuggerProjectAndBreak(app, "SteppingTest3.py", 2);
 
@@ -288,8 +295,9 @@ namespace DebuggerUITests {
             }
         }
 
-        public void Step3(VisualStudioApp app, bool useVsCodeDebugger, DotNotWaitOnNormalExit optionSetter) {
+        public void Step3(PythonVisualStudioApp app, bool useVsCodeDebugger, string interpreter, DotNotWaitOnNormalExit optionSetter) {
             var pyService = app.ServiceProvider.GetUIThread().Invoke(() => app.ServiceProvider.GetPythonToolsService());
+            using (SelectDefaultInterpreter(app, interpreter))
             using (new PythonExperimentalGeneralOptionsSetter(pyService, useVsCodeDebugger: useVsCodeDebugger)) {
                 var project = OpenDebuggerProjectAndBreak(app, "SteppingTest3.py", 2);
                 app.Dte.Debugger.StepOut(true);
@@ -303,8 +311,9 @@ namespace DebuggerUITests {
             }
         }
 
-        public void Step5(VisualStudioApp app, bool useVsCodeDebugger, DotNotWaitOnNormalExit optionSetter) {
+        public void Step5(PythonVisualStudioApp app, bool useVsCodeDebugger, string interpreter, DotNotWaitOnNormalExit optionSetter) {
             var pyService = app.ServiceProvider.GetUIThread().Invoke(() => app.ServiceProvider.GetPythonToolsService());
+            using (SelectDefaultInterpreter(app, interpreter))
             using (new PythonExperimentalGeneralOptionsSetter(pyService, useVsCodeDebugger: useVsCodeDebugger)) {
                 var project = OpenDebuggerProjectAndBreak(app, "SteppingTest5.py", 5);
                 app.Dte.Debugger.StepInto(true);
@@ -318,7 +327,7 @@ namespace DebuggerUITests {
             }
         }
 
-        public void SetNextLine(VisualStudioApp app, bool useVsCodeDebugger, DotNotWaitOnNormalExit optionSetter) {
+        public void SetNextLine(PythonVisualStudioApp app, bool useVsCodeDebugger, string interpreter, DotNotWaitOnNormalExit optionSetter) {
             if (useVsCodeDebugger) {
                 // https://github.com/Microsoft/ptvsd/issues/18
                 // This is not implemented in the experimental debugger
@@ -326,6 +335,7 @@ namespace DebuggerUITests {
                 return;
             }
             var pyService = app.ServiceProvider.GetUIThread().Invoke(() => app.ServiceProvider.GetPythonToolsService());
+            using (SelectDefaultInterpreter(app, interpreter))
             using (new PythonExperimentalGeneralOptionsSetter(pyService, useVsCodeDebugger: useVsCodeDebugger)) {
                 var project = OpenDebuggerProjectAndBreak(app, "SetNextLine.py", 7);
 
@@ -386,8 +396,9 @@ namespace DebuggerUITests {
         /// <summary>
         /// Loads the simple project and then terminates the process while we're at a breakpoint.
         /// </summary>
-        public void TerminateProcess(VisualStudioApp app, bool useVsCodeDebugger, DotNotWaitOnNormalExit optionSetter) {
+        public void TerminateProcess(PythonVisualStudioApp app, bool useVsCodeDebugger, string interpreter, DotNotWaitOnNormalExit optionSetter) {
             var pyService = app.ServiceProvider.GetUIThread().Invoke(() => app.ServiceProvider.GetPythonToolsService());
+            using (SelectDefaultInterpreter(app, interpreter))
             using (new PythonExperimentalGeneralOptionsSetter(pyService, useVsCodeDebugger: useVsCodeDebugger)) {
                 StartHelloWorldAndBreak(app);
 
@@ -403,8 +414,9 @@ namespace DebuggerUITests {
         /// <summary>
         /// Loads the simple project and makes sure we get the correct module.
         /// </summary>
-        public void EnumModules(VisualStudioApp app, bool useVsCodeDebugger, DotNotWaitOnNormalExit optionSetter) {
+        public void EnumModules(PythonVisualStudioApp app, bool useVsCodeDebugger, string interpreter, DotNotWaitOnNormalExit optionSetter) {
             var pyService = app.ServiceProvider.GetUIThread().Invoke(() => app.ServiceProvider.GetPythonToolsService());
+            using (SelectDefaultInterpreter(app, interpreter))
             using (new PythonExperimentalGeneralOptionsSetter(pyService, useVsCodeDebugger: useVsCodeDebugger)) {
                 StartHelloWorldAndBreak(app);
 
@@ -423,8 +435,9 @@ namespace DebuggerUITests {
             }
         }
 
-        public void MainThread(VisualStudioApp app, bool useVsCodeDebugger, DotNotWaitOnNormalExit optionSetter) {
+        public void MainThread(PythonVisualStudioApp app, bool useVsCodeDebugger, string interpreter, DotNotWaitOnNormalExit optionSetter) {
             var pyService = app.ServiceProvider.GetUIThread().Invoke(() => app.ServiceProvider.GetPythonToolsService());
+            using (SelectDefaultInterpreter(app, interpreter))
             using (new PythonExperimentalGeneralOptionsSetter(pyService, useVsCodeDebugger: useVsCodeDebugger)) {
                 StartHelloWorldAndBreak(app);
 
@@ -441,8 +454,9 @@ namespace DebuggerUITests {
             }
         }
 
-        public void ExpressionEvaluation(VisualStudioApp app, bool useVsCodeDebugger, DotNotWaitOnNormalExit optionSetter) {
+        public void ExpressionEvaluation(PythonVisualStudioApp app, bool useVsCodeDebugger, string interpreter, DotNotWaitOnNormalExit optionSetter) {
             var pyService = app.ServiceProvider.GetUIThread().Invoke(() => app.ServiceProvider.GetPythonToolsService());
+            using (SelectDefaultInterpreter(app, interpreter))
             using (new PythonExperimentalGeneralOptionsSetter(pyService, useVsCodeDebugger: useVsCodeDebugger)) {
                 OpenDebuggerProject(app, "Program.py");
 
@@ -523,7 +537,7 @@ namespace DebuggerUITests {
             }
         }
 
-        public void SimpleException(VisualStudioApp app, bool useVsCodeDebugger, DotNotWaitOnNormalExit optionSetter) {
+        public void SimpleException(PythonVisualStudioApp app, bool useVsCodeDebugger, string interpreter, DotNotWaitOnNormalExit optionSetter) {
             if (useVsCodeDebugger) {
                 // https://github.com/Microsoft/ptvsd/issues/312
                 // https://github.com/Microsoft/ptvsd/issues/194
@@ -531,20 +545,22 @@ namespace DebuggerUITests {
                 return;
             }
             var pyService = app.ServiceProvider.GetUIThread().Invoke(() => app.ServiceProvider.GetPythonToolsService());
+            using (SelectDefaultInterpreter(app, interpreter))
             using (new PythonExperimentalGeneralOptionsSetter(pyService, useVsCodeDebugger: useVsCodeDebugger)) {
                 ExceptionTest(app, "SimpleException.py", "Exception Thrown", "Exception", "Exception", 3);
             }
         }
 
-        public void SimpleException2(VisualStudioApp app, bool useVsCodeDebugger, DotNotWaitOnNormalExit optionSetter) {
+        public void SimpleException2(PythonVisualStudioApp app, bool useVsCodeDebugger, string interpreter, DotNotWaitOnNormalExit optionSetter) {
             var pyService = app.ServiceProvider.GetUIThread().Invoke(() => app.ServiceProvider.GetPythonToolsService());
+            using (SelectDefaultInterpreter(app, interpreter))
             using (new PythonExperimentalGeneralOptionsSetter(pyService, useVsCodeDebugger: useVsCodeDebugger)) {
                 string exceptionDescription = useVsCodeDebugger ? "ValueError('bad value',)" : "ValueError: bad value";
                 ExceptionTest(app, "SimpleException2.py", "Exception Thrown", exceptionDescription, "ValueError", 3);
             }
         }
 
-        public void SimpleExceptionUnhandled(VisualStudioApp app, bool useVsCodeDebugger, DotNotWaitOnNormalExit optionSetter) {
+        public void SimpleExceptionUnhandled(PythonVisualStudioApp app, bool useVsCodeDebugger, string interpreter, DotNotWaitOnNormalExit optionSetter) {
             if (useVsCodeDebugger) {
                 // This should be done as part of just my code and the fix for hiding debugger
                 // https://github.com/Microsoft/ptvsd/issues/194
@@ -552,14 +568,16 @@ namespace DebuggerUITests {
                 Assert.Inconclusive();
                 return;
             }
+            using (SelectDefaultInterpreter(app, interpreter))
             using (new PythonDebuggingGeneralOptionsSetter(app.Dte, waitOnAbnormalExit: false)) {
                 ExceptionTest(app, "SimpleExceptionUnhandled.py", "Exception User-Unhandled", "ValueError: bad value", "ValueError", 2);
             }
         }
 
         // https://github.com/Microsoft/PTVS/issues/275
-        public void ExceptionInImportLibNotReported(VisualStudioApp app, bool useVsCodeDebugger, DotNotWaitOnNormalExit optionSetter) {
+        public void ExceptionInImportLibNotReported(PythonVisualStudioApp app, bool useVsCodeDebugger, string interpreter, DotNotWaitOnNormalExit optionSetter) {
             var pyService = app.ServiceProvider.GetUIThread().Invoke(() => app.ServiceProvider.GetPythonToolsService());
+            using (SelectDefaultInterpreter(app, interpreter))
             using (new PythonExperimentalGeneralOptionsSetter(pyService, useVsCodeDebugger: useVsCodeDebugger))
             using (new DebuggingGeneralOptionsSetter(app.Dte, enableJustMyCode: true)) {
                 OpenDebuggerProjectAndBreak(app, "ImportLibException.py", 2);
@@ -568,8 +586,9 @@ namespace DebuggerUITests {
             }
         }
 
-        public void Breakpoints(VisualStudioApp app, bool useVsCodeDebugger, DotNotWaitOnNormalExit optionSetter) {
+        public void Breakpoints(PythonVisualStudioApp app, bool useVsCodeDebugger, string interpreter, DotNotWaitOnNormalExit optionSetter) {
             var pyService = app.ServiceProvider.GetUIThread().Invoke(() => app.ServiceProvider.GetPythonToolsService());
+            using (SelectDefaultInterpreter(app, interpreter))
             using (new PythonExperimentalGeneralOptionsSetter(pyService, useVsCodeDebugger: useVsCodeDebugger)) {
                 OpenDebuggerProjectAndBreak(app, "BreakpointTest2.py", 3);
                 var debug3 = (Debugger3)app.Dte.Debugger;
@@ -584,8 +603,9 @@ namespace DebuggerUITests {
             }
         }
 
-        public void BreakpointsDisable(VisualStudioApp app, bool useVsCodeDebugger, DotNotWaitOnNormalExit optionSetter) {
+        public void BreakpointsDisable(PythonVisualStudioApp app, bool useVsCodeDebugger, string interpreter, DotNotWaitOnNormalExit optionSetter) {
             var pyService = app.ServiceProvider.GetUIThread().Invoke(() => app.ServiceProvider.GetPythonToolsService());
+            using (SelectDefaultInterpreter(app, interpreter))
             using (new PythonExperimentalGeneralOptionsSetter(pyService, useVsCodeDebugger: useVsCodeDebugger)) {
                 OpenDebuggerProjectAndBreak(app, "BreakpointTest4.py", 2);
                 var debug3 = (Debugger3)app.Dte.Debugger;
@@ -606,8 +626,9 @@ namespace DebuggerUITests {
             }
         }
 
-        public void BreakpointsDisableReenable(VisualStudioApp app, bool useVsCodeDebugger, DotNotWaitOnNormalExit optionSetter) {
+        public void BreakpointsDisableReenable(PythonVisualStudioApp app, bool useVsCodeDebugger, string interpreter, DotNotWaitOnNormalExit optionSetter) {
             var pyService = app.ServiceProvider.GetUIThread().Invoke(() => app.ServiceProvider.GetPythonToolsService());
+            using (SelectDefaultInterpreter(app, interpreter))
             using (new PythonExperimentalGeneralOptionsSetter(pyService, useVsCodeDebugger: useVsCodeDebugger)) {
                 var debug3 = (Debugger3)app.Dte.Debugger;
                 OpenDebuggerProjectAndBreak(app, "BreakpointTest4.py", 2);
@@ -664,8 +685,9 @@ namespace DebuggerUITests {
         /// <summary>
         /// Make sure the presence of errors causes F5 to prevent running w/o a confirmation.
         /// </summary>
-        public void LaunchWithErrorsDontRun(PythonVisualStudioApp app, bool useVsCodeDebugger, DotNotWaitOnNormalExit optionSetter) {
+        public void LaunchWithErrorsDontRun(PythonVisualStudioApp app, bool useVsCodeDebugger, string interpreter, DotNotWaitOnNormalExit optionSetter) {
             var pyService = app.ServiceProvider.GetUIThread().Invoke(() => app.ServiceProvider.GetPythonToolsService());
+            using (SelectDefaultInterpreter(app, interpreter))
             using (new PythonExperimentalGeneralOptionsSetter(pyService, useVsCodeDebugger: useVsCodeDebugger)) 
             using (new PythonDebuggingGeneralOptionsSetter(app.Dte, promptBeforeRunningWithBuildErrorSetting: true)) {
                 var sln = app.CopyProjectForTest(@"TestData\ErrorProject.sln");
@@ -697,8 +719,9 @@ namespace DebuggerUITests {
         /// <summary>
         /// Start with debugging, with script but no project.
         /// </summary>
-        public void StartWithDebuggingNoProject(VisualStudioApp app, bool useVsCodeDebugger, DotNotWaitOnNormalExit optionSetter) {
+        public void StartWithDebuggingNoProject(PythonVisualStudioApp app, bool useVsCodeDebugger, string interpreter, DotNotWaitOnNormalExit optionSetter) {
             var pyService = app.ServiceProvider.GetUIThread().Invoke(() => app.ServiceProvider.GetPythonToolsService());
+            using (SelectDefaultInterpreter(app, interpreter))
             using (new PythonExperimentalGeneralOptionsSetter(pyService, useVsCodeDebugger: useVsCodeDebugger)) {
                 string scriptFilePath = TestData.GetPath(@"TestData\HelloWorld\Program.py");
 
@@ -719,8 +742,9 @@ namespace DebuggerUITests {
         /// <summary>
         /// Start without debugging, with script but no project.
         /// </summary>
-        public void StartWithoutDebuggingNoProject(VisualStudioApp app, bool useVsCodeDebugger, DotNotWaitOnNormalExit optionSetter) {
+        public void StartWithoutDebuggingNoProject(PythonVisualStudioApp app, bool useVsCodeDebugger, string interpreter, DotNotWaitOnNormalExit optionSetter) {
             var pyService = app.ServiceProvider.GetUIThread().Invoke(() => app.ServiceProvider.GetPythonToolsService());
+            using (SelectDefaultInterpreter(app, interpreter))
             using (new PythonExperimentalGeneralOptionsSetter(pyService, useVsCodeDebugger: useVsCodeDebugger)) {
                 var tempFolder = TestData.GetTempPath();
                 string scriptFilePath = Path.Combine(tempFolder, "CreateFile1.py");
@@ -740,8 +764,9 @@ namespace DebuggerUITests {
         /// <summary>
         /// Start with debugging, with script not in project.
         /// </summary>
-        public void StartWithDebuggingNotInProject(VisualStudioApp app, bool useVsCodeDebugger, DotNotWaitOnNormalExit optionSetter) {
+        public void StartWithDebuggingNotInProject(PythonVisualStudioApp app, bool useVsCodeDebugger, string interpreter, DotNotWaitOnNormalExit optionSetter) {
             var pyService = app.ServiceProvider.GetUIThread().Invoke(() => app.ServiceProvider.GetPythonToolsService());
+            using (SelectDefaultInterpreter(app, interpreter))
             using (new PythonExperimentalGeneralOptionsSetter(pyService, useVsCodeDebugger: useVsCodeDebugger)) {
                 string scriptFilePath = TestData.GetPath(@"TestData\HelloWorld\Program.py");
 
@@ -761,8 +786,9 @@ namespace DebuggerUITests {
         /// <summary>
         /// Start without debugging, with script not in project.
         /// </summary>
-        public void StartWithoutDebuggingNotInProject(VisualStudioApp app, bool useVsCodeDebugger, DotNotWaitOnNormalExit optionSetter) {
+        public void StartWithoutDebuggingNotInProject(PythonVisualStudioApp app, bool useVsCodeDebugger, string interpreter, DotNotWaitOnNormalExit optionSetter) {
             var pyService = app.ServiceProvider.GetUIThread().Invoke(() => app.ServiceProvider.GetPythonToolsService());
+            using (SelectDefaultInterpreter(app, interpreter))
             using (new PythonExperimentalGeneralOptionsSetter(pyService, useVsCodeDebugger: useVsCodeDebugger)) {
                 var tempFolder = TestData.GetTempPath();
                 string scriptFilePath = Path.Combine(tempFolder, "CreateFile2.py");
@@ -782,8 +808,9 @@ namespace DebuggerUITests {
         /// <summary>
         /// Start with debuggging, with script in project.
         /// </summary>
-        public void StartWithDebuggingInProject(VisualStudioApp app, bool useVsCodeDebugger, DotNotWaitOnNormalExit optionSetter) {
+        public void StartWithDebuggingInProject(PythonVisualStudioApp app, bool useVsCodeDebugger, string interpreter, DotNotWaitOnNormalExit optionSetter) {
             var pyService = app.ServiceProvider.GetUIThread().Invoke(() => app.ServiceProvider.GetPythonToolsService());
+            using (SelectDefaultInterpreter(app, interpreter))
             using (new PythonExperimentalGeneralOptionsSetter(pyService, useVsCodeDebugger: useVsCodeDebugger)) {
                 var proj = OpenDebuggerProject(app);
                 var projDir = PathUtils.GetParent(proj.FullName);
@@ -803,8 +830,9 @@ namespace DebuggerUITests {
         /// <summary>
         /// Start with debuggging, with script in subfolder project.
         /// </summary>
-        public void StartWithDebuggingSubfolderInProject(VisualStudioApp app, bool useVsCodeDebugger, DotNotWaitOnNormalExit optionSetter) {
+        public void StartWithDebuggingSubfolderInProject(PythonVisualStudioApp app, bool useVsCodeDebugger, string interpreter, DotNotWaitOnNormalExit optionSetter) {
             var pyService = app.ServiceProvider.GetUIThread().Invoke(() => app.ServiceProvider.GetPythonToolsService());
+            using (SelectDefaultInterpreter(app, interpreter))
             using (new PythonExperimentalGeneralOptionsSetter(pyService, useVsCodeDebugger: useVsCodeDebugger)) {
                 var proj = OpenDebuggerProject(app);
                 var projDir = PathUtils.GetParent(proj.FullName);
@@ -832,8 +860,9 @@ namespace DebuggerUITests {
         /// <summary>
         /// Start without debuggging, with script in project.
         /// </summary>
-        public void StartWithoutDebuggingInProject(VisualStudioApp app, bool useVsCodeDebugger, DotNotWaitOnNormalExit optionSetter) {
+        public void StartWithoutDebuggingInProject(PythonVisualStudioApp app, bool useVsCodeDebugger, string interpreter, DotNotWaitOnNormalExit optionSetter) {
             var pyService = app.ServiceProvider.GetUIThread().Invoke(() => app.ServiceProvider.GetPythonToolsService());
+            using (SelectDefaultInterpreter(app, interpreter))
             using (new PythonExperimentalGeneralOptionsSetter(pyService, useVsCodeDebugger: useVsCodeDebugger)) {
                 var proj = OpenDebuggerProject(app);
                 var projDir = PathUtils.GetParent(proj.FullName);
@@ -851,8 +880,9 @@ namespace DebuggerUITests {
         /// <summary>
         /// Start with debugging, no script.
         /// </summary>
-        public void StartWithDebuggingNoScript(VisualStudioApp app, bool useVsCodeDebugger, DotNotWaitOnNormalExit optionSetter) {
+        public void StartWithDebuggingNoScript(PythonVisualStudioApp app, bool useVsCodeDebugger, string interpreter, DotNotWaitOnNormalExit optionSetter) {
             var pyService = app.ServiceProvider.GetUIThread().Invoke(() => app.ServiceProvider.GetPythonToolsService());
+            using (SelectDefaultInterpreter(app, interpreter))
             using (new PythonExperimentalGeneralOptionsSetter(pyService, useVsCodeDebugger: useVsCodeDebugger)) {
                 try {
                     app.ExecuteCommand("Python.StartWithDebugging");
@@ -866,8 +896,9 @@ namespace DebuggerUITests {
         /// <summary>
         /// Start without debugging, no script.
         /// </summary>
-        public void StartWithoutDebuggingNoScript(VisualStudioApp app, bool useVsCodeDebugger, DotNotWaitOnNormalExit optionSetter) {
+        public void StartWithoutDebuggingNoScript(PythonVisualStudioApp app, bool useVsCodeDebugger, string interpreter, DotNotWaitOnNormalExit optionSetter) {
             var pyService = app.ServiceProvider.GetUIThread().Invoke(() => app.ServiceProvider.GetPythonToolsService());
+            using (SelectDefaultInterpreter(app, interpreter))
             using (new PythonExperimentalGeneralOptionsSetter(pyService, useVsCodeDebugger: useVsCodeDebugger)) {
                 try {
                     app.ExecuteCommand("Python.StartWithoutDebugging");
@@ -878,8 +909,9 @@ namespace DebuggerUITests {
             }
         }
 
-        public void WebProjectLauncherNoStartupFile(VisualStudioApp app, bool useVsCodeDebugger, DotNotWaitOnNormalExit optionSetter) {
+        public void WebProjectLauncherNoStartupFile(PythonVisualStudioApp app, bool useVsCodeDebugger, string interpreter, DotNotWaitOnNormalExit optionSetter) {
             var pyService = app.ServiceProvider.GetUIThread().Invoke(() => app.ServiceProvider.GetPythonToolsService());
+            using (SelectDefaultInterpreter(app, interpreter))
             using (new PythonExperimentalGeneralOptionsSetter(pyService, useVsCodeDebugger: useVsCodeDebugger)) {
                 var project = app.CreateProject(
                     PythonVisualStudioApp.TemplateLanguageName,
@@ -918,7 +950,7 @@ namespace DebuggerUITests {
             Assert.IsTrue(exists, "Python script was expected to create file '{0}'.", createdFilePath);
         }
 
-        private static void ExceptionTest(VisualStudioApp app, string filename, string expectedTitle, string expectedDescription, string exceptionType, int expectedLine) {
+        private static void ExceptionTest(PythonVisualStudioApp app, string filename, string expectedTitle, string expectedDescription, string exceptionType, int expectedLine) {
             var debug3 = (Debugger3)app.Dte.Debugger;
             using (new DebuggingGeneralOptionsSetter(app.Dte, enableJustMyCode: true)) {
                 OpenDebuggerProject(app, filename);
@@ -999,6 +1031,28 @@ namespace DebuggerUITests {
             }
 
             Assert.AreEqual(mode, app.Dte.Debugger.CurrentMode);
+        }
+
+        class EmptyDisposable : IDisposable {
+            public void Dispose() {
+            }
+        }
+
+        private static IDisposable SelectDefaultInterpreter(PythonVisualStudioApp app, string pythonVersion) {
+            if (string.IsNullOrEmpty(pythonVersion)) {
+                return new EmptyDisposable();
+            }
+
+            return app.SelectDefaultInterpreter(FindInterpreter(pythonVersion));
+        }
+
+        private static PythonVersion FindInterpreter(string pythonVersion) {
+            var interpreter = PythonPaths.GetVersionsByName(pythonVersion).FirstOrDefault();
+            if (interpreter == null) {
+                Assert.Inconclusive($"Interpreter '{pythonVersion}' not installed.");
+            }
+
+            return interpreter;
         }
         #endregion
 

--- a/Python/Tests/DebuggerUITests/MixedModeDebugProjectUITests.cs
+++ b/Python/Tests/DebuggerUITests/MixedModeDebugProjectUITests.cs
@@ -16,13 +16,11 @@
 
 using System.IO;
 using System.Linq;
-using System.Reflection;
 using EnvDTE;
 using TestUtilities;
 using TestUtilities.UI;
 using TestUtilities.UI.Python;
 using Assert = Microsoft.VisualStudio.TestTools.UnitTesting.Assert;
-using Thread = System.Threading.Thread;
 
 namespace DebuggerUITests {
     public class MixedModeDebugProjectUITests {
@@ -59,14 +57,7 @@ namespace DebuggerUITests {
         }
 
         private static PythonVersion FindInterpreter(string pythonVersion) {
-            // Examples of values for pythonVersion (match field names on PythonPaths):
-            // "Python36"
-            // "Python36|Python36_x64"
-            var interpreter = pythonVersion.Split('|')
-                .Select(v => typeof(PythonPaths).GetField(v, BindingFlags.Static | BindingFlags.Public)?.GetValue(null) as PythonVersion)
-                .Where(HasSymbols)
-                .FirstOrDefault();
-
+            var interpreter = PythonPaths.GetVersionsByName(pythonVersion, HasSymbols).FirstOrDefault();
             if (interpreter == null) {
                 Assert.Inconclusive($"Interpreter '{pythonVersion}' not installed.");
             }

--- a/Python/Tests/DebuggerUITestsRunner/DebugProjectUITests.cs
+++ b/Python/Tests/DebuggerUITestsRunner/DebugProjectUITests.cs
@@ -262,13 +262,11 @@ namespace DebuggerUITestsRunner {
 
     [TestClass]
     public class DebugProjectUITestsExperimental27 : DebugProjectUITestsExperimental {
-        protected override bool UseVsCodeDebugger => true;
         protected override string Interpreter => "Python27|Python27_x64";
     }
 
     [TestClass]
     public class DebugProjectUITestsExperimental36 : DebugProjectUITestsExperimental {
-        protected override bool UseVsCodeDebugger => true;
         protected override string Interpreter => "Python36|Python36_x64";
     }
 }

--- a/Python/Tests/DebuggerUITestsRunner/DebugProjectUITests.cs
+++ b/Python/Tests/DebuggerUITestsRunner/DebugProjectUITests.cs
@@ -41,218 +41,234 @@ namespace DebuggerUITestsRunner {
 
         protected abstract bool UseVsCodeDebugger { get; }
 
+        protected abstract string Interpreter { get; }
+
         [TestMethod, Priority(0)]
         [TestCategory("Installed")]
         public void DebugPythonProject() {
-            _vs.RunTest(nameof(DebuggerUITests.DebugProjectUITests.DebugPythonProject), UseVsCodeDebugger);
+            _vs.RunTest(nameof(DebuggerUITests.DebugProjectUITests.DebugPythonProject), UseVsCodeDebugger, Interpreter);
         }
 
         [TestMethod, Priority(0)]
         [TestCategory("Installed")]
         public void DebugPythonProjectSubFolderStartupFileSysPath() {
-            _vs.RunTest(nameof(DebuggerUITests.DebugProjectUITests.DebugPythonProjectSubFolderStartupFileSysPath), UseVsCodeDebugger);
+            _vs.RunTest(nameof(DebuggerUITests.DebugProjectUITests.DebugPythonProjectSubFolderStartupFileSysPath), UseVsCodeDebugger, Interpreter);
         }
 
         [TestMethod, Priority(0)]
         [TestCategory("Installed")]
         public void DebugPythonProjectWithAndWithoutClearingPythonPath() {
-            _vs.RunTest(nameof(DebuggerUITests.DebugProjectUITests.DebugPythonProjectWithAndWithoutClearingPythonPath), UseVsCodeDebugger);
+            _vs.RunTest(nameof(DebuggerUITests.DebugProjectUITests.DebugPythonProjectWithAndWithoutClearingPythonPath), UseVsCodeDebugger, Interpreter);
         }
 
         [TestMethod, Priority(0)]
         [TestCategory("Installed")]
         public void DebugPythonCustomInterpreter() {
+            // This test uses a custom 2.7 interpreter
             _vs.RunTest(nameof(DebuggerUITests.DebugProjectUITests.DebugPythonCustomInterpreter), UseVsCodeDebugger);
         }
 
         [TestMethod, Priority(0)]
         [TestCategory("Installed")]
         public void DebugPythonCustomInterpreterMissing() {
-            _vs.RunTest(nameof(DebuggerUITests.DebugProjectUITests.DebugPythonCustomInterpreterMissing), UseVsCodeDebugger);
+            _vs.RunTest(nameof(DebuggerUITests.DebugProjectUITests.DebugPythonCustomInterpreterMissing), UseVsCodeDebugger, Interpreter);
         }
 
         [TestMethod, Priority(0)]
         [TestCategory("Installed")]
         public void PendingBreakPointLocation() {
-            _vs.RunTest(nameof(DebuggerUITests.DebugProjectUITests.PendingBreakPointLocation), UseVsCodeDebugger);
+            _vs.RunTest(nameof(DebuggerUITests.DebugProjectUITests.PendingBreakPointLocation), UseVsCodeDebugger, Interpreter);
         }
 
         [TestMethod, Priority(2)]
         [TestCategory("Installed")]
         public void BoundBreakpoint() {
-            _vs.RunTest(nameof(DebuggerUITests.DebugProjectUITests.BoundBreakpoint), UseVsCodeDebugger);
+            _vs.RunTest(nameof(DebuggerUITests.DebugProjectUITests.BoundBreakpoint), UseVsCodeDebugger, Interpreter);
         }
 
         [TestMethod, Priority(0)]
         [TestCategory("Installed")]
         public void Step() {
-            _vs.RunTest(nameof(DebuggerUITests.DebugProjectUITests.Step), UseVsCodeDebugger);
+            _vs.RunTest(nameof(DebuggerUITests.DebugProjectUITests.Step), UseVsCodeDebugger, Interpreter);
         }
 
         [TestMethod, Priority(2)]
         [TestCategory("Installed")]
         public void ShowCallStackOnCodeMap() {
-            _vs.RunTest(nameof(DebuggerUITests.DebugProjectUITests.ShowCallStackOnCodeMap), UseVsCodeDebugger);
+            _vs.RunTest(nameof(DebuggerUITests.DebugProjectUITests.ShowCallStackOnCodeMap), UseVsCodeDebugger, Interpreter);
         }
 
         [TestMethod, Priority(0)]
         [TestCategory("Installed")]
         public void Step3() {
-            _vs.RunTest(nameof(DebuggerUITests.DebugProjectUITests.Step3), UseVsCodeDebugger);
+            _vs.RunTest(nameof(DebuggerUITests.DebugProjectUITests.Step3), UseVsCodeDebugger, Interpreter);
         }
 
         [TestMethod, Priority(0)]
         [TestCategory("Installed")]
         public void Step5() {
-            _vs.RunTest(nameof(DebuggerUITests.DebugProjectUITests.Step5), UseVsCodeDebugger);
+            _vs.RunTest(nameof(DebuggerUITests.DebugProjectUITests.Step5), UseVsCodeDebugger, Interpreter);
         }
 
         [TestMethod, Priority(2)]
         [TestCategory("Installed")]
         public void SetNextLine() {
-            _vs.RunTest(nameof(DebuggerUITests.DebugProjectUITests.SetNextLine), UseVsCodeDebugger);
+            _vs.RunTest(nameof(DebuggerUITests.DebugProjectUITests.SetNextLine), UseVsCodeDebugger, Interpreter);
         }
 
         [TestMethod, Priority(0)]
         [TestCategory("Installed")]
         public void TerminateProcess() {
-            _vs.RunTest(nameof(DebuggerUITests.DebugProjectUITests.TerminateProcess), UseVsCodeDebugger);
+            _vs.RunTest(nameof(DebuggerUITests.DebugProjectUITests.TerminateProcess), UseVsCodeDebugger, Interpreter);
         }
 
         [TestMethod, Priority(2)]
         [TestCategory("Installed")]
         public void EnumModules() {
-            _vs.RunTest(nameof(DebuggerUITests.DebugProjectUITests.EnumModules), UseVsCodeDebugger);
+            _vs.RunTest(nameof(DebuggerUITests.DebugProjectUITests.EnumModules), UseVsCodeDebugger, Interpreter);
         }
 
         [TestMethod, Priority(2)]
         [TestCategory("Installed")]
         public void MainThread() {
-            _vs.RunTest(nameof(DebuggerUITests.DebugProjectUITests.MainThread), UseVsCodeDebugger);
+            _vs.RunTest(nameof(DebuggerUITests.DebugProjectUITests.MainThread), UseVsCodeDebugger, Interpreter);
         }
 
         [TestMethod, Priority(2)]
         [TestCategory("Installed")]
         public void ExpressionEvaluation() {
-            _vs.RunTest(nameof(DebuggerUITests.DebugProjectUITests.ExpressionEvaluation), UseVsCodeDebugger);
+            _vs.RunTest(nameof(DebuggerUITests.DebugProjectUITests.ExpressionEvaluation), UseVsCodeDebugger, Interpreter);
         }
 
         [TestMethod, Priority(0)]
         [TestCategory("Installed")]
         public void SimpleException() {
-            _vs.RunTest(nameof(DebuggerUITests.DebugProjectUITests.SimpleException), UseVsCodeDebugger);
+            _vs.RunTest(nameof(DebuggerUITests.DebugProjectUITests.SimpleException), UseVsCodeDebugger, Interpreter);
         }
 
         [TestMethod, Priority(0)]
         [TestCategory("Installed")]
         public void SimpleException2() {
-            _vs.RunTest(nameof(DebuggerUITests.DebugProjectUITests.SimpleException2), UseVsCodeDebugger);
+            _vs.RunTest(nameof(DebuggerUITests.DebugProjectUITests.SimpleException2), UseVsCodeDebugger, Interpreter);
         }
 
         [TestMethod, Priority(0)]
         [TestCategory("Installed")]
         public void SimpleExceptionUnhandled() {
-            _vs.RunTest(nameof(DebuggerUITests.DebugProjectUITests.SimpleExceptionUnhandled), UseVsCodeDebugger);
+            _vs.RunTest(nameof(DebuggerUITests.DebugProjectUITests.SimpleExceptionUnhandled), UseVsCodeDebugger, Interpreter);
         }
 
         [TestMethod, Priority(0)]
         [TestCategory("Installed")]
         public void ExceptionInImportLibNotReported() {
-            _vs.RunTest(nameof(DebuggerUITests.DebugProjectUITests.ExceptionInImportLibNotReported), UseVsCodeDebugger);
+            _vs.RunTest(nameof(DebuggerUITests.DebugProjectUITests.ExceptionInImportLibNotReported), UseVsCodeDebugger, Interpreter);
         }
 
         [TestMethod, Priority(0)]
         [TestCategory("Installed")]
         public void Breakpoints() {
-            _vs.RunTest(nameof(DebuggerUITests.DebugProjectUITests.Breakpoints), UseVsCodeDebugger);
+            _vs.RunTest(nameof(DebuggerUITests.DebugProjectUITests.Breakpoints), UseVsCodeDebugger, Interpreter);
         }
 
         [TestMethod, Priority(2)]
         [TestCategory("Installed")]
         public void BreakpointsDisable() {
-            _vs.RunTest(nameof(DebuggerUITests.DebugProjectUITests.BreakpointsDisable), UseVsCodeDebugger);
+            _vs.RunTest(nameof(DebuggerUITests.DebugProjectUITests.BreakpointsDisable), UseVsCodeDebugger, Interpreter);
         }
 
         [TestMethod, Priority(2)]
         [TestCategory("Installed")]
         public void BreakpointsDisableReenable() {
-            _vs.RunTest(nameof(DebuggerUITests.DebugProjectUITests.BreakpointsDisableReenable), UseVsCodeDebugger);
+            _vs.RunTest(nameof(DebuggerUITests.DebugProjectUITests.BreakpointsDisableReenable), UseVsCodeDebugger, Interpreter);
         }
 
         [TestMethod, Priority(0)]
         [TestCategory("Installed")]
         public void LaunchWithErrorsDontRun() {
-            _vs.RunTest(nameof(DebuggerUITests.DebugProjectUITests.LaunchWithErrorsDontRun), UseVsCodeDebugger);
+            _vs.RunTest(nameof(DebuggerUITests.DebugProjectUITests.LaunchWithErrorsDontRun), UseVsCodeDebugger, Interpreter);
         }
 
         [TestMethod, Priority(2)]
         [TestCategory("Installed")]
         public void StartWithDebuggingNoProject() {
-            _vs.RunTest(nameof(DebuggerUITests.DebugProjectUITests.StartWithDebuggingNoProject), UseVsCodeDebugger);
+            _vs.RunTest(nameof(DebuggerUITests.DebugProjectUITests.StartWithDebuggingNoProject), UseVsCodeDebugger, Interpreter);
         }
 
         [TestMethod, Priority(0)]
         [TestCategory("Installed")]
         public void StartWithoutDebuggingNoProject() {
-            _vs.RunTest(nameof(DebuggerUITests.DebugProjectUITests.StartWithoutDebuggingNoProject), UseVsCodeDebugger);
+            _vs.RunTest(nameof(DebuggerUITests.DebugProjectUITests.StartWithoutDebuggingNoProject), UseVsCodeDebugger, Interpreter);
         }
 
         [TestMethod, Priority(0)]
         [TestCategory("Installed")]
         public void StartWithDebuggingNotInProject() {
-            _vs.RunTest(nameof(DebuggerUITests.DebugProjectUITests.StartWithDebuggingNotInProject), UseVsCodeDebugger);
+            _vs.RunTest(nameof(DebuggerUITests.DebugProjectUITests.StartWithDebuggingNotInProject), UseVsCodeDebugger, Interpreter);
         }
 
         [TestMethod, Priority(0)]
         [TestCategory("Installed")]
         public void StartWithoutDebuggingNotInProject() {
-            _vs.RunTest(nameof(DebuggerUITests.DebugProjectUITests.StartWithoutDebuggingNotInProject), UseVsCodeDebugger);
+            _vs.RunTest(nameof(DebuggerUITests.DebugProjectUITests.StartWithoutDebuggingNotInProject), UseVsCodeDebugger, Interpreter);
         }
 
         [TestMethod, Priority(0)]
         [TestCategory("Installed")]
         public void StartWithDebuggingInProject() {
-            _vs.RunTest(nameof(DebuggerUITests.DebugProjectUITests.StartWithDebuggingInProject), UseVsCodeDebugger);
+            _vs.RunTest(nameof(DebuggerUITests.DebugProjectUITests.StartWithDebuggingInProject), UseVsCodeDebugger, Interpreter);
         }
 
         [TestMethod, Priority(2)]
         [TestCategory("Installed")]
         public void StartWithDebuggingSubfolderInProject() {
-            _vs.RunTest(nameof(DebuggerUITests.DebugProjectUITests.StartWithDebuggingSubfolderInProject), UseVsCodeDebugger);
+            _vs.RunTest(nameof(DebuggerUITests.DebugProjectUITests.StartWithDebuggingSubfolderInProject), UseVsCodeDebugger, Interpreter);
         }
 
         [TestMethod, Priority(0)]
         [TestCategory("Installed")]
         public void StartWithoutDebuggingInProject() {
-            _vs.RunTest(nameof(DebuggerUITests.DebugProjectUITests.StartWithoutDebuggingInProject), UseVsCodeDebugger);
+            _vs.RunTest(nameof(DebuggerUITests.DebugProjectUITests.StartWithoutDebuggingInProject), UseVsCodeDebugger, Interpreter);
         }
 
         [TestMethod, Priority(0)]
         [TestCategory("Installed")]
         public void StartWithDebuggingNoScript() {
-            _vs.RunTest(nameof(DebuggerUITests.DebugProjectUITests.StartWithDebuggingNoScript), UseVsCodeDebugger);
+            _vs.RunTest(nameof(DebuggerUITests.DebugProjectUITests.StartWithDebuggingNoScript), UseVsCodeDebugger, Interpreter);
         }
 
         [TestMethod, Priority(0)]
         [TestCategory("Installed")]
         public void StartWithoutDebuggingNoScript() {
-            _vs.RunTest(nameof(DebuggerUITests.DebugProjectUITests.StartWithoutDebuggingNoScript), UseVsCodeDebugger);
+            _vs.RunTest(nameof(DebuggerUITests.DebugProjectUITests.StartWithoutDebuggingNoScript), UseVsCodeDebugger, Interpreter);
         }
 
         [TestMethod, Priority(0)]
         [TestCategory("Installed")]
         public void WebProjectLauncherNoStartupFile() {
-            _vs.RunTest(nameof(DebuggerUITests.DebugProjectUITests.WebProjectLauncherNoStartupFile), UseVsCodeDebugger);
+            _vs.RunTest(nameof(DebuggerUITests.DebugProjectUITests.WebProjectLauncherNoStartupFile), UseVsCodeDebugger, Interpreter);
         }
     }
 
     [TestClass]
     public class DebugProjectUITestsVS : DebugProjectUITests {
         protected override bool UseVsCodeDebugger => false;
+        protected override string Interpreter => ""; // Use the existing global default
+    }
+
+    [TestClass, Ignore]
+    public abstract class DebugProjectUITestsExperimental : DebugProjectUITests {
+        protected override bool UseVsCodeDebugger => true;
     }
 
     [TestClass]
-    public class DebugProjectUITestsExperimental : DebugProjectUITests {
+    public class DebugProjectUITestsExperimental27 : DebugProjectUITestsExperimental {
         protected override bool UseVsCodeDebugger => true;
+        protected override string Interpreter => "Python27|Python27_x64";
+    }
+
+    [TestClass]
+    public class DebugProjectUITestsExperimental36 : DebugProjectUITestsExperimental {
+        protected override bool UseVsCodeDebugger => true;
+        protected override string Interpreter => "Python36|Python36_x64";
     }
 }

--- a/Python/Tests/DebuggerUITestsRunner/DebugProjectUITests.cs
+++ b/Python/Tests/DebuggerUITestsRunner/DebugProjectUITests.cs
@@ -64,8 +64,7 @@ namespace DebuggerUITestsRunner {
         [TestMethod, Priority(0)]
         [TestCategory("Installed")]
         public void DebugPythonCustomInterpreter() {
-            // This test uses a custom 2.7 interpreter
-            _vs.RunTest(nameof(DebuggerUITests.DebugProjectUITests.DebugPythonCustomInterpreter), UseVsCodeDebugger);
+            _vs.RunTest(nameof(DebuggerUITests.DebugProjectUITests.DebugPythonCustomInterpreter), UseVsCodeDebugger, Interpreter);
         }
 
         [TestMethod, Priority(0)]

--- a/Python/Tests/Utilities.Python.Analysis/PythonPaths.cs
+++ b/Python/Tests/Utilities.Python.Analysis/PythonPaths.cs
@@ -212,6 +212,20 @@ namespace TestUtilities {
                 if (Jython27 != null) yield return Jython27;
             }
         }
+
+        /// <summary>
+        /// Get the installed Python versions that match the specified name expression and filter.
+        /// </summary>
+        /// <param name="nameExpr">Name or '|' separated list of names that match the fields on <c>PythonPaths</c>. Ex: "Python36", "Python36|Python36_x64"</param>
+        /// <param name="filter">Additional filter.</param>
+        /// <returns>Installed Python versions that match the names and filter.</returns>
+        public static PythonVersion[] GetVersionsByName(string nameExpr, Predicate<PythonVersion> filter = null) {
+            return nameExpr
+                .Split('|')
+                .Select(v => typeof(PythonPaths).GetField(v, BindingFlags.Static | BindingFlags.Public)?.GetValue(null) as PythonVersion)
+                .Where(v => v != null && (filter != null ? filter(v) : true))
+                .ToArray();
+        }
     }
 
     public class PythonVersion {


### PR DESCRIPTION
Previous behavior for the tests was to use whatever happened to be the default on that machine.

Since we're seeing version specific bugs right now, it will be useful to see results for both 2.7 and 3.6.

I didn't duplicate the old debugger tests, not as much benefit there since the code isn't changing much / at all and that would increase the test run time.