### PR TITLE
Add command handling for LS extensions

### DIFF
--- a/Python/Product/Analysis/AnalysisNetStandard.csproj
+++ b/Python/Product/Analysis/AnalysisNetStandard.csproj
@@ -4,6 +4,12 @@
     <RootNamespace>Microsoft.PythonTools.Analysis</RootNamespace>
     <AssemblyName>Microsoft.Python.Analysis.Engine</AssemblyName>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <NoWarn>1701;1702;1998</NoWarn>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <NoWarn>1701;1702;1998</NoWarn>
+  </PropertyGroup>
   <Import Project="..\NetStandard.settings" />
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
   <ItemGroup>

--- a/Python/Product/Analysis/AnalysisNetStandard.csproj
+++ b/Python/Product/Analysis/AnalysisNetStandard.csproj
@@ -5,6 +5,10 @@
     <AssemblyName>Microsoft.Python.Analysis.Engine</AssemblyName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <!-- 
+      1701, 1702 - "You may need to supply assembly policy"
+      1998 - "This async method lacks 'await'"
+    -->
     <NoWarn>1701;1702;1998</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/Python/Product/Analysis/LanguageServer/IServer.cs
+++ b/Python/Product/Analysis/LanguageServer/IServer.cs
@@ -61,6 +61,9 @@ namespace Microsoft.PythonTools.Analysis.LanguageServer {
         event EventHandler<TelemetryEventArgs> OnTelemetry;
         void Telemetry(TelemetryEventArgs e);
 
+        event EventHandler<CommandEventArgs> OnCommand;
+        void Command(CommandEventArgs e);
+
         event EventHandler<RegisterCapabilityEventArgs> OnRegisterCapability;
         Task RegisterCapability(RegistrationParams @params);
 

--- a/Python/Product/Analysis/LanguageServer/Messages.cs
+++ b/Python/Product/Analysis/LanguageServer/Messages.cs
@@ -79,6 +79,11 @@ namespace Microsoft.PythonTools.Analysis.LanguageServer {
         public object value { get; set; }
     }
 
+    public sealed class CommandEventArgs: EventArgs {
+        public string command;
+        public object[] arguments;
+    }
+
     [Serializable]
     public struct RegistrationParams {
         public Registration[] registrations;

--- a/Python/Product/Analysis/LanguageServer/Server.Completion.cs
+++ b/Python/Product/Analysis/LanguageServer/Server.Completion.cs
@@ -89,13 +89,6 @@ namespace Microsoft.PythonTools.Analysis.LanguageServer {
                     LogMessage(MessageType.Error, $"Error while post-processing completions: {ex}");
                 }
             }
-
-            for(var i = 0; i < res.items.Length; i++) {
-                res.items[i].command = new Command {
-                    command = completionItemCommand,
-                    arguments = new object[] { res.items[i].label }
-                };
-            }
             return Task.FromResult(res);
         }
 

--- a/Python/Product/Analysis/LanguageServer/Server.Completion.cs
+++ b/Python/Product/Analysis/LanguageServer/Server.Completion.cs
@@ -90,6 +90,12 @@ namespace Microsoft.PythonTools.Analysis.LanguageServer {
                 }
             }
 
+            for(var i = 0; i < res.items.Length; i++) {
+                res.items[i].command = new Command {
+                    command = completionItemCommand,
+                    arguments = new object[] { res.items[i].label }
+                };
+            }
             return Task.FromResult(res);
         }
 

--- a/Python/Product/Analysis/LanguageServer/Server.WorkspaceSymbols.cs
+++ b/Python/Product/Analysis/LanguageServer/Server.WorkspaceSymbols.cs
@@ -78,7 +78,7 @@ namespace Microsoft.PythonTools.Analysis.LanguageServer {
             var loc = m.Locations.FirstOrDefault(l => !string.IsNullOrEmpty(l.FilePath));
             if (loc != null) {
                 res.location = new Location {
-                    uri = new Uri(PathUtils.NormalizePath(loc.FilePath), UriKind.RelativeOrAbsolute),
+                    uri = new Uri(PathUtils.NormalizePath(loc.FilePath), UriKind.Absolute),
                     range = new SourceSpan(
                         new SourceLocation(loc.StartLine, loc.StartColumn),
                         new SourceLocation(loc.EndLine ?? loc.StartLine, loc.EndColumn ?? loc.StartColumn)

--- a/Python/Product/Analysis/LanguageServer/Server.WorkspaceSymbols.cs
+++ b/Python/Product/Analysis/LanguageServer/Server.WorkspaceSymbols.cs
@@ -14,7 +14,6 @@
 // See the Apache Version 2.0 License for specific language governing
 // permissions and limitations under the License.
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -78,7 +77,7 @@ namespace Microsoft.PythonTools.Analysis.LanguageServer {
             var loc = m.Locations.FirstOrDefault(l => !string.IsNullOrEmpty(l.FilePath));
             if (loc != null) {
                 res.location = new Location {
-                    uri = new Uri(PathUtils.NormalizePath(loc.FilePath), UriKind.Absolute),
+                    uri = loc.DocumentUri,
                     range = new SourceSpan(
                         new SourceLocation(loc.StartLine, loc.StartColumn),
                         new SourceLocation(loc.EndLine ?? loc.StartLine, loc.EndColumn ?? loc.StartColumn)

--- a/Python/Product/Analysis/LanguageServer/Server.cs
+++ b/Python/Product/Analysis/LanguageServer/Server.cs
@@ -33,6 +33,8 @@ using Microsoft.PythonTools.Parsing.Ast;
 
 namespace Microsoft.PythonTools.Analysis.LanguageServer {
     public sealed partial class Server : ServerBase, ILogger, IDisposable {
+        private const string completionItemCommand = "completion/itemSelected";
+
         /// <summary>
         /// Implements ability to execute module reload on the analyzer thread
         /// </summary>
@@ -138,7 +140,12 @@ namespace Microsoft.PythonTools.Analysis.LanguageServer {
                     definitionProvider = true,
                     referencesProvider = true,
                     workspaceSymbolProvider = true,
-                    documentSymbolProvider = true
+                    documentSymbolProvider = true,
+                    executeCommandProvider = new ExecuteCommandOptions {
+                        commands = new [] {
+                            completionItemCommand
+                        }
+                    }
                 }
             };
         }

--- a/Python/Product/Analysis/LanguageServer/Server.cs
+++ b/Python/Product/Analysis/LanguageServer/Server.cs
@@ -244,6 +244,14 @@ namespace Microsoft.PythonTools.Analysis.LanguageServer {
                 _queue.Enqueue(entry.Value.ProjectEntry, AnalysisPriority.Normal);
             }
         }
+
+        public override Task<object> ExecuteCommand(ExecuteCommandParams @params) {
+            Command(new CommandEventArgs {
+                command = @params.command,
+                arguments = @params.arguments
+            });
+            return Task.FromResult((object)null);
+        }
         #endregion
 
         #region Non-LSP public API

--- a/Python/Product/Analysis/LanguageServer/Server.cs
+++ b/Python/Product/Analysis/LanguageServer/Server.cs
@@ -142,14 +142,13 @@ namespace Microsoft.PythonTools.Analysis.LanguageServer {
                     workspaceSymbolProvider = true,
                     documentSymbolProvider = true,
                     executeCommandProvider = new ExecuteCommandOptions {
-                        commands = new [] {
+                        commands = new[] {
                             completionItemCommand
                         }
                     }
                 }
             };
         }
-
         public override Task Shutdown() {
             Interlocked.Exchange(ref _analyzer, null)?.Dispose();
             _projectFiles.Clear();

--- a/Python/Product/Analysis/LanguageServer/ServerBase.cs
+++ b/Python/Product/Analysis/LanguageServer/ServerBase.cs
@@ -136,9 +136,12 @@ namespace Microsoft.PythonTools.Analysis.LanguageServer {
 
         public void LogMessage(MessageType type, string message) => OnLogMessage?.Invoke(this, new LogMessageEventArgs { type = type, message = message });
 
-        public event EventHandler<TelemetryEventArgs> OnTelemetry;
 
+        public event EventHandler<TelemetryEventArgs> OnTelemetry;
         public void Telemetry(TelemetryEventArgs e) => OnTelemetry?.Invoke(this, e);
+
+        public event EventHandler<CommandEventArgs> OnCommand;
+        public void Command(CommandEventArgs e) => OnCommand?.Invoke(this, e);
 
         public event EventHandler<RegisterCapabilityEventArgs> OnRegisterCapability;
         public Task RegisterCapability(RegistrationParams @params) {


### PR DESCRIPTION
- Add OnCommand event to the server (for handling `CompletionItem.command` in extension)
- Register LS as command provider and register command for post-completion
- Suppress 'async without await' warning in .NET Core build
- Fix Linux URI handling (must always use absolute)

Works in VSC. Looking at how to update VS part.