### PR TITLE
Fixes #4406 PEP 561 support

### DIFF
--- a/Common/Tests/Utilities/AssertUtil.cs
+++ b/Common/Tests/Utilities/AssertUtil.cs
@@ -199,14 +199,17 @@ namespace TestUtilities
 
         [System.Diagnostics.DebuggerStepThrough]
         public static void DoesntContain<T>(IEnumerable<T> source, IEnumerable<T> value) {
+            var contains = new List<T>();
             foreach (var v in source) {
                 foreach (var v2 in value) {
                     if (v.Equals(v2)) {
-                        Assert.Fail(String.Format("{0} contains {1}", MakeText(source), value));
+                        contains.Add(v2);
                     }
                 }
             }
-
+            if (contains.Any()) {
+                Assert.Fail(String.Format("{0} contains {1}", MakeText(source), MakeText(contains)));
+            }
         }
 
         [System.Diagnostics.DebuggerStepThrough]

--- a/Python/Product/Analysis/Interpreter/Ast/AstCachedPythonModule.cs
+++ b/Python/Product/Analysis/Interpreter/Ast/AstCachedPythonModule.cs
@@ -16,20 +16,18 @@
 
 using System.Collections.Generic;
 using System.IO;
+using Microsoft.PythonTools.Analysis.Infrastructure;
 
 namespace Microsoft.PythonTools.Interpreter.Ast {
     class AstCachedPythonModule : AstScrapedPythonModule {
-        private readonly string _cachedModuleName;
+        private readonly string _cachePath;
 
-        public AstCachedPythonModule(string name, string cachedModuleName) : base(name, null) {
-            _cachedModuleName = cachedModuleName + ".pyi";
+        public AstCachedPythonModule(string name, string cachePath) : base(name, null) {
+            _cachePath = cachePath;
         }
 
         protected override Stream LoadCachedCode(AstPythonInterpreter interpreter) {
-            if (interpreter.Factory is AstPythonInterpreterFactory factory) {
-                return factory.ReadCachedModule(_cachedModuleName);
-            }
-            return null;
+            return PathUtils.OpenWithRetry(_cachePath, FileMode.Open, FileAccess.Read, FileShare.Read);
         }
 
         protected override List<string> GetScrapeArguments(IPythonInterpreterFactory factory) {

--- a/Python/Product/Analysis/Interpreter/Ast/AstPythonInterpreter.cs
+++ b/Python/Product/Analysis/Interpreter/Ast/AstPythonInterpreter.cs
@@ -99,7 +99,7 @@ namespace Microsoft.PythonTools.Interpreter.Ast {
             return res;
         }
 
-        private async Task<IReadOnlyDictionary<string, string>> GetUserSearchPathPackagesAsync(CancellationToken cancel) {
+        private async Task<IReadOnlyDictionary<string, string>> GetUserSearchPathPackagesAsync(CancellationToken cancellationToken) {
             _log?.Log(TraceLevel.Verbose, "GetUserSearchPathPackagesAsync");
             var ussp = _userSearchPathPackages;
             if (ussp == null) {
@@ -113,7 +113,7 @@ namespace Microsoft.PythonTools.Interpreter.Ast {
                 }
 
                 _log?.Log(TraceLevel.Verbose, "GetImportableModulesAsync");
-                ussp = await AstPythonInterpreterFactory.GetImportableModulesAsync(usp, cancel);
+                ussp = await AstPythonInterpreterFactory.GetImportableModulesAsync(usp, cancellationToken);
                 lock (_userSearchPathsLock) {
                     if (_userSearchPathPackages == null) {
                         _userSearchPathPackages = ussp;

--- a/Python/Product/Analysis/Interpreter/Ast/AstPythonInterpreterFactory.cs
+++ b/Python/Product/Analysis/Interpreter/Ast/AstPythonInterpreterFactory.cs
@@ -581,7 +581,6 @@ namespace Microsoft.PythonTools.Interpreter.Ast {
                     return TryImportModuleResult.NeedRetry;
                 }
                 sentinalValue.Complete(module);
-                sentinalValue.Dispose();
             }
 
             // Also search for type stub packages if enabled and we are not a blacklisted module

--- a/Python/Product/Analysis/Interpreter/Ast/AstPythonInterpreterFactory.cs
+++ b/Python/Product/Analysis/Interpreter/Ast/AstPythonInterpreterFactory.cs
@@ -464,18 +464,23 @@ namespace Microsoft.PythonTools.Interpreter.Ast {
         }
 
         public struct TryImportModuleResult {
-            public TryImportModuleResultCode Status;
-            public IPythonModule Module;
+            public readonly TryImportModuleResultCode Status;
+            public readonly IPythonModule Module;
 
             public TryImportModuleResult(IPythonModule module) {
                 Status = module == null ? TryImportModuleResultCode.ModuleNotFound : TryImportModuleResultCode.Success;
                 Module = module;
             }
 
-            public static TryImportModuleResult ModuleNotFound => new TryImportModuleResult { Status = TryImportModuleResultCode.ModuleNotFound };
-            public static TryImportModuleResult NeedRetry => new TryImportModuleResult { Status = TryImportModuleResultCode.NeedRetry };
-            public static TryImportModuleResult NotSupported => new TryImportModuleResult { Status = TryImportModuleResultCode.NotSupported };
-            public static TryImportModuleResult Timeout => new TryImportModuleResult { Status = TryImportModuleResultCode.Timeout };
+            public TryImportModuleResult(TryImportModuleResultCode status) {
+                Status = status;
+                Module = null;
+            }
+
+            public static TryImportModuleResult ModuleNotFound => new TryImportModuleResult(TryImportModuleResultCode.ModuleNotFound);
+            public static TryImportModuleResult NeedRetry => new TryImportModuleResult(TryImportModuleResultCode.NeedRetry);
+            public static TryImportModuleResult NotSupported => new TryImportModuleResult(TryImportModuleResultCode.NotSupported);
+            public static TryImportModuleResult Timeout => new TryImportModuleResult(TryImportModuleResultCode.Timeout);
         }
 
         public sealed class TryImportModuleContext {

--- a/Python/Product/Analysis/Interpreter/Ast/AstPythonModule.cs
+++ b/Python/Product/Analysis/Interpreter/Ast/AstPythonModule.cs
@@ -76,6 +76,15 @@ namespace Microsoft.PythonTools.Interpreter.Ast {
             );
         }
 
+        public static IPythonModule FromTypeStub(
+            IPythonInterpreter interpreter,
+            string stubFile,
+            PythonLanguageVersion langVersion,
+            string moduleFullName
+        ) {
+            return new AstCachedPythonModule(moduleFullName, stubFile);
+        }
+
         // Avoid hitting the filesystem, but exclude non-importable
         // paths. Ideally, we'd stop at the first path that's a known
         // search path, except we don't know search paths here.

--- a/Python/Product/Analysis/Interpreter/Ast/AstScrapedPythonModule.cs
+++ b/Python/Product/Analysis/Interpreter/Ast/AstScrapedPythonModule.cs
@@ -94,7 +94,7 @@ namespace Microsoft.PythonTools.Interpreter.Ast {
         protected virtual List<string> GetScrapeArguments(IPythonInterpreterFactory factory) {
             var args = new List<string> { "-B", "-E" };
 
-            ModulePath mp = AstPythonInterpreterFactory.FindModuleAsync(factory, _filePath)
+            ModulePath mp = AstPythonInterpreterFactory.FindModuleAsync(factory, _filePath, CancellationToken.None)
                 .WaitAndUnwrapExceptions();
             if (string.IsNullOrEmpty(mp.FullName)) {
                 return null;

--- a/Python/Product/Analysis/LanguageServer/CompletionAnalysis.cs
+++ b/Python/Product/Analysis/LanguageServer/CompletionAnalysis.cs
@@ -245,10 +245,8 @@ namespace Microsoft.PythonTools.Analysis.LanguageServer {
                 }
                 foreach (var t in ZipLongest(imp.Names, imp.AsNames).Reverse()) {
                     if (t.Item2 != null) {
-                        if (Index > t.Item2.EndIndex && t.Item2.EndIndex > t.Item2.StartIndex) {
+                        if (Index >= t.Item2.StartIndex && t.Item2.EndIndex > t.Item2.StartIndex) {
                             return Empty;
-                        } else if (Index >= t.Item2.StartIndex) {
-                            return Once(AsKeywordCompletion);
                         }
                     }
                     if (t.Item1 != null) {
@@ -271,10 +269,8 @@ namespace Microsoft.PythonTools.Analysis.LanguageServer {
 
                 foreach (var t in ZipLongest(fimp.Names, fimp.AsNames).Reverse()) {
                     if (t.Item2 != null) {
-                        if (Index > t.Item2.EndIndex && t.Item2.EndIndex >= t.Item2.StartIndex) {
+                        if (Index >= t.Item2.StartIndex && t.Item2.EndIndex >= t.Item2.StartIndex) {
                             return Empty;
-                        } else if (Index >= t.Item2.StartIndex) {
-                            return Once(AsKeywordCompletion);
                         }
                     }
                     if (t.Item1 != null) {

--- a/Python/Product/Analysis/LanguageServer/CompletionAnalysis.cs
+++ b/Python/Product/Analysis/LanguageServer/CompletionAnalysis.cs
@@ -245,7 +245,7 @@ namespace Microsoft.PythonTools.Analysis.LanguageServer {
                 }
                 foreach (var t in ZipLongest(imp.Names, imp.AsNames).Reverse()) {
                     if (t.Item2 != null) {
-                        if (Index >= t.Item2.StartIndex && t.Item2.EndIndex > t.Item2.StartIndex) {
+                        if (Index >= t.Item2.StartIndex) {
                             return Empty;
                         }
                     }
@@ -269,7 +269,7 @@ namespace Microsoft.PythonTools.Analysis.LanguageServer {
 
                 foreach (var t in ZipLongest(fimp.Names, fimp.AsNames).Reverse()) {
                     if (t.Item2 != null) {
-                        if (Index >= t.Item2.StartIndex && t.Item2.EndIndex >= t.Item2.StartIndex) {
+                        if (Index >= t.Item2.StartIndex) {
                             return Empty;
                         }
                     }

--- a/Python/Product/Analysis/scrape_module.py
+++ b/Python/Product/Analysis/scrape_module.py
@@ -741,7 +741,7 @@ class MemberInfo(object):
 
                 fullname = module + '.' + type_name
 
-                if fullname in LIES_ABOUT_MODULE or (in_module + '.*') in LIES_ABOUT_MODULE:
+                if in_module and (fullname in LIES_ABOUT_MODULE or (in_module + '.*') in LIES_ABOUT_MODULE):
                     # Treat the type as if it came from the current module
                     return (in_module,), type_name
 
@@ -750,6 +750,7 @@ class MemberInfo(object):
             return (), type_name
         except Exception:
             warnings.warn('could not get type of ' + repr(value_type), InspectWarning)
+            raise
             return (), None
 
     def _str_from_literal(self, lit):

--- a/Python/Product/PythonTools/PythonTools/Intellisense/ProjectAnalyzer.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/ProjectAnalyzer.cs
@@ -258,7 +258,7 @@ namespace Microsoft.PythonTools.Intellisense {
 
             var lso = _services.Python.LanguageServerOptions;
             if (!string.IsNullOrEmpty(lso.TypeShedPath)) {
-                _analysisOptions.typeStubPaths = GetTypeShedPaths(lso.TypeShedPath, _interpreterFactory.Configuration.Version).ToArray();
+                _analysisOptions.typeStubPaths = new[] { lso.TypeShedPath };
             }
             lso.Changed += LanguageServerOptions_Changed;
 
@@ -314,25 +314,6 @@ namespace Microsoft.PythonTools.Intellisense {
             var resp = await SendRequestAsync(new AP.SetAnalysisOptionsRequest {
                 options = _analysisOptions
             });
-        }
-
-        internal static IEnumerable<string> GetTypeShedPaths(string path, Version version) {
-            var stdlib = Path.Combine(path, "stdlib");
-            var thirdParty = Path.Combine(path, "third_party");
-
-            foreach (var subdir in new[] { version.ToString(), version.Major.ToString(), "2and3" }) {
-                var candidate = Path.Combine(stdlib, subdir);
-                if (Directory.Exists(candidate)) {
-                    yield return candidate;
-                }
-            }
-
-            foreach (var subdir in new[] { version.ToString(), version.Major.ToString(), "2and3" }) {
-                var candidate = Path.Combine(thirdParty, subdir);
-                if (Directory.Exists(candidate)) {
-                    yield return candidate;
-                }
-            }
         }
 
         public event EventHandler AnalyzerNeedsRestart;

--- a/Python/Product/VSInterpreters/PackageManager/PipPackageManager.cs
+++ b/Python/Product/VSInterpreters/PackageManager/PipPackageManager.cs
@@ -599,7 +599,7 @@ namespace Microsoft.PythonTools.Interpreter {
             string cachePath = null;
 
             if (_factory is Ast.AstPythonInterpreterFactory astFactory) {
-                paths = await astFactory.GetSearchPathsAsync();
+                paths = await astFactory.GetSearchPathsAsync(CancellationToken.None);
             } else if (_factory is LegacyDB.PythonInterpreterFactoryWithDatabase dbFactory) {
                 cachePath = PathUtils.GetAbsoluteFilePath(dbFactory.DatabasePath, "database.path");
             }

--- a/Python/Tests/TestData/AstAnalysis/Package-stubs/Module.pyi
+++ b/Python/Tests/TestData/AstAnalysis/Package-stubs/Module.pyi
@@ -1,0 +1,4 @@
+
+class Class:
+    def typed_method(self, a : int) -> float: ...
+

--- a/Python/Tests/TestData/AstAnalysis/Package/Module.py
+++ b/Python/Tests/TestData/AstAnalysis/Package/Module.py
@@ -1,0 +1,4 @@
+
+class Class:
+    def untyped_method(self, a): pass
+    def inferred_method(self, a = 1): return 3.14

--- a/Python/Tests/TestData/AstAnalysis/Stubs/Package/Module.pyi
+++ b/Python/Tests/TestData/AstAnalysis/Stubs/Package/Module.pyi
@@ -1,0 +1,4 @@
+
+class Class:
+    def typed_method_2(self, a : int) -> float: ...
+

--- a/Python/Tests/Utilities.Python.Analysis/PythonAnalysis.cs
+++ b/Python/Tests/Utilities.Python.Analysis/PythonAnalysis.cs
@@ -231,12 +231,12 @@ namespace TestUtilities.Python {
 
         #region Get Analysis Results
 
-        public IEnumerable<string> GetMemberNames(string exprText, int index = 0, GetMemberOptions options = GetMemberOptions.IntersectMultipleResults) {
+        public IEnumerable<string> GetMemberNames(string exprText, int index = 0, GetMemberOptions options = GetMemberOptions.None) {
             return GetMemberNames(_entries[DefaultModule], exprText, index, options);
         }
 
-        public IEnumerable<string> GetMemberNames(IPythonProjectEntry module, string exprText, int index = 0, GetMemberOptions options = GetMemberOptions.IntersectMultipleResults) {
-            return module.Analysis.GetMembersByIndex(exprText, index, options).Select(m => m.Name);
+        public IEnumerable<string> GetMemberNames(IPythonProjectEntry module, string exprText, int index = 0, GetMemberOptions options = GetMemberOptions.None) {
+            return module.Analysis.GetMembersByIndex(exprText, index, options).Select(m => m.Completion);
         }
 
         public IEnumerable<IPythonType> GetTypes(string exprText, int index = 0) {
@@ -404,37 +404,22 @@ namespace TestUtilities.Python {
 
         #region Assert Analysis Results
 
-        public void AssertHasAttr(string expr, params string[] attrs) {
-            AssertHasAttr(_entries[DefaultModule], expr, 0, attrs);
-        }
-
-        public void AssertHasAttr(string expr, int index, params string[] attrs) {
-            AssertHasAttr(_entries[DefaultModule], expr, index, attrs);
-        }
+        public void AssertHasAttr(string expr, params string[] attrs) => AssertHasAttr(_entries[DefaultModule], expr, 0, attrs);
+        public void AssertHasAttr(string expr, int index, params string[] attrs) => AssertHasAttr(_entries[DefaultModule], expr, index, attrs);
 
         public void AssertHasAttr(IPythonProjectEntry module, string expr, int index, params string[] attrs) {
             AssertUtil.ContainsAtLeast(GetMemberNames(module, expr, index), attrs);
         }
 
-        public void AssertNotHasAttr(string expr, params string[] attrs) {
-            AssertNotHasAttr(_entries[DefaultModule], expr, 0, attrs);
-        }
-
-        public void AssertNotHasAttr(string expr, int index, params string[] attrs) {
-            AssertNotHasAttr(_entries[DefaultModule], expr, index, attrs);
-        }
+        public void AssertNotHasAttr(string expr, params string[] attrs) => AssertNotHasAttr(_entries[DefaultModule], expr, 0, attrs);
+        public void AssertNotHasAttr(string expr, int index, params string[] attrs) => AssertNotHasAttr(_entries[DefaultModule], expr, index, attrs);
 
         public void AssertNotHasAttr(IPythonProjectEntry module, string expr, int index, params string[] attrs) {
             AssertUtil.DoesntContain(GetMemberNames(module, expr, index), attrs);
         }
 
-        public void AssertHasAttrExact(string expr, params string[] attrs) {
-            AssertHasAttrExact(_entries[DefaultModule], expr, 0, attrs);
-        }
-
-        public void AssertHasAttrExact(string expr, int index, params string[] attrs) {
-            AssertHasAttrExact(_entries[DefaultModule], expr, index, attrs);
-        }
+        public void AssertHasAttrExact(string expr, params string[] attrs) => AssertHasAttrExact(_entries[DefaultModule], expr, 0, attrs);
+        public void AssertHasAttrExact(string expr, int index, params string[] attrs) => AssertHasAttrExact(_entries[DefaultModule], expr, index, attrs);
 
         public void AssertHasAttrExact(IPythonProjectEntry module, string expr, int index, params string[] attrs) {
             AssertUtil.ContainsExactly(GetMemberNames(module, expr, index), attrs);


### PR DESCRIPTION
Fixes #4406 PEP 561 support
Adds support for locating type stub packages.
Makes AstPythonInterpreterFactory import process fully async and cancelable
Fixes minor bugs in import completion and module scraping