### PR TITLE
Update to ptvsd==4.1.1a9

### DIFF
--- a/Python/Product/Debugger/Debugger.csproj
+++ b/Python/Product/Debugger/Debugger.csproj
@@ -204,7 +204,7 @@
   </ItemGroup>
   <Import Project="..\ProjectAfter.settings" />
   <PropertyGroup>
-    <BundledPTVSDVersion>4.1.1a8</BundledPTVSDVersion>
+    <BundledPTVSDVersion>4.1.1a9</BundledPTVSDVersion>
   </PropertyGroup>
   <Target Name="_GatherPtvsd" BeforeTargets="_IncludePtvsd" Condition="!Exists('$(IntermediateOutputPath)Packages\ptvsd\__init__.py')">
     <PropertyGroup>


### PR DESCRIPTION
This has the fix for Python 2.7 breakpoint on line 1 being hit twice.

Both 2.7 and 3.6 sets of UI tests pass*

* modulo the 'task not completed' failures that sometimes occur when cleaning up the test at the end.