### PR TITLE
Fix conda environment manager tests

### DIFF
--- a/Python/Product/VSInterpreters/Interpreter/CondaEnvironmentFactoryProvider.cs
+++ b/Python/Product/VSInterpreters/Interpreter/CondaEnvironmentFactoryProvider.cs
@@ -254,7 +254,7 @@ namespace Microsoft.PythonTools.Interpreter {
             }
         }
 
-        private static CondaInfoResult ExecuteCondaInfo(string condaPath) {
+        internal static CondaInfoResult ExecuteCondaInfo(string condaPath) {
             using (var output = ProcessOutput.RunHiddenAndCapture(condaPath, "info", "--json")) {
                 output.Wait();
                 if (output.ExitCode == 0) {
@@ -271,7 +271,7 @@ namespace Microsoft.PythonTools.Interpreter {
             }
         }
 
-        class CondaInfoResult {
+        internal class CondaInfoResult {
             [JsonProperty("envs")]
             public string[] EnvironmentFolders = null;
 

--- a/Python/Product/VSInterpreters/Interpreter/CondaEnvironmentManager.cs
+++ b/Python/Product/VSInterpreters/Interpreter/CondaEnvironmentManager.cs
@@ -26,15 +26,16 @@ using Microsoft.PythonTools.Infrastructure;
 namespace Microsoft.PythonTools.Interpreter {
     sealed class CondaEnvironmentManager : ICondaEnvironmentManager, IDisposable {
         private readonly SemaphoreSlim _working = new SemaphoreSlim(1);
-        private readonly string _condaPath;
         private bool _isDisposed;
+
+        public string CondaPath { get; }
 
         private static readonly KeyValuePair<string, string>[] UnbufferedEnv = new[] {
             new KeyValuePair<string, string>("PYTHONUNBUFFERED", "1")
         };
 
         private CondaEnvironmentManager(string condaPath) {
-            _condaPath = condaPath;
+            CondaPath = condaPath;
         }
 
         public void Dispose() {
@@ -286,9 +287,9 @@ namespace Microsoft.PythonTools.Interpreter {
             bool success = false;
             try {
                 using (var output = ProcessOutput.Run(
-                    _condaPath,
+                    CondaPath,
                     args,
-                    Path.GetDirectoryName(_condaPath),
+                    Path.GetDirectoryName(CondaPath),
                     UnbufferedEnv,
                     false,
                     redirector ?? CondaEnvironmentManagerUIRedirector.Get(this, ui),

--- a/Python/Tests/Core/CondaEnvironmentManagerTests.cs
+++ b/Python/Tests/Core/CondaEnvironmentManagerTests.cs
@@ -286,19 +286,8 @@ namespace PythonToolsUITests {
             var mgr = CreateEnvironmentManager();
             var ui = new MockCondaEnvironmentManagerUI();
 
-            // Try a path that exists but is empty
-            var envPath = TestData.GetTempPath();
+            var envPath = Path.Combine(TestData.GetTempPath(), "test");
             var result = await mgr.DeleteAsync(envPath, ui, CancellationToken.None);
-
-            Assert.IsFalse(result, "Delete did not fail.");
-            Assert.IsTrue(ui.ErrorText.Any(line => line.Contains("Not a conda environment")));
-            Assert.IsTrue(ui.OutputText.Any(line => line.Contains($"Failed to delete '{envPath}'")));
-
-            ui.Clear();
-
-            // Try a path that doesn't exist
-            envPath = Path.Combine(TestData.GetTempPath(), "test");
-            result = await mgr.DeleteAsync(envPath, ui, CancellationToken.None);
 
             Assert.IsFalse(result, "Delete did not fail.");
             Assert.IsTrue(ui.ErrorText.Any(line => line.Contains($"Folder not found '{envPath}'")));


### PR DESCRIPTION
Fix #4416 

To work across different machine setups (different install location and different versions of conda), stop guessing where environments are created and ask conda.exe for the information instead.