### PR TITLE
Fixes #4422 import completions are not filtered for submodules

### DIFF
--- a/Python/Product/Analysis/LanguageServer/CompletionAnalysis.cs
+++ b/Python/Product/Analysis/LanguageServer/CompletionAnalysis.cs
@@ -303,7 +303,7 @@ namespace Microsoft.PythonTools.Analysis.LanguageServer {
                             return Once(AsKeywordCompletion);
                         }
                         if (Index >= t.Item1.StartIndex) {
-                            ApplicableSpan = t.Item1.GetSpan(Tree);
+                            Node = t.Item1.Names.MaybeEnumerate().LastOrDefault(n => n.StartIndex <= Index && Index <= n.EndIndex);
                             return GetModulesFromNode(t.Item1);
                         }
                     }


### PR DESCRIPTION
Fixes #4422 import completions are not filtered for submodules
Fixes applicable span when completing import statements.