### PR TITLE
Fixes #3269 Changes in search paths are not automatically noticed by the analyzer

### DIFF
--- a/Python/Product/Analysis/LanguageServer/Server.cs
+++ b/Python/Product/Analysis/LanguageServer/Server.cs
@@ -359,10 +359,10 @@ namespace Microsoft.PythonTools.Analysis.LanguageServer {
             SetSearchPaths(@params.initializationOptions.searchPaths);
             SetTypeStubSearchPaths(@params.initializationOptions.typeStubSearchPaths);
 
-            _analyzer.SearchPathsChanged += Analyzer_SearchPathsChanged;
+            _analyzer.Interpreter.ModuleNamesChanged += Interpreter_ModuleNamesChanged;
         }
 
-        private void Analyzer_SearchPathsChanged(object sender, EventArgs e) {
+        private void Interpreter_ModuleNamesChanged(object sender, EventArgs e) {
             _analyzer.Modules.ReInit();
             foreach (var entry in _analyzer.ModulesByFilename) {
                 _queue.Enqueue(entry.Value.ProjectEntry, AnalysisPriority.Normal);

--- a/Python/Product/Analysis/LanguageServer/Server.cs
+++ b/Python/Product/Analysis/LanguageServer/Server.cs
@@ -358,6 +358,15 @@ namespace Microsoft.PythonTools.Analysis.LanguageServer {
 
             SetSearchPaths(@params.initializationOptions.searchPaths);
             SetTypeStubSearchPaths(@params.initializationOptions.typeStubSearchPaths);
+
+            _analyzer.SearchPathsChanged += Analyzer_SearchPathsChanged;
+        }
+
+        private void Analyzer_SearchPathsChanged(object sender, EventArgs e) {
+            _analyzer.Modules.ReInit();
+            foreach (var entry in _analyzer.ModulesByFilename) {
+                _queue.Enqueue(entry.Value.ProjectEntry, AnalysisPriority.Normal);
+            }
         }
 
         private T ActivateObject<T>(string assemblyName, string typeName, Dictionary<string, object> properties) {


### PR DESCRIPTION
Fixes #3269 Changes in search paths are not automatically noticed by the analyzer
Adds handling for search paths changing.