### PR TITLE
Fix build on 15.8 Preview 4

### DIFF
--- a/Build/15.0/packages.config
+++ b/Build/15.0/packages.config
@@ -16,6 +16,7 @@
   <package id="Microsoft.VisualStudio.Workspace" version="15.0.401" />
   <package id="Microsoft.VisualStudio.Workspace.VSIntegration" version="15.0.401" />
   <package id="StreamJsonRpc" version="1.2.8" />
+  <package id="System.Collections.Immutable" version="1.5.0" />
   <package id="Python2" version="2.7.14" />
   <package id="Python" version="3.6.4" />
 

--- a/Python/Product/PythonTools/PythonTools.csproj
+++ b/Python/Product/PythonTools/PythonTools.csproj
@@ -194,7 +194,7 @@
       <IncludeInVSIX>True</IncludeInVSIX>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Collections.Immutable, Version=1.2.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+    <Reference Include="System.Collections.Immutable, Version=1.2.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />


### PR DESCRIPTION
System.Collections.Immutable is now AssemblyVersion 1.2.3.0 in PrivateAssemblies.

Adding the NuGet package to ensure our build machines on earlier versions of VS can still build.

Yes, pkgver 1.5 is asmver 1.2.3.0

