### PR TITLE
Fixes #3729 Report analyzer errors in activity log

### DIFF
--- a/Python/Product/PythonTools/PythonTools.csproj
+++ b/Python/Product/PythonTools/PythonTools.csproj
@@ -306,6 +306,7 @@
     <Compile Include="PythonTools\Intellisense\InvalidEncodingSquiggleProvider.cs" />
     <Compile Include="PythonTools\Editor\BraceCompletion\BraceCompletionContext.cs" />
     <Compile Include="PythonTools\Editor\BraceCompletion\BraceCompletionContextProvider.cs" />
+    <Compile Include="PythonTools\Logging\ActivityLogLogger.cs" />
     <Compile Include="PythonTools\Navigation\Navigable\NavigableSymbol.cs" />
     <Compile Include="PythonTools\Navigation\Navigable\NavigableSymbolSourceProvider.cs" />
     <Compile Include="PythonTools\Navigation\Navigable\NavigableSymbolSource.cs" />

--- a/Python/Product/PythonTools/PythonTools/Intellisense/ProjectAnalyzer.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/ProjectAnalyzer.cs
@@ -702,16 +702,16 @@ namespace Microsoft.PythonTools.Intellisense {
                 "ProjectAnalyzer"
             );
 
-            process.Exited += OnAnalysisProcessExited;
             if (process.HasExited) {
                 _stdErr.Append(process.StandardError.ReadToEnd());
-                OnAnalysisProcessExited(process, EventArgs.Empty);
+                OnAnalysisProcessExited();
             } else {
                 Task.Run(async () => {
                     try {
                         while (!process.HasExited) {
                             var line = await process.StandardError.ReadLineAsync();
                             if (line == null) {
+                                OnAnalysisProcessExited();
                                 break;
                             }
                             _stdErr.AppendLine(line);
@@ -784,7 +784,7 @@ namespace Microsoft.PythonTools.Intellisense {
             return conn;
         }
 
-        private void OnAnalysisProcessExited(object sender, EventArgs e) {
+        private void OnAnalysisProcessExited() {
             _processExitedCancelSource.Cancel();
             if (!_disposing) {
                 _abnormalAnalysisExit?.Invoke(

--- a/Python/Product/PythonTools/PythonTools/Logging/ActivityLogLogger.cs
+++ b/Python/Product/PythonTools/PythonTools/Logging/ActivityLogLogger.cs
@@ -1,0 +1,41 @@
+// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABLITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System;
+using System.ComponentModel.Composition;
+using Microsoft.PythonTools.Infrastructure;
+using Microsoft.VisualStudio.Shell;
+
+namespace Microsoft.PythonTools.Logging {
+    /// <summary>
+    /// Write errors and failures to the activity log.
+    /// </summary>
+    [Export(typeof(IPythonToolsLogger))]
+    class ActivityLogLogger : IPythonToolsLogger {
+        public void LogEvent(PythonLogEvent logEvent, object argument) {
+            switch (logEvent) {
+                case PythonLogEvent.AnalysisExitedAbnormally:
+                case PythonLogEvent.AnalysisOperationFailed:
+                    ActivityLog.TryLogError("Python", "[{0}] {1}: {2}".FormatInvariant(DateTime.Now, logEvent, argument as string ?? ""));
+                    break;
+            }
+        }
+
+        public void LogFault(Exception ex, string description, bool dumpProcess) {
+            ActivityLog.TryLogError("Python", ex.ToString());
+        }
+    }
+}

--- a/Python/Product/PythonTools/PythonTools/Project/PythonProjectNode.cs
+++ b/Python/Product/PythonTools/PythonTools/Project/PythonProjectNode.cs
@@ -80,6 +80,7 @@ namespace Microsoft.PythonTools.Project {
         private readonly HashSet<string> _validFactories = new HashSet<string>();
 
         private IPythonInterpreterFactory _active;
+        private readonly IPythonToolsLogger _logger;
 
         private IReadOnlyList<IPackageManager> _activePackageManagers;
         private readonly System.Threading.Timer _reanalyzeProjectNotification;
@@ -100,6 +101,8 @@ namespace Microsoft.PythonTools.Project {
             if (_services == null) {
                 throw new InvalidOperationException("Unable to initialize services");
             }
+
+            _logger = _services.Python.Logger;
 
             _vsProjectContext = _services.ComponentModel.GetService<VsProjectContextProvider>();
 
@@ -162,7 +165,7 @@ namespace Microsoft.PythonTools.Project {
             }
 
             try {
-                Site.GetPythonToolsService().Logger?.LogEvent(PythonLogEvent.VirtualEnvironments, _validFactories.Count);
+                _logger?.LogEvent(PythonLogEvent.VirtualEnvironments, _validFactories.Count);
             } catch (Exception ex) {
                 Debug.Fail(ex.ToUnhandledExceptionMessage(GetType()));
             }
@@ -1156,8 +1159,7 @@ namespace Microsoft.PythonTools.Project {
         }
 
         private void AnalysisProcessExited(object sender, AbnormalAnalysisExitEventArgs e) {
-            var logger = Site.GetPythonToolsService().Logger;
-            if (logger == null) {
+            if (_logger == null) {
                 return;
             }
 
@@ -1167,7 +1169,7 @@ namespace Microsoft.PythonTools.Project {
                 .AppendLine(" ------ STD ERR ------ ")
                 .Append(e.StdErr)
                 .AppendLine(" ------ END STD ERR ------ ");
-            logger.LogEvent(
+            _logger.LogEvent(
                 PythonLogEvent.AnalysisExitedAbnormally,
                 msg.ToString()
             );

--- a/Python/Product/VSCommon/Infrastructure/VSTaskExtensions.cs
+++ b/Python/Product/VSCommon/Infrastructure/VSTaskExtensions.cs
@@ -73,13 +73,6 @@ namespace Microsoft.PythonTools.Infrastructure {
                 // Unknown error prevented writing to the log
             }
 
-            try {
-                ActivityLog.LogError(Strings.ProductTitle, message);
-            } catch (InvalidOperationException) {
-                // Activity Log is unavailable.
-                logFile = null;
-            }
-
             bool alreadySeen = true;
             var key = "{0}:{1}:{2}".FormatInvariant(callerFile, callerLineNumber, ex.GetType().Name);
             lock (_displayedMessages) {


### PR DESCRIPTION
Fixes #3729 Report analyzer errors in activity log
Adds ActivityLogLogger for certain logged events.
Fixes failure to log abnormal termination events
Fixes cross-threading issue.