### PR TITLE
Change legacy/experimental debugger messages

### DIFF
--- a/Python/Product/Common/Strings.Designer.cs
+++ b/Python/Product/Common/Strings.Designer.cs
@@ -2058,15 +2058,6 @@ namespace Microsoft.PythonTools {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Enable the legacy debugger.
-        /// </summary>
-        public static string DisableExperimentalDebugger {
-            get {
-                return ResourceManager.GetString("DisableExperimentalDebugger", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Python Documentation.
         /// </summary>
         public static string DocumentationClassificationType {
@@ -3907,7 +3898,7 @@ namespace Microsoft.PythonTools {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Enable the legacy debugger.
+        ///   Looks up a localized string similar to Use the legacy debugger.
         /// </summary>
         public static string PtvsdDisableCaption {
             get {
@@ -3916,7 +3907,7 @@ namespace Microsoft.PythonTools {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Future debugging sessions will use the legacy debugger. You can change this setting back in Tools &gt; Options &gt; Python &gt; Debugging page..
+        ///   Looks up a localized string similar to Future debugging sessions will use the legacy debugger. You can also change this setting in Tools, Options, Python, Debugging page by changing the &apos;Use legacy debugger&apos; option..
         /// </summary>
         public static string PtvsdDisableSubtext {
             get {
@@ -3925,7 +3916,7 @@ namespace Microsoft.PythonTools {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to To debug this Python environment use the legacy debugger instead. It is likely using an older version of Python, see the documentation for a list of supported Python versions and environment types..
+        ///   Looks up a localized string similar to To debug this Python environment, please use the legacy debugger. Older versions of Python are not supported. See our &lt;a href=&quot;https://aka.ms/upgradeptvsd&quot;&gt;documentation&lt;/a&gt; for a list of supported Python versions and environment types..
         /// </summary>
         public static string PtvsdIncompatibleEnvMessage {
             get {

--- a/Python/Product/Common/Strings.Designer.cs
+++ b/Python/Product/Common/Strings.Designer.cs
@@ -1534,7 +1534,7 @@ namespace Microsoft.PythonTools {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to This debug REPL feature is not supported with the experimental debugger..
+        ///   Looks up a localized string similar to This debug REPL feature is only supported with the legacy debugger..
         /// </summary>
         public static string DebugReplFeatureNotSupportedWithExperimentalDebugger {
             get {
@@ -2058,7 +2058,7 @@ namespace Microsoft.PythonTools {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Disable the experimental debugger.
+        ///   Looks up a localized string similar to Enable the legacy debugger.
         /// </summary>
         public static string DisableExperimentalDebugger {
             get {
@@ -3907,7 +3907,7 @@ namespace Microsoft.PythonTools {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Disable the experimental debugger.
+        ///   Looks up a localized string similar to Enable the legacy debugger.
         /// </summary>
         public static string PtvsdDisableCaption {
             get {
@@ -3916,7 +3916,7 @@ namespace Microsoft.PythonTools {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Future debugging sessions will not use the experimental debugger. You can also change this setting in the Tools/Options/Python/Experimental page..
+        ///   Looks up a localized string similar to Future debugging sessions will use the legacy debugger. You can change this setting back in Tools &gt; Options &gt; Python &gt; Debugging page..
         /// </summary>
         public static string PtvsdDisableSubtext {
             get {
@@ -3925,7 +3925,7 @@ namespace Microsoft.PythonTools {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The experimental debugger is incompatible with this Python environment. See the documentation for a list of supported Python environments..
+        ///   Looks up a localized string similar to To debug this Python environment use the legacy debugger instead. It is likely using an older version of Python, see the documentation for a list of supported Python versions and environment types..
         /// </summary>
         public static string PtvsdIncompatibleEnvMessage {
             get {
@@ -3934,7 +3934,7 @@ namespace Microsoft.PythonTools {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Debugger is incompatible with this environment.
+        ///   Looks up a localized string similar to Debugger does not support this Python environment.
         /// </summary>
         public static string PtvsdIncompatibleEnvTitle {
             get {
@@ -3952,7 +3952,7 @@ namespace Microsoft.PythonTools {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to View documentation in your web browser on supported Python environments and how to upgrade or uninstall the ptvsd debugger package..
+        ///   Looks up a localized string similar to View documentation on supported Python environments and how to upgrade or uninstall the ptvsd debugger package..
         /// </summary>
         public static string PtvsdLearnMoreSubtext {
             get {

--- a/Python/Product/Common/Strings.resx
+++ b/Python/Product/Common/Strings.resx
@@ -2257,10 +2257,10 @@ Expand selection to the full expression?</value>
     <value>Debugger package could not be loaded</value>
   </data>
   <data name="PtvsdDisableCaption" xml:space="preserve">
-    <value>Enable the legacy debugger</value>
+    <value>Use the legacy debugger</value>
   </data>
   <data name="PtvsdDisableSubtext" xml:space="preserve">
-    <value>Future debugging sessions will use the legacy debugger. You can change this setting back in Tools &gt; Options &gt; Python &gt; Debugging page.</value>
+    <value>Future debugging sessions will use the legacy debugger. You can also change this setting in Tools, Options, Python, Debugging page by changing the 'Use legacy debugger' option.</value>
   </data>
   <data name="PtvsdLearnMoreCaption" xml:space="preserve">
     <value>Learn more</value>
@@ -2272,10 +2272,7 @@ Expand selection to the full expression?</value>
     <value>Debugger does not support this Python environment</value>
   </data>
   <data name="PtvsdIncompatibleEnvMessage" xml:space="preserve">
-    <value>To debug this Python environment use the legacy debugger instead. It is likely using an older version of Python, see the documentation for a list of supported Python versions and environment types.</value>
-  </data>
-  <data name="DisableExperimentalDebugger" xml:space="preserve">
-    <value>Enable the legacy debugger</value>
+    <value>To debug this Python environment, please use the legacy debugger. Older versions of Python are not supported. See our &lt;a href="https://aka.ms/upgradeptvsd"&gt;documentation&lt;/a&gt; for a list of supported Python versions and environment types.</value>
   </data>
   <data name="DebugReplFeatureNotSupportedWithExperimentalDebugger" xml:space="preserve">
     <value>This debug REPL feature is only supported with the legacy debugger.</value>

--- a/Python/Product/Common/Strings.resx
+++ b/Python/Product/Common/Strings.resx
@@ -2257,28 +2257,28 @@ Expand selection to the full expression?</value>
     <value>Debugger package could not be loaded</value>
   </data>
   <data name="PtvsdDisableCaption" xml:space="preserve">
-    <value>Disable the experimental debugger</value>
+    <value>Enable the legacy debugger</value>
   </data>
   <data name="PtvsdDisableSubtext" xml:space="preserve">
-    <value>Future debugging sessions will not use the experimental debugger. You can also change this setting in the Tools/Options/Python/Experimental page.</value>
+    <value>Future debugging sessions will use the legacy debugger. You can change this setting back in Tools &gt; Options &gt; Python &gt; Debugging page.</value>
   </data>
   <data name="PtvsdLearnMoreCaption" xml:space="preserve">
     <value>Learn more</value>
   </data>
   <data name="PtvsdLearnMoreSubtext" xml:space="preserve">
-    <value>View documentation in your web browser on supported Python environments and how to upgrade or uninstall the ptvsd debugger package.</value>
+    <value>View documentation on supported Python environments and how to upgrade or uninstall the ptvsd debugger package.</value>
   </data>
   <data name="PtvsdIncompatibleEnvTitle" xml:space="preserve">
-    <value>Debugger is incompatible with this environment</value>
+    <value>Debugger does not support this Python environment</value>
   </data>
   <data name="PtvsdIncompatibleEnvMessage" xml:space="preserve">
-    <value>The experimental debugger is incompatible with this Python environment. See the documentation for a list of supported Python environments.</value>
+    <value>To debug this Python environment use the legacy debugger instead. It is likely using an older version of Python, see the documentation for a list of supported Python versions and environment types.</value>
   </data>
   <data name="DisableExperimentalDebugger" xml:space="preserve">
-    <value>Disable the experimental debugger</value>
+    <value>Enable the legacy debugger</value>
   </data>
   <data name="DebugReplFeatureNotSupportedWithExperimentalDebugger" xml:space="preserve">
-    <value>This debug REPL feature is not supported with the experimental debugger.</value>
+    <value>This debug REPL feature is only supported with the legacy debugger.</value>
   </data>
   <data name="RunMypyLabel" xml:space="preserve">
     <value>Run Mypy</value>

--- a/Python/Product/Debugger/PtvsdVersionHelper.cs
+++ b/Python/Product/Debugger/PtvsdVersionHelper.cs
@@ -108,6 +108,7 @@ namespace Microsoft.PythonTools.Debugger {
                         Content = content,
                         AllowCancellation = true,
                         MainIcon = isError ? TaskDialogIcon.Error : TaskDialogIcon.Warning,
+                        EnableHyperlinks = true,
                     };
 
                     var disable = new TaskDialogButton(Strings.PtvsdDisableCaption, Strings.PtvsdDisableSubtext);

--- a/Python/Product/PythonTools/PythonTools/Debugger/DebugLaunchHelper.cs
+++ b/Python/Product/PythonTools/PythonTools/Debugger/DebugLaunchHelper.cs
@@ -192,10 +192,10 @@ namespace Microsoft.PythonTools.Debugger {
                 } else {
                     var pyService = provider.GetPythonToolsService();
                     // Set the Python debugger
-                    dti.Info.clsidCustom = pyService.ExperimentalOptions.UseVsCodeDebugger ? DebugAdapterLauncher.VSCodeDebugEngine : AD7Engine.DebugEngineGuid;
+                    dti.Info.clsidCustom = pyService.DebuggerOptions.UseLegacyDebugger ? AD7Engine.DebugEngineGuid : DebugAdapterLauncher.VSCodeDebugEngine;
                     dti.Info.grfLaunch = (uint)__VSDBGLAUNCHFLAGS.DBGLAUNCH_StopDebuggingOnEnd;
 
-                    if (pyService.ExperimentalOptions.UseVsCodeDebugger) {
+                    if (!pyService.DebuggerOptions.UseLegacyDebugger) {
                         dti.Info.bstrOptions = GetLaunchJsonForVsCodeDebugAdapter(provider, config);
                     }
                 }

--- a/Python/Product/PythonTools/PythonTools/Options/DebuggerOptions.cs
+++ b/Python/Product/PythonTools/PythonTools/Options/DebuggerOptions.cs
@@ -15,6 +15,7 @@
 // permissions and limitations under the License.
 
 using System;
+using EO = Microsoft.PythonTools.Interpreter.ExperimentalOptions;
 
 namespace Microsoft.PythonTools.Options {
     public sealed class DebuggerOptions {
@@ -32,6 +33,11 @@ namespace Microsoft.PythonTools.Options {
         internal DebuggerOptions(PythonToolsService service) {
             _service = service;
             Load();
+            EO.UseVsCodeDebuggerChanged += OnUseVsCodeDebuggerChanged;
+        }
+
+        private void OnUseVsCodeDebuggerChanged(object sender, EventArgs e) {
+            UseLegacyDebugger = !EO.GetUseVsCodeDebugger();
         }
 
         public void Load() {
@@ -41,6 +47,7 @@ namespace Microsoft.PythonTools.Options {
             TeeStandardOutput = _service.LoadBool(TeeStandardOutSetting, Category) ?? true;
             BreakOnSystemExitZero = _service.LoadBool(BreakOnSystemExitZeroSetting, Category) ?? false;
             DebugStdLib = _service.LoadBool(DebugStdLibSetting, Category) ?? false;
+            UseLegacyDebugger = !EO.GetUseVsCodeDebugger();
             Changed?.Invoke(this, EventArgs.Empty);
         }
 
@@ -51,6 +58,7 @@ namespace Microsoft.PythonTools.Options {
             _service.SaveBool(TeeStandardOutSetting, Category, TeeStandardOutput);
             _service.SaveBool(BreakOnSystemExitZeroSetting, Category, BreakOnSystemExitZero);
             _service.SaveBool(DebugStdLibSetting, Category, DebugStdLib);
+            EO.UseVsCodeDebugger = !UseLegacyDebugger;
             Changed?.Invoke(this, EventArgs.Empty);
         }
 
@@ -61,6 +69,7 @@ namespace Microsoft.PythonTools.Options {
             TeeStandardOutput = true;
             BreakOnSystemExitZero = false;
             DebugStdLib = false;
+            UseLegacyDebugger = false;
             Changed?.Invoke(this, EventArgs.Empty);
         }
 
@@ -119,6 +128,14 @@ namespace Microsoft.PythonTools.Options {
         /// </summary>
         /// <remarks>New in 1.1</remarks>
         public bool DebugStdLib {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// True to use the legacy debugger.
+        /// </summary>
+        public bool UseLegacyDebugger {
             get;
             set;
         }

--- a/Python/Product/PythonTools/PythonTools/Options/ExperimentalOptions.cs
+++ b/Python/Product/PythonTools/PythonTools/Options/ExperimentalOptions.cs
@@ -21,18 +21,12 @@ namespace Microsoft.PythonTools.Options {
     public sealed class ExperimentalOptions {
         internal ExperimentalOptions(PythonToolsService service) {
             Load();
-            EO.UseVsCodeDebuggerChanged += OnUseVsCodeDebuggerChanged;
-        }
-
-        private void OnUseVsCodeDebuggerChanged(object sender, EventArgs e) {
-            UseVsCodeDebugger = EO.GetUseVsCodeDebugger();
         }
 
         public void Load() {
             NoDatabaseFactory = EO.GetNoDatabaseFactory();
             AutoDetectCondaEnvironments = EO.GetAutoDetectCondaEnvironments();
             UseCondaPackageManager = EO.GetUseCondaPackageManager();
-            UseVsCodeDebugger = EO.GetUseVsCodeDebugger();
             Changed?.Invoke(this, EventArgs.Empty);
         }
 
@@ -40,7 +34,6 @@ namespace Microsoft.PythonTools.Options {
             EO.NoDatabaseFactory = NoDatabaseFactory;
             EO.AutoDetectCondaEnvironments = AutoDetectCondaEnvironments;
             EO.UseCondaPackageManager = UseCondaPackageManager;
-            EO.UseVsCodeDebugger = UseVsCodeDebugger;
             Changed?.Invoke(this, EventArgs.Empty);
         }
 
@@ -48,7 +41,6 @@ namespace Microsoft.PythonTools.Options {
             NoDatabaseFactory = false;
             AutoDetectCondaEnvironments = false;
             UseCondaPackageManager = false;
-            UseVsCodeDebugger = false;
             Changed?.Invoke(this, EventArgs.Empty);
         }
 
@@ -69,11 +61,5 @@ namespace Microsoft.PythonTools.Options {
         /// True to use conda for package management when available.
         /// </summary>
         public bool UseCondaPackageManager { get; set; }
-
-        /// <summary>
-        /// True to use a debugger built to run on VS Code Debug Adapter Host
-        /// </summary>
-        public bool UseVsCodeDebugger { get; set; }
-
     }
 }

--- a/Python/Product/PythonTools/PythonTools/Options/IPythonOptions.cs
+++ b/Python/Product/PythonTools/PythonTools/Options/IPythonOptions.cs
@@ -55,6 +55,11 @@ namespace Microsoft.PythonTools.Options {
             get;
             set;
         }
+
+        bool UseLegacyDebugger {
+            get;
+            set;
+        }
     }
 
     [Guid("77179244-BBD7-4AA2-B27B-F2CCC679953A")]

--- a/Python/Product/PythonTools/PythonTools/Options/IPythonOptions.cs
+++ b/Python/Product/PythonTools/PythonTools/Options/IPythonOptions.cs
@@ -55,7 +55,10 @@ namespace Microsoft.PythonTools.Options {
             get;
             set;
         }
+    }
 
+    [Guid("0AC0FBE6-C711-46DB-9856-0DD169E1EB9E")]
+    public interface IPythonOptions2 : IPythonOptions {
         bool UseLegacyDebugger {
             get;
             set;

--- a/Python/Product/PythonTools/PythonTools/Options/PythonDebuggingOptionsControl.Designer.cs
+++ b/Python/Product/PythonTools/PythonTools/Options/PythonDebuggingOptionsControl.Designer.cs
@@ -29,8 +29,9 @@ namespace Microsoft.PythonTools.Options {
             this._waitOnNormalExit = new System.Windows.Forms.CheckBox();
             this._teeStdOut = new System.Windows.Forms.CheckBox();
             this._breakOnSystemExitZero = new System.Windows.Forms.CheckBox();
-            this.tableLayoutPanel2 = new System.Windows.Forms.TableLayoutPanel();
             this._debugStdLib = new System.Windows.Forms.CheckBox();
+            this._useLegacyDebugger = new System.Windows.Forms.CheckBox();
+            this.tableLayoutPanel2 = new System.Windows.Forms.TableLayoutPanel();
             this.tableLayoutPanel2.SuspendLayout();
             this.SuspendLayout();
             // 
@@ -69,6 +70,20 @@ namespace Microsoft.PythonTools.Options {
             this._breakOnSystemExitZero.Name = "_breakOnSystemExitZero";
             this._breakOnSystemExitZero.UseVisualStyleBackColor = true;
             // 
+            // _debugStdLib
+            // 
+            resources.ApplyResources(this._debugStdLib, "_debugStdLib");
+            this._debugStdLib.AutoEllipsis = true;
+            this._debugStdLib.Name = "_debugStdLib";
+            this._debugStdLib.UseVisualStyleBackColor = true;
+            // 
+            // _useLegacyDebugger
+            // 
+            resources.ApplyResources(this._useLegacyDebugger, "_useLegacyDebugger");
+            this._useLegacyDebugger.AutoEllipsis = true;
+            this._useLegacyDebugger.Name = "_useLegacyDebugger";
+            this._useLegacyDebugger.UseVisualStyleBackColor = true;
+            // 
             // tableLayoutPanel2
             // 
             resources.ApplyResources(this.tableLayoutPanel2, "tableLayoutPanel2");
@@ -78,14 +93,8 @@ namespace Microsoft.PythonTools.Options {
             this.tableLayoutPanel2.Controls.Add(this._teeStdOut, 0, 3);
             this.tableLayoutPanel2.Controls.Add(this._breakOnSystemExitZero, 0, 4);
             this.tableLayoutPanel2.Controls.Add(this._debugStdLib, 0, 5);
+            this.tableLayoutPanel2.Controls.Add(this._useLegacyDebugger, 0, 6);
             this.tableLayoutPanel2.Name = "tableLayoutPanel2";
-            // 
-            // _debugStdLib
-            // 
-            resources.ApplyResources(this._debugStdLib, "_debugStdLib");
-            this._debugStdLib.AutoEllipsis = true;
-            this._debugStdLib.Name = "_debugStdLib";
-            this._debugStdLib.UseVisualStyleBackColor = true;
             // 
             // PythonDebuggingOptionsControl
             // 
@@ -108,6 +117,7 @@ namespace Microsoft.PythonTools.Options {
         private System.Windows.Forms.CheckBox _teeStdOut;
         private System.Windows.Forms.CheckBox _breakOnSystemExitZero;
         private System.Windows.Forms.CheckBox _debugStdLib;
+        private System.Windows.Forms.CheckBox _useLegacyDebugger;
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel2;
     }
 }

--- a/Python/Product/PythonTools/PythonTools/Options/PythonDebuggingOptionsControl.cs
+++ b/Python/Product/PythonTools/PythonTools/Options/PythonDebuggingOptionsControl.cs
@@ -30,6 +30,7 @@ namespace Microsoft.PythonTools.Options {
             _teeStdOut.Checked = pyService.DebuggerOptions.TeeStandardOutput;
             _breakOnSystemExitZero.Checked = pyService.DebuggerOptions.BreakOnSystemExitZero;
             _debugStdLib.Checked = pyService.DebuggerOptions.DebugStdLib;
+            _useLegacyDebugger.Checked = pyService.DebuggerOptions.UseLegacyDebugger;
         }
 
         internal void SyncPageWithControlSettings(PythonToolsService pyService) {
@@ -39,6 +40,7 @@ namespace Microsoft.PythonTools.Options {
             pyService.DebuggerOptions.TeeStandardOutput = _teeStdOut.Checked;
             pyService.DebuggerOptions.BreakOnSystemExitZero = _breakOnSystemExitZero.Checked;
             pyService.DebuggerOptions.DebugStdLib = _debugStdLib.Checked;
+            pyService.DebuggerOptions.UseLegacyDebugger = _useLegacyDebugger.Checked;
         }
     }
 }

--- a/Python/Product/PythonTools/PythonTools/Options/PythonDebuggingOptionsControl.resx
+++ b/Python/Product/PythonTools/PythonTools/Options/PythonDebuggingOptionsControl.resx
@@ -327,6 +327,42 @@
   <data name="&gt;&gt;_debugStdLib.ZOrder" xml:space="preserve">
     <value>5</value>
   </data>
+  <data name="_useLegacyDebugger.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Left</value>
+  </data>
+  <data name="_useLegacyDebugger.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="_useLegacyDebugger.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="_useLegacyDebugger.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 195</value>
+  </data>
+  <data name="_useLegacyDebugger.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>6, 3, 6, 3</value>
+  </data>
+  <data name="_useLegacyDebugger.Size" type="System.Drawing.Size, System.Drawing">
+    <value>127, 17</value>
+  </data>
+  <data name="_useLegacyDebugger.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
+  </data>
+  <data name="_useLegacyDebugger.Text" xml:space="preserve">
+    <value>U&amp;se legacy debugger</value>
+  </data>
+  <data name="&gt;&gt;_useLegacyDebugger.Name" xml:space="preserve">
+    <value>_useLegacyDebugger</value>
+  </data>
+  <data name="&gt;&gt;_useLegacyDebugger.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;_useLegacyDebugger.Parent" xml:space="preserve">
+    <value>tableLayoutPanel2</value>
+  </data>
+  <data name="&gt;&gt;_useLegacyDebugger.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
   <data name="tableLayoutPanel2.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
   </data>
@@ -334,7 +370,7 @@
     <value>0, 0</value>
   </data>
   <data name="tableLayoutPanel2.RowCount" type="System.Int32, mscorlib">
-    <value>7</value>
+    <value>8</value>
   </data>
   <data name="tableLayoutPanel2.Size" type="System.Drawing.Size, System.Drawing">
     <value>381, 290</value>
@@ -355,7 +391,7 @@
     <value>0</value>
   </data>
   <data name="tableLayoutPanel2.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="_promptOnBuildError" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_waitOnAbnormalExit" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_waitOnNormalExit" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_teeStdOut" Row="3" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_breakOnSystemExitZero" Row="4" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_debugStdLib" Row="5" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,Percent,50" /&gt;&lt;/TableLayoutSettings&gt;</value>
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="_promptOnBuildError" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_waitOnAbnormalExit" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_waitOnNormalExit" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_teeStdOut" Row="3" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_breakOnSystemExitZero" Row="4" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_debugStdLib" Row="5" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_useLegacyDebugger" Row="6" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,Percent,50" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>

--- a/Python/Product/PythonTools/PythonTools/Options/PythonDebuggingOptionsPage.cs
+++ b/Python/Product/PythonTools/PythonTools/Options/PythonDebuggingOptionsPage.cs
@@ -14,14 +14,22 @@
 // See the Apache Version 2.0 License for specific language governing
 // permissions and limitations under the License.
 
-using System;
 using System.Runtime.InteropServices;
-using Microsoft.PythonTools.Parsing;
+using EO = Microsoft.PythonTools.Interpreter.ExperimentalOptions;
 
 namespace Microsoft.PythonTools.Options {
     [ComVisible(true)]
     public class PythonDebuggingOptionsPage : PythonDialogPage {
         private PythonDebuggingOptionsControl _window;
+
+        public PythonDebuggingOptionsPage() {
+            EO.UseVsCodeDebuggerChanged += OnUseVsCodeDebuggerChanged;
+        }
+
+        private void OnUseVsCodeDebuggerChanged(object sender, System.EventArgs e) {
+            // Synchronize UI with backing properties.
+            _window?.SyncControlWithPageSettings(PyService);
+        }
 
         // replace the default UI of the dialog page w/ our own UI.
         protected override System.Windows.Forms.IWin32Window Window {

--- a/Python/Product/PythonTools/PythonTools/Options/PythonExperimentalOptionsControl.Designer.cs
+++ b/Python/Product/PythonTools/PythonTools/Options/PythonExperimentalOptionsControl.Designer.cs
@@ -28,7 +28,6 @@ namespace Microsoft.PythonTools.Options {
             this.tableLayoutPanel2 = new System.Windows.Forms.TableLayoutPanel();
             this._condaEnvironments = new System.Windows.Forms.CheckBox();
             this._condaPackageManager = new System.Windows.Forms.CheckBox();
-            this._useVsCodeDebugger = new System.Windows.Forms.CheckBox();
             this._mustRestartLabel = new System.Windows.Forms.Label();
             this.tableLayoutPanel2.SuspendLayout();
             this.SuspendLayout();
@@ -46,7 +45,6 @@ namespace Microsoft.PythonTools.Options {
             this.tableLayoutPanel2.Controls.Add(this._noDatabaseFactory, 0, 0);
             this.tableLayoutPanel2.Controls.Add(this._condaEnvironments, 0, 1);
             this.tableLayoutPanel2.Controls.Add(this._condaPackageManager, 0, 2);
-            this.tableLayoutPanel2.Controls.Add(this._useVsCodeDebugger, 0, 3);
             this.tableLayoutPanel2.Controls.Add(this._mustRestartLabel, 0, 5);
             this.tableLayoutPanel2.Name = "tableLayoutPanel2";
             // 
@@ -63,13 +61,6 @@ namespace Microsoft.PythonTools.Options {
             this._condaPackageManager.AutoEllipsis = true;
             this._condaPackageManager.Name = "_condaPackageManager";
             this._condaPackageManager.UseVisualStyleBackColor = true;
-            // 
-            // _useVsCodeDebugger
-            // 
-            resources.ApplyResources(this._useVsCodeDebugger, "_useVsCodeDebugger");
-            this._useVsCodeDebugger.AutoEllipsis = true;
-            this._useVsCodeDebugger.Name = "_useVsCodeDebugger";
-            this._useVsCodeDebugger.UseVisualStyleBackColor = true;
             // 
             // _mustRestartLabel
             // 
@@ -96,6 +87,5 @@ namespace Microsoft.PythonTools.Options {
         private System.Windows.Forms.Label _mustRestartLabel;
         private System.Windows.Forms.CheckBox _condaEnvironments;
         private System.Windows.Forms.CheckBox _condaPackageManager;
-        private System.Windows.Forms.CheckBox _useVsCodeDebugger;
     }
 }

--- a/Python/Product/PythonTools/PythonTools/Options/PythonExperimentalOptionsControl.cs
+++ b/Python/Product/PythonTools/PythonTools/Options/PythonExperimentalOptionsControl.cs
@@ -27,14 +27,12 @@ namespace Microsoft.PythonTools.Options {
             _noDatabaseFactory.Checked = pyService.ExperimentalOptions.NoDatabaseFactory;
             _condaEnvironments.Checked = pyService.ExperimentalOptions.AutoDetectCondaEnvironments;
             _condaPackageManager.Checked = pyService.ExperimentalOptions.UseCondaPackageManager;
-            _useVsCodeDebugger.Checked = pyService.ExperimentalOptions.UseVsCodeDebugger;
         }
 
         internal void SyncPageWithControlSettings(PythonToolsService pyService) {
             pyService.ExperimentalOptions.NoDatabaseFactory = _noDatabaseFactory.Checked;
             pyService.ExperimentalOptions.AutoDetectCondaEnvironments = _condaEnvironments.Checked;
             pyService.ExperimentalOptions.UseCondaPackageManager = _condaPackageManager.Checked;
-            pyService.ExperimentalOptions.UseVsCodeDebugger = _useVsCodeDebugger.Checked;
         }
     }
 }

--- a/Python/Product/PythonTools/PythonTools/Options/PythonExperimentalOptionsControl.resx
+++ b/Python/Product/PythonTools/PythonTools/Options/PythonExperimentalOptionsControl.resx
@@ -234,39 +234,6 @@
   <data name="&gt;&gt;_condaPackageManager.ZOrder" xml:space="preserve">
     <value>2</value>
   </data>
-  <data name="_useVsCodeDebugger.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Left</value>
-  </data>
-  <data name="_useVsCodeDebugger.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="_useVsCodeDebugger.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 72</value>
-  </data>
-  <data name="_useVsCodeDebugger.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 3, 6, 3</value>
-  </data>
-  <data name="_useVsCodeDebugger.Size" type="System.Drawing.Size, System.Drawing">
-    <value>155, 17</value>
-  </data>
-  <data name="_useVsCodeDebugger.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="_useVsCodeDebugger.Text" xml:space="preserve">
-    <value>Use experimental &amp;debugger</value>
-  </data>
-  <data name="&gt;&gt;_useVsCodeDebugger.Name" xml:space="preserve">
-    <value>_useVsCodeDebugger</value>
-  </data>
-  <data name="&gt;&gt;_useVsCodeDebugger.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;_useVsCodeDebugger.Parent" xml:space="preserve">
-    <value>tableLayoutPanel2</value>
-  </data>
-  <data name="&gt;&gt;_useVsCodeDebugger.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
   <data name="_mustRestartLabel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Left</value>
   </data>
@@ -298,7 +265,7 @@
     <value>tableLayoutPanel2</value>
   </data>
   <data name="&gt;&gt;_mustRestartLabel.ZOrder" xml:space="preserve">
-    <value>4</value>
+    <value>3</value>
   </data>
   <data name="tableLayoutPanel2.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
@@ -328,7 +295,7 @@
     <value>0</value>
   </data>
   <data name="tableLayoutPanel2.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="_noDatabaseFactory" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_condaEnvironments" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_condaPackageManager" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_useVsCodeDebugger" Row="3" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_mustRestartLabel" Row="5" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,Percent,100,AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="_noDatabaseFactory" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_condaEnvironments" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_condaPackageManager" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_mustRestartLabel" Row="5" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,Percent,100,AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>

--- a/Python/Product/PythonTools/PythonTools/Options/PythonExperimentalOptionsPage.cs
+++ b/Python/Product/PythonTools/PythonTools/Options/PythonExperimentalOptionsPage.cs
@@ -15,21 +15,11 @@
 // permissions and limitations under the License.
 
 using System.Runtime.InteropServices;
-using EO = Microsoft.PythonTools.Interpreter.ExperimentalOptions;
 
 namespace Microsoft.PythonTools.Options {
     [ComVisible(true)]
     public class PythonExperimentalOptionsPage : PythonDialogPage {
         private PythonExperimentalOptionsControl _window;
-
-        public PythonExperimentalOptionsPage() {
-            EO.UseVsCodeDebuggerChanged += OnUseVsCodeDebuggerChanged;
-        }
-
-        private void OnUseVsCodeDebuggerChanged(object sender, System.EventArgs e) {
-            // Synchronize UI with backing properties.
-            _window?.SyncControlWithPageSettings(PyService);
-        }
 
         // replace the default UI of the dialog page w/ our own UI.
         protected override System.Windows.Forms.IWin32Window Window {

--- a/Python/Product/PythonTools/PythonTools/PythonAutomation.cs
+++ b/Python/Product/PythonTools/PythonTools/PythonAutomation.cs
@@ -31,7 +31,7 @@ namespace Microsoft.PythonTools {
     /// can be fetched using Dte.GetObject("VsPython").
     /// </summary>
     [ComVisible(true)]
-    public sealed class PythonAutomation : IVsPython, IPythonOptions, IPythonIntellisenseOptions {
+    public sealed class PythonAutomation : IVsPython, IPythonOptions2, IPythonIntellisenseOptions {
         private readonly IServiceProvider _serviceProvider;
         private readonly PythonToolsService _pyService;
         private AutomationInteractiveOptions _interactiveOptions;
@@ -117,7 +117,7 @@ namespace Microsoft.PythonTools {
             }
         }
 
-        bool IPythonOptions.UseLegacyDebugger {
+        bool IPythonOptions2.UseLegacyDebugger {
             get {
                 return _pyService.DebuggerOptions.UseLegacyDebugger;
             }

--- a/Python/Product/PythonTools/PythonTools/PythonAutomation.cs
+++ b/Python/Product/PythonTools/PythonTools/PythonAutomation.cs
@@ -117,6 +117,16 @@ namespace Microsoft.PythonTools {
             }
         }
 
+        bool IPythonOptions.UseLegacyDebugger {
+            get {
+                return _pyService.DebuggerOptions.UseLegacyDebugger;
+            }
+            set {
+                _pyService.DebuggerOptions.UseLegacyDebugger = value;
+                _pyService.DebuggerOptions.Save();
+            }
+        }
+
         #endregion
 
         #region IPythonIntellisenseOptions Members

--- a/Python/Product/PythonTools/PythonToolsService.cs
+++ b/Python/Product/PythonTools/PythonToolsService.cs
@@ -162,7 +162,7 @@ namespace Microsoft.PythonTools {
                     { "NoDatabaseFactory", ExperimentalOptions.NoDatabaseFactory },
                     { "AutoDetectCondaEnvironments", ExperimentalOptions.AutoDetectCondaEnvironments },
                     { "UseCondaPackageManager", ExperimentalOptions.UseCondaPackageManager },
-                    { "UseVsCodeDebugger", ExperimentalOptions.UseVsCodeDebugger }
+                    { "UseVsCodeDebugger", !DebuggerOptions.UseLegacyDebugger }
                 });
             } catch (Exception ex) {
                 Debug.Fail(ex.ToUnhandledExceptionMessage(GetType()));

--- a/Python/Product/PythonTools/ptvsd_launcher.py
+++ b/Python/Product/PythonTools/ptvsd_launcher.py
@@ -69,7 +69,7 @@ filename = sys.argv[0]
 sys.path[0] = ''
 
 if not bundled_ptvsd and (sys.platform == 'cli' or sys.version_info < (2, 7) or
-    (sys.version_info >= (3, 0) and sys.version_info < (3, 3))):
+    (sys.version_info >= (3, 0) and sys.version_info < (3, 4))):
     # This is experimental debugger incompatibility. Exit immediately.
     # This process will be killed by VS since it does not see a debugger
     # connect to it. The exit code we will get there will be wrong.

--- a/Python/Tests/DebuggerUITests/DebugProjectUITests.cs
+++ b/Python/Tests/DebuggerUITests/DebugProjectUITests.cs
@@ -43,7 +43,7 @@ namespace DebuggerUITests {
         public void DebugPythonProject(PythonVisualStudioApp app, bool useVsCodeDebugger, string interpreter, DotNotWaitOnNormalExit optionSetter) {
             var pyService = app.ServiceProvider.GetUIThread().Invoke(() => app.ServiceProvider.GetPythonToolsService());
             using (SelectDefaultInterpreter(app, interpreter))
-            using (new PythonExperimentalGeneralOptionsSetter(pyService, useVsCodeDebugger: useVsCodeDebugger)) {
+            using (new PythonDebuggingGeneralOptionsSetter(app.Dte, useLegacyDebugger: !useVsCodeDebugger)) {
                 StartHelloWorldAndBreak(app);
 
                 app.Dte.Debugger.Go(WaitForBreakOrEnd: true);
@@ -57,7 +57,7 @@ namespace DebuggerUITests {
         public void DebugPythonProjectSubFolderStartupFileSysPath(PythonVisualStudioApp app, bool useVsCodeDebugger, string interpreter, DotNotWaitOnNormalExit optionSetter) {
             var pyService = app.ServiceProvider.GetUIThread().Invoke(() => app.ServiceProvider.GetPythonToolsService());
             using (SelectDefaultInterpreter(app, interpreter))
-            using (new PythonExperimentalGeneralOptionsSetter(pyService, useVsCodeDebugger: useVsCodeDebugger)) {
+            using (new PythonDebuggingGeneralOptionsSetter(app.Dte, useLegacyDebugger: !useVsCodeDebugger)) {
                 var sln = app.CopyProjectForTest(@"TestData\SysPath.sln");
                 var project = app.OpenProject(sln);
 
@@ -81,7 +81,7 @@ namespace DebuggerUITests {
         public void DebugPythonProjectWithAndWithoutClearingPythonPath(PythonVisualStudioApp app, bool useVsCodeDebugger, string interpreter, DotNotWaitOnNormalExit optionSetter) {
             var pyService = app.ServiceProvider.GetUIThread().Invoke(() => app.ServiceProvider.GetPythonToolsService());
             using (SelectDefaultInterpreter(app, interpreter))
-            using (new PythonExperimentalGeneralOptionsSetter(pyService, useVsCodeDebugger: useVsCodeDebugger)) {
+            using (new PythonDebuggingGeneralOptionsSetter(app.Dte, useLegacyDebugger: !useVsCodeDebugger)) {
                 var sysPathSln = app.CopyProjectForTest(@"TestData\SysPath.sln");
                 var helloWorldSln = app.CopyProjectForTest(@"TestData\HelloWorld.sln");
                 var testDataPath = Path.Combine(PathUtils.GetParent(helloWorldSln), "HelloWorld").Replace("\\", "\\\\");
@@ -113,7 +113,7 @@ namespace DebuggerUITests {
         public void DebugPythonCustomInterpreter(PythonVisualStudioApp app, bool useVsCodeDebugger, string interpreter, DotNotWaitOnNormalExit optionSetter) {
             var pyService = app.ServiceProvider.GetUIThread().Invoke(() => app.ServiceProvider.GetPythonToolsService());
             using (SelectDefaultInterpreter(app, interpreter))
-            using (new PythonExperimentalGeneralOptionsSetter(pyService, useVsCodeDebugger: useVsCodeDebugger)) {
+            using (new PythonDebuggingGeneralOptionsSetter(app.Dte, useLegacyDebugger: !useVsCodeDebugger)) {
                 var sln = app.CopyProjectForTest(@"TestData\RelativeInterpreterPath.sln");
                 var project = app.OpenProject(sln, "Program.py");
                 var interpreterFolder = PathUtils.GetParent(sln);
@@ -147,7 +147,7 @@ namespace DebuggerUITests {
         public void DebugPythonCustomInterpreterMissing(PythonVisualStudioApp app, bool useVsCodeDebugger, string interpreter, DotNotWaitOnNormalExit optionSetter) {
             var pyService = app.ServiceProvider.GetUIThread().Invoke(() => app.ServiceProvider.GetPythonToolsService());
             using (SelectDefaultInterpreter(app, interpreter))
-            using (new PythonExperimentalGeneralOptionsSetter(pyService, useVsCodeDebugger: useVsCodeDebugger)) {
+            using (new PythonDebuggingGeneralOptionsSetter(app.Dte, useLegacyDebugger: !useVsCodeDebugger)) {
                 var sln = app.CopyProjectForTest(@"TestData\RelativeInterpreterPath.sln");
                 var project = app.OpenProject(sln, "Program.py");
                 var interpreterPath = Path.Combine(PathUtils.GetParent(sln), "Interpreter.exe");
@@ -166,7 +166,7 @@ namespace DebuggerUITests {
         public void PendingBreakPointLocation(PythonVisualStudioApp app, bool useVsCodeDebugger, string interpreter, DotNotWaitOnNormalExit optionSetter) {
             var pyService = app.ServiceProvider.GetUIThread().Invoke(() => app.ServiceProvider.GetPythonToolsService());
             using (SelectDefaultInterpreter(app, interpreter))
-            using (new PythonExperimentalGeneralOptionsSetter(pyService, useVsCodeDebugger: useVsCodeDebugger)) {
+            using (new PythonDebuggingGeneralOptionsSetter(app.Dte, useLegacyDebugger: !useVsCodeDebugger)) {
                 var sln = app.CopyProjectForTest(@"TestData\DebuggerProject.sln");
                 var project = app.OpenProject(sln, "BreakpointInfo.py");
                 var bpInfo = project.ProjectItems.Item("BreakpointInfo.py");
@@ -195,7 +195,7 @@ namespace DebuggerUITests {
         public void BoundBreakpoint(PythonVisualStudioApp app, bool useVsCodeDebugger, string interpreter, DotNotWaitOnNormalExit optionSetter) {
             var pyService = app.ServiceProvider.GetUIThread().Invoke(() => app.ServiceProvider.GetPythonToolsService());
             using (SelectDefaultInterpreter(app, interpreter))
-            using (new PythonExperimentalGeneralOptionsSetter(pyService, useVsCodeDebugger: useVsCodeDebugger)) {
+            using (new PythonDebuggingGeneralOptionsSetter(app.Dte, useLegacyDebugger: !useVsCodeDebugger)) {
                 var project = OpenDebuggerProjectAndBreak(app, "BreakpointInfo.py", 2);
 
                 var pendingBp = (Breakpoint3)app.Dte.Debugger.Breakpoints.Item(1);
@@ -228,7 +228,7 @@ namespace DebuggerUITests {
         public void Step(PythonVisualStudioApp app, bool useVsCodeDebugger, string interpreter, DotNotWaitOnNormalExit optionSetter) {
             var pyService = app.ServiceProvider.GetUIThread().Invoke(() => app.ServiceProvider.GetPythonToolsService());
             using (SelectDefaultInterpreter(app, interpreter))
-            using (new PythonExperimentalGeneralOptionsSetter(pyService, useVsCodeDebugger: useVsCodeDebugger)) {
+            using (new PythonDebuggingGeneralOptionsSetter(app.Dte, useLegacyDebugger: !useVsCodeDebugger)) {
                 var project = OpenDebuggerProjectAndBreak(app, "SteppingTest.py", 1);
                 app.Dte.Debugger.StepOver(true);
                 WaitForMode(app, dbgDebugMode.dbgBreakMode);
@@ -244,7 +244,7 @@ namespace DebuggerUITests {
         public void ShowCallStackOnCodeMap(PythonVisualStudioApp app, bool useVsCodeDebugger, string interpreter, DotNotWaitOnNormalExit optionSetter) {
             var pyService = app.ServiceProvider.GetUIThread().Invoke(() => app.ServiceProvider.GetPythonToolsService());
             using (SelectDefaultInterpreter(app, interpreter))
-            using (new PythonExperimentalGeneralOptionsSetter(pyService, useVsCodeDebugger: useVsCodeDebugger)) {
+            using (new PythonDebuggingGeneralOptionsSetter(app.Dte, useLegacyDebugger: !useVsCodeDebugger)) {
                 var project = OpenDebuggerProjectAndBreak(app, "SteppingTest3.py", 2);
 
                 app.Dte.ExecuteCommand("Debug.ShowCallStackonCodeMap");
@@ -304,7 +304,7 @@ namespace DebuggerUITests {
         public void Step3(PythonVisualStudioApp app, bool useVsCodeDebugger, string interpreter, DotNotWaitOnNormalExit optionSetter) {
             var pyService = app.ServiceProvider.GetUIThread().Invoke(() => app.ServiceProvider.GetPythonToolsService());
             using (SelectDefaultInterpreter(app, interpreter))
-            using (new PythonExperimentalGeneralOptionsSetter(pyService, useVsCodeDebugger: useVsCodeDebugger)) {
+            using (new PythonDebuggingGeneralOptionsSetter(app.Dte, useLegacyDebugger: !useVsCodeDebugger)) {
                 var project = OpenDebuggerProjectAndBreak(app, "SteppingTest3.py", 2);
                 app.Dte.Debugger.StepOut(true);
                 WaitForMode(app, dbgDebugMode.dbgBreakMode);
@@ -320,7 +320,7 @@ namespace DebuggerUITests {
         public void Step5(PythonVisualStudioApp app, bool useVsCodeDebugger, string interpreter, DotNotWaitOnNormalExit optionSetter) {
             var pyService = app.ServiceProvider.GetUIThread().Invoke(() => app.ServiceProvider.GetPythonToolsService());
             using (SelectDefaultInterpreter(app, interpreter))
-            using (new PythonExperimentalGeneralOptionsSetter(pyService, useVsCodeDebugger: useVsCodeDebugger)) {
+            using (new PythonDebuggingGeneralOptionsSetter(app.Dte, useLegacyDebugger: !useVsCodeDebugger)) {
                 var project = OpenDebuggerProjectAndBreak(app, "SteppingTest5.py", 5);
                 app.Dte.Debugger.StepInto(true);
                 WaitForMode(app, dbgDebugMode.dbgBreakMode);
@@ -342,7 +342,7 @@ namespace DebuggerUITests {
             }
             var pyService = app.ServiceProvider.GetUIThread().Invoke(() => app.ServiceProvider.GetPythonToolsService());
             using (SelectDefaultInterpreter(app, interpreter))
-            using (new PythonExperimentalGeneralOptionsSetter(pyService, useVsCodeDebugger: useVsCodeDebugger)) {
+            using (new PythonDebuggingGeneralOptionsSetter(app.Dte, useLegacyDebugger: !useVsCodeDebugger)) {
                 var project = OpenDebuggerProjectAndBreak(app, "SetNextLine.py", 7);
 
                 var doc = app.Dte.Documents.Item("SetNextLine.py");
@@ -405,7 +405,7 @@ namespace DebuggerUITests {
         public void TerminateProcess(PythonVisualStudioApp app, bool useVsCodeDebugger, string interpreter, DotNotWaitOnNormalExit optionSetter) {
             var pyService = app.ServiceProvider.GetUIThread().Invoke(() => app.ServiceProvider.GetPythonToolsService());
             using (SelectDefaultInterpreter(app, interpreter))
-            using (new PythonExperimentalGeneralOptionsSetter(pyService, useVsCodeDebugger: useVsCodeDebugger)) {
+            using (new PythonDebuggingGeneralOptionsSetter(app.Dte, useLegacyDebugger: !useVsCodeDebugger)) {
                 StartHelloWorldAndBreak(app);
 
                 Assert.AreEqual(dbgDebugMode.dbgBreakMode, app.Dte.Debugger.CurrentMode);
@@ -423,7 +423,7 @@ namespace DebuggerUITests {
         public void EnumModules(PythonVisualStudioApp app, bool useVsCodeDebugger, string interpreter, DotNotWaitOnNormalExit optionSetter) {
             var pyService = app.ServiceProvider.GetUIThread().Invoke(() => app.ServiceProvider.GetPythonToolsService());
             using (SelectDefaultInterpreter(app, interpreter))
-            using (new PythonExperimentalGeneralOptionsSetter(pyService, useVsCodeDebugger: useVsCodeDebugger)) {
+            using (new PythonDebuggingGeneralOptionsSetter(app.Dte, useLegacyDebugger: !useVsCodeDebugger)) {
                 StartHelloWorldAndBreak(app);
 
                 var modules = ((Process3)app.Dte.Debugger.CurrentProcess).Modules;
@@ -444,7 +444,7 @@ namespace DebuggerUITests {
         public void MainThread(PythonVisualStudioApp app, bool useVsCodeDebugger, string interpreter, DotNotWaitOnNormalExit optionSetter) {
             var pyService = app.ServiceProvider.GetUIThread().Invoke(() => app.ServiceProvider.GetPythonToolsService());
             using (SelectDefaultInterpreter(app, interpreter))
-            using (new PythonExperimentalGeneralOptionsSetter(pyService, useVsCodeDebugger: useVsCodeDebugger)) {
+            using (new PythonDebuggingGeneralOptionsSetter(app.Dte, useLegacyDebugger: !useVsCodeDebugger)) {
                 StartHelloWorldAndBreak(app);
 
                 var thread = ((Thread2)app.Dte.Debugger.CurrentThread);
@@ -463,7 +463,7 @@ namespace DebuggerUITests {
         public void ExpressionEvaluation(PythonVisualStudioApp app, bool useVsCodeDebugger, string interpreter, DotNotWaitOnNormalExit optionSetter) {
             var pyService = app.ServiceProvider.GetUIThread().Invoke(() => app.ServiceProvider.GetPythonToolsService());
             using (SelectDefaultInterpreter(app, interpreter))
-            using (new PythonExperimentalGeneralOptionsSetter(pyService, useVsCodeDebugger: useVsCodeDebugger)) {
+            using (new PythonDebuggingGeneralOptionsSetter(app.Dte, useLegacyDebugger: !useVsCodeDebugger)) {
                 OpenDebuggerProject(app, "Program.py");
 
                 app.Dte.Debugger.Breakpoints.Add(File: "Program.py", Line: 14);
@@ -552,7 +552,7 @@ namespace DebuggerUITests {
             }
             var pyService = app.ServiceProvider.GetUIThread().Invoke(() => app.ServiceProvider.GetPythonToolsService());
             using (SelectDefaultInterpreter(app, interpreter))
-            using (new PythonExperimentalGeneralOptionsSetter(pyService, useVsCodeDebugger: useVsCodeDebugger)) {
+            using (new PythonDebuggingGeneralOptionsSetter(app.Dte, useLegacyDebugger: !useVsCodeDebugger)) {
                 ExceptionTest(app, "SimpleException.py", "Exception Thrown", "Exception", "Exception", 3);
             }
         }
@@ -560,7 +560,7 @@ namespace DebuggerUITests {
         public void SimpleException2(PythonVisualStudioApp app, bool useVsCodeDebugger, string interpreter, DotNotWaitOnNormalExit optionSetter) {
             var pyService = app.ServiceProvider.GetUIThread().Invoke(() => app.ServiceProvider.GetPythonToolsService());
             using (SelectDefaultInterpreter(app, interpreter))
-            using (new PythonExperimentalGeneralOptionsSetter(pyService, useVsCodeDebugger: useVsCodeDebugger)) {
+            using (new PythonDebuggingGeneralOptionsSetter(app.Dte, useLegacyDebugger: !useVsCodeDebugger)) {
                 string exceptionDescription = useVsCodeDebugger ? "ValueError('bad value',)" : "ValueError: bad value";
                 ExceptionTest(app, "SimpleException2.py", "Exception Thrown", exceptionDescription, "ValueError", 3);
             }
@@ -584,7 +584,7 @@ namespace DebuggerUITests {
         public void ExceptionInImportLibNotReported(PythonVisualStudioApp app, bool useVsCodeDebugger, string interpreter, DotNotWaitOnNormalExit optionSetter) {
             var pyService = app.ServiceProvider.GetUIThread().Invoke(() => app.ServiceProvider.GetPythonToolsService());
             using (SelectDefaultInterpreter(app, interpreter))
-            using (new PythonExperimentalGeneralOptionsSetter(pyService, useVsCodeDebugger: useVsCodeDebugger))
+            using (new PythonDebuggingGeneralOptionsSetter(app.Dte, useLegacyDebugger: !useVsCodeDebugger))
             using (new DebuggingGeneralOptionsSetter(app.Dte, enableJustMyCode: true)) {
                 OpenDebuggerProjectAndBreak(app, "ImportLibException.py", 2);
                 app.Dte.Debugger.Go(WaitForBreakOrEnd: true);
@@ -595,7 +595,7 @@ namespace DebuggerUITests {
         public void Breakpoints(PythonVisualStudioApp app, bool useVsCodeDebugger, string interpreter, DotNotWaitOnNormalExit optionSetter) {
             var pyService = app.ServiceProvider.GetUIThread().Invoke(() => app.ServiceProvider.GetPythonToolsService());
             using (SelectDefaultInterpreter(app, interpreter))
-            using (new PythonExperimentalGeneralOptionsSetter(pyService, useVsCodeDebugger: useVsCodeDebugger)) {
+            using (new PythonDebuggingGeneralOptionsSetter(app.Dte, useLegacyDebugger: !useVsCodeDebugger)) {
                 OpenDebuggerProjectAndBreak(app, "BreakpointTest2.py", 3);
                 var debug3 = (Debugger3)app.Dte.Debugger;
                 Assert.AreEqual((uint)3, ((StackFrame2)debug3.CurrentThread.StackFrames.Item(1)).LineNumber);
@@ -612,7 +612,7 @@ namespace DebuggerUITests {
         public void BreakpointsDisable(PythonVisualStudioApp app, bool useVsCodeDebugger, string interpreter, DotNotWaitOnNormalExit optionSetter) {
             var pyService = app.ServiceProvider.GetUIThread().Invoke(() => app.ServiceProvider.GetPythonToolsService());
             using (SelectDefaultInterpreter(app, interpreter))
-            using (new PythonExperimentalGeneralOptionsSetter(pyService, useVsCodeDebugger: useVsCodeDebugger)) {
+            using (new PythonDebuggingGeneralOptionsSetter(app.Dte, useLegacyDebugger: !useVsCodeDebugger)) {
                 OpenDebuggerProjectAndBreak(app, "BreakpointTest4.py", 2);
                 var debug3 = (Debugger3)app.Dte.Debugger;
                 Assert.AreEqual((uint)2, ((StackFrame2)debug3.CurrentThread.StackFrames.Item(1)).LineNumber);
@@ -635,7 +635,7 @@ namespace DebuggerUITests {
         public void BreakpointsDisableReenable(PythonVisualStudioApp app, bool useVsCodeDebugger, string interpreter, DotNotWaitOnNormalExit optionSetter) {
             var pyService = app.ServiceProvider.GetUIThread().Invoke(() => app.ServiceProvider.GetPythonToolsService());
             using (SelectDefaultInterpreter(app, interpreter))
-            using (new PythonExperimentalGeneralOptionsSetter(pyService, useVsCodeDebugger: useVsCodeDebugger)) {
+            using (new PythonDebuggingGeneralOptionsSetter(app.Dte, useLegacyDebugger: !useVsCodeDebugger)) {
                 var debug3 = (Debugger3)app.Dte.Debugger;
                 OpenDebuggerProjectAndBreak(app, "BreakpointTest4.py", 2);
                 Assert.AreEqual((uint)2, ((StackFrame2)debug3.CurrentThread.StackFrames.Item(1)).LineNumber);
@@ -694,8 +694,7 @@ namespace DebuggerUITests {
         public void LaunchWithErrorsDontRun(PythonVisualStudioApp app, bool useVsCodeDebugger, string interpreter, DotNotWaitOnNormalExit optionSetter) {
             var pyService = app.ServiceProvider.GetUIThread().Invoke(() => app.ServiceProvider.GetPythonToolsService());
             using (SelectDefaultInterpreter(app, interpreter))
-            using (new PythonExperimentalGeneralOptionsSetter(pyService, useVsCodeDebugger: useVsCodeDebugger)) 
-            using (new PythonDebuggingGeneralOptionsSetter(app.Dte, promptBeforeRunningWithBuildErrorSetting: true)) {
+            using (new PythonDebuggingGeneralOptionsSetter(app.Dte, useLegacyDebugger: !useVsCodeDebugger, promptBeforeRunningWithBuildErrorSetting: true)) {
                 var sln = app.CopyProjectForTest(@"TestData\ErrorProject.sln");
                 var project = app.OpenProject(sln);
                 var projectDir = PathUtils.GetParent(project.FullName);
@@ -728,7 +727,7 @@ namespace DebuggerUITests {
         public void StartWithDebuggingNoProject(PythonVisualStudioApp app, bool useVsCodeDebugger, string interpreter, DotNotWaitOnNormalExit optionSetter) {
             var pyService = app.ServiceProvider.GetUIThread().Invoke(() => app.ServiceProvider.GetPythonToolsService());
             using (SelectDefaultInterpreter(app, interpreter))
-            using (new PythonExperimentalGeneralOptionsSetter(pyService, useVsCodeDebugger: useVsCodeDebugger)) {
+            using (new PythonDebuggingGeneralOptionsSetter(app.Dte, useLegacyDebugger: !useVsCodeDebugger)) {
                 string scriptFilePath = TestData.GetPath(@"TestData\HelloWorld\Program.py");
 
                 app.DeleteAllBreakPoints();
@@ -751,7 +750,7 @@ namespace DebuggerUITests {
         public void StartWithoutDebuggingNoProject(PythonVisualStudioApp app, bool useVsCodeDebugger, string interpreter, DotNotWaitOnNormalExit optionSetter) {
             var pyService = app.ServiceProvider.GetUIThread().Invoke(() => app.ServiceProvider.GetPythonToolsService());
             using (SelectDefaultInterpreter(app, interpreter))
-            using (new PythonExperimentalGeneralOptionsSetter(pyService, useVsCodeDebugger: useVsCodeDebugger)) {
+            using (new PythonDebuggingGeneralOptionsSetter(app.Dte, useLegacyDebugger: !useVsCodeDebugger)) {
                 var tempFolder = TestData.GetTempPath();
                 string scriptFilePath = Path.Combine(tempFolder, "CreateFile1.py");
                 string resultFilePath = Path.Combine(tempFolder, "File1.txt");
@@ -773,7 +772,7 @@ namespace DebuggerUITests {
         public void StartWithDebuggingNotInProject(PythonVisualStudioApp app, bool useVsCodeDebugger, string interpreter, DotNotWaitOnNormalExit optionSetter) {
             var pyService = app.ServiceProvider.GetUIThread().Invoke(() => app.ServiceProvider.GetPythonToolsService());
             using (SelectDefaultInterpreter(app, interpreter))
-            using (new PythonExperimentalGeneralOptionsSetter(pyService, useVsCodeDebugger: useVsCodeDebugger)) {
+            using (new PythonDebuggingGeneralOptionsSetter(app.Dte, useLegacyDebugger: !useVsCodeDebugger)) {
                 string scriptFilePath = TestData.GetPath(@"TestData\HelloWorld\Program.py");
 
                 OpenDebuggerProject(app);
@@ -795,7 +794,7 @@ namespace DebuggerUITests {
         public void StartWithoutDebuggingNotInProject(PythonVisualStudioApp app, bool useVsCodeDebugger, string interpreter, DotNotWaitOnNormalExit optionSetter) {
             var pyService = app.ServiceProvider.GetUIThread().Invoke(() => app.ServiceProvider.GetPythonToolsService());
             using (SelectDefaultInterpreter(app, interpreter))
-            using (new PythonExperimentalGeneralOptionsSetter(pyService, useVsCodeDebugger: useVsCodeDebugger)) {
+            using (new PythonDebuggingGeneralOptionsSetter(app.Dte, useLegacyDebugger: !useVsCodeDebugger)) {
                 var tempFolder = TestData.GetTempPath();
                 string scriptFilePath = Path.Combine(tempFolder, "CreateFile2.py");
                 string resultFilePath = Path.Combine(tempFolder, "File2.txt");
@@ -817,7 +816,7 @@ namespace DebuggerUITests {
         public void StartWithDebuggingInProject(PythonVisualStudioApp app, bool useVsCodeDebugger, string interpreter, DotNotWaitOnNormalExit optionSetter) {
             var pyService = app.ServiceProvider.GetUIThread().Invoke(() => app.ServiceProvider.GetPythonToolsService());
             using (SelectDefaultInterpreter(app, interpreter))
-            using (new PythonExperimentalGeneralOptionsSetter(pyService, useVsCodeDebugger: useVsCodeDebugger)) {
+            using (new PythonDebuggingGeneralOptionsSetter(app.Dte, useLegacyDebugger: !useVsCodeDebugger)) {
                 var proj = OpenDebuggerProject(app);
                 var projDir = PathUtils.GetParent(proj.FullName);
                 var scriptFilePath = Path.Combine(projDir, "Program.py");
@@ -839,7 +838,7 @@ namespace DebuggerUITests {
         public void StartWithDebuggingSubfolderInProject(PythonVisualStudioApp app, bool useVsCodeDebugger, string interpreter, DotNotWaitOnNormalExit optionSetter) {
             var pyService = app.ServiceProvider.GetUIThread().Invoke(() => app.ServiceProvider.GetPythonToolsService());
             using (SelectDefaultInterpreter(app, interpreter))
-            using (new PythonExperimentalGeneralOptionsSetter(pyService, useVsCodeDebugger: useVsCodeDebugger)) {
+            using (new PythonDebuggingGeneralOptionsSetter(app.Dte, useLegacyDebugger: !useVsCodeDebugger)) {
                 var proj = OpenDebuggerProject(app);
                 var projDir = PathUtils.GetParent(proj.FullName);
                 var scriptFilePath = Path.Combine(projDir, "Sub", "paths.py");
@@ -869,7 +868,7 @@ namespace DebuggerUITests {
         public void StartWithoutDebuggingInProject(PythonVisualStudioApp app, bool useVsCodeDebugger, string interpreter, DotNotWaitOnNormalExit optionSetter) {
             var pyService = app.ServiceProvider.GetUIThread().Invoke(() => app.ServiceProvider.GetPythonToolsService());
             using (SelectDefaultInterpreter(app, interpreter))
-            using (new PythonExperimentalGeneralOptionsSetter(pyService, useVsCodeDebugger: useVsCodeDebugger)) {
+            using (new PythonDebuggingGeneralOptionsSetter(app.Dte, useLegacyDebugger: !useVsCodeDebugger)) {
                 var proj = OpenDebuggerProject(app);
                 var projDir = PathUtils.GetParent(proj.FullName);
                 var scriptFilePath = Path.Combine(projDir, "CreateFile3.py");
@@ -889,7 +888,7 @@ namespace DebuggerUITests {
         public void StartWithDebuggingNoScript(PythonVisualStudioApp app, bool useVsCodeDebugger, string interpreter, DotNotWaitOnNormalExit optionSetter) {
             var pyService = app.ServiceProvider.GetUIThread().Invoke(() => app.ServiceProvider.GetPythonToolsService());
             using (SelectDefaultInterpreter(app, interpreter))
-            using (new PythonExperimentalGeneralOptionsSetter(pyService, useVsCodeDebugger: useVsCodeDebugger)) {
+            using (new PythonDebuggingGeneralOptionsSetter(app.Dte, useLegacyDebugger: !useVsCodeDebugger)) {
                 try {
                     app.ExecuteCommand("Python.StartWithDebugging");
                 } catch (COMException e) {
@@ -905,7 +904,7 @@ namespace DebuggerUITests {
         public void StartWithoutDebuggingNoScript(PythonVisualStudioApp app, bool useVsCodeDebugger, string interpreter, DotNotWaitOnNormalExit optionSetter) {
             var pyService = app.ServiceProvider.GetUIThread().Invoke(() => app.ServiceProvider.GetPythonToolsService());
             using (SelectDefaultInterpreter(app, interpreter))
-            using (new PythonExperimentalGeneralOptionsSetter(pyService, useVsCodeDebugger: useVsCodeDebugger)) {
+            using (new PythonDebuggingGeneralOptionsSetter(app.Dte, useLegacyDebugger: !useVsCodeDebugger)) {
                 try {
                     app.ExecuteCommand("Python.StartWithoutDebugging");
                 } catch (COMException e) {
@@ -918,7 +917,7 @@ namespace DebuggerUITests {
         public void WebProjectLauncherNoStartupFile(PythonVisualStudioApp app, bool useVsCodeDebugger, string interpreter, DotNotWaitOnNormalExit optionSetter) {
             var pyService = app.ServiceProvider.GetUIThread().Invoke(() => app.ServiceProvider.GetPythonToolsService());
             using (SelectDefaultInterpreter(app, interpreter))
-            using (new PythonExperimentalGeneralOptionsSetter(pyService, useVsCodeDebugger: useVsCodeDebugger)) {
+            using (new PythonDebuggingGeneralOptionsSetter(app.Dte, useLegacyDebugger: !useVsCodeDebugger)) {
                 var project = app.CreateProject(
                     PythonVisualStudioApp.TemplateLanguageName,
                     PythonVisualStudioApp.EmptyWebProjectTemplate,

--- a/Python/Tests/Utilities.Python/PythonDebuggingGeneralOptionsSetter.cs
+++ b/Python/Tests/Utilities.Python/PythonDebuggingGeneralOptionsSetter.cs
@@ -112,6 +112,6 @@ namespace TestUtilities.Python {
             }
         }
 
-        private IPythonOptions GetOptions() => (IPythonOptions)_dte.GetObject("VsPython");
+        private IPythonOptions2 GetOptions() => (IPythonOptions2)_dte.GetObject("VsPython");
     }
 }

--- a/Python/Tests/Utilities.Python/PythonDebuggingGeneralOptionsSetter.cs
+++ b/Python/Tests/Utilities.Python/PythonDebuggingGeneralOptionsSetter.cs
@@ -28,6 +28,7 @@ namespace TestUtilities.Python {
         private readonly bool? _teeStandardOutput;
         private readonly bool? _waitOnAbnormalExit;
         private readonly bool? _waitOnNormalExit;
+        private readonly bool? _useLegacyDebugger;
 
         public PythonDebuggingGeneralOptionsSetter(
             DTE dte,
@@ -36,7 +37,8 @@ namespace TestUtilities.Python {
             Severity? indentationInconsistencySeverity = null,
             bool? teeStandardOutput = null,
             bool? waitOnAbnormalExit = null,
-            bool? waitOnNormalExit = null
+            bool? waitOnNormalExit = null,
+            bool? useLegacyDebugger = null
         ) {
             _dte = dte;
             var options = GetOptions();
@@ -71,6 +73,10 @@ namespace TestUtilities.Python {
                 options.WaitOnNormalExit = waitOnNormalExit.Value;
             }
 
+            if (useLegacyDebugger.HasValue) {
+                _useLegacyDebugger = options.UseLegacyDebugger;
+                options.UseLegacyDebugger = useLegacyDebugger.Value;
+            }
         }
 
 
@@ -99,6 +105,10 @@ namespace TestUtilities.Python {
 
             if (_waitOnNormalExit.HasValue) {
                 options.WaitOnNormalExit = _waitOnNormalExit.Value;
+            }
+
+            if (_useLegacyDebugger.HasValue) {
+                options.UseLegacyDebugger = _useLegacyDebugger.Value;
             }
         }
 

--- a/Python/Tests/Utilities.Python/PythonExperimentalGeneralOptionsSetter.cs
+++ b/Python/Tests/Utilities.Python/PythonExperimentalGeneralOptionsSetter.cs
@@ -24,14 +24,12 @@ namespace TestUtilities.Python {
         private readonly bool? _noDatabaseFactory;
         private readonly bool? _autoDetectCondaEnvironments;
         private readonly bool? _useCondaPackageManager;
-        private readonly bool? _useVsCodeDebugger;
 
         public PythonExperimentalGeneralOptionsSetter(
             PythonToolsService pyService,
             bool? noDatabaseFactory = null,
             bool? autoDetectCondaEnvironments = null,
-            bool? useCondaPackageManager = null,
-            bool? useVsCodeDebugger = null
+            bool? useCondaPackageManager = null
         ) {
             _pyService = pyService;
             var options = _pyService.ExperimentalOptions;
@@ -50,11 +48,6 @@ namespace TestUtilities.Python {
                 _useCondaPackageManager = options.UseCondaPackageManager;
                 options.UseCondaPackageManager = useCondaPackageManager.Value;
             }
-
-            if (useVsCodeDebugger.HasValue) {
-                _useVsCodeDebugger = options.UseVsCodeDebugger;
-                options.UseVsCodeDebugger = useVsCodeDebugger.Value;
-            }
         }
 
         public void Dispose() {
@@ -70,10 +63,6 @@ namespace TestUtilities.Python {
 
             if (_useCondaPackageManager.HasValue) {
                 options.UseCondaPackageManager = _useCondaPackageManager.Value;
-            }
-
-            if (_useVsCodeDebugger.HasValue) {
-                options.UseVsCodeDebugger = _useVsCodeDebugger.Value;
             }
         }
     }


### PR DESCRIPTION
Fix #4479 

Use legacy instead of experimental when mentioning the ptvsd debuggers.
Move the option from experimental page to debugger page.
Add Python 3.3 as an incompatible environment.

I kept the storage of the option in VSInterpreters, we still need to access it from the Debugger project which doesn't have access to DebuggerOptions.