### PR TITLE
Fixes #4229 Refactor rename incorrect when using import *

### DIFF
--- a/Python/Product/Analysis/AnalysisLog.cs
+++ b/Python/Product/Analysis/AnalysisLog.cs
@@ -49,6 +49,8 @@ namespace Microsoft.PythonTools.Analysis {
             }
         }
 
+        private static bool Active => _log != null;
+
         public static void Flush() {
             _log?.Flush();
         }
@@ -75,25 +77,25 @@ namespace Microsoft.PythonTools.Analysis {
         }
 
         public static void Enqueue(Deque<AnalysisUnit> deque, AnalysisUnit unit) {
-            if (Output != null) {
+            if (Active) {
                 Add("E", IdDispenser.GetId(unit), deque.Count);
             }
         }
 
         public static void Dequeue(Deque<AnalysisUnit> deque, AnalysisUnit unit) {
-            if (Output != null) {
+            if (Active) {
                 Add("D", IdDispenser.GetId(unit), deque.Count);
             }
         }
 
         public static void NewUnit(AnalysisUnit unit) {
-            if (Output != null) {
+            if (Active) {
                 Add("N", IdDispenser.GetId(unit), unit.FullName, unit.ToString());
             }
         }
 
         public static void UpdateUnit(AnalysisUnit unit) {
-            if (Output != null) {
+            if (Active) {
                 Add("U", IdDispenser.GetId(unit), unit.FullName, unit.ToString());
             }
         }

--- a/Python/Product/Analysis/AnalysisUnit.cs
+++ b/Python/Product/Analysis/AnalysisUnit.cs
@@ -129,7 +129,11 @@ namespace Microsoft.PythonTools.Analysis {
             if (!ForEval && !IsInQueue && !_suppressEnqueue) {
                 State.Queue.Append(this);
                 AnalysisLog.Enqueue(State.Queue, this);
-                this.IsInQueue = true;
+                IsInQueue = true;
+
+                if (DeclaringModule?.Scope == Scope) {
+                    DeclaringModule.ModuleDefinition.EnqueueDependents();
+                }
             }
         }
 
@@ -424,8 +428,8 @@ namespace Microsoft.PythonTools.Analysis {
             ddg.WalkBody(Ast.Body, classInfo.AnalysisUnit);
 
             ddg.SetCurrentUnit(_outerUnit);
-            var v = _outerUnit.Scope.AddLocatedVariable(Ast.Name, Ast.NameExpression, this);
-            v.AddTypes(this, ProcessClassDecorators(ddg, classInfo));
+            _outerUnit.Scope.AddLocatedVariable(Ast.Name, Ast.NameExpression, this);
+            _outerUnit.Scope.AssignVariable(Ast.Name, Ast.NameExpression, this, ProcessClassDecorators(ddg, classInfo));
         }
 
         private IAnalysisSet ProcessClassDecorators(DDG ddg, ClassInfo classInfo) {

--- a/Python/Product/Analysis/Analyzer/DDG.cs
+++ b/Python/Product/Analysis/Analyzer/DDG.cs
@@ -342,7 +342,7 @@ namespace Microsoft.PythonTools.Analysis.Analyzer {
         /// True to add <paramref name="node"/> as a reference of the
         /// imported value.
         /// </param>
-        private void ImportModuleOrMember(ModuleReference module, IReadOnlyList<string> attribute, string importAs, Node node, bool addRef) {
+        private void FinishImportModuleOrMember(ModuleReference module, IReadOnlyList<string> attribute, string importAs, Node node, bool addRef) {
             if (AssignImportedModuleOrMember(
                 importAs,
                 GetImportedModuleOrMember(module, attribute, node, addRef, importAs),
@@ -392,14 +392,14 @@ namespace Microsoft.PythonTools.Analysis.Analyzer {
                             fullImpName[fullImpName.Length - 1] = varName;
 
                             // Don't add references to "*" node
-                            ImportModuleOrMember(modRef, fullImpName, varName, nameNode, false);
+                            FinishImportModuleOrMember(modRef, fullImpName, varName, nameNode, false);
                         }
                     }
                 } else {
                     fullImpName[fullImpName.Length - 1] = impName;
 
                     var varName = asNames[i]?.Name ?? impName;
-                    ImportModuleOrMember(modRef, fullImpName, varName, nameNode, true);
+                    FinishImportModuleOrMember(modRef, fullImpName, varName, nameNode, true);
                 }
             }
 
@@ -545,7 +545,7 @@ namespace Microsoft.PythonTools.Analysis.Analyzer {
                 // "import fob.oar as baz" is handled as
                 // baz = import_module('fob.oar')
                 if (asName != null) {
-                    ImportModuleOrMember(modRef, bits, asName.Name, asName, true);
+                    FinishImportModuleOrMember(modRef, bits, asName.Name, asName, true);
                     continue;
                 }
 
@@ -555,7 +555,7 @@ namespace Microsoft.PythonTools.Analysis.Analyzer {
                 var name = curName.Names[0];
                 // Should be able to just get the module, as we only just imported it
                 if (ProjectState.Modules.TryGetImportedModule(name.Name, out modRef)) {
-                    ImportModuleOrMember(modRef, null, name.Name, name, true);
+                    FinishImportModuleOrMember(modRef, null, name.Name, name, true);
                     continue;
                 }
 

--- a/Python/Product/Analysis/Analyzer/DDG.cs
+++ b/Python/Product/Analysis/Analyzer/DDG.cs
@@ -252,53 +252,108 @@ namespace Microsoft.PythonTools.Analysis.Analyzer {
             return false;
         }
 
-        private bool AssignImportedMember(Node node, IModule userMod, string[] attributes, string assignName) {
-            if (attributes == null) {
-                throw new ArgumentNullException(nameof(attributes));
-            } else if (attributes.Length == 0) {
-                throw new ArgumentException("non-empty attributes required", nameof(attributes));
+        /// <summary>
+        /// Resolves and returns an imported member.
+        /// </summary>
+        /// <param name="module">
+        /// The module to import or import from.
+        /// </param>
+        /// <param name="attribute">
+        /// An optional attribute (already split at the dots) to
+        /// </param>
+        /// <param name="node">
+        /// The import location. If <paramref name="addRef"/> is true,
+        /// this location will be marked as a reference of the imported
+        /// value.
+        /// </param>
+        /// <param name="addRef">
+        /// True to make <paramref name="node"/> a reference to the
+        /// imported member.
+        /// </param>
+        /// <param name="linkToName">
+        /// If not null, the name in the current scope to link to the
+        /// value in the module. This is only used when 
+        /// <paramref name="attribute"/> contains one element.
+        /// </param>
+        /// <returns>The imported member, or null.</returns>
+        private IAnalysisSet GetImportedModuleOrMember(ModuleReference module, IReadOnlyList<string> attribute, Node node, bool addRef, string linkToName) {
+            if (module?.Module == null) {
+                return null;
             }
-            return AssignImportedModuleOrMember(node, userMod, null, attributes, assignName, attributes?.Length == 1);
+
+            if (attribute == null || attribute.Count == 0) {
+                return module.AnalysisModule;
+            }
+
+            var value = module.Module.GetModuleMember(node, _unit, attribute[0], addRef, Scope, attribute.Count == 1 ? linkToName : null);
+            foreach (var n in attribute.Skip(1)) {
+                if (value.IsNullOrEmpty()) {
+                    return null;
+                }
+                value = value.GetMember(node, _unit, n);
+            }
+            return value.IsNullOrEmpty() ? null : value;
         }
 
-        private bool AssignImportedModule(Node node, ModuleReference modRef, IReadOnlyList<string> attributes, string assignName) {
-            return AssignImportedModuleOrMember(node, modRef.Module, modRef.AnalysisModule, attributes, assignName, false);
-        }
+        /// <summary>
+        /// Creates the variable for containing an imported member.
+        /// </summary>
+        /// <param name="name">The name of the variable.</param>
+        /// <param name="node">
+        /// The imported location. If <paramref name="addRef"/> is 
+        /// true, this location will be marked as a reference of the
+        /// imported value.
+        /// </param>
+        /// <param name="addRef">
+        /// True to make <paramref name="node"/> a reference to the
+        /// imported member.
+        /// </param>
+        /// <returns>The variable for the imported member.</returns>
+        private bool AssignImportedModuleOrMember(string name, IAnalysisSet value, Node node, bool addRef) {
+            var v = Scope.CreateVariable(node, _unit, name, addRef);
+            v.IsAlwaysAssigned = true;
 
-        private bool AssignImportedModuleOrMember(Node node, IModule userMod, IAnalysisSet analysisMod, IReadOnlyList<string> attributes, string assignName, bool addLink) {
-            var variable = Scope.CreateVariable(node, _unit, assignName, false);
-            if (userMod == null) {
-                return false;
-            }
-
-            bool added = false;
-            if (attributes == null) {
-                if (analysisMod != null) {
-                    added = Assign(variable, analysisMod, node);
-                }
-            } else {
-                var value = userMod.GetModuleMember(node, _unit, attributes[0], true, Scope, addLink ? assignName : null);
-                foreach (var n in attributes.Skip(1)) {
-                    value = value.GetMember(node, _unit, n);
-                }
-
-                added = Assign(variable, value, node);
-            }
-
-            if (added) {
-                // anyone who read from the module will now need to get the new values
+            if (!value.IsNullOrEmpty() && v.AddTypes(_unit, value)) {
                 GlobalScope.ModuleDefinition.EnqueueDependents();
+                return true;
             }
 
-            return added;
+            return false;
         }
 
-        private bool Assign(VariableDef variable, IAnalysisSet value, Node locationNode) {
-            var added = variable.AddTypes(_unit, value);
-            if (added) {
-                variable.AddAssignment(new EncodedLocation(_unit, locationNode), _unit.ProjectEntry);
+        /// <summary>
+        /// Finishes importing a module or module member.
+        /// </summary>
+        /// <param name="module">
+        /// The imported module, as returned from TryImportModule.
+        /// </param>
+        /// <param name="attribute">
+        /// Attribute within the module to resolve, already split at
+        /// dots, as returned from TryImportModule.
+        /// </param>
+        /// <param name="importAs">
+        /// The name to save the imported module or member under.
+        /// </param>
+        /// <param name="node">
+        /// If <paramref name="addRef"/> is true, this node will be
+        /// added as a reference of the imported value.
+        /// </param>
+        /// <param name="addRef">
+        /// True to add <paramref name="node"/> as a reference of the
+        /// imported value.
+        /// </param>
+        private void ImportModuleOrMember(ModuleReference module, IReadOnlyList<string> attribute, string importAs, Node node, bool addRef) {
+            if (AssignImportedModuleOrMember(
+                importAs,
+                GetImportedModuleOrMember(module, attribute, node, addRef, importAs),
+                node,
+                addRef
+            )) {
+                // Imports into our global scope need to enqueue modules that have imported us
+                if (Scope == GlobalScope.Scope) {
+                    GlobalScope.ModuleDefinition.EnqueueDependents();
+                }
             }
-            return added;
         }
 
         public override bool Walk(FromImportStatement node) {
@@ -309,10 +364,8 @@ namespace Microsoft.PythonTools.Analysis.Analyzer {
                 return false;
             }
 
-            _unit.DeclaringModule.AddModuleReference(modRef);
-
             Debug.Assert(modRef.Module != null);
-            var userMod = modRef.Module;
+            modRef.Module.Imported(_unit);
 
             string[] fullImpName;
             if (bits != null) {
@@ -328,27 +381,25 @@ namespace Microsoft.PythonTools.Analysis.Analyzer {
             for (int i = 0; i < len; i++) {
                 var nameNode = asNames[i] ?? node.Names[i];
                 var impName = node.Names[i].Name;
-                var newName = asNames[i] != null ? asNames[i].Name : null;
 
                 if (string.IsNullOrEmpty(impName)) {
                     // incomplete import statement
                     continue;
                 } else if (impName == "*") {
                     // Handle "import *"
-                    if (userMod != null) {
-                        userMod.Imported(_unit);
+                    foreach (var varName in modRef.Module.GetModuleMemberNames(GlobalScope.InterpreterContext)) {
+                        if (!varName.StartsWithOrdinal("_")) {
+                            fullImpName[fullImpName.Length - 1] = varName;
 
-                        foreach (var varName in userMod.GetModuleMemberNames(GlobalScope.InterpreterContext)) {
-                            if (!varName.StartsWithOrdinal("_")) {
-                                fullImpName[fullImpName.Length - 1] = varName;
-                                AssignImportedMember(nameNode, userMod, fullImpName, varName);
-                            }
+                            // Don't add references to "*" node
+                            ImportModuleOrMember(modRef, fullImpName, varName, nameNode, false);
                         }
                     }
                 } else {
-                    userMod.Imported(_unit);
                     fullImpName[fullImpName.Length - 1] = impName;
-                    AssignImportedMember(nameNode, userMod, fullImpName, newName ?? impName);
+
+                    var varName = asNames[i]?.Name ?? impName;
+                    ImportModuleOrMember(modRef, fullImpName, varName, nameNode, true);
                 }
             }
 
@@ -369,6 +420,7 @@ namespace Microsoft.PythonTools.Analysis.Analyzer {
             var candidates = ModuleResolver.ResolvePotentialModuleNames(_unit.ProjectEntry, modName, forceAbsolute).ToArray();
             foreach (var name in candidates) {
                 if (ProjectState.Modules.TryImport(name, out moduleRef)) {
+                    _unit.DeclaringModule.AddModuleReference(moduleRef);
                     return true;
                 }
             }
@@ -386,13 +438,19 @@ namespace Microsoft.PythonTools.Analysis.Analyzer {
                         if (moduleRef.Name.Length + 1 < name.Length) {
                             remainingParts = name.Substring(moduleRef.Name.Length + 1).Split('.');
                         }
+                        _unit.DeclaringModule.AddModuleReference(moduleRef);
                         return true;
                     } else {
                         break;
                     }
                 }
             }
-            return moduleRef?.Module != null;
+
+            if (moduleRef?.Module != null) {
+                _unit.DeclaringModule.AddModuleReference(moduleRef);
+                return true;
+            }
+            return false;
         }
 
         internal List<AnalysisValue> LookupBaseMethods(string name, IEnumerable<IAnalysisSet> bases, Node node, AnalysisUnit unit) {
@@ -473,52 +531,36 @@ namespace Microsoft.PythonTools.Analysis.Analyzer {
             for (var i = 0; i < len; i++) {
                 var curName = node.Names[i];
                 var asName = node.AsNames[i];
-
-                string importing, saveName;
-                NameExpression nameNode;
-                if (curName.Names.Count == 0) {
+                var importing = curName?.MakeString();
+                if (string.IsNullOrEmpty(importing)) {
                     continue;
-                } else if (curName.Names.Count > 1) {
-                    // import fob.oar
-                    if (asName != null) {
-                        // import fob.oar as baz, baz becomes the value of the oar module
-                        importing = curName.MakeString();
-                        saveName = asName.Name;
-                        nameNode = asName;
-                    } else {
-                        // plain import fob.oar, we bring in fob into the scope
-                        saveName = importing = curName.Names[0].Name;
-                        nameNode = curName.Names[0];
-                    }
+                }
+
+                if (TryImportModule(importing, node.ForceAbsolute, out var modRef, out var bits)) {
+                    modRef.Module.Imported(_unit);
                 } else {
-                    // import fob
-                    importing = curName.Names[0].Name;
-                    if (asName != null) {
-                        saveName = asName.Name;
-                        nameNode = asName;
-                    } else {
-                        saveName = importing;
-                        nameNode = curName.Names[0];
-                    }
+                    _unit.DeclaringModule.AddUnresolvedModule(importing, node.ForceAbsolute);
                 }
 
-                // Ensure a variable exists, even if the import fails
-                Scope.CreateVariable(nameNode, _unit, saveName);
-
-                if (!TryImportModule(importing, node.ForceAbsolute, out var modRef, out var bits)) {
-                    _unit.DeclaringModule.AddUnresolvedModule(importing, node.ForceAbsolute);
+                // "import fob.oar as baz" is handled as
+                // baz = import_module('fob.oar')
+                if (asName != null) {
+                    ImportModuleOrMember(modRef, bits, asName.Name, asName, true);
                     continue;
                 }
 
-                _unit.DeclaringModule.AddModuleReference(modRef);
-
-                var userMod = modRef.Module;
-                Debug.Assert(userMod != null);
-
-                if (userMod != null) {
-                    userMod.Imported(_unit);
-                    AssignImportedModule(nameNode, modRef, bits, saveName);
+                // "import fob.oar" is handled as
+                // import_module('fob.oar')
+                // fob = import_module('fob')
+                var name = curName.Names[0];
+                // Should be able to just get the module, as we only just imported it
+                if (ProjectState.Modules.TryGetImportedModule(name.Name, out modRef)) {
+                    ImportModuleOrMember(modRef, null, name.Name, name, true);
+                    continue;
                 }
+
+                Debug.Fail("Failed to get module we just imported");
+                Scope.CreateEphemeralVariable(name, _unit, name.Name, false);
             }
             return true;
         }

--- a/Python/Product/Analysis/Analyzer/FunctionAnalysisUnit.cs
+++ b/Python/Product/Analysis/Analyzer/FunctionAnalysisUnit.cs
@@ -81,14 +81,14 @@ namespace Microsoft.PythonTools.Analysis.Analyzer {
             var funcType = ProcessFunctionDecorators(ddg);
             EnsureParameterZero();
 
-            var v = ddg.Scope.AddLocatedVariable(Ast.Name, Ast.NameExpression, this);
+            _declUnit.Scope.AddLocatedVariable(Ast.Name, Ast.NameExpression, this);
 
             // Set the scope to within the function
             ddg.Scope = Scope;
 
             Ast.Body.Walk(ddg);
 
-            v.AddTypes(this, funcType);
+            _declUnit.Scope.AssignVariable(Ast.Name, Ast.NameExpression, this, funcType);
         }
 
 

--- a/Python/Product/Analysis/Analyzer/InterpreterScope.cs
+++ b/Python/Product/Analysis/Analyzer/InterpreterScope.cs
@@ -219,7 +219,9 @@ namespace Microsoft.PythonTools.Analysis.Analyzer {
                 locatedVariable.Location = new EncodedLocation(unit, node);
                 locatedVariable.DeclaringVersion = unit.ProjectEntry.AnalysisVersion;
             } else {
+                var oldVariable = variable;
                 variable = AddVariable(name, new LocatedVariableDef(unit.ProjectEntry, new EncodedLocation(unit, node)));
+                oldVariable?.CopyTo(variable);
             }
 
             if (addRef) {

--- a/Python/Product/Analysis/Analyzer/ModuleScope.cs
+++ b/Python/Product/Analysis/Analyzer/ModuleScope.cs
@@ -14,9 +14,7 @@
 // See the Apache Version 2.0 License for specific language governing
 // permissions and limitations under the License.
 
-using System.Text;
 using Microsoft.PythonTools.Analysis.Values;
-using Microsoft.PythonTools.Parsing;
 
 namespace Microsoft.PythonTools.Analysis.Analyzer {
     sealed class ModuleScope : InterpreterScope {

--- a/Python/Product/Analysis/ModuleAnalysis.cs
+++ b/Python/Product/Analysis/ModuleAnalysis.cs
@@ -1157,7 +1157,7 @@ namespace Microsoft.PythonTools.Analysis {
         private static string GetMemberName(string privatePrefix, GetMemberOptions options, string name) {
             if (privatePrefix != null && name.StartsWithOrdinal(privatePrefix) && !name.EndsWithOrdinal("__")) {
                 // private prefix inside of the class, filter out the prefix.
-                return name.Substring(privatePrefix.Length - 2);
+                return name.Substring(privatePrefix.Length);
             } else if (!_otherPrivateRegex.IsMatch(name) || !options.HideAdvanced()) {
                 return name;
             }
@@ -1176,7 +1176,7 @@ namespace Microsoft.PythonTools.Analysis {
         private static string GetPrivatePrefix(InterpreterScope scope) {
             string classScopePrefix = GetPrivatePrefixClassName(scope);
             if (classScopePrefix != null) {
-                return "_" + classScopePrefix + "__";
+                return "_" + classScopePrefix;
             }
             return null;
         }

--- a/Python/Product/Analysis/Parsing/Parser.cs
+++ b/Python/Product/Analysis/Parsing/Parser.cs
@@ -1648,22 +1648,10 @@ namespace Microsoft.PythonTools.Parsing {
         private string SetPrivatePrefix(string name) {
             string oldPrefix = _privatePrefix;
 
-            _privatePrefix = GetPrivatePrefix(name);
+            // Remove any leading underscores before saving the prefix
+            _privatePrefix = name?.TrimStart('_');
 
             return oldPrefix;
-        }
-
-        internal static string GetPrivatePrefix(string name) {
-            // Remove any leading underscores before saving the prefix
-            if (name != null) {
-                for (int i = 0; i < name.Length; i++) {
-                    if (name[i] != '_') {
-                        return name.Substring(i);
-                    }
-                }
-            }
-            // Name consists of '_'s only, no private prefix mapping
-            return null;
         }
 
         private ErrorExpression Error(string verbatimImage = null, Expression preceeding = null) {

--- a/Python/Product/Analysis/PythonAnalyzer.cs
+++ b/Python/Product/Analysis/PythonAnalyzer.cs
@@ -1012,8 +1012,11 @@ namespace Microsoft.PythonTools.Analysis {
                 }
                 // Try and acquire the lock before disposing. This helps avoid
                 // some (non-fatal) exceptions.
-                _reloadLock.Wait(TimeSpan.FromSeconds(10));
-                _reloadLock.Dispose();
+                try {
+                    _reloadLock.Wait(TimeSpan.FromSeconds(10));
+                    _reloadLock.Dispose();
+                } catch (ObjectDisposedException) {
+                }
             }
         }
 

--- a/Python/Product/PythonTools/PythonTools/Refactoring/LocationPreviewItem.cs
+++ b/Python/Product/PythonTools/PythonTools/Refactoring/LocationPreviewItem.cs
@@ -76,7 +76,7 @@ namespace Microsoft.PythonTools.Refactoring {
                     return;
                 }
 
-                if (!GetSpanWithPrefix(text, origName, locationInfo, "_" + prefix, newName, out start, out length)) {
+                if (!GetSpanWithPrefix(text, origName, locationInfo, prefix, newName, out start, out length)) {
                     // Not renaming a prefixed name
                     Debug.Fail("Failed to find '{0}' in '{1}'".FormatInvariant(origName, text));
                     return;

--- a/Python/Product/PythonTools/PythonTools/Refactoring/VariableRenamer.cs
+++ b/Python/Product/PythonTools/PythonTools/Refactoring/VariableRenamer.cs
@@ -77,7 +77,7 @@ namespace Microsoft.PythonTools.Refactoring {
                 .Where(n => !string.IsNullOrEmpty(n))
                 .FirstOrDefault() ?? analysis.Expression;
 
-            if (analysis.PrivatePrefix != null && originalName != null && originalName.StartsWithOrdinal("_" + analysis.PrivatePrefix)) {
+            if (analysis.PrivatePrefix != null && originalName != null && originalName.StartsWithOrdinal(analysis.PrivatePrefix)) {
                 originalName = originalName.Substring(analysis.PrivatePrefix.Length + 1);
                 privatePrefix = analysis.PrivatePrefix;
             }

--- a/Python/Tests/Analysis/AnalysisTest.cs
+++ b/Python/Tests/Analysis/AnalysisTest.cs
@@ -19,7 +19,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
@@ -155,8 +154,8 @@ f(x=42, y = 'abc')
             var analyzer = CreateAnalyzer(DefaultFactoryV3);
 
             var fob = analyzer.AddModule("fob", "from oar import *", "fob\\__init__.py");
-            var oar = analyzer.AddModule("fob.oar", "from baz import *", "fob\\oar\\__init__.py");
-            var baz = analyzer.AddModule("fob.oar.baz", "import quox\r\nfunc = quox.func");
+            var oar = analyzer.AddModule("fob.oar", "from .baz import *", "fob\\oar\\__init__.py");
+            var baz = analyzer.AddModule("fob.oar.baz", "import fob.oar.quox as quox\r\nfunc = quox.func");
             var quox = analyzer.AddModule("fob.oar.quox", "def func(): return 42");
             analyzer.ReanalyzeAll();
 
@@ -678,7 +677,6 @@ class D(object):
             state.AssertReferences(mod2, "D", 0,
                 new VariableLocation(2, 1, VariableType.Value, "mod2"),
                 new VariableLocation(2, 7, VariableType.Definition, "mod2"),
-                new VariableLocation(2, 18, VariableType.Reference, "mod1"),
                 new VariableLocation(4, 5, VariableType.Reference, "mod1")
             );
         }
@@ -1461,6 +1459,9 @@ class C:
 
     def y(self):
         self.__x()
+
+    def g(self):
+        self._C__x()
 ";
 
             var entry = ProcessTextV2(text);
@@ -1468,7 +1469,8 @@ class C:
             entry.AssertReferences("self.__x", text.IndexOf("self.__"),
                 new VariableLocation(3, 5, VariableType.Value),
                 new VariableLocation(3, 9, VariableType.Definition),
-                new VariableLocation(7, 14, VariableType.Reference));
+                new VariableLocation(7, 14, VariableType.Reference),
+                new VariableLocation(10, 14, VariableType.Reference));
         }
 
         [TestMethod, Priority(0)]
@@ -2985,10 +2987,40 @@ from baz import abc2 as abc";
                 new VariableLocation(1, 25, VariableType.Reference, "oarbaz"),
                 new VariableLocation(2, 25, VariableType.Reference, "oarbaz"),    // as
                 new VariableLocation(2, 20, VariableType.Reference, "fob"),    // import
-                new VariableLocation(1, 25, VariableType.Definition, "oarbaz"),
-                new VariableLocation(2, 25, VariableType.Definition, "oarbaz"),    // as
-                new VariableLocation(2, 20, VariableType.Definition, "fob"),    // import
                 new VariableLocation(4, 1, VariableType.Reference, "fob")     // call
+            );
+        }
+
+        [TestMethod, Priority(0)]
+        public void ImportStarReferences() {
+            var state = CreateAnalyzer();
+            var fobMod = state.AddModule("fob", @"
+CONSTANT = 1
+class Class: pass
+def fn(): pass");
+            var oarMod = state.AddModule("oar", @"from fob import *
+
+
+
+x = CONSTANT
+c = Class()
+f = fn()");
+
+            state.ReanalyzeAll();
+
+            state.AssertReferences(oarMod, "CONSTANT", 0,
+                new VariableLocation(2, 1, VariableType.Definition, "fob"),
+                new VariableLocation(5, 5, VariableType.Reference, "oar")
+            );
+            state.AssertReferences(oarMod, "Class", 0,
+                new VariableLocation(3, 1, VariableType.Value, "fob"),
+                new VariableLocation(3, 7, VariableType.Definition, "fob"),
+                new VariableLocation(6, 5, VariableType.Reference, "oar")
+            );
+            state.AssertReferences(oarMod, "fn", 0,
+                new VariableLocation(4, 1, VariableType.Value, "fob"),
+                new VariableLocation(4, 5, VariableType.Definition, "fob"),
+                new VariableLocation(7, 5, VariableType.Reference, "oar")
             );
         }
 

--- a/Python/Tests/PythonToolsMockTests/NavigableTests.cs
+++ b/Python/Tests/PythonToolsMockTests/NavigableTests.cs
@@ -18,9 +18,11 @@ extern alias analysis;
 extern alias pythontools;
 using System;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using analysis::Microsoft.PythonTools.Analysis;
 using analysis::Microsoft.PythonTools.Interpreter;
+using Microsoft.PythonTools.Infrastructure;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Classification;
@@ -56,7 +58,7 @@ namespace PythonToolsMockTests {
 ";
             using (var helper = new NavigableHelper(code, Version)) {
                 // os
-                await helper.CheckDefinitionLocations(7, 2, ExternalLocation(1, 1, "os.py"), Location(1, 8));
+                await helper.CheckDefinitionLocations(7, 2, ExternalLocation(1, 1, "os.py"));
             }
         }
 
@@ -68,7 +70,7 @@ sys.version
 ";
             using (var helper = new NavigableHelper(code, Version)) {
                 // sys
-                await helper.CheckDefinitionLocations(14, 3, Location(1, 8));
+                await helper.CheckDefinitionLocations(14, 3, null);
 
                 // version
                 await helper.CheckDefinitionLocations(18, 7, null);
@@ -183,11 +185,11 @@ print(obj._my_attr_val)
 ";
             using (var helper = new NavigableHelper(code, Version)) {
                 // my_attr
-                await helper.CheckDefinitionLocations(71, 7, Location(4, 5), Location(8, 5), Location(9, 9));
-                await helper.CheckDefinitionLocations(128, 7, Location(4, 5), Location(8, 5), Location(9, 9));
-                await helper.CheckDefinitionLocations(152, 7, Location(4, 5), Location(8, 5), Location(9, 9));
-                await helper.CheckDefinitionLocations(229, 7, Location(4, 5), Location(8, 5), Location(9, 9), Location(13, 5));
-                await helper.CheckDefinitionLocations(252, 7, Location(4, 5), Location(8, 5), Location(9, 9), Location(13, 5));
+                await helper.CheckDefinitionLocations(71, 7, Location(4, 5), Location(5, 9), Location(8, 5), Location(9, 9));
+                await helper.CheckDefinitionLocations(128, 7, Location(4, 5), Location(5, 9), Location(8, 5), Location(9, 9));
+                await helper.CheckDefinitionLocations(152, 7, Location(4, 5), Location(5, 9), Location(8, 5), Location(9, 9));
+                await helper.CheckDefinitionLocations(229, 7, Location(4, 5), Location(5, 9), Location(8, 5), Location(9, 9), Location(13, 5));
+                await helper.CheckDefinitionLocations(252, 7, Location(4, 5), Location(5, 9), Location(8, 5), Location(9, 9), Location(13, 5));
 
                 // val
                 await helper.CheckDefinitionLocations(166, 3, Location(9, 23));
@@ -233,6 +235,9 @@ res = my_var * 10
             public NavigableHelper(string code, PythonVersion version) {
                 var factory = InterpreterFactoryCreator.CreateInterpreterFactory(version.Configuration, new InterpreterFactoryCreationOptions() { WatchFileSystem = false });
                 _view = new PythonEditor("", version.Version, factory: factory);
+                if (_view.Analyzer.IsAnalyzing) {
+                    _view.Analyzer.WaitForCompleteAnalysis(_ => true);
+                }
                 _view.Text = code;
             }
 
@@ -248,13 +253,21 @@ res = my_var * 10
                 var snapshotSpan = trackingSpan.GetSpan(_view.CurrentSnapshot);
                 Console.WriteLine("Finding definition of \"{0}\"", snapshotSpan.GetText());
                 var actualLocations = await NavigableSymbolSource.GetDefinitionLocationsAsync(entry, snapshotSpan.Start);
+
+                Console.WriteLine($"Actual locations for pos={pos}, length={length}:");
+                foreach (var actualLocation in actualLocations) {
+                    Console.WriteLine($"file={actualLocation.Location.DocumentUri},line={actualLocation.Location.StartLine},col={actualLocation.Location.StartColumn}");
+                }
+
+                // Check that any real locations are not our test files. These may be included in debug builds,
+                // but we don't want to be testing them.
+                // Fake paths are from our tests, so always include them.
+                actualLocations = actualLocations
+                    .Where(v => !File.Exists(v.Location.FilePath) || !PathUtils.IsSubpathOf(PathUtils.GetParent(typeof(IAnalysisVariable).Assembly.Location), v.Location.FilePath))
+                    .ToArray();
+
                 if (expectedLocations != null) {
                     Assert.IsNotNull(actualLocations);
-
-                    Console.WriteLine($"Actual locations for pos={pos}, length={length}:");
-                    foreach (var actualLocation in actualLocations) {
-                        Console.WriteLine($"file={actualLocation.Location.DocumentUri},line={actualLocation.Location.StartLine},col={actualLocation.Location.StartColumn}");
-                    }
 
                     Assert.AreEqual(expectedLocations.Length, actualLocations.Length, "incorrect number of locations");
                     for (int i = 0; i < expectedLocations.Length; i++) {


### PR DESCRIPTION
Fixes #4229 Refactor rename incorrect when using import *
Use correct references when importing modules or members
Streamlines import analysis code
Fixes dependencies not being notified of new module members
Fixes transitive module dependencies
Fixes analysis log not recording all messages
Fixes some handling of private name prefixes