### PR TITLE
Fixes #4033 Remote attach with source reference crashes VS

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Editor/PythonTextBufferInfo.cs
+++ b/Python/Product/PythonTools/PythonTools/Editor/PythonTextBufferInfo.cs
@@ -191,11 +191,18 @@ namespace Microsoft.PythonTools.Editor {
             var path = Filename;
             if (!string.IsNullOrEmpty(path)) {
                 try {
-                    return new Uri(path);
+                    if (Path.IsPathRooted(path)) {
+                        return new Uri(path);
+                    }
+                    // Make an opaque identifier for this file
+                    var ub = new UriBuilder("python://", Guid.NewGuid().ToString("N")) { Path = path };
+                    return ub.Uri;
+                } catch (ArgumentException ex) {
+                    Debug.Fail("{0} is not a valid path.{1}{2}".FormatInvariant(path, Environment.NewLine, ex.ToUnhandledExceptionMessage(GetType())));
                 } catch (UriFormatException ex) {
                     Debug.Fail("{0} is not a valid URI.{1}{2}".FormatInvariant(path, Environment.NewLine, ex.ToUnhandledExceptionMessage(GetType())));
-                    return null;
                 }
+                return null;
             }
 
             var replEval = Buffer.GetInteractiveWindow()?.Evaluator as IPythonInteractiveIntellisense;


### PR DESCRIPTION
Fixes #4033 Remote attach with source reference crashes VS
Handles non-absolute paths by generating a false URI