### PR TITLE
Fixes #3705 Format selection breaks code

### DIFF
--- a/Python/Product/Analyzer/Intellisense/OutOfProcProjectAnalyzer.cs
+++ b/Python/Product/Analyzer/Intellisense/OutOfProcProjectAnalyzer.cs
@@ -743,7 +743,7 @@ namespace Microsoft.PythonTools.Intellisense {
             return new AP.FormatCodeResponse() {
                 version = version,
                 changes = selectedCode.ReplaceByLines(
-                    walker.Target.StartIncludingLeadingWhiteSpace.Line,
+                    walker.Target.StartIncludingLeadingWhiteSpace,
                     body.ToCodeString(ast, request.options),
                     request.newLine
                 ).Select(AP.ChangeInfo.FromDocumentChange).ToArray()

--- a/Python/Tests/Core/CodeFormatterTests.cs
+++ b/Python/Tests/Core/CodeFormatterTests.cs
@@ -75,6 +75,31 @@ class Oar(object):
         }
 
         [TestMethod, Priority(0)]
+        public async Task TestCodeFormattingMidLineSelection() {
+            var input = @"
+def f(x):
+    f( x+1)
+    pass
+";
+
+            string selection = "x+1";
+
+            string expected = @"
+def f(x):
+    f( x + 1)
+    pass
+";
+
+            var options = new CodeFormattingOptions() {
+                SpacesAroundBinaryOperators = true,
+                // Even though true, we aren't formatting the call, so it shouldn't apply
+                SpaceWithinCallParens = true
+            };
+
+            await CodeFormattingTest(input, selection, expected, " x + 1", options);
+        }
+
+        [TestMethod, Priority(0)]
         public async Task TestCodeFormattingEndOfFile() {
             var input = @"print('Hello World')
 


### PR DESCRIPTION
Fixes #3705 Format selection breaks code
Ensures formatting edits are offset by correct starting location.