### PR TITLE
Fixes #4494 Refactor rename with "import ... as" not working

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Refactoring/LocationPreviewItem.cs
+++ b/Python/Product/PythonTools/PythonTools/Refactoring/LocationPreviewItem.cs
@@ -36,62 +36,70 @@ namespace Microsoft.PythonTools.Refactoring {
         private bool _checked = true;
         private static readonly char[] _whitespace = new[] { ' ', '\t', '\f' };
 
-        public LocationPreviewItem(VsProjectAnalyzer analyzer, FilePreviewItem parent, LocationInfo locationInfo, VariableType type) {
+        private LocationPreviewItem(FilePreviewItem parent, string text, int line, int column, Span span) {
+            _parent = parent;
+            _text = text;
+            Line = line;
+            Column = column;
+            _span = span;
+        }
+
+        public static LocationPreviewItem Create(VsProjectAnalyzer analyzer, FilePreviewItem parent, LocationInfo locationInfo, VariableType type) {
             Debug.Assert(locationInfo.StartColumn >= 1, "Invalid location info (Column)");
             Debug.Assert(locationInfo.StartLine >= 1, "Invalid location info (Line)");
-            _parent = parent;
-            Type = type;
-            _text = string.Empty;
 
-            var origName = _parent?.Engine?.OriginalName;
+            var origName = parent?.Engine?.OriginalName;
             if (string.IsNullOrEmpty(origName)) {
-                return;
+                return null;
             }
 
             var analysis = analyzer.GetAnalysisEntryFromUri(locationInfo.DocumentUri) ??
                 analyzer.GetAnalysisEntryFromPath(locationInfo.FilePath);
             if (analysis == null) {
-                return;
+                return null;
             }
 
             var text = analysis.GetLine(locationInfo.StartLine);
             if (string.IsNullOrEmpty(text)) {
-                return;
+                return null;
             }
 
             int start, length;
             if (!GetSpan(text, origName, locationInfo, out start, out length)) {
-                // Name does not match exactly, so we should be renaming a prefixed name
+                // Name does not match exactly, so we might be renaming a prefixed name
                 var prefix = parent.Engine.PrivatePrefix;
                 if (string.IsNullOrEmpty(prefix)) {
-                    // No prefix available, so fail
-                    Debug.Fail("Failed to find '{0}' in '{1}' because we had no private prefix".FormatInvariant(origName, text));
-                    return;
+                    // No prefix available, so don't rename this
+                    return null;
                 }
 
                 var newName = parent.Engine.Request.Name;
                 if (string.IsNullOrEmpty(newName)) {
                     // No incoming name
                     Debug.Fail("No incoming name");
-                    return;
+                    return null;
                 }
 
                 if (!GetSpanWithPrefix(text, origName, locationInfo, prefix, newName, out start, out length)) {
                     // Not renaming a prefixed name
                     Debug.Fail("Failed to find '{0}' in '{1}'".FormatInvariant(origName, text));
-                    return;
+                    return null;
                 }
             }
 
             if (start < 0 || length <= 0) {
                 Debug.Fail("Expected valid span");
-                return;
+                return null;
             }
 
-            _text = text.TrimStart(_whitespace);
-            Line = locationInfo.StartLine;
-            Column = start + 1;
-            _span = new Span(start - (text.Length - _text.Length), length);
+            var trimText = text.TrimStart(_whitespace);
+            return new LocationPreviewItem(
+                parent,
+                trimText,
+                locationInfo.StartLine,
+                start + 1,
+                new Span(start - (text.Length - trimText.Length), length)
+            );
         }
 
         private static bool GetSpan(string text, string origName, LocationInfo loc, out int start, out int length) {
@@ -103,7 +111,7 @@ namespace Microsoft.PythonTools.Refactoring {
             }
 
             start = loc.StartColumn - 1;
-            length = origName.Length;
+            length = (loc.EndLine == loc.StartLine ? loc.EndColumn - loc.StartColumn : null) ?? origName.Length;
             if (start < 0 || length <= 0) {
                 Debug.Fail("Invalid span for '{0}': [{1}..{2})".FormatInvariant(origName, start, start + length));
                 return false;

--- a/Python/Product/PythonTools/PythonTools/Refactoring/PreviewChangesEngine.cs
+++ b/Python/Product/PythonTools/PythonTools/Refactoring/PreviewChangesEngine.cs
@@ -71,8 +71,8 @@ namespace Microsoft.PythonTools.Refactoring {
 
                         if (!curLocations.Contains(variable.Location)) {
                             try {
-                                var item = new LocationPreviewItem(_analyzer, fileItem, variable.Location, variable.Type);
-                                if (item.Length > 0) {
+                                var item = LocationPreviewItem.Create(_analyzer, fileItem, variable.Location, variable.Type);
+                                if (item != null && item.Length > 0) {
                                     fileItem.Items.Add(item);
                                     curLocations.Add(variable.Location);
                                 }

--- a/Python/Tests/Analysis/AnalysisTest.cs
+++ b/Python/Tests/Analysis/AnalysisTest.cs
@@ -2974,17 +2974,21 @@ from baz import abc2 as abc";
             state.AssertReferences(oarMod, "abc1", oarText.IndexOf("abc1"),
                 new VariableLocation(1, 1, VariableType.Value),
                 new VariableLocation(1, 7, VariableType.Definition),
+                new VariableLocation(1, 17, VariableType.Reference, "oarbaz"),
                 new VariableLocation(1, 25, VariableType.Reference, "oarbaz")
             );
             state.AssertReferences(bazMod, "abc2", bazText.IndexOf("abc2"),
                 new VariableLocation(5, 1, VariableType.Value),
                 new VariableLocation(5, 7, VariableType.Definition),
+                new VariableLocation(2, 17, VariableType.Reference, "oarbaz"),
                 new VariableLocation(2, 25, VariableType.Reference, "oarbaz")
             );
             state.AssertReferences(fobMod, "abc", 0,
                 new VariableLocation(1, 1, VariableType.Value, "oar"),
                 new VariableLocation(5, 1, VariableType.Value, "baz"),
-                new VariableLocation(1, 25, VariableType.Reference, "oarbaz"),
+                new VariableLocation(1, 17, VariableType.Reference, "oarbaz"),
+                new VariableLocation(1, 25, VariableType.Reference, "oarbaz"),    // as
+                new VariableLocation(2, 17, VariableType.Reference, "oarbaz"),
                 new VariableLocation(2, 25, VariableType.Reference, "oarbaz"),    // as
                 new VariableLocation(2, 20, VariableType.Reference, "fob"),    // import
                 new VariableLocation(4, 1, VariableType.Reference, "fob")     // call
@@ -3018,6 +3022,66 @@ f = fn()");
                 new VariableLocation(6, 5, VariableType.Reference, "oar")
             );
             state.AssertReferences(oarMod, "fn", 0,
+                new VariableLocation(4, 1, VariableType.Value, "fob"),
+                new VariableLocation(4, 5, VariableType.Definition, "fob"),
+                new VariableLocation(7, 5, VariableType.Reference, "oar")
+            );
+        }
+
+        [TestMethod, Priority(0)]
+        public void ImportAsReferences() {
+            var state = CreateAnalyzer();
+            var fobMod = state.AddModule("fob", @"
+CONSTANT = 1
+class Class: pass
+def fn(): pass");
+            var oarMod = state.AddModule("oar", @"from fob import CONSTANT as CO, Class as Cl, fn as f
+
+
+
+x = CO
+c = Cl()
+g = f()");
+
+            state.ReanalyzeAll();
+
+            state.AssertReferences(oarMod, "CO", 0,
+                new VariableLocation(1, 17, VariableType.Reference, "oar"),
+                new VariableLocation(1, 29, VariableType.Reference, "oar"),
+                new VariableLocation(2, 1, VariableType.Definition, "fob"),
+                new VariableLocation(5, 5, VariableType.Reference, "oar")
+            );
+            state.AssertReferences(oarMod, "Cl", 0,
+                new VariableLocation(1, 33, VariableType.Reference, "oar"),
+                new VariableLocation(1, 42, VariableType.Reference, "oar"),
+                new VariableLocation(3, 1, VariableType.Value, "fob"),
+                new VariableLocation(3, 7, VariableType.Definition, "fob"),
+                new VariableLocation(6, 5, VariableType.Reference, "oar")
+            );
+            state.AssertReferences(oarMod, "f", 0,
+                new VariableLocation(1, 46, VariableType.Reference, "oar"),
+                new VariableLocation(1, 52, VariableType.Reference, "oar"),
+                new VariableLocation(4, 1, VariableType.Value, "fob"),
+                new VariableLocation(4, 5, VariableType.Definition, "fob"),
+                new VariableLocation(7, 5, VariableType.Reference, "oar")
+            );
+
+            state.AssertReferences(fobMod, "CONSTANT", 0,
+                new VariableLocation(1, 17, VariableType.Reference, "oar"),
+                new VariableLocation(1, 29, VariableType.Reference, "oar"),
+                new VariableLocation(2, 1, VariableType.Definition, "fob"),
+                new VariableLocation(5, 5, VariableType.Reference, "oar")
+            );
+            state.AssertReferences(fobMod, "Class", 0,
+                new VariableLocation(1, 33, VariableType.Reference, "oar"),
+                new VariableLocation(1, 42, VariableType.Reference, "oar"),
+                new VariableLocation(3, 1, VariableType.Value, "fob"),
+                new VariableLocation(3, 7, VariableType.Definition, "fob"),
+                new VariableLocation(6, 5, VariableType.Reference, "oar")
+            );
+            state.AssertReferences(fobMod, "fn", 0,
+                new VariableLocation(1, 46, VariableType.Reference, "oar"),
+                new VariableLocation(1, 52, VariableType.Reference, "oar"),
                 new VariableLocation(4, 1, VariableType.Value, "fob"),
                 new VariableLocation(4, 5, VariableType.Definition, "fob"),
                 new VariableLocation(7, 5, VariableType.Reference, "oar")


### PR DESCRIPTION
Fixes #4494 Refactor rename with "import ... as" not working
Adds correct references to imported names
Improves handling of references that should not be renamed