### PR TITLE
Fixes #4497 Asserts on go to definition

### DIFF
--- a/Python/Product/Analysis/Deque.cs
+++ b/Python/Product/Analysis/Deque.cs
@@ -17,6 +17,8 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
 
 namespace Microsoft.PythonTools.Analysis {
     class Deque<T> : IEnumerable, ICollection {
@@ -29,9 +31,24 @@ namespace Microsoft.PythonTools.Analysis {
             Clear();
         }
 
+#if DEBUG
+        internal SynchronizationContext SynchronizationContext { get; set; }
+
+        private void AssertContext() {
+            var ctx = SynchronizationContext.Current;
+            Debug.Assert(ctx == SynchronizationContext);
+        }
+#else
+        [Conditional("DEBUG")]
+        private void AssertContext() { }
+#endif
+
+
         #region core deque APIs
 
         public void Append(T x) {
+            AssertContext();
+
             _version++;
 
             if (_itemCnt == _data.Length) {
@@ -46,6 +63,8 @@ namespace Microsoft.PythonTools.Analysis {
         }
 
         public void AppendLeft(T x) {
+            AssertContext();
+
             _version++;
 
             if (_itemCnt == _data.Length) {
@@ -62,6 +81,8 @@ namespace Microsoft.PythonTools.Analysis {
         }
 
         public void Clear() {
+            AssertContext();
+
             _version++;
 
             _head = _tail = 0;
@@ -70,6 +91,8 @@ namespace Microsoft.PythonTools.Analysis {
         }
 
         public T Pop() {
+            AssertContext();
+
             if (_itemCnt == 0) {
                 throw new InvalidOperationException("pop from an empty deque");
             }
@@ -88,6 +111,8 @@ namespace Microsoft.PythonTools.Analysis {
         }
 
         public T PopLeft() {
+            AssertContext();
+
             if (_itemCnt == 0) {
                 throw new InvalidOperationException("pop from an empty deque");
             }
@@ -106,6 +131,7 @@ namespace Microsoft.PythonTools.Analysis {
         }
 
         public void Remove(T value) {
+            AssertContext();
 
             int found = -1;
             int startVersion = _version;

--- a/Python/Product/Analysis/Intellisense/AnalysisQueue.cs
+++ b/Python/Product/Analysis/Intellisense/AnalysisQueue.cs
@@ -169,6 +169,8 @@ namespace Microsoft.PythonTools.Intellisense {
 
         public int AnalysisPending => _analysisPending;
 
+        internal SynchronizationContext SynchronizationContext { get; private set; }
+
         #region IDisposable Members
         public void Dispose() {
             _disposed = true;
@@ -195,7 +197,8 @@ namespace Microsoft.PythonTools.Intellisense {
 
         private void Worker(object threadStarted) {
             try {
-                SynchronizationContext.SetSynchronizationContext(new AnalysisSynchronizationContext(this));
+                SynchronizationContext = new AnalysisSynchronizationContext(this);
+                SynchronizationContext.SetSynchronizationContext(SynchronizationContext);
             } finally {
                 ((AutoResetEvent)threadStarted).Set();
             }

--- a/Python/Product/Analysis/PythonAnalyzer.cs
+++ b/Python/Product/Analysis/PythonAnalyzer.cs
@@ -235,12 +235,17 @@ namespace Microsoft.PythonTools.Analysis {
             }
         }
 
+        public void RemoveModule(IProjectEntry entry) => RemoveModule(entry, null);
+
         /// <summary>
         /// Removes the specified project entry from the current analysis.
         /// 
         /// This method is thread safe.
         /// </summary>
-        public void RemoveModule(IProjectEntry entry) {
+        /// <param name="entry">The entry to remove.</param>
+        /// <param name="onImporter">Action to perform on each module that
+        /// had imported the one being removed.</param>
+        public void RemoveModule(IProjectEntry entry, Action<IPythonProjectEntry> onImporter) {
             if (entry == null) {
                 throw new ArgumentNullException(nameof(entry));
             }
@@ -252,7 +257,6 @@ namespace Microsoft.PythonTools.Analysis {
                 importers = GetEntriesThatImportModule(pyEntry.ModuleName, false).ToArray();
             }
 
-
             if (!string.IsNullOrEmpty(entry.FilePath) && _modulesByFilename.TryRemove(entry.FilePath, out var moduleInfo)) {
                 lock (_modulesWithUnresolvedImportsLock) {
                     _modulesWithUnresolvedImports.Remove(moduleInfo);
@@ -262,10 +266,14 @@ namespace Microsoft.PythonTools.Analysis {
             entry.RemovedFromProject();
             ClearDiagnostics(entry);
 
+            if (onImporter == null) {
+                onImporter = e => e.Analyze(CancellationToken.None, enqueueOnly: true);
+            }
+
             if (!string.IsNullOrEmpty(pyEntry?.ModuleName)) {
                 Modules.TryRemove(pyEntry.ModuleName, out var _);
                 foreach (var e in importers.MaybeEnumerate()) {
-                    e.Analyze(CancellationToken.None, enqueueOnly: true);
+                    onImporter(e);
                 }
             }
         }


### PR DESCRIPTION
Fixes #4497 Asserts on go to definition
Add asserts when modifying the analyzer queue from the wrong context.
Allow the caller to re-enqueue modules when unloading an entry.