### PR TITLE
Fixes #1865 Unit tests refresh too often

### DIFF
--- a/Python/Product/TestAdapter.Analysis/TestCaseInfo.cs
+++ b/Python/Product/TestAdapter.Analysis/TestCaseInfo.cs
@@ -57,6 +57,12 @@ namespace Microsoft.PythonTools.TestAdapter {
                 { TestAnalyzer.Serialize.Kind, Kind.ToString() },
             };
         }
+
+        // Compare based on Python name, so that editing the file doesn't replace the object
+        private object CompareKey => new { Filename, ClassName, MethodName, StartLine };
+
+        public override bool Equals(object obj) => CompareKey.Equals((obj as TestCaseInfo)?.CompareKey);
+        public override int GetHashCode() => CompareKey.GetHashCode();
     }
 
     internal enum TestCaseKind {


### PR DESCRIPTION
Fixes #1865 Unit tests refresh too often
Makes TestCaseInfo use value equality.