### PR TITLE
[15.8] Fixes #4493 Class name not colorized in import ... as

### DIFF
--- a/Python/Product/Analysis/Intellisense/ClassifierWalker.cs
+++ b/Python/Product/Analysis/Intellisense/ClassifierWalker.cs
@@ -352,8 +352,13 @@ namespace Microsoft.PythonTools.Intellisense {
                 }
             }
             if (node.Names != null) {
-                foreach (var name in node.Names) {
-                    if (name != null && !string.IsNullOrEmpty(name.Name)) {
+                for (int i = 0; i < node.Names.Count; ++i) {
+                    var name = node.Names[i];
+                    var asName = (i < node.AsNames?.Count) ? node.AsNames[i] : null;
+                    if (!string.IsNullOrEmpty(asName?.Name)) {
+                        _head.Names.Add(Tuple.Create(asName.Name, Span.FromBounds(name.StartIndex, name.EndIndex)));
+                        _head.Names.Add(Tuple.Create(asName.Name, Span.FromBounds(asName.StartIndex, asName.EndIndex)));
+                    } else if (!string.IsNullOrEmpty(name?.Name)) {
                         _head.Names.Add(Tuple.Create(name.Name, Span.FromBounds(name.StartIndex, name.EndIndex)));
                     }
                 }

--- a/Python/Product/Analysis/Interpreter/Ast/AstPythonMultipleMembers.cs
+++ b/Python/Product/Analysis/Interpreter/Ast/AstPythonMultipleMembers.cs
@@ -73,6 +73,8 @@ namespace Microsoft.PythonTools.Interpreter.Ast {
 
             if (members.Length == 1) {
                 return members[0];
+            } else if (members.Length == 0) {
+                return null;
             }
 
             if (members.All(m => m is IPythonFunction)) {

--- a/Python/Tests/PythonToolsMockTests/ClassifierTests.cs
+++ b/Python/Tests/PythonToolsMockTests/ClassifierTests.cs
@@ -112,6 +112,7 @@ abc = True
             // module.
             var code = @"import abc as x
 from os import name_not_in_os
+from datetime import datetime as DATETIME
 
 abc
 x
@@ -119,8 +120,8 @@ os
 name_not_in_os
 ";
             using (var helper = new ClassifierHelper(code, PythonLanguageVersion.V27)) {
-                helper.CheckAstClassifierSpans("kiki kiki i i i i");
-                helper.CheckAnalysisClassifierSpans("m<abc>m<x>m<os>m<x>");
+                helper.CheckAstClassifierSpans("kiki kiki kikiki i i i i");
+                helper.CheckAnalysisClassifierSpans("m<abc>m<x>m<os>m<datetime>c<datetime>c<DATETIME>m<x>");
             }
         }
 


### PR DESCRIPTION
Fixes #4493 Class name not colorized in import ... as
Adds imported 'as' name as resolvable name for classifications.
Also fixes member with no types being treated as a function.