### PR TITLE
[15.8] Fixes #4526 Assert while/after creating a virtual env

### DIFF
--- a/Python/Product/Analysis/Intellisense/AnalysisSynchronizationContext.cs
+++ b/Python/Product/Analysis/Intellisense/AnalysisSynchronizationContext.cs
@@ -34,7 +34,10 @@ namespace Microsoft.PythonTools.Intellisense {
         }
 
         public override void Post(SendOrPostCallback d, object state) {
-            _queue.Enqueue(new AnalysisItem(d, state), AnalysisPriority.High);
+            try {
+                _queue.Enqueue(new AnalysisItem(d, state), AnalysisPriority.High);
+            } catch (ObjectDisposedException) {
+            }
         }
 
         public override void Send(SendOrPostCallback d, object state) {
@@ -42,8 +45,11 @@ namespace Microsoft.PythonTools.Intellisense {
                 _waitEvent = new AutoResetEvent(false);
             }
             var waitable = new WaitableAnalysisItem(d, state);
-            _queue.Enqueue(waitable, AnalysisPriority.High);
-            _waitEvent.WaitOne();
+            try {
+                _queue.Enqueue(waitable, AnalysisPriority.High);
+                _waitEvent.WaitOne();
+            } catch (ObjectDisposedException) {
+            }
         }
 
         class AnalysisItem : IAnalyzable {

--- a/Python/Product/Analysis/LanguageServer/Server.cs
+++ b/Python/Product/Analysis/LanguageServer/Server.cs
@@ -52,9 +52,8 @@ namespace Microsoft.PythonTools.Analysis.LanguageServer {
                 }
 
                 var currentTcs = Interlocked.Exchange(ref _tcs, new TaskCompletionSource<bool>());
-                var task = Task.Run(() => _analyzer.ReloadModulesAsync(), cancel);
                 try {
-                    task.WaitAndUnwrapExceptions();
+                    _analyzer.ReloadModulesAsync().WaitAndUnwrapExceptions();
                     currentTcs.TrySetResult(true);
                 } catch (OperationCanceledException oce) {
                     currentTcs.TrySetCanceled(oce.CancellationToken);

--- a/Python/Product/Analysis/PythonAnalyzer.cs
+++ b/Python/Product/Analysis/PythonAnalyzer.cs
@@ -179,7 +179,7 @@ namespace Microsoft.PythonTools.Analysis {
                 _interpreterFactory.NotifyImportNamesChanged();
                 _modules.ReInit();
 
-                await LoadKnownTypesAsync().ConfigureAwait(false);
+                await LoadKnownTypesAsync();
 
                 _interpreter.Initialize(this);
 


### PR DESCRIPTION
Fixes #4526 Assert while/after creating a virtual env
Ensures module reload occurs on analysis thread
Prevent exceptions when attempting to enqueue operations after the analyzer is closed