### PR TITLE
[15.8] Prevent crash in analyzer when django url() first parameter is not a …

### DIFF
--- a/Python/Product/Django.Analysis/DjangoAnalyzer.cs
+++ b/Python/Product/Django.Analysis/DjangoAnalyzer.cs
@@ -357,7 +357,9 @@ namespace Microsoft.PythonTools.Django.Analysis {
 
             string urlName = urlNames.First().GetConstantValueAsString();
             string urlRegex = args.First().First().GetConstantValueAsString();
-            _urls.Add(new DjangoUrl(urlName, urlRegex));
+            if (urlName != null && urlRegex != null) {
+                _urls.Add(new DjangoUrl(urlName, urlRegex));
+            }
 
             return AnalysisSet.Empty;
         }

--- a/Python/Product/Django.Analysis/DjangoUrl.cs
+++ b/Python/Product/Django.Analysis/DjangoUrl.cs
@@ -40,8 +40,8 @@ namespace Microsoft.PythonTools.Django.Analysis {
         public DjangoUrl() { }
 
         public DjangoUrl(string urlName, string urlRegex) {
-            Name = urlName;
-            _urlRegex = urlRegex;
+            Name = urlName ?? throw new ArgumentNullException(nameof(urlName));
+            _urlRegex = urlRegex ?? throw new ArgumentNullException(nameof(urlRegex));
 
             ParseUrlRegex();
         }


### PR DESCRIPTION
Fix #4557 Intellisense not working when using composed regex in Django url pattern