### PR TITLE
[15.8] Alternate fix for repl completions

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Intellisense/CompletionAnalysis.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/CompletionAnalysis.cs
@@ -19,6 +19,7 @@ using System.Diagnostics;
 using System.Linq;
 using Microsoft.PythonTools.Editor;
 using Microsoft.PythonTools.Editor.Core;
+using Microsoft.PythonTools.Infrastructure;
 using Microsoft.PythonTools.Interpreter;
 using Microsoft.PythonTools.Repl;
 using Microsoft.VisualStudio.InteractiveWindow;
@@ -92,9 +93,9 @@ namespace Microsoft.PythonTools.Intellisense {
                 _options.MemberOptions,
                 triggerChar == '\0' ? Analysis.LanguageServer.CompletionTriggerKind.Invoked : Analysis.LanguageServer.CompletionTriggerKind.TriggerCharacter,
                 triggerChar == '\0' ? null : triggerChar.ToString()
-            ), "GetCompletions.GetMembers");
+            ), "GetCompletions.GetMembers", null, pyReplEval?.Analyzer == null ? 1 : 5);
 
-            if (completions?.items == null) {
+            if (completions == null) {
                 return null;
             }
 
@@ -103,7 +104,7 @@ namespace Microsoft.PythonTools.Intellisense {
                 : new SnapshotSpan(point, 0);
             _span = bufferInfo.CurrentSnapshot.CreateTrackingSpan(snapshotSpan, SpanTrackingMode.EdgeInclusive);
 
-            var members = completions.items.Select(c => new CompletionResult(
+            var members = completions.items.MaybeEnumerate().Select(c => new CompletionResult(
                 c.label,
                 c.insertText ?? c.label,
                 c.documentation?.value,
@@ -113,7 +114,10 @@ namespace Microsoft.PythonTools.Intellisense {
 
             if (pyReplEval?.Analyzer != null && (string.IsNullOrEmpty(completions._expr) || pyReplEval.Analyzer.ShouldEvaluateForCompletion(completions._expr))) {
                 var replMembers = pyReplEval.GetMemberNames(completions._expr ?? "");
-                if (replMembers != null) {
+
+                if (_services.Python.InteractiveOptions.LiveCompletionsOnly) {
+                    members = replMembers ?? Array.Empty<CompletionResult>();
+                } else if (replMembers != null) {
                     members = members.Union(replMembers, CompletionComparer.MemberEquality);
                 }
             }

--- a/Python/Product/PythonTools/PythonTools/Intellisense/CompletionAnalysis.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/CompletionAnalysis.cs
@@ -106,7 +106,7 @@ namespace Microsoft.PythonTools.Intellisense {
             var members = completions.items.MaybeEnumerate().Select(c => new CompletionResult(
                 // if a method stub generation (best guess by comparing length),
                 // merge entry based on label, for everything else, use insertion text
-                c.filterText ?? ((c.insertText ?? c.label).Length > c.label.Length ? c.label : c.insertText ?? c.label),
+                c.filterText ?? (c.insertText != null && c.insertText.Length <= c.label.Length ? c.insertText : c.label),
                 c.label,
                 c.insertText ?? c.label,
                 c.documentation?.value,

--- a/Python/Product/PythonTools/PythonTools/Intellisense/CompletionComparer.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/CompletionComparer.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.PythonTools.Analysis;
 using Microsoft.PythonTools.Infrastructure;
 using Microsoft.VisualStudio.Language.Intellisense;
@@ -30,11 +31,7 @@ namespace Microsoft.PythonTools.Intellisense {
         /// the end of the list.
         /// </summary>
         public static readonly CompletionComparer UnderscoresLast = new CompletionComparer(true);
-        /// <summary>
-        /// A CompletionComparer that determines whether
-        /// <see cref="MemberResult" /> structures are equal.
-        /// </summary>
-        public static readonly IEqualityComparer<CompletionResult> MemberEquality = UnderscoresLast;
+
         /// <summary>
         /// A CompletionComparer that sorts names beginning with underscores to
         /// the start of the list.
@@ -85,39 +82,44 @@ namespace Microsoft.PythonTools.Intellisense {
         }
 
         /// <summary>
-        /// Compares two <see cref="MemberResult"/> structures using their
+        /// Compares two <see cref="CompletionResult"/> structures using their
         /// names.
         /// </summary>
         /// <param name="x"></param>
         /// <param name="y"></param>
         /// <returns></returns>
         public int Compare(CompletionResult x, CompletionResult y) {
-            int i = Compare(x.Completion, y.Completion);
-            return i == 0 ? 0 : Compare(x.Name, y.Name);
+            return Compare(x.Name, y.Name);
         }
 
         /// <summary>
-        /// Compares two <see cref="MemberResult"/> structures for equality.
+        /// Compares two <see cref="CompletionResult"/> structures for equality.
         /// </summary>
         public bool Equals(CompletionResult x, CompletionResult y) {
-            return x.Name.Equals(y.Name) || x.Completion.Equals(y.Completion);
+            return x.Name.Equals(y.Name);
         }
 
         /// <summary>
-        /// Gets the hash code for a <see cref="MemberResult"/> structure.
+        /// Gets the hash code for a <see cref="CompletionResult"/> structure.
         /// </summary>
         public int GetHashCode(CompletionResult obj) {
-            if (obj.Name.Length < obj.Completion.Length && obj.Completion.StartsWithOrdinal(obj.Name)) {
-                return obj.Name.GetHashCode();
-            } else if (obj.Name.Length > obj.Completion.Length && obj.Name.StartsWith(obj.Completion)) {
-                return obj.Completion.GetHashCode();
-            }
-            for (int i = 0; i < obj.Name.Length && i < obj.Completion.Length; ++i) {
-                if (obj.Name[i] != obj.Completion[i]) {
-                    return obj.Name.Substring(0, i).GetHashCode();
-                }
-            }
             return obj.Name.GetHashCode();
+        }
+    }
+
+    /// <summary>
+    /// A comparer for use with <see cref="Enumerable.Union{TSource}(IEnumerable{TSource}, IEnumerable{TSource}, IEqualityComparer{TSource})"/>
+    /// to eliminate duplicate items with the same <see cref="CompletionResult.MergeKey"/>.
+    /// </summary>
+    class CompletionMergeKeyComparer : IEqualityComparer<CompletionResult> {
+        public static readonly CompletionMergeKeyComparer Instance = new CompletionMergeKeyComparer();
+
+        public bool Equals(CompletionResult x, CompletionResult y) {
+            return x.MergeKey.Equals(y.MergeKey);
+        }
+
+        public int GetHashCode(CompletionResult obj) {
+            return obj.MergeKey.GetHashCode();
         }
     }
 }

--- a/Python/Product/PythonTools/PythonTools/Intellisense/CompletionComparer.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/CompletionComparer.cs
@@ -92,20 +92,31 @@ namespace Microsoft.PythonTools.Intellisense {
         /// <param name="y"></param>
         /// <returns></returns>
         public int Compare(CompletionResult x, CompletionResult y) {
-            return Compare(x.Name, y.Name);
+            int i = Compare(x.Completion, y.Completion);
+            return i == 0 ? 0 : Compare(x.Name, y.Name);
         }
 
         /// <summary>
         /// Compares two <see cref="MemberResult"/> structures for equality.
         /// </summary>
         public bool Equals(CompletionResult x, CompletionResult y) {
-            return x.Name.Equals(y.Name);
+            return x.Name.Equals(y.Name) || x.Completion.Equals(y.Completion);
         }
 
         /// <summary>
         /// Gets the hash code for a <see cref="MemberResult"/> structure.
         /// </summary>
         public int GetHashCode(CompletionResult obj) {
+            if (obj.Name.Length < obj.Completion.Length && obj.Completion.StartsWithOrdinal(obj.Name)) {
+                return obj.Name.GetHashCode();
+            } else if (obj.Name.Length > obj.Completion.Length && obj.Name.StartsWith(obj.Completion)) {
+                return obj.Completion.GetHashCode();
+            }
+            for (int i = 0; i < obj.Name.Length && i < obj.Completion.Length; ++i) {
+                if (obj.Name[i] != obj.Completion[i]) {
+                    return obj.Name.Substring(0, i).GetHashCode();
+                }
+            }
             return obj.Name.GetHashCode();
         }
     }

--- a/Python/Product/PythonTools/PythonTools/Intellisense/CompletionResult.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/CompletionResult.cs
@@ -21,29 +21,32 @@ namespace Microsoft.PythonTools.Intellisense {
     using AP = AnalysisProtocol;
 
     sealed class CompletionResult {
-        private readonly string _completion;
-        private readonly PythonMemberType _memberType;
-        private readonly string _name, _doc;
         private readonly AP.CompletionValue[] _values;
 
         internal CompletionResult(string name, PythonMemberType memberType) {
-            _name = name;
-            _completion = name;
-            _memberType = memberType;
+            MergeKey = name;
+            Name = name;
+            Completion = name;
+            MemberType = memberType;
         }
 
-        internal CompletionResult(string name, string completion, string doc, PythonMemberType memberType, AP.CompletionValue[] values) {
-            _name = name;
-            _memberType = memberType;
-            _completion = completion;
-            _doc = doc;
+        internal CompletionResult(string mergeKey, string name, string completion, string doc, PythonMemberType memberType, AP.CompletionValue[] values) {
+            MergeKey = mergeKey;
+            Name = name;
+            MemberType = memberType;
+            Completion = completion;
+            Documentation = doc;
             _values = values;
         }
 
-        public string Completion => _completion;
-        public string Documentation => _doc;
-        public PythonMemberType MemberType => _memberType;
-        public string Name => _name;
+        public string Completion { get; }
+        public string Documentation { get; }
+        public PythonMemberType MemberType { get; }
+        public string Name { get; }
+        /// <summary>
+        /// Items with the same merge key may be merged together.
+        /// </summary>
+        public string MergeKey { get; }
 
         internal AP.CompletionValue[] Values => _values ?? Array.Empty<AP.CompletionValue>();
     }

--- a/Python/Product/PythonTools/PythonTools/Intellisense/CompletionResult.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/CompletionResult.cs
@@ -24,17 +24,17 @@ namespace Microsoft.PythonTools.Intellisense {
         private readonly AP.CompletionValue[] _values;
 
         internal CompletionResult(string name, PythonMemberType memberType) {
-            MergeKey = name;
+            MergeKey = name ?? throw new ArgumentNullException(nameof(name));
             Name = name;
             Completion = name;
             MemberType = memberType;
         }
 
         internal CompletionResult(string mergeKey, string name, string completion, string doc, PythonMemberType memberType, AP.CompletionValue[] values) {
-            MergeKey = mergeKey;
-            Name = name;
+            MergeKey = mergeKey ?? throw new ArgumentNullException(nameof(mergeKey));
+            Name = name ?? throw new ArgumentNullException(nameof(name));
+            Completion = completion ?? throw new ArgumentNullException(nameof(completion));
             MemberType = memberType;
-            Completion = completion;
             Documentation = doc;
             _values = values;
         }

--- a/Python/Product/PythonTools/PythonTools/Intellisense/ExpansionCompletionSource.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/ExpansionCompletionSource.cs
@@ -57,6 +57,7 @@ namespace Microsoft.PythonTools.Intellisense {
                     res.Add(new CompletionResult(
                         e.shortcut,
                         e.shortcut,
+                        e.shortcut,
                         e.description,
                         PythonMemberType.CodeSnippet,
                         null

--- a/Python/Product/PythonTools/PythonTools/Intellisense/IntellisenseController.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/IntellisenseController.cs
@@ -966,6 +966,9 @@ namespace Microsoft.PythonTools.Intellisense {
 
             if (triggerChar == ' ' || triggerChar == '.') {
                 var bi = _textView.TextBuffer.TryGetInfo();
+                if (bi == null) {
+                    bi = _textView.MapDownToPythonBuffer(_textView.Caret.Position.BufferPosition)?.Snapshot.TextBuffer.TryGetInfo();
+                }
                 var bp = bi?.AnalysisEntry?.TryGetBufferParser();
                 if (bp != null) {
                     await bp.EnsureCodeSyncedAsync(bi.Buffer);

--- a/Python/Product/PythonTools/PythonTools/Intellisense/ProjectAnalyzer.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/ProjectAnalyzer.cs
@@ -1861,6 +1861,7 @@ namespace Microsoft.PythonTools.Intellisense {
         private static CompletionResult ToMemberResult(AP.Completion member) {
             return new CompletionResult(
                 member.name,
+                member.name,
                 member.completion ?? member.name,
                 member.doc,
                 member.memberType,


### PR DESCRIPTION
Fix REPL completions not respecting the "live completions only" option and not synchronizing the buffer.

A bit simpler than https://github.com/Microsoft/PTVS/pull/4564 but produces same results.