### PR TITLE
Fixes #4533 NullReferenceException when switching active environment

### DIFF
--- a/Python/Product/Analysis/AggregateProjectEntry.cs
+++ b/Python/Product/Analysis/AggregateProjectEntry.cs
@@ -55,7 +55,7 @@ namespace Microsoft.PythonTools.Analysis {
 
         public void RemovedFromProject() {
             _aggregating.Clear();
-            _next.Clear();
+            _next?.Clear();
             _version = -1;
         }
 


### PR DESCRIPTION
Fixes #4533 NullReferenceException when switching active environment
Prevent analyzer crashing when referencing deliberately uninitialised variable.