### PR TITLE
Prevent crash due to NullReferenceException in interactive window component

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Repl/PythonInteractiveEvaluator.CommandProcessorThread.cs
+++ b/Python/Product/PythonTools/PythonTools/Repl/PythonInteractiveEvaluator.CommandProcessorThread.cs
@@ -277,7 +277,10 @@ namespace Microsoft.PythonTools.Repl {
             private void StdErrReceived(object sender, DataReceivedEventArgs e) {
                 if (e.Data != null) {
                     if (!AppendPreConnectionOutput(e)) {
-                        _eval.WriteError(FixNewLines(e.Data));
+                        try {
+                            _eval.WriteError(FixNewLines(e.Data));
+                        } catch (Exception ex) when (!ex.IsCriticalException()) {
+                        }
                     }
                 }
             }
@@ -285,7 +288,10 @@ namespace Microsoft.PythonTools.Repl {
             private void StdOutReceived(object sender, DataReceivedEventArgs e) {
                 if (e.Data != null) {
                     if (!AppendPreConnectionOutput(e)) {
-                        _eval.WriteOutput(FixNewLines(e.Data));
+                        try {
+                            _eval.WriteOutput(FixNewLines(e.Data));
+                        } catch (Exception ex) when (!ex.IsCriticalException()) {
+                        }
                     }
                 }
             }

--- a/Python/Product/PythonTools/PythonTools/Repl/PythonInteractiveEvaluator.CommandProcessorThread.cs
+++ b/Python/Product/PythonTools/PythonTools/Repl/PythonInteractiveEvaluator.CommandProcessorThread.cs
@@ -279,8 +279,7 @@ namespace Microsoft.PythonTools.Repl {
                     if (!AppendPreConnectionOutput(e)) {
                         try {
                             _eval.WriteError(FixNewLines(e.Data));
-                        } catch (Exception ex) when (!ex.IsCriticalException() &&
-                            (_eval.CurrentWindow.TextView.VisualElement.Dispatcher?.HasShutdownStarted ?? true)) {
+                        } catch (Exception ex) when (!ex.IsCriticalException() && HasShutdownStarted()) {
                         }
                     }
                 }
@@ -291,11 +290,14 @@ namespace Microsoft.PythonTools.Repl {
                     if (!AppendPreConnectionOutput(e)) {
                         try {
                             _eval.WriteOutput(FixNewLines(e.Data));
-                        } catch (Exception ex) when (!ex.IsCriticalException() &&
-                            (_eval.CurrentWindow.TextView.VisualElement.Dispatcher?.HasShutdownStarted ?? true)) {
+                        } catch (Exception ex) when (!ex.IsCriticalException() && HasShutdownStarted()) {
                         }
                     }
                 }
+            }
+
+            private bool HasShutdownStarted() {
+                return _eval.CurrentWindow.TextView.VisualElement.Dispatcher?.HasShutdownStarted ?? true;
             }
 
             private bool AppendPreConnectionOutput(DataReceivedEventArgs e) {

--- a/Python/Product/PythonTools/PythonTools/Repl/PythonInteractiveEvaluator.CommandProcessorThread.cs
+++ b/Python/Product/PythonTools/PythonTools/Repl/PythonInteractiveEvaluator.CommandProcessorThread.cs
@@ -279,7 +279,8 @@ namespace Microsoft.PythonTools.Repl {
                     if (!AppendPreConnectionOutput(e)) {
                         try {
                             _eval.WriteError(FixNewLines(e.Data));
-                        } catch (Exception ex) when (!ex.IsCriticalException()) {
+                        } catch (Exception ex) when (!ex.IsCriticalException() &&
+                            (_eval.CurrentWindow.TextView.VisualElement.Dispatcher?.HasShutdownStarted ?? true)) {
                         }
                     }
                 }
@@ -290,7 +291,8 @@ namespace Microsoft.PythonTools.Repl {
                     if (!AppendPreConnectionOutput(e)) {
                         try {
                             _eval.WriteOutput(FixNewLines(e.Data));
-                        } catch (Exception ex) when (!ex.IsCriticalException()) {
+                        } catch (Exception ex) when (!ex.IsCriticalException() &&
+                            (_eval.CurrentWindow.TextView.VisualElement.Dispatcher?.HasShutdownStarted ?? true)) {
                         }
                     }
                 }


### PR DESCRIPTION
Fix #4513 

Adding the same type of protection we already had in `ProcessExited` handler to the `StdErrReceived` and `StdOutReceived` handlers.