### PR TITLE
Add option to disable language server

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Intellisense/IntellisenseController.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/IntellisenseController.cs
@@ -241,7 +241,9 @@ namespace Microsoft.PythonTools.Intellisense {
                 }
 
                 if (entry == null) {
-                    Debug.Fail($"Failed to analyze {buffer.DocumentUri}");
+                    if (!_services.Python.LanguageServerOptions.ServerDisabled) {
+                        Debug.Fail($"Failed to analyze {buffer.DocumentUri}");
+                    }
                     return;
                 }
 

--- a/Python/Product/PythonTools/PythonTools/Intellisense/ProjectAnalyzer.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/ProjectAnalyzer.cs
@@ -230,6 +230,15 @@ namespace Microsoft.PythonTools.Intellisense {
         private string DefaultComment => "Global Analysis";
 
         private async Task InitializeAsync(bool outOfProc, string comment, string rootDir, bool analyzeAllFiles) {
+            if (_services.Python.LanguageServerOptions.ServerDisabled) {
+                _conn = null;
+                _userCount = 1;
+                _processingTask = null;
+                _analysisOptions = new AP.AnalysisOptions();
+                _analysisProcess = null;
+                return;
+            }
+
             _conn = outOfProc 
                 ? StartSubprocessConnection(comment.IfNullOrEmpty(DefaultComment), out _analysisProcess) 
                 : StartThreadConnection(comment.IfNullOrEmpty(DefaultComment), out _analysisProcess);
@@ -532,7 +541,10 @@ namespace Microsoft.PythonTools.Intellisense {
                 _services.CommentTaskProvider?.Clear(path, TaskCommentMoniker);
             }
 
-            Debug.WriteLine(String.Format("Disposing of parser {0}", _analysisProcess));
+            if (_analysisProcess != null) {
+                Debug.WriteLine(String.Format("Disposing of parser {0}", _analysisProcess));
+            }
+
             if (_services.CommentTaskProvider != null) {
                 _services.CommentTaskProvider.TokensChanged -= CommentTaskTokensChanged;
             }
@@ -555,23 +567,25 @@ namespace Microsoft.PythonTools.Intellisense {
                 _logger.LogEvent(PythonLogEvent.AnalysisRequestSummary, info);
             }
 
-            SendRequestAsync(new AP.ExitRequest()).ContinueWith(t => {
-                // give the task a chance to exit cleanly
-                _processingTask?.Wait(1000);
+            if (_analysisProcess != null) {
+                SendRequestAsync(new AP.ExitRequest()).ContinueWith(t => {
+                    // give the task a chance to exit cleanly
+                    _processingTask?.Wait(1000);
 
-                try {
-                    if (!_analysisProcess.WaitForExit(500)) {
-                        _analysisProcess.Kill();
+                    try {
+                        if (!_analysisProcess.WaitForExit(500)) {
+                            _analysisProcess.Kill();
+                        }
+                    } catch (Win32Exception) {
+                        // access denied
+                    } catch (InvalidOperationException) {
+                        // race w/ process exit...
                     }
-                } catch (Win32Exception) {
-                    // access denied
-                } catch (InvalidOperationException) {
-                    // race w/ process exit...
-                }
-                _analysisProcess.Dispose();
-                _conn?.Dispose();
-                _conn = null;
-            });
+                    _analysisProcess.Dispose();
+                    _conn?.Dispose();
+                    _conn = null;
+                });
+            }
 
             try {
                 _processExitedCancelSource.Cancel();
@@ -827,7 +841,7 @@ namespace Microsoft.PythonTools.Intellisense {
         private event EventHandler<AbnormalAnalysisExitEventArgs> _abnormalAnalysisExit;
         internal event EventHandler<AbnormalAnalysisExitEventArgs> AbnormalAnalysisExit {
             add {
-                if (_analysisProcess.HasExited && !_disposing) {
+                if ((_analysisProcess?.HasExited ?? false) && !_disposing) {
                     value?.Invoke(this, new AbnormalAnalysisExitEventArgs(_stdErr.ToString(), _analysisProcess.ExitCode));
                 }
                 _abnormalAnalysisExit += value;

--- a/Python/Product/PythonTools/PythonTools/Options/LanguageServerOptions.cs
+++ b/Python/Product/PythonTools/PythonTools/Options/LanguageServerOptions.cs
@@ -32,22 +32,26 @@ namespace Microsoft.PythonTools.Options {
 
         public string TypeShedPath { get; set; }
         public bool SuppressTypeShed { get; set; }
+        public bool ServerDisabled { get; set; }
 
         public void Load() {
             TypeShedPath = _pyService.LoadString(nameof(TypeShedPath), Category);
             SuppressTypeShed = _pyService.LoadBool(nameof(SuppressTypeShed), Category) ?? false;
+            ServerDisabled = _pyService.LoadBool(nameof(ServerDisabled), Category) ?? false;
             Changed?.Invoke(this, EventArgs.Empty);
         }
 
         public void Save() {
             _pyService.SaveString(nameof(TypeShedPath), Category, TypeShedPath);
             _pyService.SaveBool(nameof(SuppressTypeShed), Category, SuppressTypeShed);
+            _pyService.SaveBool(nameof(ServerDisabled), Category, ServerDisabled);
             Changed?.Invoke(this, EventArgs.Empty);
         }
 
         public void Reset() {
             TypeShedPath = string.Empty;
             SuppressTypeShed = false;
+            ServerDisabled = false;
             Changed?.Invoke(this, EventArgs.Empty);
         }
 

--- a/Python/Product/PythonTools/PythonTools/Options/LanguageServerOptionsControl.Designer.cs
+++ b/Python/Product/PythonTools/PythonTools/Options/LanguageServerOptionsControl.Designer.cs
@@ -27,50 +27,24 @@ namespace Microsoft.PythonTools.Options {
             System.Windows.Forms.Label typeShedPathLabel;
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(LanguageServerOptionsControl));
             System.Windows.Forms.GroupBox groupBox1;
+            this.tableLayoutPanel2 = new System.Windows.Forms.TableLayoutPanel();
+            this.suppressTypeShedCheckbox = new System.Windows.Forms.CheckBox();
+            this.browseTypeShedPathButton = new System.Windows.Forms.Button();
+            this.typeShedPathTextBox = new System.Windows.Forms.TextBox();
             this._tooltips = new System.Windows.Forms.ToolTip(this.components);
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
-            this.typeShedPathTextBox = new System.Windows.Forms.TextBox();
-            this.browseTypeShedPathButton = new System.Windows.Forms.Button();
-            this.suppressTypeShedCheckbox = new System.Windows.Forms.CheckBox();
-            this.tableLayoutPanel2 = new System.Windows.Forms.TableLayoutPanel();
+            this._disableLanguageServerCheckbox = new System.Windows.Forms.CheckBox();
             typeShedPathLabel = new System.Windows.Forms.Label();
             groupBox1 = new System.Windows.Forms.GroupBox();
-            this.tableLayoutPanel1.SuspendLayout();
             groupBox1.SuspendLayout();
             this.tableLayoutPanel2.SuspendLayout();
+            this.tableLayoutPanel1.SuspendLayout();
             this.SuspendLayout();
             // 
             // typeShedPathLabel
             // 
             resources.ApplyResources(typeShedPathLabel, "typeShedPathLabel");
             typeShedPathLabel.Name = "typeShedPathLabel";
-            // 
-            // tableLayoutPanel1
-            // 
-            resources.ApplyResources(this.tableLayoutPanel1, "tableLayoutPanel1");
-            this.tableLayoutPanel1.Controls.Add(groupBox1, 0, 0);
-            this.tableLayoutPanel1.Name = "tableLayoutPanel1";
-            // 
-            // typeShedPathTextBox
-            // 
-            resources.ApplyResources(this.typeShedPathTextBox, "typeShedPathTextBox");
-            this.typeShedPathTextBox.Name = "typeShedPathTextBox";
-            this.typeShedPathTextBox.TextChanged += new System.EventHandler(this.TypeShedPath_TextChanged);
-            // 
-            // browseTypeShedPathButton
-            // 
-            resources.ApplyResources(this.browseTypeShedPathButton, "browseTypeShedPathButton");
-            this.browseTypeShedPathButton.Name = "browseTypeShedPathButton";
-            this.browseTypeShedPathButton.UseVisualStyleBackColor = true;
-            this.browseTypeShedPathButton.Click += new System.EventHandler(this.browseTypeShedPathButton_Click);
-            // 
-            // suppressTypeShedCheckbox
-            // 
-            resources.ApplyResources(this.suppressTypeShedCheckbox, "suppressTypeShedCheckbox");
-            this.tableLayoutPanel2.SetColumnSpan(this.suppressTypeShedCheckbox, 3);
-            this.suppressTypeShedCheckbox.Name = "suppressTypeShedCheckbox";
-            this.suppressTypeShedCheckbox.UseVisualStyleBackColor = true;
-            this.suppressTypeShedCheckbox.CheckedChanged += new System.EventHandler(this.suppressTypeShedCheckbox_CheckedChanged);
             // 
             // groupBox1
             // 
@@ -88,18 +62,54 @@ namespace Microsoft.PythonTools.Options {
             this.tableLayoutPanel2.Controls.Add(typeShedPathLabel, 0, 1);
             this.tableLayoutPanel2.Name = "tableLayoutPanel2";
             // 
+            // suppressTypeShedCheckbox
+            // 
+            resources.ApplyResources(this.suppressTypeShedCheckbox, "suppressTypeShedCheckbox");
+            this.tableLayoutPanel2.SetColumnSpan(this.suppressTypeShedCheckbox, 3);
+            this.suppressTypeShedCheckbox.Name = "suppressTypeShedCheckbox";
+            this.suppressTypeShedCheckbox.UseVisualStyleBackColor = true;
+            this.suppressTypeShedCheckbox.CheckedChanged += new System.EventHandler(this.suppressTypeShedCheckbox_CheckedChanged);
+            // 
+            // browseTypeShedPathButton
+            // 
+            resources.ApplyResources(this.browseTypeShedPathButton, "browseTypeShedPathButton");
+            this.browseTypeShedPathButton.Name = "browseTypeShedPathButton";
+            this.browseTypeShedPathButton.UseVisualStyleBackColor = true;
+            this.browseTypeShedPathButton.Click += new System.EventHandler(this.browseTypeShedPathButton_Click);
+            // 
+            // typeShedPathTextBox
+            // 
+            resources.ApplyResources(this.typeShedPathTextBox, "typeShedPathTextBox");
+            this.typeShedPathTextBox.Name = "typeShedPathTextBox";
+            this.typeShedPathTextBox.TextChanged += new System.EventHandler(this.TypeShedPath_TextChanged);
+            // 
+            // tableLayoutPanel1
+            // 
+            resources.ApplyResources(this.tableLayoutPanel1, "tableLayoutPanel1");
+            this.tableLayoutPanel1.Controls.Add(groupBox1, 0, 0);
+            this.tableLayoutPanel1.Controls.Add(this._disableLanguageServerCheckbox, 0, 2);
+            this.tableLayoutPanel1.Name = "tableLayoutPanel1";
+            // 
+            // _disableLanguageServerCheckbox
+            // 
+            resources.ApplyResources(this._disableLanguageServerCheckbox, "_disableLanguageServerCheckbox");
+            this._disableLanguageServerCheckbox.Name = "_disableLanguageServerCheckbox";
+            this._tooltips.SetToolTip(this._disableLanguageServerCheckbox, resources.GetString("_disableLanguageServerCheckbox.ToolTip"));
+            this._disableLanguageServerCheckbox.UseVisualStyleBackColor = true;
+            this._disableLanguageServerCheckbox.CheckedChanged += new System.EventHandler(this._enableLanguageServer_CheckedChanged);
+            // 
             // LanguageServerOptionsControl
             // 
             resources.ApplyResources(this, "$this");
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.Controls.Add(this.tableLayoutPanel1);
             this.Name = "LanguageServerOptionsControl";
-            this.tableLayoutPanel1.ResumeLayout(false);
-            this.tableLayoutPanel1.PerformLayout();
             groupBox1.ResumeLayout(false);
             groupBox1.PerformLayout();
             this.tableLayoutPanel2.ResumeLayout(false);
             this.tableLayoutPanel2.PerformLayout();
+            this.tableLayoutPanel1.ResumeLayout(false);
+            this.tableLayoutPanel1.PerformLayout();
             this.ResumeLayout(false);
 
         }
@@ -111,5 +121,6 @@ namespace Microsoft.PythonTools.Options {
         private System.Windows.Forms.Button browseTypeShedPathButton;
         private System.Windows.Forms.CheckBox suppressTypeShedCheckbox;
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel2;
+        private System.Windows.Forms.CheckBox _disableLanguageServerCheckbox;
     }
 }

--- a/Python/Product/PythonTools/PythonTools/Options/LanguageServerOptionsControl.cs
+++ b/Python/Product/PythonTools/PythonTools/Options/LanguageServerOptionsControl.cs
@@ -41,6 +41,7 @@ namespace Microsoft.PythonTools.Options {
             try {
                 typeShedPathTextBox.Text = _options.TypeShedPath;
                 suppressTypeShedCheckbox.Checked = _options.SuppressTypeShed;
+                _disableLanguageServerCheckbox.Checked = _options.ServerDisabled;
             } finally {
                 _changing = false;
             }
@@ -62,6 +63,12 @@ namespace Microsoft.PythonTools.Options {
         private void suppressTypeShedCheckbox_CheckedChanged(object sender, EventArgs e) {
             if (!_changing) {
                 _options.SuppressTypeShed = suppressTypeShedCheckbox.Checked;
+            }
+        }
+
+        private void _enableLanguageServer_CheckedChanged(object sender, EventArgs e) {
+            if (!_changing) {
+                _options.ServerDisabled = _disableLanguageServerCheckbox.Checked;
             }
         }
     }

--- a/Python/Product/PythonTools/PythonTools/Options/LanguageServerOptionsControl.resx
+++ b/Python/Product/PythonTools/PythonTools/Options/LanguageServerOptionsControl.resx
@@ -153,12 +153,6 @@
   <data name="&gt;&gt;typeShedPathLabel.ZOrder" xml:space="preserve">
     <value>3</value>
   </data>
-  <metadata name="_tooltips.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 17</value>
-  </metadata>
-  <data name="tableLayoutPanel1.ColumnCount" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
   <metadata name="groupBox1.GenerateMember" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>False</value>
   </metadata>
@@ -168,11 +162,119 @@
   <data name="groupBox1.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
     <value>GrowAndShrink</value>
   </data>
+  <data name="&gt;&gt;tableLayoutPanel2.Name" xml:space="preserve">
+    <value>tableLayoutPanel2</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel2.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel2.Parent" xml:space="preserve">
+    <value>groupBox1</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel2.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="tableLayoutPanel2.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="suppressTypeShedCheckbox" Row="0" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="browseTypeShedPathButton" Row="1" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="typeShedPathTextBox" Row="1" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="typeShedPathLabel" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,50,Percent,100,AutoSize,20" /&gt;&lt;Rows Styles="AutoSize,50,AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
+  </data>
+  <data name="groupBox1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="groupBox1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 3</value>
+  </data>
+  <data name="groupBox1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>485, 71</value>
+  </data>
+  <data name="groupBox1.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="groupBox1.Text" xml:space="preserve">
+    <value>Typeshed</value>
+  </data>
+  <data name="&gt;&gt;groupBox1.Name" xml:space="preserve">
+    <value>groupBox1</value>
+  </data>
+  <data name="&gt;&gt;groupBox1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;groupBox1.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;groupBox1.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
   <data name="tableLayoutPanel2.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
   <data name="tableLayoutPanel2.ColumnCount" type="System.Int32, mscorlib">
     <value>3</value>
+  </data>
+  <data name="&gt;&gt;suppressTypeShedCheckbox.Name" xml:space="preserve">
+    <value>suppressTypeShedCheckbox</value>
+  </data>
+  <data name="&gt;&gt;suppressTypeShedCheckbox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;suppressTypeShedCheckbox.Parent" xml:space="preserve">
+    <value>tableLayoutPanel2</value>
+  </data>
+  <data name="&gt;&gt;suppressTypeShedCheckbox.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;browseTypeShedPathButton.Name" xml:space="preserve">
+    <value>browseTypeShedPathButton</value>
+  </data>
+  <data name="&gt;&gt;browseTypeShedPathButton.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;browseTypeShedPathButton.Parent" xml:space="preserve">
+    <value>tableLayoutPanel2</value>
+  </data>
+  <data name="&gt;&gt;browseTypeShedPathButton.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;typeShedPathTextBox.Name" xml:space="preserve">
+    <value>typeShedPathTextBox</value>
+  </data>
+  <data name="&gt;&gt;typeShedPathTextBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;typeShedPathTextBox.Parent" xml:space="preserve">
+    <value>tableLayoutPanel2</value>
+  </data>
+  <data name="&gt;&gt;typeShedPathTextBox.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="tableLayoutPanel2.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="tableLayoutPanel2.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 16</value>
+  </data>
+  <data name="tableLayoutPanel2.RowCount" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="tableLayoutPanel2.Size" type="System.Drawing.Size, System.Drawing">
+    <value>479, 52</value>
+  </data>
+  <data name="tableLayoutPanel2.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel2.Name" xml:space="preserve">
+    <value>tableLayoutPanel2</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel2.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel2.Parent" xml:space="preserve">
+    <value>groupBox1</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel2.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="tableLayoutPanel2.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="suppressTypeShedCheckbox" Row="0" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="browseTypeShedPathButton" Row="1" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="typeShedPathTextBox" Row="1" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="typeShedPathLabel" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,50,Percent,100,AutoSize,20" /&gt;&lt;Rows Styles="AutoSize,50,AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <data name="suppressTypeShedCheckbox.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Left</value>
@@ -261,62 +363,41 @@
   <data name="&gt;&gt;typeShedPathTextBox.ZOrder" xml:space="preserve">
     <value>2</value>
   </data>
-  <data name="tableLayoutPanel2.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
+  <metadata name="_tooltips.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+  <data name="tableLayoutPanel1.ColumnCount" type="System.Int32, mscorlib">
+    <value>1</value>
   </data>
-  <data name="tableLayoutPanel2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 16</value>
+  <data name="_disableLanguageServerCheckbox.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
   </data>
-  <data name="tableLayoutPanel2.RowCount" type="System.Int32, mscorlib">
-    <value>2</value>
+  <data name="_disableLanguageServerCheckbox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 80</value>
   </data>
-  <data name="tableLayoutPanel2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>479, 52</value>
+  <data name="_disableLanguageServerCheckbox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>289, 17</value>
   </data>
-  <data name="tableLayoutPanel2.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
+  <data name="_disableLanguageServerCheckbox.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
   </data>
-  <data name="&gt;&gt;tableLayoutPanel2.Name" xml:space="preserve">
-    <value>tableLayoutPanel2</value>
+  <data name="_disableLanguageServerCheckbox.Text" xml:space="preserve">
+    <value>Disable language &amp;server, IntelliSense and other features</value>
   </data>
-  <data name="&gt;&gt;tableLayoutPanel2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="_disableLanguageServerCheckbox.ToolTip" xml:space="preserve">
+    <value>When disabled, the language server will not start, resulting in lower memory and cpu usage, but many editor features will be unavailable.</value>
   </data>
-  <data name="&gt;&gt;tableLayoutPanel2.Parent" xml:space="preserve">
-    <value>groupBox1</value>
+  <data name="&gt;&gt;_disableLanguageServerCheckbox.Name" xml:space="preserve">
+    <value>_disableLanguageServerCheckbox</value>
   </data>
-  <data name="&gt;&gt;tableLayoutPanel2.ZOrder" xml:space="preserve">
-    <value>0</value>
+  <data name="&gt;&gt;_disableLanguageServerCheckbox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="tableLayoutPanel2.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="suppressTypeShedCheckbox" Row="0" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="browseTypeShedPathButton" Row="1" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="typeShedPathTextBox" Row="1" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="typeShedPathLabel" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,50,Percent,100,AutoSize,20" /&gt;&lt;Rows Styles="AutoSize,50,AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
-  </data>
-  <data name="groupBox1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="groupBox1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 3</value>
-  </data>
-  <data name="groupBox1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>485, 71</value>
-  </data>
-  <data name="groupBox1.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="groupBox1.Text" xml:space="preserve">
-    <value>Typeshed</value>
-  </data>
-  <data name="&gt;&gt;groupBox1.Name" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;groupBox1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;groupBox1.Parent" xml:space="preserve">
+  <data name="&gt;&gt;_disableLanguageServerCheckbox.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
   </data>
-  <data name="&gt;&gt;groupBox1.ZOrder" xml:space="preserve">
-    <value>0</value>
+  <data name="&gt;&gt;_disableLanguageServerCheckbox.ZOrder" xml:space="preserve">
+    <value>1</value>
   </data>
   <data name="tableLayoutPanel1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
@@ -346,7 +427,7 @@
     <value>0</value>
   </data>
   <data name="tableLayoutPanel1.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="groupBox1" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,100,Percent,100" /&gt;&lt;/TableLayoutSettings&gt;</value>
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="groupBox1" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_disableLanguageServerCheckbox" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,100,Percent,100" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>


### PR DESCRIPTION
Fix #4587 

Most code could already handle not getting analysis entry or getting null from an analyzer request, so this is mostly just adding the option, and not starting analysis.

Not entirely satisfied with the option name.

I'm convinced we need this as an escape hatch for problematic projects (I've seen users kill the analyzer process and try to rename it to prevent it from starting), and having the choice between feature and resource usage is good to have.

I'll leave it open until others are back from vacation so we can discuss.