### PR TITLE
 Fix #4560: IntelliSense completions don't reliably appear

### DIFF
--- a/Python/Product/Analysis/Analysis.csproj
+++ b/Python/Product/Analysis/Analysis.csproj
@@ -76,6 +76,7 @@
     <Compile Include="Infrastructure\SingleThreadSynchronizationContext.cs" />
     <Compile Include="Infrastructure\StringBuilderExtensions.cs" />
     <Compile Include="Infrastructure\StringExtensions.cs" />
+    <Compile Include="Infrastructure\TaskCompletionSourceExtensions.cs" />
     <Compile Include="Infrastructure\TaskExtensions.cs" />
     <Compile Include="Infrastructure\TestEnvironment.cs" />
     <Compile Include="Infrastructure\UriEqualityComparer.cs" />

--- a/Python/Product/Analysis/Analyzer/DDG.cs
+++ b/Python/Product/Analysis/Analyzer/DDG.cs
@@ -73,6 +73,7 @@ namespace Microsoft.PythonTools.Analysis.Analyzer {
                     SetCurrentUnit(_unit);
                     AnalyzedEntries.Add(_unit.ProjectEntry);
                     _unit.Analyze(this, cancel);
+                    _unit.ProjectEntry.SetCompleteAnalysis();
                 }
 
                 if (reportQueueSize != null) {

--- a/Python/Product/Analysis/Infrastructure/TaskCompletionSourceExtensions.cs
+++ b/Python/Product/Analysis/Infrastructure/TaskCompletionSourceExtensions.cs
@@ -1,0 +1,69 @@
+﻿// Visual Studio Shared Project
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABLITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.PythonTools.Analysis.Infrastructure {
+    internal static class TaskCompletionSourceExtensions {
+        public static void TrySetResultOnThreadPool<T>(this TaskCompletionSource<T> taskCompletionSource, T result) 
+            => ThreadPool.QueueUserWorkItem(new TrySetResultStateAction<T>(taskCompletionSource, result).Invoke);
+
+        public static CancellationTokenRegistration RegisterForCancellation<T>(this TaskCompletionSource<T> taskCompletionSource, CancellationToken cancellationToken) 
+            => taskCompletionSource.RegisterForCancellation(-1, cancellationToken);
+
+        public static CancellationTokenRegistration RegisterForCancellation<T>(this TaskCompletionSource<T> taskCompletionSource, int millisecondsDelay, CancellationToken cancellationToken) {
+            if (millisecondsDelay >= 0) {
+                var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                cts.CancelAfter(millisecondsDelay);
+                cancellationToken = cts.Token;
+            }
+
+            var action = new CancelOnTokenAction<T>(taskCompletionSource, cancellationToken);
+            return cancellationToken.Register(action.Invoke);
+        }
+
+        private struct TrySetResultStateAction<T> {
+            public TaskCompletionSource<T> Tcs { get; }
+            public T Result { get; }
+
+            public TrySetResultStateAction(TaskCompletionSource<T> tcs, T result) {
+                Tcs = tcs;
+                Result = result;
+            }
+
+            public void Invoke(object state) => Tcs.TrySetResult(Result);
+        }
+
+        private struct CancelOnTokenAction<T> {
+            private readonly TaskCompletionSource<T> _taskCompletionSource;
+            private readonly CancellationToken _cancellationToken;
+
+            public CancelOnTokenAction(TaskCompletionSource<T> taskCompletionSource, CancellationToken cancellationToken) {
+                _taskCompletionSource = taskCompletionSource;
+                _cancellationToken = cancellationToken;
+            }
+
+            public void Invoke() {
+                if (!_taskCompletionSource.Task.IsCompleted) {
+                    ThreadPool.QueueUserWorkItem(TryCancel);
+                }
+            }
+
+            private void TryCancel(object state) => _taskCompletionSource.TrySetCanceled(_cancellationToken);
+        }
+    }
+}

--- a/Python/Product/Analysis/LanguageServer/EditorFiles.cs
+++ b/Python/Product/Analysis/LanguageServer/EditorFiles.cs
@@ -79,7 +79,7 @@ namespace Microsoft.PythonTools.Analysis.LanguageServer {
             _syncContext.Post(_ => HideDiagnostics(documentUri), null);
         }
 
-        public void DidChangeTextDocument(DidChangeTextDocumentParams @params, Action<IDocument> enqueueAction) {
+        public void DidChangeTextDocument(DidChangeTextDocumentParams @params, bool enqueueForParsing) {
             var changes = @params.contentChanges;
             if (changes == null || changes.Length == 0) {
                 return;
@@ -134,12 +134,12 @@ namespace Microsoft.PythonTools.Analysis.LanguageServer {
                     }
                 }
                 if (next.HasValue) {
-                    DidChangeTextDocument(next.Value, null);
+                    DidChangeTextDocument(next.Value, false);
                 }
             } finally {
-                if (enqueueAction != null) {
+                if (enqueueForParsing) {
                     _server.TraceMessage($"Applied changes to {uri}");
-                    enqueueAction(doc);
+                    _server.EnqueueItem(doc, enqueueForAnalysis: @params._enqueueForAnalysis ?? true);
                 }
             }
         }

--- a/Python/Product/Analysis/LanguageServer/Server.Hover.cs
+++ b/Python/Product/Analysis/LanguageServer/Server.Hover.cs
@@ -14,42 +14,40 @@
 // See the Apache Version 2.0 License for specific language governing
 // permissions and limitations under the License.
 
-using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.PythonTools.Analysis.Infrastructure;
 using Microsoft.PythonTools.Intellisense;
 using Microsoft.PythonTools.Parsing;
 using Microsoft.PythonTools.Parsing.Ast;
 
 namespace Microsoft.PythonTools.Analysis.LanguageServer {
     public sealed partial class Server {
-        private static Hover EmptyHover = new Hover {
+        private static readonly Hover EmptyHover = new Hover {
             contents = new MarkupContent { kind = MarkupKind.PlainText, value = string.Empty }
         };
+
         private DocumentationBuilder _displayTextBuilder;
 
         public override Task<Hover> Hover(TextDocumentPositionParams @params) => Hover(@params, CancellationToken.None);
 
-        internal Task<Hover> Hover(TextDocumentPositionParams @params, CancellationToken cancellationToken) {
+        internal async Task<Hover> Hover(TextDocumentPositionParams @params, CancellationToken cancellationToken) {
             var uri = @params.textDocument.uri;
             ProjectFiles.GetAnalysis(@params.textDocument, @params.position, @params._version, out var entry, out var tree);
 
             TraceMessage($"Hover in {uri} at {@params.position}");
 
-            var analysis = entry?.Analysis;
+            var analysis = entry != null ? await entry.GetAnalysisAsync(50, cancellationToken) : null;
             if (analysis == null) {
                 TraceMessage($"No analysis found for {uri}");
-                return Task.FromResult(EmptyHover);
+                return EmptyHover;
             }
 
             tree = GetParseTree(entry, uri, cancellationToken, out var version) ?? tree;
 
             Expression expr;
             SourceSpan? exprSpan;
-            Analyzer.InterpreterScope scope = null;
 
             var finder = new ExpressionFinder(tree, GetExpressionOptions.Hover);
             expr = finder.GetExpression(@params.position) as Expression;
@@ -57,13 +55,13 @@ namespace Microsoft.PythonTools.Analysis.LanguageServer {
 
             if (expr == null) {
                 TraceMessage($"No hover info found in {uri} at {@params.position}");
-                return Task.FromResult(EmptyHover);
+                return EmptyHover;
             }
 
             TraceMessage($"Getting hover for {expr.ToCodeString(tree, CodeFormattingOptions.Traditional)}");
 
             // First try values from expression. This works for the import statement most of the time.
-            var values = analysis.GetValues(expr, @params.position, scope).ToList();
+            var values = analysis.GetValues(expr, @params.position, null).ToList();
             if (values.Count == 0) {
                 // See if this is hover over import statement
                 var index = tree.LocationToIndex(@params.position);
@@ -86,10 +84,10 @@ namespace Microsoft.PythonTools.Analysis.LanguageServer {
                         }
                     }
                     if (sb.Length > 0) {
-                        return Task.FromResult(new Hover {
+                        return new Hover {
                             contents = sb.ToString(),
                             range = span
-                        });
+                        };
                     }
                 }
             }
@@ -114,10 +112,10 @@ namespace Microsoft.PythonTools.Analysis.LanguageServer {
                     _version = version?.Version,
                     _typeNames = names
                 };
-                return Task.FromResult(res);
+                return res;
             }
 
-            return Task.FromResult(EmptyHover);
+            return EmptyHover;
         }
 
         private static string GetFullTypeName(AnalysisValue value) {

--- a/Python/Product/Analysis/ProjectEntry.cs
+++ b/Python/Product/Analysis/ProjectEntry.cs
@@ -17,11 +17,13 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.PythonTools.Analysis.Analyzer;
 using Microsoft.PythonTools.Analysis.Infrastructure;
 using Microsoft.PythonTools.Analysis.Values;
@@ -40,6 +42,7 @@ namespace Microsoft.PythonTools.Analysis {
         Justification = "Unclear ownership makes it unlikely this object will be disposed correctly")]
     internal sealed class ProjectEntry : IPythonProjectEntry, IAggregateableProjectEntry, IDocument {
         private AnalysisUnit _unit;
+        private TaskCompletionSource<ModuleAnalysis> _analysisTcs;
         private readonly SortedDictionary<int, DocumentBuffer> _buffers;
         private readonly ConcurrentQueue<WeakReference<ReferenceDict>> _backReferences = new ConcurrentQueue<WeakReference<ReferenceDict>>();
         internal readonly HashSet<AggregateProjectEntry> _aggregates = new HashSet<AggregateProjectEntry>();
@@ -133,6 +136,37 @@ namespace Microsoft.PythonTools.Analysis {
             }
         }
 
+        internal Task<ModuleAnalysis> GetAnalysisAsync(int waitingTimeout = -1, CancellationToken cancellationToken = default(CancellationToken)) {
+            Task<ModuleAnalysis> task;
+            lock (this) {
+                task = _analysisTcs.Task;
+            }
+
+            if (task.IsCompleted || waitingTimeout == -1 && !cancellationToken.CanBeCanceled) {
+                return task;
+            }
+
+            var timeoutTask = Task.Delay(waitingTimeout, cancellationToken).ContinueWith(t => {
+                lock (this) {
+                    return Analysis;
+                }
+            }, cancellationToken);
+
+            return Task.WhenAny(timeoutTask, _analysisTcs.Task).Unwrap();
+        }
+
+        internal void SetCompleteAnalysis() {
+            lock (this) {
+                _analysisTcs.TrySetResultOnThreadPool(Analysis);
+            }
+        }
+
+        internal void ResetCompleteAnalysis() {
+            lock (this) {
+                _analysisTcs = new TaskCompletionSource<ModuleAnalysis>();
+            }
+        }
+
         public void SetCurrentParse(PythonAst tree, IAnalysisCookie cookie, bool notify = true) {
             lock (this) {
                 Tree = tree;
@@ -188,6 +222,9 @@ namespace Microsoft.PythonTools.Analysis {
         public bool IsAnalyzed => Analysis != null;
 
         private void Parse(bool enqueueOnly, CancellationToken cancel) {
+#if DEBUG
+            Debug.Assert(Monitor.IsEntered(this));      
+#endif
             var parse = GetCurrentParse();
             var tree = parse?.Tree;
             var cookie = parse?.Cookie;

--- a/Python/Product/Analysis/SingleDict.cs
+++ b/Python/Product/Analysis/SingleDict.cs
@@ -193,23 +193,6 @@ namespace Microsoft.PythonTools.Analysis {
         }
 
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-        internal AnalysisDictionary<TKey, TValue> InternalDict {
-            get {
-                return _data as AnalysisDictionary<TKey, TValue>;
-            }
-            set {
-                if (value.Count == 1) {
-                    using (var e = value.GetEnumerator()) {
-                        e.MoveNext();
-                        _data = new SingleDependency(e.Current.Key, e.Current.Value, value.Comparer);
-                    }
-                } else {
-                    _data = value;
-                }
-            }
-        }
-
-        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         public IEnumerable<TValue> Values {
             get {
                 SingleDependency single;
@@ -254,10 +237,6 @@ namespace Microsoft.PythonTools.Analysis {
 
                 return 0;
             }
-        }
-
-        public void Clear() {
-            _data = Comparer;
         }
 
         #region IEnumerable<KeyValuePair<TKey,TValue>> Members


### PR DESCRIPTION
Create a `TaskCompletionSource` at the beginning of parsing to be able to wait for the corresponding analysis.