### PR TITLE
Fix #2017  Language service fails when using Python 2.7 interpreter

### DIFF
--- a/Python/Product/Analysis/Interpreter/Ast/AstPythonInterpreter.cs
+++ b/Python/Product/Analysis/Interpreter/Ast/AstPythonInterpreter.cs
@@ -204,6 +204,8 @@ namespace Microsoft.PythonTools.Interpreter.Ast {
                 return _builtinModule;
             }
 
+            Debug.Assert(_analyzer != null);
+
             var ctxt = new AstPythonInterpreterFactory.TryImportModuleContext {
                 Interpreter = this,
                 ModuleCache = _modules,

--- a/Python/Product/Analysis/PythonAnalyzer.cs
+++ b/Python/Product/Analysis/PythonAnalyzer.cs
@@ -179,10 +179,9 @@ namespace Microsoft.PythonTools.Analysis {
             try {
                 _interpreterFactory.NotifyImportNamesChanged();
                 _modules.ReInit();
+                _interpreter.Initialize(this);
 
                 await LoadKnownTypesAsync(token);
-
-                _interpreter.Initialize(this);
 
                 foreach (var mod in _modulesByFilename.Values) {
                     mod.Clear();


### PR DESCRIPTION
Fixes https://github.com/Microsoft/vscode-python/issues/2017
Make sure interpreter is initialized before attempting to import types