### PR TITLE
Relative import fails in Python 2.7

### DIFF
--- a/Python/Product/VSCode/AnalysisVsc/LanguageServer.cs
+++ b/Python/Product/VSCode/AnalysisVsc/LanguageServer.cs
@@ -159,7 +159,8 @@ namespace Microsoft.Python.LanguageServer.Implementation {
             if (watchSearchPaths) {
                 _pathsWatcher = new PathsWatcher(
                     _initParams.initializationOptions.searchPaths, 
-                    () => _server.ReloadModulesAsync(CancellationToken.None).DoNotWait()
+                    () => _server.ReloadModulesAsync(CancellationToken.None).DoNotWait(),
+                    _server
                  );
             }
 

--- a/Python/Product/VSCode/AnalysisVsc/PathsWatcher.cs
+++ b/Python/Product/VSCode/AnalysisVsc/PathsWatcher.cs
@@ -20,17 +20,20 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using Microsoft.DsTools.Core.Disposables;
+using ILogger = Microsoft.PythonTools.Analysis.LanguageServer.ILogger;
 
 namespace Microsoft.Python.LanguageServer {
     internal sealed class PathsWatcher : IDisposable {
         private readonly DisposableBag _disposableBag = new DisposableBag(nameof(PathsWatcher));
         private readonly Action _onChanged;
         private readonly object _lock = new object();
+        private readonly ILogger _log;
 
         private Timer _throttleTimer;
         private bool _changedSinceLastTick;
 
-        public PathsWatcher(string[] paths, Action onChanged) {
+        public PathsWatcher(string[] paths, Action onChanged, ILogger log) {
+            _log = log;
             if (paths?.Length == 0) {
                 return;
             }
@@ -40,19 +43,26 @@ namespace Microsoft.Python.LanguageServer {
             var list = new List<FileSystemWatcher>();
             var reduced = ReduceToCommonRoots(paths);
             foreach (var p in reduced) {
-                var fsw = new FileSystemWatcher(p);
-                fsw.IncludeSubdirectories = true;
-                fsw.EnableRaisingEvents = true;
+                if(!Directory.Exists(p)) {
+                    continue;
+                }
+                try {
+                    var fsw = new FileSystemWatcher(p);
+                    fsw.IncludeSubdirectories = true;
+                    fsw.EnableRaisingEvents = true;
 
-                fsw.Changed += OnChanged;
-                fsw.Created += OnChanged;
-                fsw.Deleted += OnChanged;
+                    fsw.Changed += OnChanged;
+                    fsw.Created += OnChanged;
+                    fsw.Deleted += OnChanged;
 
-                _disposableBag
-                    .Add(() => fsw.Changed -= OnChanged)
-                    .Add(() => fsw.Created -= OnChanged)
-                    .Add(() => fsw.Deleted -= OnChanged)
-                    .Add(fsw);
+                    _disposableBag
+                        .Add(() => fsw.Changed -= OnChanged)
+                        .Add(() => fsw.Created -= OnChanged)
+                        .Add(() => fsw.Deleted -= OnChanged)
+                        .Add(fsw);
+                } catch(ArgumentException ex) {
+                    _log.TraceMessage($"Unable to create file watcher for {p}, exception {ex.Message}");
+                }
             }
         }
 

--- a/Python/Product/VSCode/AnalysisVsc/PathsWatcher.cs
+++ b/Python/Product/VSCode/AnalysisVsc/PathsWatcher.cs
@@ -43,13 +43,20 @@ namespace Microsoft.Python.LanguageServer {
             var list = new List<FileSystemWatcher>();
             var reduced = ReduceToCommonRoots(paths);
             foreach (var p in reduced) {
-                if(!Directory.Exists(p)) {
+                try {
+                    if (!Directory.Exists(p)) {
+                        continue;
+                    }
+                } catch(IOException ex) {
+                    _log.TraceMessage($"Unable to access directory {p}, exception {ex.Message}");
                     continue;
                 }
+
                 try {
-                    var fsw = new FileSystemWatcher(p);
-                    fsw.IncludeSubdirectories = true;
-                    fsw.EnableRaisingEvents = true;
+                    var fsw = new FileSystemWatcher(p) {
+                        IncludeSubdirectories = true,
+                        EnableRaisingEvents = true
+                    };
 
                     fsw.Changed += OnChanged;
                     fsw.Created += OnChanged;


### PR DESCRIPTION
Fixes #4610

The issue was that file watcher ctor throws when folder in search paths does not exist.

I was able to repro the issue in VS but it was much harder, the reason is different. Most probably adding 'hello.py' first leads to creation of unresolved 'imported' and later, when 'imported' is actually added the module table is not updated.