### PR TITLE
Make tests run without a Visual Studio instance.

### DIFF
--- a/Common/Tests/Utilities/TestEnvironmentImpl.cs
+++ b/Common/Tests/Utilities/TestEnvironmentImpl.cs
@@ -15,6 +15,7 @@
 // permissions and limitations under the License.
 
 using System;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -30,7 +31,7 @@ namespace TestUtilities {
         private readonly string _binPath = typeof(TestEnvironmentImpl).Assembly.GetAssemblyDirectory();
 
         public TestEnvironmentImpl AddAssemblyResolvePaths(params string[] paths) {
-            _assemblyLoader.AddPaths(paths);
+            _assemblyLoader.AddPaths(paths.Where(n => !string.IsNullOrEmpty(n)).ToArray());
             return this;
         }
 

--- a/Common/Tests/Utilities/VisualStudioPath.cs
+++ b/Common/Tests/Utilities/VisualStudioPath.cs
@@ -38,9 +38,9 @@ namespace TestUtilities {
                 var path = current.ResolvePath(current.GetProductPath());
                 return Path.GetDirectoryName(path);
             } catch (COMException) {
-                var path = Environment.GetEnvironmentVariable($"VisualStudio_{AssemblyVersionInfo.VSVersion}");
+                var path = Environment.GetEnvironmentVariable($"VisualStudio_IDE_{AssemblyVersionInfo.VSVersion}");
                 if (string.IsNullOrEmpty(path)) {
-                    path = Environment.GetEnvironmentVariable("VisualStudio");
+                    path = Environment.GetEnvironmentVariable("VisualStudio_IDE");
                 }
                 return path;
             }

--- a/Common/Tests/Utilities/VisualStudioPath.cs
+++ b/Common/Tests/Utilities/VisualStudioPath.cs
@@ -16,14 +16,15 @@
 
 using System;
 using System.IO;
+using System.Runtime.InteropServices;
 using Microsoft.VisualStudio.Setup.Configuration;
 
 namespace TestUtilities {
     public static class VisualStudioPath {
         private static Lazy<string> RootLazy { get; } = new Lazy<string>(GetVsRoot);
-        private static Lazy<string> CommonExtensionsLazy { get; } = new Lazy<string>(() => Path.Combine(Root, @"CommonExtensions\"));
-        private static Lazy<string> PrivateAssembliesLazy { get; } = new Lazy<string>(() => Path.Combine(Root, @"PrivateAssemblies\"));
-        private static Lazy<string> PublicAssembliesLazy { get; } = new Lazy<string>(() => Path.Combine(Root, @"PublicAssemblies\"));
+        private static Lazy<string> CommonExtensionsLazy { get; } = new Lazy<string>(() => Root == null ? null : Path.Combine(Root, @"CommonExtensions\"));
+        private static Lazy<string> PrivateAssembliesLazy { get; } = new Lazy<string>(() => Root == null ? null : Path.Combine(Root, @"PrivateAssemblies\"));
+        private static Lazy<string> PublicAssembliesLazy { get; } = new Lazy<string>(() => Root == null ? null : Path.Combine(Root, @"PublicAssemblies\"));
 
         public static string Root => RootLazy.Value;
         public static string CommonExtensions => CommonExtensionsLazy.Value;
@@ -31,10 +32,18 @@ namespace TestUtilities {
         public static string PublicAssemblies => PublicAssembliesLazy.Value;
 
         private static string GetVsRoot() {
-            var configuration = (ISetupConfiguration2)new SetupConfiguration();
-            var current = (ISetupInstance2)configuration.GetInstanceForCurrentProcess();
-            var path = current.ResolvePath(current.GetProductPath());
-            return Path.GetDirectoryName(path);
+            try {
+                var configuration = (ISetupConfiguration2)new SetupConfiguration();
+                var current = (ISetupInstance2)configuration.GetInstanceForCurrentProcess();
+                var path = current.ResolvePath(current.GetProductPath());
+                return Path.GetDirectoryName(path);
+            } catch (COMException) {
+                var path = Environment.GetEnvironmentVariable($"VisualStudio_{AssemblyVersionInfo.VSVersion}");
+                if (string.IsNullOrEmpty(path)) {
+                    path = Environment.GetEnvironmentVariable("VisualStudio");
+                }
+                return path;
+            }
         }
     }
 }


### PR DESCRIPTION
Many tests are failing on our v16 builds because this crashes. We can fall back on the environment variable in most cases.