### PR TITLE
[15.9] Fixes #4625 General pane in output window is unlocalised

### DIFF
--- a/Python/Product/Cookiecutter/Shared/Infrastructure/OutputWindowRedirector.cs
+++ b/Python/Product/Cookiecutter/Shared/Infrastructure/OutputWindowRedirector.cs
@@ -58,7 +58,7 @@ namespace Microsoft.CookiecutterTools.Infrastructure {
         /// not be found or created.</exception>
         public static OutputWindowRedirector GetGeneral(IServiceProvider provider) {
             if (_generalPane == null) {
-                _generalPane = Get(provider, VSConstants.OutputWindowPaneGuid.GeneralPane_guid, "General");
+                _generalPane = Get(provider, VSConstants.OutputWindowPaneGuid.GeneralPane_guid, Strings.Settings_General_Category);
             }
             return _generalPane;
         }

--- a/Python/Product/VSCommon/Infrastructure/OutputWindowRedirector.cs
+++ b/Python/Product/VSCommon/Infrastructure/OutputWindowRedirector.cs
@@ -58,7 +58,7 @@ namespace Microsoft.PythonTools.Infrastructure {
         /// not be found or created.</exception>
         public static OutputWindowRedirector GetGeneral(IServiceProvider provider) {
             if (_generalPane == null) {
-                _generalPane = Get(provider, VSConstants.OutputWindowPaneGuid.GeneralPane_guid, "General");
+                _generalPane = Get(provider, VSConstants.OutputWindowPaneGuid.GeneralPane_guid, Strings.PythonGeneralPropertyPageLabel);
             }
             return _generalPane;
         }


### PR DESCRIPTION
Fixes #4625 General pane in output window is unlocalised
Fixes string using existing resources with same text.