### PR TITLE
Vtune sourcemap (cleaned up to account for 15.8)

### DIFF
--- a/Python/Product/ExternalProfilerDriver/DWJsonModel.cs
+++ b/Python/Product/ExternalProfilerDriver/DWJsonModel.cs
@@ -60,11 +60,12 @@ namespace Microsoft.PythonTools.Profiling.ExternalProfilerDriver {
         public IList<LongInt> frameIPs { get; set; }
     }
 
-    class FunctionSpec {
+    public class FunctionSpec {
         public string name { get; set; }
         [JsonProperty("base")]
         public LongInt @base { get; set; }
         public LongInt size { get; set; }
+        public IList<LineSpec> lines { get; set; }
 
         public FunctionSpec(string _name, long _base, long _size) {
             name = _name;
@@ -73,7 +74,7 @@ namespace Microsoft.PythonTools.Profiling.ExternalProfilerDriver {
         }
     }
 
-    class ModuleSpec {
+    public class ModuleSpec {
         public string name { get; set; }
         public int id { get; set; }
         public LongInt begin { get; set; }
@@ -82,6 +83,7 @@ namespace Microsoft.PythonTools.Profiling.ExternalProfilerDriver {
         public LongInt @base { get; set; }
         public LongInt size { get; set; }
         public IList<FunctionSpec> ranges { get; set; }
+        public IList<FileIDMapSpec> fileIdMapping { get; set; }
 
         public ModuleSpec() {
             /* empty */
@@ -96,6 +98,22 @@ namespace Microsoft.PythonTools.Profiling.ExternalProfilerDriver {
             name = _name;
             ranges = _ranges.ToList();
         }
+    }
+
+    public class LineSpec
+    {
+      public int fileId      { get; set; }
+      public int offset      { get; set; } 
+      public int lineBegin   {get; set; } 
+      public int lineEnd     {get; set; } 
+      public int columnBegin {get; set; } 
+      public int columnEnd   {get; set; } 
+    }
+
+    public class FileIDMapSpec
+    {
+        public int id { get; set; }
+        public string file { get; set; }
     }
 
     class ThreadSpec {

--- a/Python/Product/ExternalProfilerDriver/ExternalProfilerDriver.csproj
+++ b/Python/Product/ExternalProfilerDriver/ExternalProfilerDriver.csproj
@@ -65,6 +65,7 @@
     <Compile Include="VTuneCPUUtilizationParser.cs" />
     <Compile Include="VTuneStackParser.cs" />
     <Compile Include="VTuneToDWJSON.cs" />
+    <Compile Include="VTuneUtils.cs" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="$(PackagesPath)\Newtonsoft.Json\lib\net45\Newtonsoft.Json.dll">

--- a/Python/Product/ExternalProfilerDriver/Program.cs
+++ b/Python/Product/ExternalProfilerDriver/Program.cs
@@ -37,6 +37,9 @@ namespace Microsoft.PythonTools.Profiling.ExternalProfilerDriver {
         [Option('c', "callstack", HelpText = "Specify the pre-generated callstack report to process")]
         public string CallStackFNameToParse { get; set; }
 
+        [Option('s', "sympath", HelpText = "Specify the path(s) to search symbols in")]
+        public string SymbolPath { get; set; }
+
         [Option('d', "dwjsondir", HelpText = "Specify the directory in which to dump resulting dwjson (contents are overwritten)")]
         public string DWJsonOutDir { get; set; }
 
@@ -73,6 +76,12 @@ namespace Microsoft.PythonTools.Profiling.ExternalProfilerDriver {
                 VTuneCollectHotspotsSpec spec = new VTuneCollectHotspotsSpec() {
                     WorkloadSpec = String.Join(" ", RestArgs)
                 };
+
+                if (opts.SymbolPath != string.Empty) {
+                    Console.WriteLine("Symbol path specified");
+                    spec.SymbolPath = opts.SymbolPath;
+                }
+
                 string vtuneCollectArgs = spec.FullCLI();
 
                 VTuneReportCallstacksSpec repspec = new VTuneReportCallstacksSpec();

--- a/Python/Product/ExternalProfilerDriver/VTuneInvoker.cs
+++ b/Python/Product/ExternalProfilerDriver/VTuneInvoker.cs
@@ -150,6 +150,7 @@ namespace Microsoft.PythonTools.Profiling.ExternalProfilerDriver {
     public abstract class VTuneCollectSpec : VTuneSpec {
         public abstract string AnalysisName { get; }
         public string WorkloadSpec { get; set; }
+        public string SymbolPath { get; set; }
         public string AnalysisCLI {
             get { return "-collect" + " " + AnalysisName; }
         }
@@ -170,6 +171,19 @@ namespace Microsoft.PythonTools.Profiling.ExternalProfilerDriver {
             sb.Append(" " + ResultDirCLI);
             sb.Append(WorkloadCLI);
             return sb.ToString();
+            #if false
+            StringBuilder sb = new StringBuilder();
+            sb.Append(AnalysisCLI);
+            sb.Append(" " + UserDataDirCLI());
+            sb.Append(" " + ResultDirCLI);
+
+            if (!string.IsNullOrEmpty(this.SymbolPath)) {
+                sb.Append($" -search-dir {this.SymbolPath}");
+            }
+
+            sb.Append(WorkloadCLI);
+            return sb.ToString();
+            #endif
         }
     }
 

--- a/Python/Product/ExternalProfilerDriver/VTuneStackParser.cs
+++ b/Python/Product/ExternalProfilerDriver/VTuneStackParser.cs
@@ -70,15 +70,6 @@ namespace Microsoft.PythonTools.Profiling.ExternalProfilerDriver {
     }
 
     static class VTuneStackParser {
-        public static IEnumerable<string> ReadFromFile(string filePath) {
-            string line;
-            using (var reader = File.OpenText(filePath)) {
-                while ((line = reader.ReadLine()) != null) {
-                    yield return line;
-                }
-            }
-        }
-
         public static string RemovePrePosComma(string str) {
             if (str.Length > 0) {
                 if (str[0] == '"') { str = str.Substring(1, str.Length - 1); }

--- a/Python/Product/ExternalProfilerDriver/VTuneToDWJSON.cs
+++ b/Python/Product/ExternalProfilerDriver/VTuneToDWJSON.cs
@@ -190,7 +190,9 @@ namespace Microsoft.PythonTools.Profiling.ExternalProfilerDriver {
                 modules = mods.ToList()
             };
 
-            string json = JsonConvert.SerializeObject(trace, Formatting.Indented);
+            string json = JsonConvert.SerializeObject(trace, Formatting.Indented, new JsonSerializerSettings {
+                NullValueHandling = NullValueHandling.Ignore
+            });
             File.WriteAllText(outfname, json);
 
             return total;
@@ -243,7 +245,9 @@ namespace Microsoft.PythonTools.Profiling.ExternalProfilerDriver {
                 counters = vts
             };
 
-            string json = JsonConvert.SerializeObject(trace, Formatting.Indented);
+            string json = JsonConvert.SerializeObject(trace, Formatting.Indented, new JsonSerializerSettings {
+                NullValueHandling = NullValueHandling.Ignore
+            });
 
             // var fs = new FileStream(@"C:\users\perf\Sample2.counters", FileMode.Create);
             var fs = new FileStream(outfname, FileMode.Create);

--- a/Python/Product/ExternalProfilerDriver/VTuneUtils.cs
+++ b/Python/Product/ExternalProfilerDriver/VTuneUtils.cs
@@ -1,0 +1,79 @@
+// Python Tools for Visual Studio
+// Copyright(c) 2018 Intel Corporation.  All rights reserved.
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABLITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System;
+using System.IO;
+using System.Collections.Generic;
+using System.Linq;
+using System.Diagnostics;
+
+namespace Microsoft.PythonTools.Profiling.ExternalProfilerDriver {
+    public static class Utils
+    {
+        // from an idea in https://github.com/dotnet/corefx/issues/3093
+        public static IEnumerable<T> Emit<T>(T element)
+        {
+          return Enumerable.Repeat(element, 1);
+        }
+
+        /// <summary>
+        /// Finds file name <param>fname</param> under directory <param>rootDir</param> (recursively)
+        /// </summary>
+        public static string FindFileInDir(string fname, string rootDir)
+        {
+            var candidates = Directory.GetFiles(rootDir, fname, SearchOption.AllDirectories);
+            if (candidates.Length <= 0) {
+                throw new FileNotFoundException($"Cannot find file {fname} under directory {rootDir}");
+            } else {
+                return candidates[0];
+            }
+        }
+
+        public static IEnumerable<string> ReadFromFile(string filePath)
+        {
+            string line;
+            using (var reader = File.OpenText(filePath))
+            {
+                while ((line = reader.ReadLine()) != null)
+                {
+                    yield return line;
+                }
+            }
+        }
+
+        public static IEnumerable<string> QuickExecute(string cmd, string args)
+        {
+            ProcessStartInfo psi = new ProcessStartInfo(cmd)
+            {
+                UseShellExecute = false,
+                Arguments = args,
+                RedirectStandardOutput = true
+            };
+
+            Process process = new Process
+            {
+                StartInfo = psi,
+            };
+
+            process.Start();
+            while (!process.StandardOutput.EndOfStream) {
+                yield return process.StandardOutput.ReadLine();
+            }
+            process.WaitForExit();
+        }
+    }
+}


### PR DESCRIPTION
Generates diagsession traces, still unstable on source file/line number information because need to account for symbols generated by setup.py-based builds.