### PR TITLE
Fixes #4608 Crash in Microsoft.PythonTools.Analysis.AnalysisLogWriter.Dump

### DIFF
--- a/Python/Product/Analysis/AnalysisLogWriter.cs
+++ b/Python/Product/Analysis/AnalysisLogWriter.cs
@@ -219,6 +219,7 @@ namespace Microsoft.PythonTools.Analysis {
                         }
                     }
                 }
+            } catch (IOException) {
             } finally {
                 try {
                     _dumping.Release();


### PR DESCRIPTION
Fixes #4608 Crash in Microsoft.PythonTools.Analysis.AnalysisLogWriter.Dump
Handle unexpected IOExceptions.