### PR TITLE
Improve reliability of document outline population in VS Code

### DIFF
--- a/Python/Product/Analysis/LanguageServer/Server.WorkspaceSymbols.cs
+++ b/Python/Product/Analysis/LanguageServer/Server.WorkspaceSymbols.cs
@@ -42,9 +42,7 @@ namespace Microsoft.PythonTools.Analysis.LanguageServer {
             var opts = GetMemberOptions.ExcludeBuiltins | GetMemberOptions.DeclaredOnly;
             var entry = ProjectFiles.GetEntry(@params.textDocument);
 
-            await WaitForCompleteAnalysisAsync();
             var members = await GetModuleVariablesAsync(entry as ProjectEntry, opts, string.Empty, 50);
-            
             return members
                 .GroupBy(mr => mr.Name)
                 .Select(g => g.First())

--- a/Python/Product/Analysis/LanguageServer/Server.WorkspaceSymbols.cs
+++ b/Python/Product/Analysis/LanguageServer/Server.WorkspaceSymbols.cs
@@ -42,7 +42,7 @@ namespace Microsoft.PythonTools.Analysis.LanguageServer {
             var opts = GetMemberOptions.ExcludeBuiltins | GetMemberOptions.DeclaredOnly;
             var entry = ProjectFiles.GetEntry(@params.textDocument);
 
-            await WaitForEntryAnalysisComplete(entry, 1000);
+            await WaitForCompleteAnalysisAsync();
             var members = await GetModuleVariablesAsync(entry as ProjectEntry, opts, string.Empty, 50);
             
             return members
@@ -50,15 +50,6 @@ namespace Microsoft.PythonTools.Analysis.LanguageServer {
                 .Select(g => g.First())
                 .Select(ToSymbolInformation)
                 .ToArray();
-        }
-
-        private Task WaitForEntryAnalysisComplete(IProjectEntry entry, int timeout) {
-            var cts = new CancellationTokenSource(timeout);
-            return Task.Run(async () => {
-                while (!entry.IsAnalyzed && !cts.IsCancellationRequested) {
-                    await Task.Delay(100);
-                }
-            });
         }
 
         private static async Task<List<MemberResult>> GetModuleVariablesAsync(ProjectEntry entry, GetMemberOptions opts, string prefix, int timeout) {

--- a/Python/Product/Analysis/LanguageServer/Server.cs
+++ b/Python/Product/Analysis/LanguageServer/Server.cs
@@ -127,32 +127,31 @@ namespace Microsoft.PythonTools.Analysis.LanguageServer {
         public override Task<InitializeResult> Initialize(InitializeParams @params) => Initialize(@params, CancellationToken.None);
 
         internal InitializeResult GetInitializeResult() => new InitializeResult {
-                capabilities = new ServerCapabilities {
-                    textDocumentSync = new TextDocumentSyncOptions {
-                        openClose = true,
-                        change = TextDocumentSyncKind.Incremental
-                    },
-                    completionProvider = new CompletionOptions {
-                        triggerCharacters = new[] { "." }
-                    },
-                    hoverProvider = true,
-                    signatureHelpProvider = new SignatureHelpOptions { triggerCharacters = new[] { "(,)" } },
-                    definitionProvider = true,
-                    referencesProvider = true,
-                    workspaceSymbolProvider = true,
-                    documentSymbolProvider = true,
-                    executeCommandProvider = new ExecuteCommandOptions {
-                        commands = new[] {
+            capabilities = new ServerCapabilities {
+                textDocumentSync = new TextDocumentSyncOptions {
+                    openClose = true,
+                    change = TextDocumentSyncKind.Incremental
+                },
+                completionProvider = new CompletionOptions {
+                    triggerCharacters = new[] { "." }
+                },
+                hoverProvider = true,
+                signatureHelpProvider = new SignatureHelpOptions { triggerCharacters = new[] { "(,)" } },
+                definitionProvider = true,
+                referencesProvider = true,
+                workspaceSymbolProvider = true,
+                documentSymbolProvider = true,
+                executeCommandProvider = new ExecuteCommandOptions {
+                    commands = new[] {
                             completionItemCommand
                         }
-                    }
                 }
-            };
+            }
+        };
 
         internal async Task<InitializeResult> Initialize(InitializeParams @params, CancellationToken cancellationToken) {
             ThrowIfDisposed();
             await DoInitializeAsync(@params, cancellationToken);
-
             return GetInitializeResult();
         }
 

--- a/Python/Product/VSCode/AnalysisVsc/AnalysisVsc.csproj
+++ b/Python/Product/VSCode/AnalysisVsc/AnalysisVsc.csproj
@@ -23,7 +23,7 @@
         </PackageReference>
         <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="2.1.0" />
         <PackageReference Include="NewtonSoft.Json" Version="10.0.1" />
-        <PackageReference Include="StreamJsonRpc" Version="1.4.102-beta" />
+        <PackageReference Include="StreamJsonRpc" Version="1.4.121" />
     </ItemGroup>
     <ItemGroup Condition="$(AnalysisReference) == ''">
         <ProjectReference Include="../../Analysis/AnalysisNetStandard.csproj" />

--- a/Python/Product/VSCode/AnalysisVsc/LanguageServer.cs
+++ b/Python/Product/VSCode/AnalysisVsc/LanguageServer.cs
@@ -488,11 +488,10 @@ namespace Microsoft.Python.LanguageServer.Implementation {
                 while (!_ppc.IsDisposed) {
                     try {
                         var item = await _ppc.ConsumeAsync();
-
                         if (item.IsAwaitable) {
                             var disposable = new PrioritizerDisposable(_ppc.CancellationToken);
                             item.SetResult(disposable);
-                            await disposable;
+                            await disposable.Task;
                         } else {
                             item.SetResult(EmptyDisposable.Instance);
                         }
@@ -525,7 +524,7 @@ namespace Microsoft.Python.LanguageServer.Implementation {
                 public Task<IDisposable> Task => _tcs.Task;
                 public bool IsAwaitable { get; }
 
-                public QueueItem(bool completeBeforeNext, CancellationToken cancellationToken) {
+                public QueueItem(bool isAwaitable, CancellationToken cancellationToken) {
                     _tcs = new TaskCompletionSource<IDisposable>();
                     IsAwaitable = isAwaitable;
                     _tcs.RegisterForCancellation(cancellationToken).UnregisterOnCompletion(_tcs.Task);
@@ -542,6 +541,7 @@ namespace Microsoft.Python.LanguageServer.Implementation {
                     _tcs.RegisterForCancellation(cancellationToken).UnregisterOnCompletion(_tcs.Task);
                 }
 
+                public Task Task => _tcs.Task;
                 public void Dispose() => _tcs.TrySetResult(0);
             }
 

--- a/Python/Product/VSCode/PythonVsc.sln
+++ b/Python/Product/VSCode/PythonVsc.sln
@@ -7,8 +7,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AnalysisNetStandard", "..\A
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AnalysisVsc", "AnalysisVsc\AnalysisVsc.csproj", "{7A809E90-ECE3-4EAE-8AC0-CFDDE8A1A1E3}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Publish", "Publish\Publish.csproj", "{9E1242D1-C6D8-43F5-A37E-8B5D13798B89}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -23,10 +21,6 @@ Global
 		{7A809E90-ECE3-4EAE-8AC0-CFDDE8A1A1E3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7A809E90-ECE3-4EAE-8AC0-CFDDE8A1A1E3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7A809E90-ECE3-4EAE-8AC0-CFDDE8A1A1E3}.Release|Any CPU.Build.0 = Release|Any CPU
-		{9E1242D1-C6D8-43F5-A37E-8B5D13798B89}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{9E1242D1-C6D8-43F5-A37E-8B5D13798B89}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{9E1242D1-C6D8-43F5-A37E-8B5D13798B89}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{9E1242D1-C6D8-43F5-A37E-8B5D13798B89}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Addresses https://github.com/Microsoft/vscode-python/issues/2224

Symbols nature is currently not always known until analysis completes. However, blindly waiting for analysis to complete does not make sense. So added cancellable wait - VSC does not cancel request for document symbols, but user command (as in Palette -> Go To Symbol) can be canceled.

VSC does not provide API to update document outline. It simple asks for symbols when document changes.