### PR TITLE
Test fixes

### DIFF
--- a/Common/Tests/Utilities.UI/UI/VisualStudioApp.cs
+++ b/Common/Tests/Utilities.UI/UI/VisualStudioApp.cs
@@ -388,6 +388,7 @@ namespace TestUtilities.UI {
         }
 
         public OutputWindowPane GetOutputWindow(string name) {
+            ((DTE2)Dte).ToolWindows.OutputWindow.Parent.Activate();
             return ((DTE2)Dte).ToolWindows.OutputWindow.OutputWindowPanes.Item(name);
         }
 
@@ -411,6 +412,7 @@ namespace TestUtilities.UI {
 
         public string GetOutputWindowText(string name) {
             var window = GetOutputWindow(name);
+            window.Activate();
             var doc = window.TextDocument;
             doc.Selection.SelectAll();
             return doc.Selection.Text;

--- a/Python/Tests/DebuggerTests/DebuggerTests.cs
+++ b/Python/Tests/DebuggerTests/DebuggerTests.cs
@@ -2202,7 +2202,10 @@ namespace DebuggerTests {
 
             var process = processRunInfo.Process;
 
+            var oldEncoding = Console.InputEncoding;
             try {
+                Console.InputEncoding = Encoding.ASCII;
+
                 await process.StartAsync();
 
                 AssertWaited(processRunInfo.ProcessLoaded);
@@ -2211,6 +2214,7 @@ namespace DebuggerTests {
                 Thread.Sleep(1000);
                 process.SendStringToStdInput("fob\n");
             } finally {
+                Console.InputEncoding = oldEncoding;
                 WaitForExit(process);
             }
 

--- a/Python/Tests/DebuggerUITests/DebugProjectUITests.cs
+++ b/Python/Tests/DebuggerUITests/DebugProjectUITests.cs
@@ -706,7 +706,7 @@ namespace DebuggerUITests {
                 var items = app.WaitForErrorListItems(7);
 
                 var debug3 = (Debugger3)app.Dte.Debugger;
-                ThreadPool.QueueUserWorkItem(x => debug3.Go(true));
+                debug3.Go(true);
 
                 var dialog = new PythonLaunchWithErrorsDialog(app.WaitForDialog());
                 dialog.No();

--- a/Python/Tests/ProjectUITests/SourceControl.cs
+++ b/Python/Tests/ProjectUITests/SourceControl.cs
@@ -163,6 +163,9 @@ namespace ProjectUITests {
                     Assert.IsNotNull(project.ProjectItems.Item(fileName));
                     AssertDocumentEvents(Path.GetDirectoryName(project.FullName),
                         OnQueryAddFiles(fileName),
+#if DEV16_OR_LATER      // We get queried twice now, it seems
+                        OnQueryAddFiles(fileName),
+#endif
                         OnAfterAddFilesEx(fileName)
                     );
                 }


### PR DESCRIPTION
Forces Output Window to activate before accessing contents.
Handle analyzer shutdown during file transfer.
Call debugger interop functions from UI thread.
Fix handling of double-query in source control test.
Fix console encoding around input() test.