### PR TITLE
15.9: Language service fails when using Python 2.7 interpreter

### DIFF
--- a/Python/Product/Analysis/Interpreter/Ast/AstPythonInterpreter.cs
+++ b/Python/Product/Analysis/Interpreter/Ast/AstPythonInterpreter.cs
@@ -204,6 +204,8 @@ namespace Microsoft.PythonTools.Interpreter.Ast {
                 return _builtinModule;
             }
 
+            Debug.Assert(_analyzer != null);
+
             var ctxt = new AstPythonInterpreterFactory.TryImportModuleContext {
                 Interpreter = this,
                 ModuleCache = _modules,

--- a/Python/Product/Analysis/PythonAnalyzer.cs
+++ b/Python/Product/Analysis/PythonAnalyzer.cs
@@ -178,10 +178,9 @@ namespace Microsoft.PythonTools.Analysis {
             try {
                 _interpreterFactory.NotifyImportNamesChanged();
                 _modules.ReInit();
+                _interpreter.Initialize(this);
 
                 await LoadKnownTypesAsync();
-
-                _interpreter.Initialize(this);
 
                 foreach (var mod in _modulesByFilename.Values) {
                     mod.Clear();


### PR DESCRIPTION
Fix https://github.com/Microsoft/PTVS/issues/4660 for 15.9 (already fixed in master)