### PR TITLE
Optimize file loading in VS Code

### DIFF
--- a/Python/Product/Analysis/LanguageServer/Server.cs
+++ b/Python/Product/Analysis/LanguageServer/Server.cs
@@ -172,6 +172,7 @@ namespace Microsoft.PythonTools.Analysis.LanguageServer {
                 if (@params.textDocument.text != null) {
                     doc.ResetDocument(@params.textDocument.version, @params.textDocument.text);
                 }
+                EnqueueItem(doc);
             } else if (entry == null) {
                 IAnalysisCookie cookie = null;
                 if (@params.textDocument.text != null) {
@@ -181,10 +182,6 @@ namespace Microsoft.PythonTools.Analysis.LanguageServer {
                     };
                 }
                 entry = await AddFileAsync(@params.textDocument.uri, null, cookie);
-            }
-
-            if ((doc = entry as IDocument) != null) {
-                EnqueueItem(doc);
             }
         }
 
@@ -575,7 +572,6 @@ namespace Microsoft.PythonTools.Analysis.LanguageServer {
                     entry.ResetCompleteAnalysis();
                 }
 
-                AnalysisQueued(doc.DocumentUri);
                 // The call must be fire and forget, but should not be yielding.
                 // It is called from DidChangeTextDocument which must fully finish
                 // since otherwise Complete() may come before the change is enqueued
@@ -608,7 +604,7 @@ namespace Microsoft.PythonTools.Analysis.LanguageServer {
                 }
 
                 if (doc is IAnalyzable analyzable && enqueueForAnalysis) {
-                    TraceMessage($"Enqueing document {doc.DocumentUri} for analysis");
+                    AnalysisQueued(doc.DocumentUri);
                     _queue.Enqueue(analyzable, priority);
                 }
 

--- a/Python/Product/VSCode/AnalysisVsc/LanguageServer.cs
+++ b/Python/Product/VSCode/AnalysisVsc/LanguageServer.cs
@@ -194,10 +194,10 @@ namespace Microsoft.Python.LanguageServer.Implementation {
 
                 await _server.DidChangeConfiguration(new DidChangeConfigurationParams { settings = settings }, cancellationToken);
 
-                if (!_filesLoaded) {
+                if (!_filesLoaded && !settings.analysis.openFilesOnly) {
                     await LoadDirectoryFiles();
-                    _filesLoaded = true;
                 }
+                _filesLoaded = true;
             }
         }
 


### PR DESCRIPTION
- Eliminate double analysis enqueue on file open (`AddFileAsync` already does it)
- Do not load the entire directory if user is interested in 'open files only'