### PR TITLE
Fixes #4679 Analyzer stuck in psutil

### DIFF
--- a/Python/Product/Analysis/AnalysisUnit.cs
+++ b/Python/Product/Analysis/AnalysisUnit.cs
@@ -174,7 +174,7 @@ namespace Microsoft.PythonTools.Analysis {
 
             foreach (var variableInfo in DeclaringModule.Scope.AllVariables) {
                 variableInfo.Value.ClearOldValues(ProjectEntry);
-                if (!variableInfo.Value.HasTypes && !variableInfo.Value.IsAssigned) {
+                if (!variableInfo.Value.HasTypes && !variableInfo.Value.IsAssigned && !variableInfo.Value.IsEphemeral) {
                     toRemove = toRemove ?? new List<KeyValuePair<string, VariableDef>>();
                     toRemove.Add(variableInfo);
                 }

--- a/Python/Product/Analysis/Values/ModuleInfo.cs
+++ b/Python/Product/Analysis/Values/ModuleInfo.cs
@@ -346,7 +346,7 @@ namespace Microsoft.PythonTools.Analysis.Values {
         #endregion
 
         public IAnalysisSet GetModuleMember(Node node, AnalysisUnit unit, string name, bool addRef = true, InterpreterScope linkedScope = null, string linkedName = null) {
-            var importedValue = Scope.CreateVariable(node, unit, name, addRef);
+            var importedValue = Scope.CreateEphemeralVariable(node, unit, name, addRef);
             ModuleDefinition.AddDependency(unit);
 
             if (linkedScope != null) {


### PR DESCRIPTION
Fixes #4679 Analyzer stuck in psutil
Uses ephemeral variables for imported module members, and only clears out non-ephemeral variables.