### PR TITLE
Re-enable all file loading

### DIFF
--- a/Python/Product/VSCode/AnalysisVsc/LanguageServer.cs
+++ b/Python/Product/VSCode/AnalysisVsc/LanguageServer.cs
@@ -195,7 +195,7 @@ namespace Microsoft.Python.LanguageServer.Implementation {
 
                 await _server.DidChangeConfiguration(new DidChangeConfigurationParams { settings = settings }, cancellationToken);
 
-                if (!_filesLoaded && !settings.analysis.openFilesOnly) {
+                if (!_filesLoaded) {
                     await LoadDirectoryFiles();
                 }
                 _filesLoaded = true;


### PR DESCRIPTION
Optimization does not work in all cases, such as when A.py import B.py we don't actually load B.py. A different approach is needed. 