### PR TITLE
Propagate return types of derived methods to their bases

### DIFF
--- a/Python/Product/Analysis/Analyzer/DDG.cs
+++ b/Python/Product/Analysis/Analyzer/DDG.cs
@@ -463,13 +463,13 @@ namespace Microsoft.PythonTools.Analysis.Analyzer {
             return false;
         }
 
-        internal List<AnalysisValue> LookupBaseMethods(string name, IEnumerable<IAnalysisSet> bases, Node node, AnalysisUnit unit) {
+        internal List<AnalysisValue> LookupBaseMethods(string name, IEnumerable<IAnalysisSet> mro, Node node, AnalysisUnit unit) {
             var result = new List<AnalysisValue>();
-            foreach (var b in bases) {
-                foreach (var curType in b) {
-                    var klass = curType as BuiltinClassInfo;
-                    if (klass != null) {
-                        var value = klass.GetMember(node, unit, name);
+            foreach (var @class in mro.Skip(1)) {
+                foreach (var curType in @class) {
+                    bool isClass = curType is ClassInfo || curType is BuiltinClassInfo;
+                    if (isClass) {
+                        var value = curType.GetMember(node, unit, name);
                         if (value != null) {
                             result.AddRange(value);
                         }
@@ -581,9 +581,30 @@ namespace Microsoft.PythonTools.Analysis.Analyzer {
 
         public override bool Walk(ReturnStatement node) {
             var fnScope = CurrentFunction;
-            if (node.Expression != null && fnScope != null) {
+            if (fnScope == null)
+                return true;
+
+            if (node.Expression != null) {
                 var lookupRes = _eval.Evaluate(node.Expression);
                 fnScope.AddReturnTypes(node, _unit, lookupRes);
+
+                var function = fnScope.Function;
+                var analysisUnit = (FunctionAnalysisUnit)function.AnalysisUnit;
+
+                if (Scope.OuterScope is ClassScope curClass)
+                {
+                    var bases = LookupBaseMethods(
+                        analysisUnit.Ast.Name,
+                        curClass.Class.Mro,
+                        analysisUnit.Ast,
+                        analysisUnit
+                    );
+                    foreach (FunctionInfo baseFunction in bases.OfType<FunctionInfo>())
+                    {
+                        var baseAnalysisUnit = (FunctionAnalysisUnit)baseFunction.AnalysisUnit;
+                        baseAnalysisUnit.ReturnValue.AddTypes(_unit, lookupRes);
+                    }
+                }
             }
             return true;
         }

--- a/Python/Tests/Analysis/AnalysisTests.csproj
+++ b/Python/Tests/Analysis/AnalysisTests.csproj
@@ -60,6 +60,7 @@
     <Compile Include="EventTaskSources.cs" />
     <Compile Include="ExpressionFinderTests.cs" />
     <Compile Include="FunctionBodyAnalysisTests.cs" />
+    <Compile Include="InheritanceTests.cs" />
     <Compile Include="LanguageServerTests.cs" />
     <Compile Include="LongestCommonSequenceTests.cs" />
     <Compile Include="ModulePathTests.cs" />

--- a/Python/Tests/Analysis/InheritanceTests.cs
+++ b/Python/Tests/Analysis/InheritanceTests.cs
@@ -1,0 +1,65 @@
+﻿// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABLITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System.IO;
+using System.Linq;
+using Microsoft.PythonTools;
+using Microsoft.PythonTools.Analysis;
+using Microsoft.PythonTools.Interpreter;
+using Microsoft.PythonTools.Interpreter.Ast;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using TestUtilities;
+
+namespace AnalysisTests {
+    [TestClass]
+    public class InheritanceTests : BaseAnalysisTest {
+        [TestInitialize]
+        public void TestInitialize() => TestEnvironmentImpl.TestInitialize();
+
+        [TestCleanup]
+        public void TestCleanup() => TestEnvironmentImpl.TestCleanup();
+
+        [TestMethod]
+        public void AbstractMethodReturnTypeIgnored() {
+            var python = (PythonPaths.Python36_x64 ?? PythonPaths.Python36);
+            python.AssertInstalled();
+            var analyzer = CreateAnalyzer(
+                new AstPythonInterpreterFactory(python.Configuration, new InterpreterFactoryCreationOptions { WatchFileSystem = false })
+            );
+            analyzer.AddModule("test-module", @"
+import abc
+
+class A:
+    @abc.abstractmethod
+    def virt():
+        pass
+
+class B(A):
+    def virt():
+        return 42
+
+a = A()
+b = a.virt()
+");
+
+            // this example is artificial, as generally one should not be able to call A.virt
+            // but it is the easiest way to reproduce
+            analyzer.WaitForAnalysis();
+
+            analyzer.AssertIsInstance("b", BuiltinTypeId.Int);
+        }
+    }
+}


### PR DESCRIPTION
This change fixes #4715 

Rationale:
If `class A(B)`, and both have method `foo`, then any variable `v` of type `B` can potentially hold value of type `A`. Which means, that `v.foo()` can return a value of type that of return value of `A.foo` or `B.foo`.

To achieve that, when function return type is determined by `DDG`, it is also added as a potential return type for all of the function's bases (e.g. functions, that this function overrides).

In addition to that, this change also improves `DDG.LookupBaseMethods`, which previously only took into account built-in classes.