### PR TITLE
Some accessibility fixes for environments window, language server options

### DIFF
--- a/Common/Product/SharedProject/Wpf/Controls.cs
+++ b/Common/Product/SharedProject/Wpf/Controls.cs
@@ -38,6 +38,9 @@ namespace Microsoft.VisualStudioTools.Wpf {
         public static readonly object HotTrackKey = VsBrushes.CommandBarHoverKey;
         public static readonly object HotTrackTextKey = VsBrushes.CommandBarTextHoverKey;
 
+        public static readonly object ListBoxItemSelectedKey = TreeViewColors.SelectedItemActiveBrushKey;
+        public static readonly object ListBoxItemSelectedTextKey = TreeViewColors.SelectedItemActiveTextBrushKey;
+
         public static readonly object TooltipBackgroundKey = new ThemeResourceKey(EnvCategory, "ToolTip", ThemeResourceKeyType.BackgroundBrush);
         public static readonly object TooltipBackgroundColorKey = new ThemeResourceKey(EnvCategory, "ToolTip", ThemeResourceKeyType.BackgroundColor);
         public static readonly object TooltipTextKey = new ThemeResourceKey(EnvCategory, "ToolTip", ThemeResourceKeyType.ForegroundBrush);

--- a/Common/Product/SharedProject/Wpf/Controls.xaml
+++ b/Common/Product/SharedProject/Wpf/Controls.xaml
@@ -714,8 +714,8 @@
                             <Setter Property="Foreground" Value="{DynamicResource {x:Static wpf:Controls.HotTrackTextKey}}" />
                         </Trigger>
                         <Trigger Property="IsSelected" Value="True">
-                            <Setter Property="Background" Value="{DynamicResource {x:Static wpf:Controls.HighlightKey}}" />
-                            <Setter Property="Foreground" Value="{DynamicResource {x:Static wpf:Controls.HighlightTextKey}}" />
+                            <Setter Property="Background" Value="{DynamicResource {x:Static wpf:Controls.ListBoxItemSelectedKey}}" />
+                            <Setter Property="Foreground" Value="{DynamicResource {x:Static wpf:Controls.ListBoxItemSelectedTextKey}}" />
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>

--- a/Python/Product/Cookiecutter/Shared/Wpf/Controls.cs
+++ b/Python/Product/Cookiecutter/Shared/Wpf/Controls.cs
@@ -38,6 +38,9 @@ namespace Microsoft.VisualStudioTools.Wpf {
         public static readonly object HotTrackKey = VsBrushes.CommandBarHoverKey;
         public static readonly object HotTrackTextKey = VsBrushes.CommandBarTextHoverKey;
 
+        public static readonly object ListBoxItemSelectedKey = TreeViewColors.SelectedItemActiveBrushKey;
+        public static readonly object ListBoxItemSelectedTextKey = TreeViewColors.SelectedItemActiveTextBrushKey;
+
         public static readonly object TooltipBackgroundKey = new ThemeResourceKey(EnvCategory, "ToolTip", ThemeResourceKeyType.BackgroundBrush);
         public static readonly object TooltipBackgroundColorKey = new ThemeResourceKey(EnvCategory, "ToolTip", ThemeResourceKeyType.BackgroundColor);
         public static readonly object TooltipTextKey = new ThemeResourceKey(EnvCategory, "ToolTip", ThemeResourceKeyType.ForegroundBrush);

--- a/Python/Product/Cookiecutter/Shared/Wpf/Controls.xaml
+++ b/Python/Product/Cookiecutter/Shared/Wpf/Controls.xaml
@@ -714,8 +714,8 @@
                             <Setter Property="Foreground" Value="{DynamicResource {x:Static wpf:Controls.HotTrackTextKey}}" />
                         </Trigger>
                         <Trigger Property="IsSelected" Value="True">
-                            <Setter Property="Background" Value="{DynamicResource {x:Static wpf:Controls.HighlightKey}}" />
-                            <Setter Property="Foreground" Value="{DynamicResource {x:Static wpf:Controls.HighlightTextKey}}" />
+                            <Setter Property="Background" Value="{DynamicResource {x:Static wpf:Controls.ListBoxItemSelectedKey}}" />
+                            <Setter Property="Foreground" Value="{DynamicResource {x:Static wpf:Controls.ListBoxItemSelectedTextKey}}" />
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>

--- a/Python/Product/EnvironmentsList/ToolWindow.xaml
+++ b/Python/Product/EnvironmentsList/ToolWindow.xaml
@@ -190,12 +190,6 @@
                             Focusable="False"
                             ContentTemplate="{StaticResource EnvironmentHeader}" />
 
-            <CheckBox x:Name="HelpVisibility_Horizontal"
-                      Grid.Row="0" Grid.Column="3"
-                      HorizontalAlignment="Center" VerticalAlignment="Top"
-                      Style="{StaticResource HelpCheckBox}"
-                      AutomationProperties.Name="{x:Static l:Resources.ToolWindow_HelpVisibilityName}"/>
-
             <!-- These content controls are not laid out correctly when their
                  ColumnSpan property is set, but they seem to work okay when put
                  in their own grid. -->
@@ -205,13 +199,6 @@
                     <RowDefinition Height="auto" />
                     <RowDefinition Height="*" />
                 </Grid.RowDefinitions>
-
-                <ContentControl Grid.Row="0"
-                                Style="{StaticResource HelpContentStyle}"
-                                Content="{Binding Extensions.CurrentItem.HelpContent}"
-                                AutomationProperties.Name="{x:Static l:Resources.ToolWindow_HelpContentName}"
-                                AutomationProperties.HelpText="{Binding Extensions.CurrentItem.HelpText,Mode=OneWay}"
-                                IsEnabled="{Binding IsChecked,ElementName=HelpVisibility_Horizontal}"/>
 
                 <ContentControl x:Name="ContentView_Horizontal"
                                 Grid.Row="1"
@@ -263,25 +250,12 @@
                       AutomationProperties.Name="{x:Static l:Resources.ToolWindow_ExtensionsName}"
                       ItemContainerStyle="{StaticResource Combo_WithLocalizedName}" />
 
-            <CheckBox x:Name="HelpVisibility_Vertical"
-                      Grid.Row="1" Grid.Column="1"
-                      HorizontalAlignment="Center" VerticalAlignment="Center"
-                      Style="{StaticResource HelpCheckBox}"
-                      AutomationProperties.Name="{x:Static l:Resources.ToolWindow_HelpVisibilityName}"/>
-
             <Grid x:Name="ContentGrid_Vertical"
                   Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2">
                 <Grid.RowDefinitions>
                     <RowDefinition Height="auto" />
                     <RowDefinition Height="*" />
                 </Grid.RowDefinitions>
-
-                <ContentControl Grid.Row="0"
-                                Style="{StaticResource HelpContentStyle}"
-                                Content="{Binding Extensions.CurrentItem.HelpContent}"
-                                IsEnabled="{Binding IsChecked,ElementName=HelpVisibility_Vertical}"
-                                AutomationProperties.Name="{x:Static l:Resources.ToolWindow_HelpContentName}"
-                                AutomationProperties.HelpText="{Binding Extensions.CurrentItem.HelpText}"/>
 
                 <ContentControl x:Name="ContentView_Vertical"
                                 Grid.Row="1"

--- a/Python/Product/EnvironmentsList/ToolWindow.xaml
+++ b/Python/Product/EnvironmentsList/ToolWindow.xaml
@@ -190,23 +190,12 @@
                             Focusable="False"
                             ContentTemplate="{StaticResource EnvironmentHeader}" />
 
-            <!-- These content controls are not laid out correctly when their
-                 ColumnSpan property is set, but they seem to work okay when put
-                 in their own grid. -->
-            <Grid x:Name="ContentGrid_Horizontal"
-                  Grid.Row="1" Grid.Column="2" Grid.RowSpan="2" Grid.ColumnSpan="2">
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="auto" />
-                    <RowDefinition Height="*" />
-                </Grid.RowDefinitions>
-
-                <ContentControl x:Name="ContentView_Horizontal"
-                                Grid.Row="1"
-                                HorizontalAlignment="Stretch"
-                                VerticalAlignment="Stretch"
-                                Focusable="False"
-                                DataContext="{Binding Environments.CurrentItem}" />
-            </Grid>
+            <ContentControl x:Name="ContentView_Horizontal"
+                            Grid.Row="1" Grid.Column="2" Grid.RowSpan="2" Grid.ColumnSpan="2"
+                            HorizontalAlignment="Stretch"
+                            VerticalAlignment="Stretch"
+                            Focusable="False"
+                            DataContext="{Binding Environments.CurrentItem}" />
         </Grid>
 
         <Grid x:Name="VerticalLayout" Visibility="Collapsed">
@@ -250,20 +239,12 @@
                       AutomationProperties.Name="{x:Static l:Resources.ToolWindow_ExtensionsName}"
                       ItemContainerStyle="{StaticResource Combo_WithLocalizedName}" />
 
-            <Grid x:Name="ContentGrid_Vertical"
-                  Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2">
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="auto" />
-                    <RowDefinition Height="*" />
-                </Grid.RowDefinitions>
-
-                <ContentControl x:Name="ContentView_Vertical"
-                                Grid.Row="1"
-                                HorizontalAlignment="Stretch"
-                                VerticalAlignment="Stretch"
-                                Focusable="False"
-                                DataContext="{Binding Environments.CurrentItem}"/>
-            </Grid>
+            <ContentControl x:Name="ContentView_Vertical"
+                            Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2"
+                            HorizontalAlignment="Stretch"
+                            VerticalAlignment="Stretch"
+                            Focusable="False"
+                            DataContext="{Binding Environments.CurrentItem}"/>
         </Grid>
     </Grid>
 </UserControl>

--- a/Python/Product/PythonTools/PythonTools/Options/LanguageServerOptionsControl.resx
+++ b/Python/Product/PythonTools/PythonTools/Options/LanguageServerOptionsControl.resx
@@ -151,7 +151,7 @@
     <value>tableLayoutPanel2</value>
   </data>
   <data name="&gt;&gt;typeShedPathLabel.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>1</value>
   </data>
   <metadata name="groupBox1.GenerateMember" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>False</value>
@@ -198,6 +198,33 @@
   <data name="&gt;&gt;suppressTypeShedCheckbox.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
+  <data name="typeShedPathTextBox.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Left, Right</value>
+  </data>
+  <data name="typeShedPathTextBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>128, 27</value>
+  </data>
+  <data name="typeShedPathTextBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>316, 20</value>
+  </data>
+  <data name="typeShedPathTextBox.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;typeShedPathTextBox.Name" xml:space="preserve">
+    <value>typeShedPathTextBox</value>
+  </data>
+  <data name="&gt;&gt;typeShedPathTextBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;typeShedPathTextBox.Parent" xml:space="preserve">
+    <value>tableLayoutPanel2</value>
+  </data>
+  <data name="&gt;&gt;typeShedPathTextBox.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="browseTypeShedPathButton.AccessibleName" xml:space="preserve">
+    <value>Browse Folder</value>
+  </data>
   <data name="browseTypeShedPathButton.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Left, Right</value>
   </data>
@@ -229,31 +256,7 @@
     <value>tableLayoutPanel2</value>
   </data>
   <data name="&gt;&gt;browseTypeShedPathButton.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="typeShedPathTextBox.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Left, Right</value>
-  </data>
-  <data name="typeShedPathTextBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>128, 27</value>
-  </data>
-  <data name="typeShedPathTextBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>316, 20</value>
-  </data>
-  <data name="typeShedPathTextBox.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;typeShedPathTextBox.Name" xml:space="preserve">
-    <value>typeShedPathTextBox</value>
-  </data>
-  <data name="&gt;&gt;typeShedPathTextBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;typeShedPathTextBox.Parent" xml:space="preserve">
-    <value>tableLayoutPanel2</value>
-  </data>
-  <data name="&gt;&gt;typeShedPathTextBox.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>3</value>
   </data>
   <data name="tableLayoutPanel2.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
@@ -283,7 +286,7 @@
     <value>0</value>
   </data>
   <data name="tableLayoutPanel2.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="suppressTypeShedCheckbox" Row="0" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="browseTypeShedPathButton" Row="1" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="typeShedPathTextBox" Row="1" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="typeShedPathLabel" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,50,Percent,100,AutoSize,20" /&gt;&lt;Rows Styles="AutoSize,50,AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="suppressTypeShedCheckbox" Row="0" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="typeShedPathLabel" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="typeShedPathTextBox" Row="1" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="browseTypeShedPathButton" Row="1" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,50,Percent,100,AutoSize,20" /&gt;&lt;Rows Styles="AutoSize,50,AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <data name="groupBox1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>


### PR DESCRIPTION
Fix narrator for language server option browse button (I checked the tab order, it is correct)
Fix contrast for environments window listbox selected items (it was a slightly different blue than seen in the rest of VS - toolbox, error list, etc)
Remove the help button from environments view