### PR TITLE
Fix NuiImageGetColorPixelCoordinatesFromDepthPixel 

### DIFF
--- a/Python/Product/PyKinect/PyKinect/pykinect/nui/_interop.py
+++ b/Python/Product/PyKinect/PyKinect/pykinect/nui/_interop.py
@@ -191,7 +191,7 @@ class _NuiInstance(ctypes.c_voidp):
 
     def NuiImageGetColorPixelCoordinatesFromDepthPixel(self, eColorResolution, pcViewArea, lDepthX, lDepthY, usDepthValue):
         x, y = ctypes.c_long(), ctypes.c_long()
-        _NuiInstance._NuiImageGetColorPixelCoordinatesFromDepthPixel(self, eColorResolution, pcViewArea, lDepthX, lDepthY, usDepthValue, byref(x), byref(y))
+        _NuiInstance._NuiImageGetColorPixelCoordinatesFromDepthPixel(self, eColorResolution, pcViewArea, lDepthX, lDepthY, usDepthValue, ctypes.byref(x), ctypes.byref(y))
         return x.value, y.value
 
     def NuiCameraElevationSetAngle(self, lAngleDegrees):


### PR DESCRIPTION
Wrong use of byref(x), byref(y). Must be ctypes.byref(x), ctypes.byref(y)