### PR TITLE
Backport fix for NullReferenceException in GetModuleFullName.

### DIFF
--- a/Python/Product/Analysis/ModuleResolver.cs
+++ b/Python/Product/Analysis/ModuleResolver.cs
@@ -93,7 +93,7 @@ namespace Microsoft.PythonTools.Analysis {
             string relativeModuleName,
             bool absoluteImports
         ) {
-            string importingFrom = null;
+            string importingFrom = string.Empty;
             if (!string.IsNullOrEmpty(importingFromModuleName)) {
                 importingFrom = importingFromModuleName;
                 if (!string.IsNullOrEmpty(importingFromFilePath) && ModulePath.IsInitPyFile(importingFromFilePath)) {
@@ -149,7 +149,7 @@ namespace Microsoft.PythonTools.Analysis {
 
         private static string GetModuleFullName(string originatingModule, string relativePath) {
             // Check if it is indeed relative
-            if (string.IsNullOrEmpty(relativePath) || relativePath[0] != '.') {
+            if (string.IsNullOrEmpty(originatingModule) || string.IsNullOrEmpty(relativePath) || relativePath[0] != '.') {
                 return relativePath;
             }
 


### PR DESCRIPTION
Original fix: https://github.com/Microsoft/python-language-server/pull/88/files
Original bug: https://github.com/Microsoft/python-language-server/issues/72

Reported on 15.8 at https://developercommunity.visualstudio.com/content/problem/346930/vs-158-intellisense-for-python-37-not-working.html