### PR TITLE
Mark the miniconda distro folder as vendored.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -13,4 +13,4 @@
 *.bat eol=crlf
 
 # Language detection
-PTVS/Python/Product/Miniconda/Miniconda3-x64/ linguist-vendored
+Python/Product/Miniconda/Miniconda3-x64/* linguist-vendored

--- a/.gitattributes
+++ b/.gitattributes
@@ -11,3 +11,6 @@
 
 # Some Windows-specific files should always be CRLF
 *.bat eol=crlf
+
+# Language detection
+PTVS/Python/Product/Miniconda/Miniconda3-x64/ linguist-vendored


### PR DESCRIPTION
Fix #4900 

https://github.com/github/linguist#overrides

Didn't bother doing that with typeshed folder, since Analysis project will be removed soon.