### PR TITLE
Issue 4879: Workspace interpreters not updated after rename or delete

### DIFF
--- a/Python/Product/Common/Infrastructure/PathUtils.cs
+++ b/Python/Product/Common/Infrastructure/PathUtils.cs
@@ -821,5 +821,35 @@ namespace Microsoft.PythonTools.Infrastructure {
             }
             return string.Compare(filePath, i + 1, ext, (ext[0] == '.' ? 1 : 0), int.MaxValue, StringComparison.OrdinalIgnoreCase) == 0;
         }
+
+        /// <summary>
+        /// Returns the depth (# of subfolders) between two paths
+        /// 
+        /// If both paths are in same directory, returns 0
+        /// 
+        /// If secondPath is subfolder of firstPath, returns a
+        ///     positive number which represents number of 
+        ///     subfolder iterations from firstPath to secondPath
+        ///     
+        /// If firstPath is subfolder of secondPath, returns a
+        ///     negative number which represents number of 
+        ///     parent iterations from firstPath to secondPath
+        ///     
+        /// </summary>
+        public static int DepthDifferenceBetweenPath(string firstPath, string secondPath) {
+            if (IsSamePath(firstPath, secondPath) || ShareSameDirectory(firstPath, secondPath)) {
+                return 0;
+            } else if(IsSubpathOf(firstPath, secondPath) || IsSubpathOf(secondPath, firstPath)) {
+                return (secondPath.Split(DirectorySeparators).Length - firstPath.Split(DirectorySeparators).Length);
+            }
+
+            return 0;
+        }
+        
+        //Returns true if both paths are in the same parent directory
+        public static bool ShareSameDirectory(string firstPath, string secondPath) {
+            return IsSameDirectory(Directory.GetParent(firstPath).FullName, Directory.GetParent(secondPath).FullName);
+        }
+
     }
 }

--- a/Python/Product/Common/Infrastructure/PathUtils.cs
+++ b/Python/Product/Common/Infrastructure/PathUtils.cs
@@ -822,34 +822,5 @@ namespace Microsoft.PythonTools.Infrastructure {
             return string.Compare(filePath, i + 1, ext, (ext[0] == '.' ? 1 : 0), int.MaxValue, StringComparison.OrdinalIgnoreCase) == 0;
         }
 
-        /// <summary>
-        /// Returns the depth (# of subfolders) between two paths
-        /// 
-        /// If both paths are in same directory, returns 0
-        /// 
-        /// If secondPath is subfolder of firstPath, returns a
-        ///     positive number which represents number of 
-        ///     subfolder iterations from firstPath to secondPath
-        ///     
-        /// If firstPath is subfolder of secondPath, returns a
-        ///     negative number which represents number of 
-        ///     parent iterations from firstPath to secondPath
-        ///     
-        /// </summary>
-        public static int DepthDifferenceBetweenPaths(string firstPath, string secondPath) {
-            if (IsSamePath(firstPath, secondPath) || ShareSameDirectory(firstPath, secondPath)) {
-                return 0;
-            } else if(IsSubpathOf(firstPath, secondPath) || IsSubpathOf(secondPath, firstPath)) {
-                return (secondPath.Split(DirectorySeparators).Length - firstPath.Split(DirectorySeparators).Length);
-            }
-
-            return 0;
-        }
-        
-        //Returns true if both paths are in the same parent directory
-        public static bool ShareSameDirectory(string firstPath, string secondPath) {
-            return IsSameDirectory(Directory.GetParent(firstPath).FullName, Directory.GetParent(secondPath).FullName);
-        }
-
     }
 }

--- a/Python/Product/Common/Infrastructure/PathUtils.cs
+++ b/Python/Product/Common/Infrastructure/PathUtils.cs
@@ -836,7 +836,7 @@ namespace Microsoft.PythonTools.Infrastructure {
         ///     parent iterations from firstPath to secondPath
         ///     
         /// </summary>
-        public static int DepthDifferenceBetweenPath(string firstPath, string secondPath) {
+        public static int DepthDifferenceBetweenPaths(string firstPath, string secondPath) {
             if (IsSamePath(firstPath, secondPath) || ShareSameDirectory(firstPath, secondPath)) {
                 return 0;
             } else if(IsSubpathOf(firstPath, secondPath) || IsSubpathOf(secondPath, firstPath)) {

--- a/Python/Product/VSInterpreters/Interpreter/WorkspaceInterpreterFactoryProvider.cs
+++ b/Python/Product/VSInterpreters/Interpreter/WorkspaceInterpreterFactoryProvider.cs
@@ -218,7 +218,6 @@ namespace Microsoft.PythonTools.Interpreter {
 
         private static IEnumerable<PythonInterpreterInformation> FindInterpretersInSubFolders(string workspaceFolder) {
             foreach (var dir in PathUtils.EnumerateDirectories(workspaceFolder, recurse: false)) {
-                //-1 because it's already searching in each subdirectory of root
                 var file = PathUtils.FindFile(dir, "python.exe", depthLimit: 1);
                 if (!string.IsNullOrEmpty(file)) {
                     yield return CreateEnvironmentInfo(file);
@@ -242,10 +241,7 @@ namespace Microsoft.PythonTools.Interpreter {
                                 _refreshPythonInterpreters = true;
                                 _folderWatcherTimer?.Change(1000, Timeout.Infinite);
                             }
-                        }
-
-                        //Created or deleted
-                        if ((e.ChangeType == WatcherChangeTypes.Created || e.ChangeType == WatcherChangeTypes.Deleted)
+                        } else if ((e.ChangeType == WatcherChangeTypes.Created || e.ChangeType == WatcherChangeTypes.Deleted)
                             && DetectPythonEnvironment(e)
                         ) {
                             _refreshPythonInterpreters = true;
@@ -263,7 +259,7 @@ namespace Microsoft.PythonTools.Interpreter {
             }
 
             int pythonExecutableDepth = fileChangeEventArgs.Name.Split(Path.DirectorySeparatorChar).Length;
-            return (pythonExecutableDepth != 0 && (pythonExecutableDepth <= 3));
+            return pythonExecutableDepth != 0 && pythonExecutableDepth <= 3;
         }
 
         private void OnFileChangesTimerElapsed(object state) {

--- a/Python/Product/VSInterpreters/Interpreter/WorkspaceInterpreterFactoryProvider.cs
+++ b/Python/Product/VSInterpreters/Interpreter/WorkspaceInterpreterFactoryProvider.cs
@@ -229,7 +229,18 @@ namespace Microsoft.PythonTools.Interpreter {
             lock (_factories) {
                 try {
                     if (Directory.Exists(e.FullPath) && e.ChangeType == WatcherChangeTypes.Renamed) {
-                        _refreshPythonInterpreters = true;
+                        RenamedEventArgs renamedFileInformation = e as RenamedEventArgs;
+                        if (renamedFileInformation != null) {
+                            string interpreterFactoryKey = _factories
+                                .Where(a => PathUtils.IsSameDirectory(a.Value.Configuration.PrefixPath, renamedFileInformation.OldFullPath))
+                                .Select(a => a.Key)
+                                .FirstOrDefault();
+
+                            if (!string.IsNullOrEmpty(interpreterFactoryKey)) {
+                                _refreshPythonInterpreters = true;
+                            }
+                        }
+
                     } else if (string.Compare(Path.GetFileName(e.FullPath), "python.exe", StringComparison.OrdinalIgnoreCase) == 0) {
                         if (e.ChangeType == WatcherChangeTypes.Created || e.ChangeType == WatcherChangeTypes.Deleted) {
                             _refreshPythonInterpreters = true;

--- a/Python/Product/VSInterpreters/Interpreter/WorkspaceInterpreterFactoryProvider.cs
+++ b/Python/Product/VSInterpreters/Interpreter/WorkspaceInterpreterFactoryProvider.cs
@@ -36,7 +36,6 @@ namespace Microsoft.PythonTools.Interpreter {
     [Export(typeof(WorkspaceInterpreterFactoryProvider))]
     [PartCreationPolicy(CreationPolicy.Shared)]
     class WorkspaceInterpreterFactoryProvider : IPythonInterpreterFactoryProvider, IDisposable {
-        private const int PythonExecutableEnvDetectionDepthLimit = 3;
         private readonly IVsFolderWorkspaceService _workspaceService;
         private IWorkspace _workspace;
         private IWorkspaceSettingsManager _workspaceSettingsMgr;
@@ -220,7 +219,7 @@ namespace Microsoft.PythonTools.Interpreter {
         private static IEnumerable<PythonInterpreterInformation> FindInterpretersInSubFolders(string workspaceFolder) {
             foreach (var dir in PathUtils.EnumerateDirectories(workspaceFolder, recurse: false)) {
                 //-1 because it's already searching in each subdirectory of root
-                var file = PathUtils.FindFile(dir, "python.exe", PythonExecutableEnvDetectionDepthLimit - 1);
+                var file = PathUtils.FindFile(dir, "python.exe", depthLimit: 1);
                 if (!string.IsNullOrEmpty(file)) {
                     yield return CreateEnvironmentInfo(file);
                 }
@@ -263,8 +262,8 @@ namespace Microsoft.PythonTools.Interpreter {
                 return false;
             }
 
-            int pythonExecutableDepth = PathUtils.DepthDifferenceBetweenPaths(_workspace.Location, fileChangeEventArgs.FullPath);
-            return (pythonExecutableDepth != 0 && (pythonExecutableDepth <= PythonExecutableEnvDetectionDepthLimit));
+            int pythonExecutableDepth = fileChangeEventArgs.Name.Split(Path.DirectorySeparatorChar).Length;
+            return (pythonExecutableDepth != 0 && (pythonExecutableDepth <= 3));
         }
 
         private void OnFileChangesTimerElapsed(object state) {

--- a/Python/Product/VSInterpreters/Interpreter/WorkspaceInterpreterFactoryProvider.cs
+++ b/Python/Product/VSInterpreters/Interpreter/WorkspaceInterpreterFactoryProvider.cs
@@ -217,18 +217,12 @@ namespace Microsoft.PythonTools.Interpreter {
         }
 
         private static IEnumerable<PythonInterpreterInformation> FindInterpretersInSubFolders(string workspaceFolder) {
-            foreach (var directory in PathUtils.EnumerateDirectories(workspaceFolder, recurse: false)) {
-                yield return FindInterpreterInFolder(directory);
+            foreach (var dir in PathUtils.EnumerateDirectories(workspaceFolder, recurse: false)) {
+                var file = PathUtils.FindFile(dir, "python.exe", depthLimit: 1);
+                if (!string.IsNullOrEmpty(file)) {
+                    yield return CreateEnvironmentInfo(file);
+                }
             }
-        }
-
-        private static PythonInterpreterInformation FindInterpreterInFolder(string folder) {
-            var file = PathUtils.FindFile(folder, "python.exe", 1);
-            if (!string.IsNullOrEmpty(file)) {
-                return CreateEnvironmentInfo(file);
-            }
-
-            return null;
         }
 
         private void OnFileCreatedDeletedRenamed(object sender, FileSystemEventArgs e) {

--- a/Python/Tests/Core/WorkspaceInterpreterFactoryTests.cs
+++ b/Python/Tests/Core/WorkspaceInterpreterFactoryTests.cs
@@ -99,16 +99,10 @@ namespace PythonToolsTests {
             var workspaceService = new MockWorkspaceService(workspace);
 
             // Create virtual env inside the workspace folder (one level from root)
-            Action triggerDiscovery = () => {
-                using (var p = ProcessOutput.RunHiddenAndCapture(python.InterpreterPath, "-m", "venv", envFolder)) {
-                    Console.WriteLine(p.Arguments);
-                    p.Wait();
-                    Console.WriteLine(string.Join(Environment.NewLine, p.StandardOutputLines.Concat(p.StandardErrorLines)));
-                    Assert.AreEqual(0, p.ExitCode);
-                }
-            };
-
-            var configs = TestTriggerDiscovery(workspaceService, triggerDiscovery).ToArray();
+            var configs = TestTriggerDiscovery(
+                workspaceService,
+                () => CreatePythonVirtualEnv(python.InterpreterPath, workspaceFolder, "env")
+            ).ToArray();
 
             Assert.AreEqual(1, configs.Length);
             Assert.IsTrue(PathUtils.IsSamePath(
@@ -162,25 +156,22 @@ namespace PythonToolsTests {
         [TestMethod, Priority(0)]
         public void WatchWorkspaceVirtualEnvRenamed() {
             const string ENV_NAME = "env";
-            var workspaceService = CreateEnvAndGetService(ENV_NAME);
+            var workspaceService = CreateEnvAndGetWorkspaceService(ENV_NAME);
 
             string envPath = Path.Combine(workspaceService.CurrentWorkspace.Location, ENV_NAME);
+            string renamedEnvPath = Path.Combine(workspaceService.CurrentWorkspace.Location, string.Concat(ENV_NAME, "1"));
             var configs = TestTriggerDiscovery
-                (workspaceService, () => Directory.Move(envPath, string.Concat(envPath, "1"))).ToArray();
+                (workspaceService, () => Directory.Move(envPath, renamedEnvPath)).ToArray();
 
             Assert.AreEqual(1, configs.Length);
-            Assert.IsTrue(PathUtils.IsSamePath(
-                Path.Combine(string.Concat(envPath, "1"), "scripts", "python.exe"),
-                configs[0].InterpreterPath));
+            Assert.IsTrue(PathUtils.IsSamePath(Path.Combine(renamedEnvPath, "scripts", "python.exe"),configs[0].InterpreterPath));
             Assert.AreEqual("Workspace|Workspace|env1", configs[0].Id);
-
-            Directory.Delete(workspaceService.CurrentWorkspace.Location, true);
         }
 
         [TestMethod, Priority(0)]
         public void WatchWorkspaceVirtualEnvDeleted() {
             const string ENV_NAME = "env";
-            var workspaceService = CreateEnvAndGetService(ENV_NAME);
+            var workspaceService = CreateEnvAndGetWorkspaceService(ENV_NAME);
 
             string envPath = Path.Combine(workspaceService.CurrentWorkspace.Location, ENV_NAME);
             var configs = TestTriggerDiscovery(workspaceService, () => Directory.Delete(envPath, true)).ToArray();
@@ -188,29 +179,11 @@ namespace PythonToolsTests {
             Assert.AreEqual(0, configs.Length);
         }
 
-        private MockWorkspaceService CreateEnvAndGetService(string envName) {
-            var python = PythonPaths.Python37_x64 ?? PythonPaths.Python37;
-
-            var workspacePath = TestData.GetTempPath();
-            Directory.CreateDirectory(workspacePath);
-            File.WriteAllText(Path.Combine(workspacePath, "app.py"), string.Empty);
-
-            //Creating virtual environment and confirming it was created
-            using (var p = ProcessOutput.RunHiddenAndCapture(python.InterpreterPath, "-m", "venv", Path.Combine(workspacePath, envName))) {
-                Console.WriteLine(p.Arguments);
-                Assert.IsTrue(p.Wait(TimeSpan.FromMinutes(3)));
-                Console.WriteLine(string.Join(Environment.NewLine, p.StandardOutputLines.Concat(p.StandardErrorLines)));
-                Assert.AreEqual(0, p.ExitCode);
-            }
-            Assert.IsTrue(File.Exists(Path.Combine(workspacePath, envName, "scripts", "python.exe")));
-
-            return (new MockWorkspaceService(new MockWorkspace(workspacePath)));
-        }
-
         private static IEnumerable<InterpreterConfiguration> TestTriggerDiscovery(
                 IVsFolderWorkspaceService workspaceService,
                 Action triggerDiscovery,
-                bool useDiscoveryStartedEvent = false) {
+                bool useDiscoveryStartedEvent = false
+        ) {
             using (var evt = new AutoResetEvent(false))
             using (var provider = new WorkspaceInterpreterFactoryProvider(workspaceService)) {
                 // This initializes the provider, discovers the initial set
@@ -231,6 +204,29 @@ namespace PythonToolsTests {
                 Assert.IsTrue(evt.WaitOne(5000), "Failed to trigger discovery.");
                 return provider.GetInterpreterConfigurations();
             }
+        }
+
+        private MockWorkspaceService CreateEnvAndGetWorkspaceService(string envName) {
+            var python = PythonPaths.Python37_x64 ?? PythonPaths.Python37;
+
+            var workspacePath = TestData.GetTempPath();
+            Directory.CreateDirectory(workspacePath);
+            File.WriteAllText(Path.Combine(workspacePath, "app.py"), string.Empty);
+
+            CreatePythonVirtualEnv(python.InterpreterPath, workspacePath, envName);
+
+            return new MockWorkspaceService(new MockWorkspace(workspacePath));
+        }
+
+        private static void CreatePythonVirtualEnv(string pythonInterpreterPath, string workspacePath, string envName) {
+            //Creating virtual environment and confirming it was created
+            using (var p = ProcessOutput.RunHiddenAndCapture(pythonInterpreterPath, "-m", "venv", Path.Combine(workspacePath, envName))) {
+                Console.WriteLine(p.Arguments);
+                Assert.IsTrue(p.Wait(TimeSpan.FromMinutes(3)));
+                Console.WriteLine(string.Join(Environment.NewLine, p.StandardOutputLines.Concat(p.StandardErrorLines)));
+                Assert.AreEqual(0, p.ExitCode);
+            }
+            Assert.IsTrue(File.Exists(Path.Combine(workspacePath, envName, "scripts", "python.exe")));
         }
 
         class MockWorkspaceService : IVsFolderWorkspaceService {


### PR DESCRIPTION
Fix #4879

Work space interpreters will properly refresh on rename or delete. If the selected interpreter is renamed or deleted, the default interpreter should be selected. 
