### PR TITLE
Don't deploy live share extension when building outside of VS. 

### DIFF
--- a/Python/Product/LiveShare/LiveShare.csproj
+++ b/Python/Product/LiveShare/LiveShare.csproj
@@ -37,7 +37,7 @@
     <CreateVsixContainer>true</CreateVsixContainer>
     <GeneratePkgDefFile>false</GeneratePkgDefFile>
     <CopyVsixManifestToOutput>true</CopyVsixManifestToOutput>
-    <DeployExtension>true</DeployExtension>
+    <DeployExtension>$(BuildingInsideVisualStudio)</DeployExtension>
     <DefineConstants>$(DefineConstants);$(SignedSym)</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>


### PR DESCRIPTION
This matches the setting for the other projects.

Hopefully helps avoid the build machine getting stuck when building live share project.