### PR TITLE
Store relative path to virtual env in workspace settings.

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Environments/VirtualEnv.cs
+++ b/Python/Product/PythonTools/PythonTools/Environments/VirtualEnv.cs
@@ -132,7 +132,8 @@ namespace Microsoft.PythonTools.Environments {
 
                     var workspaceFactoryProvider = site.GetComponentModel().GetService<WorkspaceInterpreterFactoryProvider>();
                     using (workspaceFactoryProvider?.SuppressDiscoverFactories(forceDiscoveryOnDispose: true)) {
-                        await workspace.SetInterpreterAsync(interpExe);
+                        var relativeInterpExe = PathUtils.GetRelativeFilePath(workspace.Location, interpExe);
+                        await workspace.SetInterpreterAsync(relativeInterpExe);
                     }
 
                     var factory = workspaceFactoryProvider?


### PR DESCRIPTION
Fix #4937

FYI `PathUtils.GetRelativePath` returns an absolute path if a relative path cannot be determined (I've tested it).