### PR TITLE
Fix analysis for workspaces.

### DIFF
--- a/Python/Product/PythonTools/PythonTools.csproj
+++ b/Python/Product/PythonTools/PythonTools.csproj
@@ -287,6 +287,8 @@
     <Compile Include="PythonTools\Environments\EnvironmentViewBase.cs" />
     <Compile Include="PythonTools\Environments\ProjectView.cs" />
     <Compile Include="PythonTools\Environments\UserSpecifiedCondaLocator.cs" />
+    <Compile Include="PythonTools\Intellisense\WorkspaceAnalyzer.cs" />
+    <Compile Include="PythonTools\Intellisense\WorkspaceAnalysis.cs" />
     <Compile Include="PythonTools\Options\CondaOptions.cs" />
     <Compile Include="PythonTools\Options\PythonCondaOptionsControl.cs">
       <SubType>UserControl</SubType>
@@ -1178,6 +1180,7 @@
       <SubType>Designer</SubType>
     </Page>
   </ItemGroup>
+  <ItemGroup />
   <PropertyGroup>
     <SharedProject_IncludeUIThreadBase>false</SharedProject_IncludeUIThreadBase>
   </PropertyGroup>

--- a/Python/Product/PythonTools/PythonTools/Editor/PythonTextBufferInfo.cs
+++ b/Python/Product/PythonTools/PythonTools/Editor/PythonTextBufferInfo.cs
@@ -23,11 +23,9 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.PythonTools.Analysis;
-using Microsoft.PythonTools.Editor.Core;
 using Microsoft.PythonTools.Infrastructure;
 using Microsoft.PythonTools.Intellisense;
 using Microsoft.PythonTools.Parsing;
-using Microsoft.PythonTools.Parsing.Ast;
 using Microsoft.PythonTools.Projects;
 using Microsoft.PythonTools.Repl;
 using Microsoft.VisualStudio.InteractiveWindow;
@@ -761,6 +759,12 @@ namespace Microsoft.PythonTools.Editor {
                 return analyzer;
             }
 
+            var workspaceAnalysis = site.GetComponentModel().GetService<WorkspaceAnalysis>();
+            analyzer = await workspaceAnalysis.GetAnalyzerAsync();
+            if (analyzer != null) {
+                return analyzer;
+            }
+
             return null;
         }
 
@@ -789,6 +793,15 @@ namespace Microsoft.PythonTools.Editor {
                     if (firstOnly) {
                         return found.ToArray();
                     }
+                }
+            }
+
+            var workspaceAnalysis = site.GetComponentModel().GetService<WorkspaceAnalysis>();
+            var workspaceAnalyzer = workspaceAnalysis.TryGetWorkspaceAnalyzer();
+            if (workspaceAnalyzer != null) {
+                found.Add(workspaceAnalyzer);
+                if (firstOnly) {
+                    return found.ToArray();
                 }
             }
 
@@ -824,10 +837,7 @@ namespace Microsoft.PythonTools.Editor {
                 }
             }
 
-            // TODO: When we add non-project attached analyzers, return them here
-
             return found.ToArray();
         }
-
     }
 }

--- a/Python/Product/PythonTools/PythonTools/Environments/AddCondaEnvironmentOperation.cs
+++ b/Python/Product/PythonTools/PythonTools/Environments/AddCondaEnvironmentOperation.cs
@@ -25,7 +25,6 @@ using Microsoft.PythonTools.Logging;
 using Microsoft.PythonTools.Project;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.TaskStatusCenter;
-using Microsoft.VisualStudio.Workspace;
 using Microsoft.VisualStudioTools;
 
 namespace Microsoft.PythonTools.Environments {
@@ -33,7 +32,7 @@ namespace Microsoft.PythonTools.Environments {
         private readonly IServiceProvider _site;
         private readonly ICondaEnvironmentManager _condaMgr;
         private readonly PythonProjectNode _project;
-        private readonly IWorkspace _workspace;
+        private readonly IPythonWorkspaceContext _workspace;
         private readonly string _envNameOrPath;
         private readonly string _actualName;
         private readonly string _envFilePath;
@@ -54,7 +53,7 @@ namespace Microsoft.PythonTools.Environments {
             IServiceProvider site,
             ICondaEnvironmentManager condaMgr,
             PythonProjectNode project,
-            IWorkspace workspace,
+            IPythonWorkspaceContext workspace,
             string envNameOrPath,
             string envFilePath,
             List<PackageSpec> packages,

--- a/Python/Product/PythonTools/PythonTools/Environments/AddEnvironmentDialog.xaml.cs
+++ b/Python/Product/PythonTools/PythonTools/Environments/AddEnvironmentDialog.xaml.cs
@@ -28,7 +28,6 @@ using Microsoft.PythonTools.Interpreter;
 using Microsoft.PythonTools.Project;
 using Microsoft.PythonTools.Wpf;
 using Microsoft.VisualStudio.Shell.Interop;
-using Microsoft.VisualStudio.Workspace;
 
 namespace Microsoft.PythonTools.Environments {
     internal partial class AddEnvironmentDialog : ModernDialog, IDisposable {
@@ -56,7 +55,7 @@ namespace Microsoft.PythonTools.Environments {
         public static async Task ShowAddEnvironmentDialogAsync(
             IServiceProvider site,
             PythonProjectNode project,
-            IWorkspace workspace,
+            IPythonWorkspaceContext workspace,
             string existingCondaEnvName,
             string environmentYmlPath,
             string requirementsTxtPath,
@@ -77,7 +76,7 @@ namespace Microsoft.PythonTools.Environments {
         public static async Task ShowAddVirtualEnvironmentDialogAsync(
             IServiceProvider site,
             PythonProjectNode project,
-            IWorkspace workspace,
+            IPythonWorkspaceContext workspace,
             string existingCondaEnvName,
             string environmentYmlPath,
             string requirementsTxtPath,
@@ -98,7 +97,7 @@ namespace Microsoft.PythonTools.Environments {
         public static async Task ShowAddCondaEnvironmentDialogAsync(
             IServiceProvider site,
             PythonProjectNode project,
-            IWorkspace workspace,
+            IPythonWorkspaceContext workspace,
             string existingCondaEnvName,
             string environmentYmlPath,
             string requirementsTxtPath,
@@ -119,7 +118,7 @@ namespace Microsoft.PythonTools.Environments {
         public static async Task ShowAddExistingEnvironmentDialogAsync(
             IServiceProvider site,
             PythonProjectNode project,
-            IWorkspace workspace,
+            IPythonWorkspaceContext workspace,
             string existingCondaEnvName,
             string environmentYmlPath,
             string requirementsTxtPath,
@@ -141,7 +140,7 @@ namespace Microsoft.PythonTools.Environments {
             PageKind activePage,
             IServiceProvider site,
             PythonProjectNode project,
-            IWorkspace workspace,
+            IPythonWorkspaceContext workspace,
             string existingCondaEnvName,
             string environmentYmlPath,
             string requirementsTxtPath,
@@ -157,8 +156,7 @@ namespace Microsoft.PythonTools.Environments {
             if (workspace != null) {
                 var registryService = site.GetComponentModel().GetService<IInterpreterRegistryService>();
                 var optionsService = site.GetComponentModel().GetService<IInterpreterOptionsService>();
-                var factory = workspace.GetInterpreterFactory(registryService, optionsService);
-                selectedProjectView = new ProjectView(workspace, factory);
+                selectedProjectView = new ProjectView(workspace);
                 projectViews = new ProjectView[] { selectedProjectView };
             } else {
                 try {

--- a/Python/Product/PythonTools/PythonTools/Environments/AddVirtualEnvironmentOperation.cs
+++ b/Python/Product/PythonTools/PythonTools/Environments/AddVirtualEnvironmentOperation.cs
@@ -31,7 +31,7 @@ namespace Microsoft.PythonTools.Environments {
     sealed class AddVirtualEnvironmentOperation {
         private readonly IServiceProvider _site;
         private readonly PythonProjectNode _project;
-        private readonly IWorkspace _workspace;
+        private readonly IPythonWorkspaceContext _workspace;
         private readonly string _virtualEnvPath;
         private readonly string _baseInterpreter;
         private readonly bool _useVEnv;
@@ -51,7 +51,7 @@ namespace Microsoft.PythonTools.Environments {
         public AddVirtualEnvironmentOperation(
             IServiceProvider site,
             PythonProjectNode project,
-            IWorkspace workspace,
+            IPythonWorkspaceContext workspace,
             string virtualEnvPath,
             string baseInterpreterId,
             bool useVEnv,

--- a/Python/Product/PythonTools/PythonTools/Environments/EnvironmentSwitcherWorkspaceContext.cs
+++ b/Python/Product/PythonTools/PythonTools/Environments/EnvironmentSwitcherWorkspaceContext.cs
@@ -18,45 +18,38 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.PythonTools.Interpreter;
-using Microsoft.VisualStudio.Workspace;
-using Microsoft.VisualStudio.Workspace.Settings;
 
 namespace Microsoft.PythonTools.Environments {
     sealed class EnvironmentSwitcherWorkspaceContext : IEnvironmentSwitcherContext {
         private readonly IServiceProvider _serviceProvider;
-        private readonly IInterpreterOptionsService _optionsService;
         private readonly IInterpreterRegistryService _registryService;
-        private readonly IWorkspace _workspace;
-        private readonly IWorkspaceSettingsManager _workspaceSettingsMgr;
+        private readonly IPythonWorkspaceContext _pythonWorkspace;
 
-        public EnvironmentSwitcherWorkspaceContext(IServiceProvider serviceProvider, IWorkspace workspace) {
+        public EnvironmentSwitcherWorkspaceContext(IServiceProvider serviceProvider, IPythonWorkspaceContext pythonWorkspace) {
             _serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
-            _optionsService = serviceProvider.GetComponentModel().GetService<IInterpreterOptionsService>();
+            _pythonWorkspace = pythonWorkspace ?? throw new ArgumentNullException(nameof(pythonWorkspace));
             _registryService = serviceProvider.GetComponentModel().GetService<IInterpreterRegistryService>();
-            _workspace = workspace ?? throw new ArgumentNullException(nameof(workspace));
-            _workspaceSettingsMgr = _workspace.GetSettingsManager();
-            _workspaceSettingsMgr.OnWorkspaceSettingsChanged += OnSettingsChanged;
+            _pythonWorkspace.ActiveInterpreterChanged += OnActiveInterpreterChanged;
         }
 
         public IEnumerable<IPythonInterpreterFactory> AllFactories => _registryService.Interpreters;
 
-        public IPythonInterpreterFactory CurrentFactory => _workspace.GetInterpreterFactory(_registryService, _optionsService);
+        public IPythonInterpreterFactory CurrentFactory => Workspace.CurrentFactory;
 
-        public IWorkspace Workspace => _workspace;
+        public IPythonWorkspaceContext Workspace => _pythonWorkspace;
 
         public event EventHandler EnvironmentsChanged;
 
         public async Task ChangeFactoryAsync(IPythonInterpreterFactory factory) {
-            await _workspace.SetInterpreterFactoryAsync(factory);
+            await _pythonWorkspace.SetInterpreterFactoryAsync(factory);
         }
 
-        private Task OnSettingsChanged(object sender, EventArgs e) {
+        private void OnActiveInterpreterChanged(object sender, EventArgs e) {
             EnvironmentsChanged?.Invoke(this, EventArgs.Empty);
-            return Task.CompletedTask;
         }
 
         public void Dispose() {
-            _workspaceSettingsMgr.OnWorkspaceSettingsChanged -= OnSettingsChanged;
+            _pythonWorkspace.ActiveInterpreterChanged -= OnActiveInterpreterChanged;
         }
     }
 }

--- a/Python/Product/PythonTools/PythonTools/Environments/ProjectView.cs
+++ b/Python/Product/PythonTools/PythonTools/Environments/ProjectView.cs
@@ -18,12 +18,11 @@ using System;
 using System.Linq;
 using Microsoft.PythonTools.Interpreter;
 using Microsoft.PythonTools.Project;
-using Microsoft.VisualStudio.Workspace;
 
 namespace Microsoft.PythonTools.Environments {
     sealed class ProjectView {
         public PythonProjectNode Node { get; }
-        public IWorkspace Workspace { get; }
+        public IPythonWorkspaceContext Workspace { get; }
         public string Name { get; set; }
         public string HomeFolder { get; set; }
         public string[] InterpreterIds { get; set; }
@@ -42,13 +41,14 @@ namespace Microsoft.PythonTools.Environments {
             EnvironmentYmlPath = node.GetEnvironmentYmlPath();
         }
 
-        public ProjectView(IWorkspace workspace, IPythonInterpreterFactory currentFactory) {
+        public ProjectView(IPythonWorkspaceContext workspace) {
             Workspace = workspace ?? throw new ArgumentNullException(nameof(workspace));
-            Name = workspace.GetName();
+            Name = workspace.WorkspaceName;
             HomeFolder = workspace.Location;
-            if (currentFactory != null) {
-                InterpreterIds = new string[] { currentFactory.Configuration.Id };
-                ActiveInterpreterId = currentFactory.Configuration.Id;
+            if (workspace.CurrentFactory != null) {
+                var id = workspace.CurrentFactory.Configuration.Id;
+                InterpreterIds = new string[] { id };
+                ActiveInterpreterId = id;
             } else {
                 InterpreterIds = new string[0];
                 ActiveInterpreterId = string.Empty;

--- a/Python/Product/PythonTools/PythonTools/Environments/VirtualEnv.cs
+++ b/Python/Product/PythonTools/PythonTools/Environments/VirtualEnv.cs
@@ -24,7 +24,6 @@ using System.Threading.Tasks;
 using Microsoft.PythonTools.Infrastructure;
 using Microsoft.PythonTools.Interpreter;
 using Microsoft.PythonTools.Project;
-using Microsoft.VisualStudio.Workspace;
 
 namespace Microsoft.PythonTools.Environments {
     static class VirtualEnv {
@@ -66,7 +65,7 @@ namespace Microsoft.PythonTools.Environments {
             IInterpreterRegistryService registry,
             IInterpreterOptionsService options,
             PythonProjectNode project,
-            IWorkspace workspace,
+            IPythonWorkspaceContext workspace,
             string path,
             IPythonInterpreterFactory baseInterp,
             bool registerAsCustomEnv,

--- a/Python/Product/PythonTools/PythonTools/Intellisense/WorkspaceAnalysis.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/WorkspaceAnalysis.cs
@@ -1,0 +1,101 @@
+﻿// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.Threading.Tasks;
+using Microsoft.PythonTools.Interpreter;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudioTools;
+
+namespace Microsoft.PythonTools.Intellisense {
+    [Export(typeof(WorkspaceAnalysis))]
+    [PartCreationPolicy(CreationPolicy.Shared)]
+    internal class WorkspaceAnalysis : IDisposable {
+        private readonly IPythonWorkspaceContextProvider _pythonWorkspaceService;
+        private readonly IInterpreterOptionsService _optionsService;
+        private readonly IServiceProvider _site;
+        private readonly Dictionary<IPythonWorkspaceContext, WorkspaceAnalyzer> _analyzers;
+
+        [ImportingConstructor]
+        public WorkspaceAnalysis(
+            [Import] IPythonWorkspaceContextProvider pythonWorkspaceService,
+            [Import] IInterpreterOptionsService optionsService,
+            [Import(typeof(SVsServiceProvider), AllowDefault = true)] IServiceProvider site = null
+        ) {
+            _pythonWorkspaceService = pythonWorkspaceService;
+            _optionsService = optionsService;
+            _site = site;
+            _analyzers = new Dictionary<IPythonWorkspaceContext, WorkspaceAnalyzer>();
+
+            _pythonWorkspaceService.WorkspaceClosing += OnWorkspaceClosing;
+        }
+
+        public string WorkspaceName => _pythonWorkspaceService.Workspace?.WorkspaceName;
+
+        public void Dispose() {
+            _pythonWorkspaceService.WorkspaceClosing -= OnWorkspaceClosing;
+        }
+
+        public VsProjectAnalyzer TryGetWorkspaceAnalyzer() {
+            _site.MustBeCalledFromUIThread();
+
+            if (_analyzers.TryGetValue(_pythonWorkspaceService.Workspace, out WorkspaceAnalyzer analyzer)) {
+                return analyzer.Analyzer;
+            }
+
+            return null;
+        }
+
+        public async Task<VsProjectAnalyzer> GetAnalyzerAsync() {
+            _site.MustBeCalledFromUIThread();
+
+            var workspace = _pythonWorkspaceService.Workspace;
+            if (workspace == null) {
+                return null;
+            }
+
+            if (_analyzers.TryGetValue(workspace, out WorkspaceAnalyzer analyzer)) {
+                return analyzer.Analyzer;
+            }
+
+            if (workspace.CurrentFactory != null) {
+                analyzer = new WorkspaceAnalyzer(workspace, _optionsService, _site);
+                await analyzer.InitializeAsync();
+                _analyzers[workspace] = analyzer;
+                return analyzer.Analyzer;
+            }
+
+            return null;
+        }
+
+        private void OnWorkspaceClosing(object sender, PythonWorkspaceContextEventArgs e) {
+            _site.GetUIThread().Invoke(() => {
+                CloseAnalyzer(e.Workspace);
+            });
+        }
+
+        private void CloseAnalyzer(IPythonWorkspaceContext workspace) {
+            _site.MustBeCalledFromUIThread();
+
+            if (_analyzers.TryGetValue(workspace, out WorkspaceAnalyzer analyzer)) {
+                _analyzers.Remove(workspace);
+                analyzer.Dispose();
+            }
+        }
+    }
+}

--- a/Python/Product/PythonTools/PythonTools/Intellisense/WorkspaceAnalyzer.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/WorkspaceAnalyzer.cs
@@ -1,0 +1,397 @@
+﻿// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.PythonTools.Editor;
+using Microsoft.PythonTools.Infrastructure;
+using Microsoft.PythonTools.Interpreter;
+using Microsoft.PythonTools.Logging;
+using Microsoft.PythonTools.Project;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudioTools;
+using Task = System.Threading.Tasks.Task;
+
+namespace Microsoft.PythonTools.Intellisense {
+    internal class WorkspaceAnalyzer : IDisposable {
+        private readonly IPythonWorkspaceContext _pythonWorkspace;
+        private readonly IInterpreterOptionsService _optionsService;
+        private readonly IServiceProvider _site;
+        private readonly IPythonToolsLogger _logger;
+
+        private IReadOnlyList<IPackageManager> _activePackageManagers;
+        private readonly Timer _deferredModulesChangeNotification;
+
+        private FileWatcher _workspaceFileWatcher;
+        private readonly HashSet<AnalysisEntry> _pendingChanges, _pendingDeletes;
+        private readonly Timer _deferredWorkspaceFileChangeNotification;
+
+        private readonly SemaphoreSlim _recreatingAnalyzer;
+        private VsProjectAnalyzer _analyzer;
+
+        public event EventHandler WorkspaceAnalyzerChanged;
+
+        public event EventHandler<AnalyzerChangingEventArgs> WorkspaceAnalyzerChanging;
+
+        public WorkspaceAnalyzer(
+            IPythonWorkspaceContext pythonWorkspace,
+            IInterpreterOptionsService optionsService,
+            IServiceProvider site
+        ) {
+            _pythonWorkspace = pythonWorkspace ?? throw new ArgumentNullException(nameof(pythonWorkspace));
+            _optionsService = optionsService ?? throw new ArgumentNullException(nameof(optionsService));
+            _site = site ?? throw new ArgumentNullException(nameof(site));
+
+            _logger = (IPythonToolsLogger)_site.GetService(typeof(IPythonToolsLogger));
+            _pendingChanges = new HashSet<AnalysisEntry>();
+            _pendingDeletes = new HashSet<AnalysisEntry>();
+
+            _recreatingAnalyzer = new SemaphoreSlim(1);
+            _deferredWorkspaceFileChangeNotification = new Timer(OnDeferredWorkspaceFileChanged);
+            _deferredModulesChangeNotification = new Timer(OnDeferredModulesChanged);
+
+            _pythonWorkspace.ActiveInterpreterChanged += OnActiveInterpreterChanged;
+            _pythonWorkspace.SearchPathsSettingChanged += OnSearchPathsChanged;
+        }
+
+        public VsProjectAnalyzer Analyzer => _analyzer;
+
+        public void Dispose() {
+            _site.MustBeCalledFromUIThread();
+
+            _deferredModulesChangeNotification.Dispose();
+            _deferredWorkspaceFileChangeNotification.Dispose();
+            _recreatingAnalyzer.Dispose();
+
+            _pythonWorkspace.ActiveInterpreterChanged -= OnActiveInterpreterChanged;
+            _pythonWorkspace.SearchPathsSettingChanged -= OnSearchPathsChanged;
+
+            if (_analyzer != null) {
+                _analyzer.ClearAllTasks();
+
+                if (_analyzer.RemoveUser()) {
+                    _analyzer.AbnormalAnalysisExit -= OnAnalysisProcessExited;
+                    _analyzer.Dispose();
+                }
+
+                _analyzer = null;
+            }
+
+            UnsubscribePackageManagers();
+
+            var watcher = _workspaceFileWatcher;
+            _workspaceFileWatcher = null;
+            watcher?.Dispose();
+        }
+
+        public async Task InitializeAsync() {
+            SubscribePackageManagers();
+            await ReanalyzeAsync();
+        }
+
+        private void SubscribePackageManagers() {
+            _site.MustBeCalledFromUIThread();
+
+            _activePackageManagers = _optionsService.GetPackageManagers(_pythonWorkspace.CurrentFactory).ToArray();
+            foreach (var pm in _activePackageManagers) {
+                pm.InstalledFilesChanged += OnInstalledFilesChanged;
+                pm.EnableNotifications();
+            }
+        }
+
+        private void UnsubscribePackageManagers() {
+            _site.MustBeCalledFromUIThread();
+
+            var oldPms = _activePackageManagers;
+            _activePackageManagers = null;
+
+            foreach (var pm in oldPms.MaybeEnumerate()) {
+                pm.DisableNotifications();
+                pm.InstalledFilesChanged -= OnInstalledFilesChanged;
+            }
+        }
+
+        private async Task<VsProjectAnalyzer> CreateAnalyzerAsync(IPythonInterpreterFactory factory, string location) {
+            _site.MustBeCalledFromUIThread();
+
+            var pythonServices = _site.GetPythonToolsService();
+            var res = await VsProjectAnalyzer.CreateForWorkspaceAsync(
+                pythonServices.EditorServices,
+                factory,
+                location
+            );
+
+            res.AbnormalAnalysisExit += OnAnalysisProcessExited;
+
+            await UpdateAnalyzerSearchPathsAsync(res);
+            return res;
+        }
+
+        private async Task UpdateAnalyzerSearchPathsAsync(VsProjectAnalyzer analyzer) {
+            _site.MustBeCalledFromUIThread();
+
+            var workspace = _pythonWorkspace;
+            analyzer = analyzer ?? _analyzer;
+            if (workspace != null && analyzer != null) {
+                await analyzer.SetSearchPathsAsync(workspace.GetAbsoluteSearchPaths());
+            }
+        }
+
+        private void OnWorkspaceFileDeleted(object sender, FileSystemEventArgs e) {
+            var entry = _analyzer?.GetAnalysisEntryFromPath(e.FullPath);
+            if (entry != null) {
+                lock (_pendingChanges) {
+                    _pendingDeletes.Add(entry);
+                    try {
+                        _deferredWorkspaceFileChangeNotification.Change(500, Timeout.Infinite);
+                    } catch (ObjectDisposedException) {
+                    }
+                }
+            }
+        }
+
+        private void OnWorkspaceFileChanged(object sender, FileSystemEventArgs e) {
+            var entry = _analyzer?.GetAnalysisEntryFromPath(e.FullPath);
+            if (entry != null) {
+                lock (_pendingChanges) {
+                    _pendingChanges.Add(entry);
+                    try {
+                        _deferredWorkspaceFileChangeNotification.Change(500, Timeout.Infinite);
+                    } catch (ObjectDisposedException) {
+                    }
+                }
+            }
+        }
+
+        private void OnDeferredWorkspaceFileChanged(object state) {
+            var analyzer = _analyzer;
+            Uri[] changed, deleted;
+
+            lock (_pendingChanges) {
+                if (analyzer == null) {
+                    return;
+                }
+                changed = _pendingChanges.Concat(_pendingDeletes.Where(e => File.Exists(e.Path))).Select(e => e.DocumentUri).ToArray();
+                deleted = _pendingDeletes.Where(e => !File.Exists(e.Path)).Select(e => e.DocumentUri).ToArray();
+                _pendingChanges.Clear();
+                _pendingDeletes.Clear();
+            }
+
+            analyzer.NotifyFileChangesAsync(Enumerable.Empty<Uri>(), deleted, changed)
+                .HandleAllExceptions(_site, GetType())
+                .DoNotWait();
+        }
+
+        private void OnDeferredModulesChanged(object state) {
+            _site.GetUIThread().InvokeTask(async () => {
+                if (_analyzer != null) {
+                    await _analyzer.NotifyModulesChangedAsync().ConfigureAwait(false);
+                }
+            }).HandleAllExceptions(_site).DoNotWait();
+        }
+
+        private async Task ReanalyzeAsync() {
+            var factory = _pythonWorkspace.CurrentFactory;
+            await _site.GetUIThread().InvokeTask(async () => {
+                await ReanalyzeWorkspaceAsync(factory);
+            });
+        }
+
+        private async Task ReanalyzeWorkspaceAsync(IPythonInterpreterFactory factory) {
+            _site.MustBeCalledFromUIThread();
+
+#if DEBUG
+            var output = OutputWindowRedirector.GetGeneral(_site);
+            await ReanalyzeWorkspaceHelperAsync(factory, output);
+#else
+            await ReanalyzeWorkspaceHelperAsync(factory, null);
+#endif
+        }
+
+        private async Task ReanalyzeWorkspaceHelperAsync(IPythonInterpreterFactory factory, Redirector log) {
+            _site.MustBeCalledFromUIThread();
+
+            try {
+                if (!_recreatingAnalyzer.Wait(0)) {
+                    // Someone else is recreating, so wait for them to finish and return
+                    log?.WriteLine("Waiting for existing call");
+                    await _recreatingAnalyzer.WaitAsync();
+                    try {
+                        log?.WriteLine("Existing call complete");
+                    } catch {
+                        _recreatingAnalyzer.Release();
+                        throw;
+                    }
+                    if (_analyzer?.InterpreterFactory == factory) {
+                        _recreatingAnalyzer.Release();
+                        return;
+                    }
+                }
+            } catch (ObjectDisposedException) {
+                return;
+            }
+
+            IVsStatusbar statusBar = null;
+            bool statusBarConfigured = false;
+            try {
+                if ((statusBar = _site.GetService(typeof(SVsStatusbar)) as IVsStatusbar) != null) {
+                    statusBar.SetText(Strings.AnalyzingProject);
+                    try {
+                        object index = (short)0;
+                        statusBar.Animation(1, ref index);
+                    } catch (ArgumentNullException) {
+                        // Issue in status bar implementation
+                        // https://github.com/Microsoft/PTVS/issues/3064
+                        // Silently suppress since animation is not critical.
+                    }
+                    statusBar.FreezeOutput(1);
+                    statusBarConfigured = true;
+                }
+
+                var oldWatcher = _workspaceFileWatcher;
+                _workspaceFileWatcher = new FileWatcher(_pythonWorkspace.Location) {
+                    EnableRaisingEvents = true,
+                    IncludeSubdirectories = true,
+                    NotifyFilter = NotifyFilters.FileName | NotifyFilters.LastWrite
+                };
+                _workspaceFileWatcher.Changed += OnWorkspaceFileChanged;
+                _workspaceFileWatcher.Deleted += OnWorkspaceFileDeleted;
+                oldWatcher?.Dispose();
+
+                log?.WriteLine("Creating new workspace analyzer");
+                var analyzer = await CreateAnalyzerAsync(factory, _pythonWorkspace.Location);
+                Debug.Assert(analyzer != null);
+                log?.WriteLine($"Created workspace analyzer {analyzer}");
+
+                WorkspaceAnalyzerChanging?.Invoke(this, new AnalyzerChangingEventArgs(_analyzer, analyzer));
+
+                var oldAnalyzer = Interlocked.Exchange(ref _analyzer, analyzer);
+
+                if (oldAnalyzer != null) {
+                    if (analyzer != null) {
+                        int beforeCount = analyzer.Files.Count();
+                        log?.WriteLine($"Transferring from old analyzer {oldAnalyzer}, which has {oldAnalyzer.Files.Count()} files");
+                        await analyzer.TransferFromOldAnalyzer(oldAnalyzer);
+                        log?.WriteLine($"Tranferred {analyzer.Files.Count() - beforeCount} files");
+                        log?.WriteLine($"Old analyzer now has {oldAnalyzer.Files.Count()} files");
+                    }
+                    if (oldAnalyzer.RemoveUser()) {
+                        log?.WriteLine("Disposing old analyzer");
+                        oldAnalyzer.Dispose();
+                    }
+                }
+
+                var files = new List<string>();
+                var pythonServices = _site.GetPythonToolsService();
+                foreach (var existing in pythonServices.GetActiveSharedAnalyzers().Select(kv => kv.Value).Where(v => !v.IsDisposed)) {
+                    foreach (var kv in existing.LoadedFiles) {
+                        files.Add(kv.Key);
+                        log?.WriteLine($"Unloading {kv.Key} from default analyzer");
+                        foreach (var b in (kv.Value.TryGetBufferParser()?.AllBuffers).MaybeEnumerate()) {
+                            PythonTextBufferInfo.MarkForReplacement(b);
+                        }
+                        try {
+                            await existing.UnloadFileAsync(kv.Value);
+                        } catch (ObjectDisposedException) {
+                            break;
+                        }
+                    }
+                }
+
+                if (analyzer != null) {
+                    // Set search paths first, as it will save full reanalysis later
+                    log?.WriteLine("Setting search paths");
+                    await analyzer.SetSearchPathsAsync(_pythonWorkspace.GetAbsoluteSearchPaths());
+
+                    // Add all our files into our analyzer
+                    log?.WriteLine($"Adding {files.Count} files");
+                    await analyzer.AnalyzeFileAsync(files.ToArray());
+                }
+
+                WorkspaceAnalyzerChanged?.Invoke(this, EventArgs.Empty);
+            } catch (ObjectDisposedException) {
+                // Raced with disposal
+            } catch (Exception ex) {
+                log?.WriteErrorLine(ex.ToString());
+                throw;
+            } finally {
+                try {
+                    if (statusBar != null && statusBarConfigured) {
+                        statusBar.FreezeOutput(0);
+                        object index = (short)0;
+                        statusBar.Animation(0, ref index);
+                        statusBar.Clear();
+                    }
+                } finally {
+                    try {
+                        _recreatingAnalyzer.Release();
+                    } catch (ObjectDisposedException) {
+                    }
+                }
+            }
+        }
+
+        private void OnAnalysisProcessExited(object sender, AbnormalAnalysisExitEventArgs e) {
+            if (_logger == null) {
+                return;
+            }
+
+            var msg = new StringBuilder()
+                .AppendFormat("Exit Code: {0}", e.ExitCode)
+                .AppendLine()
+                .AppendLine(" ------ STD ERR ------ ")
+                .Append(e.StdErr)
+                .AppendLine(" ------ END STD ERR ------ ");
+            _logger.LogEvent(
+                PythonLogEvent.AnalysisExitedAbnormally,
+                msg.ToString()
+            );
+
+            // Start a new analyzer
+            ReanalyzeAsync().HandleAllExceptions(_site).DoNotWait();
+        }
+
+        private void OnInstalledFilesChanged(object sender, EventArgs e) {
+            try {
+                _deferredModulesChangeNotification.Change(500, Timeout.Infinite);
+            } catch (ObjectDisposedException) {
+            }
+        }
+
+        private void OnSearchPathsChanged(object sender, EventArgs e) {
+            _site.GetUIThread().InvokeTask(async () => {
+                await UpdateAnalyzerSearchPathsAsync(_analyzer);
+            }).HandleAllExceptions(_site).DoNotWait();
+        }
+
+        private void OnActiveInterpreterChanged(object sender, EventArgs e) {
+            OnActiveInterpreterChangedAsync().HandleAllExceptions(_site).DoNotWait();
+        }
+
+        private async Task OnActiveInterpreterChangedAsync() {
+            UnsubscribePackageManagers();
+            await ReanalyzeAsync();
+            SubscribePackageManagers();
+        }
+    }
+}

--- a/Python/Product/PythonTools/PythonToolsService.cs
+++ b/Python/Product/PythonTools/PythonToolsService.cs
@@ -262,6 +262,12 @@ namespace Microsoft.PythonTools {
                     yield return new KeyValuePair<string, VsProjectAnalyzer>(proj.Caption, analyzer);
                 }
             }
+
+            var workspaceAnalysis = _container.GetComponentModel().GetService<WorkspaceAnalysis>();
+            var workspaceAnalyzer = workspaceAnalysis.TryGetWorkspaceAnalyzer();
+            if (workspaceAnalyzer != null) {
+                yield return new KeyValuePair<string, VsProjectAnalyzer>(workspaceAnalysis.WorkspaceName, workspaceAnalyzer);
+            }
         }
 
         public AdvancedEditorOptions AdvancedOptions => _advancedOptions.Value;

--- a/Python/Product/VSCommon/Logging/PythonToolsLoggerData.cs
+++ b/Python/Product/VSCommon/Logging/PythonToolsLoggerData.cs
@@ -79,6 +79,7 @@ namespace Microsoft.PythonTools.Logging {
 
     static class AnalysisInitializeReasons {
         public const string Project = "Project";
+        public const string Workspace = "Workspace";
         public const string Interactive = "Interactive";
         public const string Default = "Default";
     }

--- a/Python/Product/VSInterpreters/Interpreter/IPythonWorkspaceContext.cs
+++ b/Python/Product/VSInterpreters/Interpreter/IPythonWorkspaceContext.cs
@@ -1,0 +1,119 @@
+﻿// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Microsoft.PythonTools.Interpreter {
+    public interface IPythonWorkspaceContext : IDisposable {
+        /// <summary>
+        /// Interpreter setting string has changed.
+        /// </summary>
+        event EventHandler InterpreterSettingChanged;
+
+        /// <summary>
+        /// Search paths setting has changed.
+        /// </summary>
+        event EventHandler SearchPathsSettingChanged;
+
+        /// <summary>
+        /// Effective interpreter factory for the workspace has changed.
+        /// </summary>
+        event EventHandler ActiveInterpreterChanged;
+
+        /// <summary>
+        /// Display name for the workspace.
+        /// </summary>
+        string WorkspaceName { get; }
+
+        /// <summary>
+        /// Full path to the workspace folder.
+        /// </summary>
+        string Location { get; }
+
+        /// <summary>
+        /// Effective interpreter factory for the workspace.
+        /// If there's no interpreter setting specified in
+        /// workspace, then this will be the global default.
+        /// May be <c>null</c> if no interpreter factories are
+        /// installed on the system.
+        /// </summary>
+        IPythonInterpreterFactory CurrentFactory { get; }
+
+        /// <summary>
+        /// Get an absolute path from a workspace relative path.
+        /// </summary>
+        /// <param name="path">Relative path.</param>
+        /// <returns>Absolute path.</returns>
+        string MakeRooted(string path);
+
+        /// <summary>
+        /// Read the interpreter setting string from PythonSettings.json.
+        /// </summary>
+        /// <remarks>
+        /// Most callers should use <see cref="CurrentFactory"/> but
+        /// some factory providers need to read the setting directly.
+        /// </remarks>
+        /// <returns>
+        /// Current value of the interpreter setting. May be <c>null</c>.
+        /// </returns>
+        string ReadInterpreterSetting();
+
+        /// <summary>
+        /// Get the effective search paths for the workspace, calculated
+        /// from the SearchPaths array setting in PythonSettings.json.
+        /// </summary>
+        /// <remarks>
+        /// The workspace folder is always included as the first item.
+        /// </remarks>
+        /// <returns>Absolute search paths.</returns>
+        IEnumerable<string> GetAbsoluteSearchPaths();
+
+        /// <summary>
+        /// Get the absolute path to the workspace's requirements.txt file.
+        /// </summary>
+        /// <returns>
+        /// Absolute path to file or <c>null</c> if there is none.
+        /// </returns>
+        string GetRequirementsTxtPath();
+
+        /// <summary>
+        /// Get the absolute path to the workspace's environment.yml file.
+        /// </summary>
+        /// <returns>
+        /// Absolute path to file or <c>null</c> if there is none.
+        /// </returns>
+        string GetEnvironmentYmlPath();
+
+        /// <summary>
+        /// Update the interpreter setting in PythonSettings.json to
+        /// the specified factory's id or interpreter path, as appropriate.
+        /// </summary>
+        /// <remarks>
+        /// This will raise a <see cref="ActiveInterpreterChanged"/> if there
+        /// is an effective interpreter change.
+        /// </remarks>
+        /// <param name="factory">New factory.</param>
+        Task SetInterpreterFactoryAsync(IPythonInterpreterFactory factory);
+
+        /// <summary>
+        /// Update the interpreter setting to the specified value.
+        /// </summary>
+        /// <param name="interpreter">New interpreter setting.</param>
+        Task SetInterpreterAsync(string interpreter);
+    }
+}

--- a/Python/Product/VSInterpreters/Interpreter/IPythonWorkspaceContextProvider.cs
+++ b/Python/Product/VSInterpreters/Interpreter/IPythonWorkspaceContextProvider.cs
@@ -1,0 +1,48 @@
+﻿// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System;
+
+namespace Microsoft.PythonTools.Interpreter {
+    public interface IPythonWorkspaceContextProvider {
+        /// <summary>
+        /// Workspace has been closed in VS but the workspace context has not
+        /// been disposed yet.
+        /// </summary>
+        event EventHandler<PythonWorkspaceContextEventArgs> WorkspaceClosing;
+
+        /// <summary>
+        /// Workspace context is done closing and has been disposed.
+        /// </summary>
+        event EventHandler<PythonWorkspaceContextEventArgs> WorkspaceClosed;
+
+        /// <summary>
+        /// Workspace context is created but not fully initialized yet.
+        /// The settings can be accessed but the current factory is not set yet.
+        /// </summary>
+        event EventHandler<PythonWorkspaceContextEventArgs> WorkspaceOpening;
+
+        /// <summary>
+        /// Workspace context is done initializing (current factory is set).
+        /// </summary>
+        event EventHandler<PythonWorkspaceContextEventArgs> WorkspaceInitialized;
+
+        /// <summary>
+        /// The currently loaded workspace.
+        /// </summary>
+        IPythonWorkspaceContext Workspace { get; }
+    }
+}

--- a/Python/Product/VSInterpreters/Interpreter/PythonWorkspaceContext.cs
+++ b/Python/Product/VSInterpreters/Interpreter/PythonWorkspaceContext.cs
@@ -1,0 +1,267 @@
+﻿// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.PythonTools.Infrastructure;
+using Microsoft.VisualStudio.Workspace;
+using Microsoft.VisualStudio.Workspace.Settings;
+
+namespace Microsoft.PythonTools.Interpreter {
+    class PythonWorkspaceContext : IPythonWorkspaceContext {
+        private const string PythonSettingsType = "PythonSettings";
+        private const string InterpreterProperty = "Interpreter";
+        private const string SearchPathsProperty = "SearchPaths";
+
+        private readonly IWorkspace _workspace;
+        private readonly IInterpreterOptionsService _optionsService;
+        private readonly IInterpreterRegistryService _registryService;
+        private readonly IWorkspaceSettingsManager _workspaceSettingsMgr;
+
+        private bool _isDisposed;
+
+        // Cached settings values
+        // OnSettingsChanged compares with current value to raise more specific events.
+        private object _cacheLock = new object();
+        private string[] _searchPaths;
+        private string _interpreter;
+
+        // These are set in initialize
+        private IPythonInterpreterFactory _factory;
+        private bool? _factoryIsDefault;
+
+        public PythonWorkspaceContext(
+            IWorkspace workspace,
+            IInterpreterOptionsService optionsService,
+            IInterpreterRegistryService registryService) {
+            _workspace = workspace ?? throw new ArgumentNullException(nameof(workspace));
+            _optionsService = optionsService ?? throw new ArgumentNullException(nameof(optionsService));
+            _registryService = registryService ?? throw new ArgumentNullException(nameof(registryService));
+            _workspaceSettingsMgr = _workspace.GetSettingsManager();
+        }
+
+        public event EventHandler InterpreterSettingChanged;
+
+        public event EventHandler SearchPathsSettingChanged;
+
+        /// <summary>
+        /// The effective interpreter for this workspace has changed.
+        /// This can be due to an interpreter setting change in the json or a
+        /// global interpreter change when the workspace relies on the default.
+        /// </summary>
+        public event EventHandler ActiveInterpreterChanged;
+
+        public string WorkspaceName => _workspace.GetName();
+
+        public string Location => _workspace.Location;
+
+        public IPythonInterpreterFactory CurrentFactory {
+            get {
+                lock (_cacheLock) {
+                    return _factory;
+                }
+            }
+        }
+
+        public void Initialize() {
+            _interpreter = ReadInterpreterSetting();
+            _searchPaths = ReadSearchPathsSetting();
+
+            RefreshCurrentFactory();
+
+            _workspaceSettingsMgr.OnWorkspaceSettingsChanged += OnSettingsChanged;
+            _optionsService.DefaultInterpreterChanged += OnDefaultInterpreterChanged;
+            _registryService.InterpretersChanged += OnInterpretersChanged;
+        }
+
+        public void Dispose() {
+            if (_isDisposed) {
+                return;
+            }
+
+            _isDisposed = true;
+            _workspaceSettingsMgr.OnWorkspaceSettingsChanged -= OnSettingsChanged;
+            _optionsService.DefaultInterpreterChanged -= OnDefaultInterpreterChanged;
+            _registryService.InterpretersChanged -= OnInterpretersChanged;
+        }
+
+        public string MakeRooted(string path) => _workspace.MakeRooted(path);
+
+        public string ReadInterpreterSetting() {
+            var settingsMgr = _workspace.GetSettingsManager();
+            var settings = settingsMgr.GetAggregatedSettings(PythonSettingsType);
+            settings.GetProperty(InterpreterProperty, out string interpreter);
+
+            return interpreter;
+        }
+
+        private string[] ReadSearchPathsSetting() {
+            var settingsMgr = _workspace.GetSettingsManager();
+            var settings = settingsMgr.GetAggregatedSettings(PythonSettingsType);
+            var searchPaths = settings.UnionPropertyArray<string>(SearchPathsProperty);
+
+            return searchPaths.ToArray();
+        }
+
+        public IEnumerable<string> GetAbsoluteSearchPaths() {
+            lock (_cacheLock) {
+                return new[] { "." }.Union(_searchPaths).Select(sp => PathUtils.GetAbsoluteDirectoryPath(_workspace.Location, sp));
+            }
+        }
+
+        public string GetRequirementsTxtPath() {
+            return _workspace.GetRequirementsTxtPath();
+        }
+
+        public string GetEnvironmentYmlPath() {
+            return _workspace.GetEnvironmentYmlPath();
+        }
+
+        public Task SetInterpreterFactoryAsync(IPythonInterpreterFactory factory) {
+            return _workspace.SetInterpreterFactoryAsync(factory);
+        }
+
+        public Task SetInterpreterAsync(string interpreter) {
+            return _workspace.SetInterpreterAsync(interpreter);
+        }
+
+        private void RefreshCurrentFactory() {
+            string interpreter;
+            lock (_cacheLock) {
+                interpreter = _interpreter;
+            }
+
+            var factory = GetFactory(interpreter, _workspace, _registryService);
+            lock (_cacheLock) {
+                _factory = factory;
+                _factoryIsDefault = _factory == null;
+                if (_factoryIsDefault == true) {
+                    _factory = _optionsService.DefaultInterpreter;
+                }
+            }
+        }
+
+        private static IPythonInterpreterFactory GetFactory(string interpreter, IWorkspace workspace, IInterpreterRegistryService registryService) {
+            IPythonInterpreterFactory factory = null;
+            if (interpreter != null && registryService != null) {
+                factory = registryService.FindInterpreter(interpreter);
+                if (factory == null) {
+                    if (PathUtils.IsValidPath(interpreter) && !Path.IsPathRooted(interpreter)) {
+                        interpreter = workspace.MakeRooted(interpreter);
+                    }
+                    factory = registryService.Interpreters.SingleOrDefault(f => PathUtils.IsSamePath(f.Configuration.InterpreterPath, interpreter));
+                }
+            }
+
+            return factory;
+        }
+
+        private void OnInterpretersChanged(object sender, EventArgs e) {
+            if (_isDisposed) {
+                return;
+            }
+
+            // The environment referenced by the interpreter setting may no longer exist.
+            ReloadInterpreterSetting();
+        }
+
+        private void OnDefaultInterpreterChanged(object sender, EventArgs e) {
+            if (_isDisposed) {
+                return;
+            }
+
+            bool? isDefault = false;
+            lock (_cacheLock) {
+                isDefault = _factoryIsDefault;
+            }
+
+            if (isDefault == true) {
+                ReloadInterpreterSetting();
+            }
+        }
+
+        private void ReloadInterpreterSetting() {
+            IPythonInterpreterFactory oldFactory;
+            lock (_cacheLock) {
+                oldFactory = _factory;
+                _interpreter = ReadInterpreterSetting();
+            }
+
+            RefreshCurrentFactory();
+
+            IPythonInterpreterFactory newFactory;
+            lock (_cacheLock) {
+                newFactory = _factory;
+            }
+
+            if (oldFactory?.Configuration.Id != newFactory?.Configuration.Id) {
+                ActiveInterpreterChanged?.Invoke(this, EventArgs.Empty);
+            }
+        }
+
+        private Task OnSettingsChanged(object sender, EventArgs e) {
+            if (_isDisposed) {
+                return Task.CompletedTask;
+            }
+
+            // The SettingsChanged event is raised frequently, often regarding
+            // changes that don't affect us. We cache the settings that we
+            // care about, and check if those have changed, then raise our
+            // own changed events as applicable.
+            bool interpreterChanged = false;
+            bool searchPathsChanged = false;
+            lock (_cacheLock) {
+                var oldInterpreter = _interpreter;
+                var oldSearchPaths = _searchPaths;
+
+                _interpreter = ReadInterpreterSetting();
+                _searchPaths = ReadSearchPathsSetting();
+
+                interpreterChanged = oldInterpreter != _interpreter;
+                searchPathsChanged = !oldSearchPaths.SequenceEqual(_searchPaths);
+            }
+
+            if (interpreterChanged) {
+                // Avoid potentially raising more than one ActiveInterpreterChanged
+                // by unregistering from events that could raise that event.
+                _optionsService.DefaultInterpreterChanged -= OnDefaultInterpreterChanged;
+                _registryService.InterpretersChanged -= OnInterpretersChanged;
+                try {
+                    InterpreterSettingChanged?.Invoke(this, EventArgs.Empty);
+                } finally {
+                    _optionsService.DefaultInterpreterChanged += OnDefaultInterpreterChanged;
+                    _registryService.InterpretersChanged += OnInterpretersChanged;
+                }
+
+                var oldFactory = CurrentFactory;
+                RefreshCurrentFactory();
+
+                if (oldFactory != CurrentFactory) {
+                    ActiveInterpreterChanged?.Invoke(this, EventArgs.Empty);
+                }
+            }
+
+            if (searchPathsChanged) {
+                SearchPathsSettingChanged?.Invoke(this, EventArgs.Empty);
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/Python/Product/VSInterpreters/Interpreter/PythonWorkspaceContextProvider.cs
+++ b/Python/Product/VSInterpreters/Interpreter/PythonWorkspaceContextProvider.cs
@@ -1,0 +1,110 @@
+﻿// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System;
+using System.ComponentModel.Composition;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Workspace.VSIntegration.Contracts;
+
+namespace Microsoft.PythonTools.Interpreter {
+    [Export(typeof(IPythonWorkspaceContextProvider))]
+    [Export(typeof(PythonWorkspaceContextProvider))]
+    [PartCreationPolicy(CreationPolicy.Shared)]
+    class PythonWorkspaceContextProvider : IPythonWorkspaceContextProvider, IDisposable {
+        private readonly IVsFolderWorkspaceService _workspaceService;
+        private readonly IInterpreterOptionsService _optionsService;
+        private readonly IInterpreterRegistryService _registryService;
+
+        private readonly object _currentContextLock = new object();
+        private IPythonWorkspaceContext _currentContext;
+
+        [ImportingConstructor]
+        public PythonWorkspaceContextProvider(
+            [Import] IVsFolderWorkspaceService workspaceService,
+            [Import] IInterpreterOptionsService optionsService,
+            [Import] IInterpreterRegistryService registryService
+        ) {
+            _workspaceService = workspaceService;
+            _optionsService = optionsService;
+            _registryService = registryService;
+
+            _workspaceService.OnActiveWorkspaceChanged += OnActiveWorkspaceChanged;
+
+            InitializeCurrentContext();
+        }
+
+        public event EventHandler<PythonWorkspaceContextEventArgs> WorkspaceClosing;
+
+        public event EventHandler<PythonWorkspaceContextEventArgs> WorkspaceClosed;
+
+        public event EventHandler<PythonWorkspaceContextEventArgs> WorkspaceOpening;
+
+        public event EventHandler<PythonWorkspaceContextEventArgs> WorkspaceInitialized;
+
+        public IPythonWorkspaceContext Workspace {
+            get {
+                lock (_currentContextLock) {
+                    return _currentContext;
+                }
+            }
+        }
+
+        public void Dispose() {
+            _workspaceService.OnActiveWorkspaceChanged -= OnActiveWorkspaceChanged;
+        }
+
+        private Task OnActiveWorkspaceChanged(object sender, EventArgs e) {
+            CloseCurrentContext();
+            InitializeCurrentContext();
+
+            return Task.CompletedTask;
+        }
+
+        private void CloseCurrentContext() {
+            lock (_currentContextLock) {
+                var current = _currentContext;
+                if (current != null) {
+                    WorkspaceClosing?.Invoke(this, new PythonWorkspaceContextEventArgs(current));
+                    current.Dispose();
+                    WorkspaceClosed?.Invoke(this, new PythonWorkspaceContextEventArgs(current));
+                }
+                _currentContext = null;
+            }
+        }
+
+        private void InitializeCurrentContext() {
+            var workspace = _workspaceService.CurrentWorkspace;
+            if (workspace != null) {
+                var context = new PythonWorkspaceContext(workspace, _optionsService, _registryService);
+
+                // Workspace interpreter factory provider will rescan the
+                // workspace folder for factories.
+                WorkspaceOpening?.Invoke(this, new PythonWorkspaceContextEventArgs(context));
+
+                // Workspace sets its interpreter factory instance,
+                // now that they've been discovered by the factory provider.
+                context.Initialize();
+
+                lock (_currentContextLock) {
+                    _currentContext = context;
+                }
+
+                // Let users know this workspace context is all initialized
+                WorkspaceInitialized?.Invoke(this, new PythonWorkspaceContextEventArgs(context));
+            }
+        }
+    }
+}

--- a/Python/Product/VSInterpreters/PythonWorkspaceContextEventArgs.cs
+++ b/Python/Product/VSInterpreters/PythonWorkspaceContextEventArgs.cs
@@ -1,0 +1,27 @@
+﻿// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System;
+
+namespace Microsoft.PythonTools.Interpreter {
+    public class PythonWorkspaceContextEventArgs : EventArgs {
+        public PythonWorkspaceContextEventArgs(IPythonWorkspaceContext workspace) {
+            Workspace = workspace;
+        }
+
+        public IPythonWorkspaceContext Workspace { get; }
+    }
+}

--- a/Python/Product/VSInterpreters/VSInterpreters.csproj
+++ b/Python/Product/VSInterpreters/VSInterpreters.csproj
@@ -85,6 +85,10 @@
     <Compile Include="Interpreter\LaunchConfiguration.cs" />
     <Compile Include="Interpreter\PythonInterpreterFactoryExtensions.cs" />
     <Compile Include="Interpreter\VisualStudioInterpreterConfiguration.cs" />
+    <Compile Include="Interpreter\IPythonWorkspaceContext.cs" />
+    <Compile Include="Interpreter\PythonWorkspaceContext.cs" />
+    <Compile Include="Interpreter\PythonWorkspaceContextProvider.cs" />
+    <Compile Include="Interpreter\IPythonWorkspaceContextProvider.cs" />
     <Compile Include="Interpreter\WorkspaceInterpreterFactoryConstants.cs" />
     <Compile Include="Interpreter\CondaLocatorProvider.cs" />
     <Compile Include="Interpreter\WorkspaceInterpreterFactoryProvider.cs" />
@@ -129,6 +133,7 @@
     <Compile Include="Interpreter\PythonInterpreterInformation.cs" />
     <Compile Include="Interpreter\PythonRegistrySearch.cs" />
     <Compile Include="RegistryWatcher.cs" />
+    <Compile Include="PythonWorkspaceContextEventArgs.cs" />
     <Compile Include="WorkspaceExtensions.cs" />
   </ItemGroup>
   <Import Project="..\ProjectAfter.settings" />

--- a/Python/Product/Workspace/PythonLaunchConfigurationProvider.cs
+++ b/Python/Product/Workspace/PythonLaunchConfigurationProvider.cs
@@ -35,6 +35,7 @@ namespace Microsoft.PythonTools.Workspace {
             launchSettings[PythonLaunchDebugTargetProvider.InterpreterKey] = "(default)";
             launchSettings[PythonLaunchDebugTargetProvider.InterpreterArgumentsKey] = string.Empty;
             launchSettings[PythonLaunchDebugTargetProvider.ScriptArgumentsKey] = string.Empty;
+            launchSettings[PythonLaunchDebugTargetProvider.EnvKey] = PropertySettings.EmptySettings;
             launchSettings[PythonLaunchDebugTargetProvider.NativeDebuggingKey] = false;
             launchSettings[PythonLaunchDebugTargetProvider.WebBrowserUrlKey] = string.Empty;
         }

--- a/Python/Tests/Core/PythonToolsTests.csproj
+++ b/Python/Tests/Core/PythonToolsTests.csproj
@@ -108,6 +108,8 @@
     <Compile Include="AutoIndentTests.cs" />
     <Compile Include="BuildTasksTests.cs" />
     <Compile Include="CodeCellTests.cs" />
+    <Compile Include="PythonWorkspaceContextProviderTests.cs" />
+    <Compile Include="PythonWorkspaceContextTests.cs" />
     <Compile Include="WorkspaceInterpreterFactoryTests.cs" />
     <Compile Include="CoverageTests.cs" />
     <Compile Include="CondaEnvironmentManagerTests.cs" />
@@ -137,6 +139,7 @@
     <Compile Include="SocketUtilsTests.cs" />
     <Compile Include="TaskExtensionsTests.cs" />
     <Compile Include="TestExpressions.cs" />
+    <Compile Include="WorkspaceTestHelper.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Product\BuildTasks\BuildTasks.csproj">

--- a/Python/Tests/Core/PythonWorkspaceContextProviderTests.cs
+++ b/Python/Tests/Core/PythonWorkspaceContextProviderTests.cs
@@ -1,0 +1,142 @@
+// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System.Threading;
+using Microsoft.PythonTools.Interpreter;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using TestUtilities;
+
+namespace PythonToolsTests {
+    [TestClass]
+    public class PythonWorkspaceContextProviderTests {
+        [ClassInitialize]
+        public static void DoDeployment(TestContext context) {
+            AssertListener.Initialize();
+        }
+
+        [TestMethod, Priority(0)]
+        public void AlreadyOpenedWorkspace() {
+            var workspaceFolder = WorkspaceTestHelper.CreateWorkspaceFolder();
+            var workspace = WorkspaceTestHelper.CreateMockWorkspace(workspaceFolder, WorkspaceTestHelper.PythonNoId);
+            var workspaceService = new WorkspaceTestHelper.MockWorkspaceService(workspace);
+            var optionsService = new WorkspaceTestHelper.MockOptionsService(WorkspaceTestHelper.DefaultFactory);
+            var registryService = new WorkspaceTestHelper.MockRegistryService(WorkspaceTestHelper.AllFactories);
+            var provider = new PythonWorkspaceContextProvider(workspaceService, optionsService, registryService);
+
+            Assert.AreEqual(workspaceFolder, provider.Workspace.Location);
+            Assert.AreEqual(WorkspaceTestHelper.DefaultFactory, provider.Workspace.CurrentFactory);
+        }
+
+        [TestMethod, Priority(0)]
+        public void LoadWorkspace() {
+            var workspaceFolder = WorkspaceTestHelper.CreateWorkspaceFolder();
+            var workspace = WorkspaceTestHelper.CreateMockWorkspace(workspaceFolder, WorkspaceTestHelper.PythonNoId);
+            var workspaceService = new WorkspaceTestHelper.MockWorkspaceService(null);
+            var optionsService = new WorkspaceTestHelper.MockOptionsService(WorkspaceTestHelper.DefaultFactory);
+            var registryService = new WorkspaceTestHelper.MockRegistryService(WorkspaceTestHelper.AllFactories);
+            var provider = new PythonWorkspaceContextProvider(workspaceService, optionsService, registryService);
+
+            Assert.AreEqual(null, provider.Workspace);
+
+            using (var openEvent = new AutoResetEvent(false))
+            using (var initEvent = new AutoResetEvent(false))
+            using (var closingEvent = new AutoResetEvent(false))
+            using (var closedEvent = new AutoResetEvent(false)) {
+                provider.WorkspaceOpening += (sender, e) => { openEvent.Set(); };
+                provider.WorkspaceInitialized += (sender, e) => { initEvent.Set(); };
+                provider.WorkspaceClosed += (sender, e) => { closedEvent.Set(); };
+                provider.WorkspaceClosing += (sender, e) => { closingEvent.Set(); };
+
+                workspaceService.SimulateChangeWorkspace(workspace);
+
+                Assert.IsTrue(openEvent.WaitOne(1000), $"Expected {nameof(provider.WorkspaceOpening)}.");
+                Assert.IsTrue(initEvent.WaitOne(1000), $"Expected {nameof(provider.WorkspaceInitialized)}.");
+                Assert.IsFalse(closingEvent.WaitOne(1000), $"Unexpected {nameof(provider.WorkspaceClosing)}.");
+                Assert.IsFalse(closedEvent.WaitOne(1000), $"Unexpected {nameof(provider.WorkspaceClosed)}.");
+
+                Assert.AreEqual(workspaceFolder, provider.Workspace.Location);
+                Assert.AreEqual(WorkspaceTestHelper.DefaultFactory, provider.Workspace.CurrentFactory);
+            }
+        }
+
+        [TestMethod, Priority(0)]
+        public void CloseWorkspace() {
+            var workspaceFolder = WorkspaceTestHelper.CreateWorkspaceFolder();
+            var workspace = WorkspaceTestHelper.CreateMockWorkspace(workspaceFolder, WorkspaceTestHelper.PythonNoId);
+            var workspaceService = new WorkspaceTestHelper.MockWorkspaceService(workspace);
+            var optionsService = new WorkspaceTestHelper.MockOptionsService(WorkspaceTestHelper.DefaultFactory);
+            var registryService = new WorkspaceTestHelper.MockRegistryService(WorkspaceTestHelper.AllFactories);
+            var provider = new PythonWorkspaceContextProvider(workspaceService, optionsService, registryService);
+
+            Assert.AreEqual(workspaceFolder, provider.Workspace.Location);
+            Assert.AreEqual(WorkspaceTestHelper.DefaultFactory, provider.Workspace.CurrentFactory);
+
+            using (var openEvent = new AutoResetEvent(false))
+            using (var initEvent = new AutoResetEvent(false))
+            using (var closingEvent = new AutoResetEvent(false))
+            using (var closedEvent = new AutoResetEvent(false)) {
+                provider.WorkspaceOpening += (sender, e) => { openEvent.Set(); };
+                provider.WorkspaceInitialized += (sender, e) => { initEvent.Set();};
+                provider.WorkspaceClosed += (sender, e) => { closedEvent.Set(); };
+                provider.WorkspaceClosing += (sender, e) => { closingEvent.Set(); };
+
+                workspaceService.SimulateChangeWorkspace(null);
+
+                Assert.IsFalse(openEvent.WaitOne(1000), $"Unexpected {nameof(provider.WorkspaceOpening)}.");
+                Assert.IsFalse(initEvent.WaitOne(1000), $"Unexpected {nameof(provider.WorkspaceInitialized)}.");
+                Assert.IsTrue(closingEvent.WaitOne(1000), $"Expected {nameof(provider.WorkspaceClosing)}.");
+                Assert.IsTrue(closedEvent.WaitOne(1000), $"Expected {nameof(provider.WorkspaceClosed)}.");
+
+                Assert.AreEqual(null, provider.Workspace);
+            }
+        }
+
+        [TestMethod, Priority(0)]
+        public void SwitchWorkspace() {
+            var workspaceFolder1 = WorkspaceTestHelper.CreateWorkspaceFolder();
+            var workspaceFolder2 = WorkspaceTestHelper.CreateWorkspaceFolder();
+            var workspace1 = WorkspaceTestHelper.CreateMockWorkspace(workspaceFolder1, WorkspaceTestHelper.Python27Id);
+            var workspace2 = WorkspaceTestHelper.CreateMockWorkspace(workspaceFolder2, WorkspaceTestHelper.Python37Id);
+            var workspaceService = new WorkspaceTestHelper.MockWorkspaceService(workspace1);
+            var optionsService = new WorkspaceTestHelper.MockOptionsService(WorkspaceTestHelper.DefaultFactory);
+            var registryService = new WorkspaceTestHelper.MockRegistryService(WorkspaceTestHelper.AllFactories);
+            var provider = new PythonWorkspaceContextProvider(workspaceService, optionsService, registryService);
+
+            Assert.AreEqual(workspaceFolder1, provider.Workspace.Location);
+            Assert.AreEqual(WorkspaceTestHelper.Python27Factory, provider.Workspace.CurrentFactory);
+
+            using (var openEvent = new AutoResetEvent(false))
+            using (var initEvent = new AutoResetEvent(false))
+            using (var closingEvent = new AutoResetEvent(false))
+            using (var closedEvent = new AutoResetEvent(false)) {
+                provider.WorkspaceOpening += (sender, e) => { openEvent.Set(); };
+                provider.WorkspaceInitialized += (sender, e) => { initEvent.Set(); };
+                provider.WorkspaceClosed += (sender, e) => { closedEvent.Set(); };
+                provider.WorkspaceClosing += (sender, e) => { closingEvent.Set(); };
+
+                workspaceService.SimulateChangeWorkspace(workspace2);
+
+                Assert.IsTrue(openEvent.WaitOne(1000), $"Expected {nameof(provider.WorkspaceOpening)}.");
+                Assert.IsTrue(initEvent.WaitOne(1000), $"Expected {nameof(provider.WorkspaceInitialized)}.");
+                Assert.IsTrue(closingEvent.WaitOne(1000), $"Expected {nameof(provider.WorkspaceClosing)}.");
+                Assert.IsTrue(closedEvent.WaitOne(1000), $"Expected {nameof(provider.WorkspaceClosed)}.");
+
+                Assert.AreEqual(workspaceFolder2, provider.Workspace.Location);
+                Assert.AreEqual(WorkspaceTestHelper.Python37Factory, provider.Workspace.CurrentFactory);
+            }
+        }
+    }
+}

--- a/Python/Tests/Core/PythonWorkspaceContextTests.cs
+++ b/Python/Tests/Core/PythonWorkspaceContextTests.cs
@@ -1,0 +1,299 @@
+// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using Microsoft.PythonTools.Infrastructure;
+using Microsoft.PythonTools.Interpreter;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using TestUtilities;
+
+namespace PythonToolsTests {
+    [TestClass]
+    public class PythonWorkspaceContextTests {
+        [ClassInitialize]
+        public static void DoDeployment(TestContext context) {
+            AssertListener.Initialize();
+        }
+
+        [TestMethod, Priority(0)]
+        public void DefaultInterpreter() {
+            var data = PrepareWorkspace(WorkspaceTestHelper.PythonNoId);
+
+            var workspaceContext = new PythonWorkspaceContext(data.Workspace, data.OptionsService, data.RegistryService);
+            workspaceContext.Initialize();
+
+            var interpreter = workspaceContext.ReadInterpreterSetting();
+            Assert.AreEqual(WorkspaceTestHelper.PythonNoId, interpreter);
+            Assert.AreEqual(WorkspaceTestHelper.DefaultFactory, workspaceContext.CurrentFactory);
+        }
+
+        [TestMethod, Priority(0)]
+        public void InstalledInterpreter() {
+            var data = PrepareWorkspace(WorkspaceTestHelper.Python27Id);
+
+            var workspaceContext = new PythonWorkspaceContext(data.Workspace, data.OptionsService, data.RegistryService);
+            workspaceContext.Initialize();
+
+            var interpreter = workspaceContext.ReadInterpreterSetting();
+            Assert.AreEqual(WorkspaceTestHelper.Python27Id, interpreter);
+            Assert.AreEqual(WorkspaceTestHelper.Python27Factory, workspaceContext.CurrentFactory);
+        }
+
+        [TestMethod, Priority(0)]
+        public void UnavailableInterpreter() {
+            var data = PrepareWorkspace(WorkspaceTestHelper.PythonUnavailableId);
+
+            var workspaceContext = new PythonWorkspaceContext(data.Workspace, data.OptionsService, data.RegistryService);
+            workspaceContext.Initialize();
+
+            var interpreter = workspaceContext.ReadInterpreterSetting();
+            Assert.AreEqual(WorkspaceTestHelper.PythonUnavailableId, interpreter);
+            Assert.AreEqual(WorkspaceTestHelper.DefaultFactory, workspaceContext.CurrentFactory);
+        }
+
+        [TestMethod, Priority(0)]
+        public void ChangeInterpreterSetting() {
+            var data = PrepareWorkspace(WorkspaceTestHelper.Python27Id);
+
+            var workspaceContext = new PythonWorkspaceContext(data.Workspace, data.OptionsService, data.RegistryService);
+            workspaceContext.Initialize();
+
+            var interpreter = workspaceContext.ReadInterpreterSetting();
+            Assert.AreEqual(WorkspaceTestHelper.Python27Id, interpreter);
+            Assert.AreEqual(WorkspaceTestHelper.Python27Factory, workspaceContext.CurrentFactory);
+
+            using (var activeInterpreterEvent = new AutoResetEvent(false))
+            using (var interpreterSettingEvent = new AutoResetEvent(false)) {
+                workspaceContext.ActiveInterpreterChanged += (sender, e) => {
+                    activeInterpreterEvent.Set();
+                };
+
+                workspaceContext.InterpreterSettingChanged += (sender, e) => {
+                    interpreterSettingEvent.Set();
+                };
+
+                var updatedSettings = new WorkspaceTestHelper.MockWorkspaceSettings(
+                    new Dictionary<string, string> { { "Interpreter", WorkspaceTestHelper.Python37Id } }
+                );
+                data.Workspace.SettingsManager.SimulateChangeSettings(updatedSettings);
+
+                Assert.IsTrue(activeInterpreterEvent.WaitOne(1000), "Failed to raise ActiveInterpreterChanged.");
+                Assert.IsTrue(interpreterSettingEvent.WaitOne(1000), "Failed to raise InterpreterSettingChanged.");
+
+                var updatedInterpreter = workspaceContext.ReadInterpreterSetting();
+                Assert.AreEqual(WorkspaceTestHelper.Python37Id, updatedInterpreter);
+                Assert.AreEqual(WorkspaceTestHelper.Python37Factory, workspaceContext.CurrentFactory);
+            }
+        }
+
+        [TestMethod, Priority(0)]
+        public void RemoveInterpreterSetting() {
+            var data = PrepareWorkspace(WorkspaceTestHelper.Python27Id);
+
+            var workspaceContext = new PythonWorkspaceContext(data.Workspace, data.OptionsService, data.RegistryService);
+            workspaceContext.Initialize();
+
+            var interpreter = workspaceContext.ReadInterpreterSetting();
+            Assert.AreEqual(WorkspaceTestHelper.Python27Id, interpreter);
+            Assert.AreEqual(WorkspaceTestHelper.Python27Factory, workspaceContext.CurrentFactory);
+
+            using (var activeInterpreterEvent = new AutoResetEvent(false))
+            using (var interpreterSettingEvent = new AutoResetEvent(false)) {
+                workspaceContext.ActiveInterpreterChanged += (sender, e) => {
+                    activeInterpreterEvent.Set();
+                };
+
+                workspaceContext.InterpreterSettingChanged += (sender, e) => {
+                    interpreterSettingEvent.Set();
+                };
+
+                var updatedSettings = new WorkspaceTestHelper.MockWorkspaceSettings(
+                    new Dictionary<string, string> { { "Interpreter", WorkspaceTestHelper.PythonNoId } }
+                );
+                data.Workspace.SettingsManager.SimulateChangeSettings(updatedSettings);
+
+                Assert.IsTrue(activeInterpreterEvent.WaitOne(1000), "Failed to raise ActiveInterpreterChanged.");
+                Assert.IsTrue(interpreterSettingEvent.WaitOne(1000), "Failed to raise InterpreterSettingChanged.");
+
+                var updatedInterpreter = workspaceContext.ReadInterpreterSetting();
+                Assert.AreEqual(WorkspaceTestHelper.PythonNoId, updatedInterpreter);
+                Assert.AreEqual(WorkspaceTestHelper.DefaultFactory, workspaceContext.CurrentFactory);
+            }
+        }
+
+        [TestMethod, Priority(0)]
+        public void RemoveInterpreterSettingAlreadyDefault() {
+            var data = PrepareWorkspace(WorkspaceTestHelper.DefaultFactory.Configuration.Id);
+
+            var workspaceContext = new PythonWorkspaceContext(data.Workspace, data.OptionsService, data.RegistryService);
+            workspaceContext.Initialize();
+
+            var interpreter = workspaceContext.ReadInterpreterSetting();
+            Assert.AreEqual(WorkspaceTestHelper.DefaultFactory.Configuration.Id, interpreter);
+            Assert.AreEqual(WorkspaceTestHelper.DefaultFactory, workspaceContext.CurrentFactory);
+
+            using (var activeInterpreterEvent = new AutoResetEvent(false))
+            using (var interpreterSettingEvent = new AutoResetEvent(false)) {
+                workspaceContext.ActiveInterpreterChanged += (sender, e) => {
+                    activeInterpreterEvent.Set();
+                };
+
+                workspaceContext.InterpreterSettingChanged += (sender, e) => {
+                    interpreterSettingEvent.Set();
+                };
+
+                var updatedSettings = new WorkspaceTestHelper.MockWorkspaceSettings(
+                    new Dictionary<string, string> { { "Interpreter", WorkspaceTestHelper.PythonNoId } }
+                );
+                data.Workspace.SettingsManager.SimulateChangeSettings(updatedSettings);
+
+                Assert.IsFalse(activeInterpreterEvent.WaitOne(1000), "Should not have raised ActiveInterpreterChanged.");
+                Assert.IsTrue(interpreterSettingEvent.WaitOne(1000), "Failed to raise InterpreterSettingChanged.");
+
+                var updatedInterpreter = workspaceContext.ReadInterpreterSetting();
+                Assert.AreEqual(WorkspaceTestHelper.PythonNoId, updatedInterpreter);
+                Assert.AreEqual(WorkspaceTestHelper.DefaultFactory, workspaceContext.CurrentFactory);
+            }
+        }
+
+        [TestMethod, Priority(0)]
+        public void ChangeDefaultInterpreterInUse() {
+            var data = PrepareWorkspace(WorkspaceTestHelper.PythonNoId);
+
+            var workspaceContext = new PythonWorkspaceContext(data.Workspace, data.OptionsService, data.RegistryService);
+            workspaceContext.Initialize();
+
+            var interpreter = workspaceContext.ReadInterpreterSetting();
+            Assert.AreEqual(WorkspaceTestHelper.PythonNoId, interpreter);
+            Assert.AreEqual(WorkspaceTestHelper.DefaultFactory, workspaceContext.CurrentFactory);
+
+            using (var activeInterpreterEvent = new AutoResetEvent(false)) {
+                workspaceContext.ActiveInterpreterChanged += (sender, e) => {
+                    activeInterpreterEvent.Set();
+                };
+
+                data.OptionsService.SimulateChangeDefaultInterpreter(WorkspaceTestHelper.Python37Factory);
+
+                Assert.IsTrue(activeInterpreterEvent.WaitOne(1000), "Failed to raise ActiveInterpreterChanged.");
+
+                var updatedInterpreter = workspaceContext.ReadInterpreterSetting();
+                Assert.AreEqual(WorkspaceTestHelper.PythonNoId, updatedInterpreter);
+                Assert.AreEqual(WorkspaceTestHelper.Python37Factory, workspaceContext.CurrentFactory);
+            }
+        }
+
+        [TestMethod, Priority(0)]
+        public void ChangeDefaultInterpreterNotInUse() {
+            // We don't use the global default
+            var data = PrepareWorkspace(WorkspaceTestHelper.Python27Id);
+
+            var workspaceContext = new PythonWorkspaceContext(data.Workspace, data.OptionsService, data.RegistryService);
+            workspaceContext.Initialize();
+
+            var interpreter = workspaceContext.ReadInterpreterSetting();
+            Assert.AreEqual(WorkspaceTestHelper.Python27Id, interpreter);
+            Assert.AreEqual(WorkspaceTestHelper.Python27Factory, workspaceContext.CurrentFactory);
+
+            using (var activeInterpreterEvent = new AutoResetEvent(false)) {
+                workspaceContext.ActiveInterpreterChanged += (sender, e) => {
+                    activeInterpreterEvent.Set();
+                };
+
+                data.OptionsService.SimulateChangeDefaultInterpreter(WorkspaceTestHelper.Python37Factory);
+
+                Assert.IsFalse(activeInterpreterEvent.WaitOne(1000), "Should not have raised ActiveInterpreterChanged.");
+
+                var updatedInterpreter = workspaceContext.ReadInterpreterSetting();
+                Assert.AreEqual(WorkspaceTestHelper.Python27Id, updatedInterpreter);
+                Assert.AreEqual(WorkspaceTestHelper.Python27Factory, workspaceContext.CurrentFactory);
+            }
+        }
+
+        [TestMethod, Priority(0)]
+        public void RemoveInterpreterInUse() {
+            var data = PrepareWorkspace(WorkspaceTestHelper.Python27Id);
+
+            var workspaceContext = new PythonWorkspaceContext(data.Workspace, data.OptionsService, data.RegistryService);
+            workspaceContext.Initialize();
+
+            var interpreter = workspaceContext.ReadInterpreterSetting();
+            Assert.AreEqual(WorkspaceTestHelper.Python27Id, interpreter);
+            Assert.AreEqual(WorkspaceTestHelper.Python27Factory, workspaceContext.CurrentFactory);
+
+            using (var activeInterpreterEvent = new AutoResetEvent(false)) {
+                workspaceContext.ActiveInterpreterChanged += (sender, e) => {
+                    activeInterpreterEvent.Set();
+                };
+
+                // Uninstall Python 2.7 - in use
+                var newFactories = WorkspaceTestHelper.AllFactories.Except(WorkspaceTestHelper.Python27Factory);
+                data.RegistryService.SimulateChangeInterpreters(newFactories);
+
+                Assert.IsTrue(activeInterpreterEvent.WaitOne(1000), "Failed to raise ActiveInterpreterChanged.");
+
+                var updatedInterpreter = workspaceContext.ReadInterpreterSetting();
+                Assert.AreEqual(WorkspaceTestHelper.Python27Id, updatedInterpreter);
+                Assert.AreEqual(WorkspaceTestHelper.DefaultFactory, workspaceContext.CurrentFactory);
+            }
+        }
+
+        [TestMethod, Priority(0)]
+        public void RemoveInterpreterNotInUse() {
+            var data = PrepareWorkspace(WorkspaceTestHelper.Python27Id);
+
+            var workspaceContext = new PythonWorkspaceContext(data.Workspace, data.OptionsService, data.RegistryService);
+            workspaceContext.Initialize();
+
+            var interpreter = workspaceContext.ReadInterpreterSetting();
+            Assert.AreEqual(WorkspaceTestHelper.Python27Id, interpreter);
+            Assert.AreEqual(WorkspaceTestHelper.Python27Factory, workspaceContext.CurrentFactory);
+
+            using (var activeInterpreterEvent = new AutoResetEvent(false)) {
+                workspaceContext.ActiveInterpreterChanged += (sender, e) => {
+                    activeInterpreterEvent.Set();
+                };
+
+                // Uninstall Python 3.7 - not in use
+                var newFactories = WorkspaceTestHelper.AllFactories.Except(WorkspaceTestHelper.Python37Factory);
+                data.RegistryService.SimulateChangeInterpreters(newFactories);
+
+                Assert.IsFalse(activeInterpreterEvent.WaitOne(1000), "Should not have raised ActiveInterpreterChanged.");
+
+                var updatedInterpreter = workspaceContext.ReadInterpreterSetting();
+                Assert.AreEqual(WorkspaceTestHelper.Python27Id, updatedInterpreter);
+                Assert.AreEqual(WorkspaceTestHelper.Python27Factory, workspaceContext.CurrentFactory);
+            }
+        }
+
+        private static TestSetupData PrepareWorkspace(string interpreterSetting) {
+            return new TestSetupData {
+                OptionsService = new WorkspaceTestHelper.MockOptionsService(WorkspaceTestHelper.DefaultFactory),
+                RegistryService = new WorkspaceTestHelper.MockRegistryService(WorkspaceTestHelper.AllFactories),
+                Workspace = WorkspaceTestHelper.CreateMockWorkspace(WorkspaceTestHelper.CreateWorkspaceFolder(), interpreterSetting),
+            };
+        }
+
+        class TestSetupData {
+            public WorkspaceTestHelper.MockOptionsService OptionsService { get; set; }
+
+            public WorkspaceTestHelper.MockRegistryService RegistryService { get; set; }
+
+            public WorkspaceTestHelper.MockWorkspace Workspace { get; set; }
+        }
+    }
+}

--- a/Python/Tests/Core/WorkspaceInterpreterFactoryTests.cs
+++ b/Python/Tests/Core/WorkspaceInterpreterFactoryTests.cs
@@ -19,15 +19,9 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.PythonTools.Infrastructure;
 using Microsoft.PythonTools.Interpreter;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Microsoft.VisualStudio.Threading;
-using Microsoft.VisualStudio.Workspace;
-using Microsoft.VisualStudio.Workspace.Intellisense;
-using Microsoft.VisualStudio.Workspace.Settings;
-using Microsoft.VisualStudio.Workspace.VSIntegration.Contracts;
 using TestUtilities;
 
 namespace PythonToolsTests {
@@ -48,17 +42,22 @@ namespace PythonToolsTests {
             Directory.CreateDirectory(workspaceFolder2);
             File.WriteAllText(Path.Combine(workspaceFolder2, "app2.py"), string.Empty);
 
-            var workspace1 = new MockWorkspace(workspaceFolder1);
-            var workspace2 = new MockWorkspace(workspaceFolder2);
+            var workspace1 = new WorkspaceTestHelper.MockWorkspace(workspaceFolder1);
+            var workspace2 = new WorkspaceTestHelper.MockWorkspace(workspaceFolder2);
 
-            var workspaceService = new MockWorkspaceService(workspace1);
+            var workspaceContext1 = new WorkspaceTestHelper.MockWorkspaceContext(workspace1);
+            var workspaceContext2 = new WorkspaceTestHelper.MockWorkspaceContext(workspace2);
 
-            // Load a different workspace
-            Action triggerDiscovery = () => {
-                workspaceService.ChangeWorkspace(workspace2);
-            };
+            var workspaceContextProvider = new WorkspaceTestHelper.MockWorkspaceContextProvider(workspaceContext1);
 
-            TestTriggerDiscovery(workspaceService, triggerDiscovery, true);
+            using (var factoryProvider = new WorkspaceInterpreterFactoryProvider(workspaceContextProvider)) {
+                // Load a different workspace
+                Action triggerDiscovery = () => {
+                    workspaceContextProvider.SimulateChangeWorkspace(workspaceContext2);
+                };
+
+                TestTriggerDiscovery(workspaceContext1, triggerDiscovery, workspaceContextProvider, true);
+            }
         }
 
         [TestMethod, Priority(0)]
@@ -67,22 +66,15 @@ namespace PythonToolsTests {
             Directory.CreateDirectory(workspaceFolder);
             File.WriteAllText(Path.Combine(workspaceFolder, "app.py"), string.Empty);
 
-            var aggregatedSettings1 = new MockWorkspaceSettings(
-                new Dictionary<string, string> { { "Interpreter", null } }
-            );
-            var aggregatedSettings2 = new MockWorkspaceSettings(
-                new Dictionary<string, string> { { "Interpreter", "Global|PythonCore|3.7" } }
-            );
-            var settingsManager = new MockWorkspaceSettingsManager(aggregatedSettings1);
-            var workspace = new MockWorkspace(workspaceFolder, settingsManager);
-            var workspaceService = new MockWorkspaceService(workspace);
+            var workspace = new WorkspaceTestHelper.MockWorkspace(workspaceFolder);
+            var workspaceContext = new WorkspaceTestHelper.MockWorkspaceContext(workspace);
 
             // Modify settings
             Action triggerDiscovery = () => {
-                settingsManager.ChangeSettings(aggregatedSettings2);
+                workspaceContext.SimulateChangeInterpreterSetting("Global|PythonCore|3.7");
             };
 
-            TestTriggerDiscovery(workspaceService, triggerDiscovery, true);
+            TestTriggerDiscovery(workspaceContext, triggerDiscovery, null, true);
         }
 
         [TestMethod, Priority(0)]
@@ -95,12 +87,12 @@ namespace PythonToolsTests {
 
             string envFolder = Path.Combine(workspaceFolder, "env");
 
-            var workspace = new MockWorkspace(workspaceFolder);
-            var workspaceService = new MockWorkspaceService(workspace);
+            var workspace = new WorkspaceTestHelper.MockWorkspace(workspaceFolder);
+            var workspaceContext = new WorkspaceTestHelper.MockWorkspaceContext(workspace);
 
             // Create virtual env inside the workspace folder (one level from root)
             var configs = TestTriggerDiscovery(
-                workspaceService,
+                workspaceContext,
                 () => CreatePythonVirtualEnv(python.InterpreterPath, workspaceFolder, "env")
             ).ToArray();
 
@@ -134,15 +126,13 @@ namespace PythonToolsTests {
             // Normally a local virtual environment outside the workspace
             // wouldn't be detected, but it is when it's referenced from
             // the workspace python settings.
-            var aggregatedSettings = new MockWorkspaceSettings(
-                new Dictionary<string, string> { { "Interpreter", @"..\outside\scripts\python.exe" } }
-            );
-            var settingsManager = new MockWorkspaceSettingsManager(aggregatedSettings);
-            var workspace = new MockWorkspace(workspaceFolder, settingsManager);
-            var workspaceService = new MockWorkspaceService(workspace);
+            var workspace = new WorkspaceTestHelper.MockWorkspace(workspaceFolder);
+            var workspaceContext = new WorkspaceTestHelper.MockWorkspaceContext(workspace, @"..\outside\scripts\python.exe");
+            var workspaceContextProvider = new WorkspaceTestHelper.MockWorkspaceContextProvider(workspaceContext);
 
-            using (var provider = new WorkspaceInterpreterFactoryProvider(workspaceService)) {
-                var configs = provider.GetInterpreterConfigurations().ToArray();
+            using (var factoryProvider = new WorkspaceInterpreterFactoryProvider(workspaceContextProvider)) {
+                workspaceContextProvider.SimulateChangeWorkspace(workspaceContext);
+                var configs = factoryProvider.GetInterpreterConfigurations().ToArray();
 
                 Assert.AreEqual(1, configs.Length);
                 Assert.IsTrue(PathUtils.IsSamePath(
@@ -156,39 +146,42 @@ namespace PythonToolsTests {
         [TestMethod, Priority(0)]
         public void WatchWorkspaceVirtualEnvRenamed() {
             const string ENV_NAME = "env";
-            var workspaceService = CreateEnvAndGetWorkspaceService(ENV_NAME);
+            var workspaceContext = CreateEnvAndGetWorkspaceService(ENV_NAME);
 
-            string envPath = Path.Combine(workspaceService.CurrentWorkspace.Location, ENV_NAME);
-            string renamedEnvPath = Path.Combine(workspaceService.CurrentWorkspace.Location, string.Concat(ENV_NAME, "1"));
-            var configs = TestTriggerDiscovery
-                (workspaceService, () => Directory.Move(envPath, renamedEnvPath)).ToArray();
+            string envPath = Path.Combine(workspaceContext.Location, ENV_NAME);
+            string renamedEnvPath = Path.Combine(workspaceContext.Location, string.Concat(ENV_NAME, "1"));
+            var configs = TestTriggerDiscovery(workspaceContext, () => Directory.Move(envPath, renamedEnvPath)).ToArray();
 
             Assert.AreEqual(1, configs.Length);
-            Assert.IsTrue(PathUtils.IsSamePath(Path.Combine(renamedEnvPath, "scripts", "python.exe"),configs[0].InterpreterPath));
+            Assert.IsTrue(PathUtils.IsSamePath(Path.Combine(renamedEnvPath, "scripts", "python.exe"), configs[0].InterpreterPath));
             Assert.AreEqual("Workspace|Workspace|env1", configs[0].Id);
         }
 
         [TestMethod, Priority(0)]
         public void WatchWorkspaceVirtualEnvDeleted() {
             const string ENV_NAME = "env";
-            var workspaceService = CreateEnvAndGetWorkspaceService(ENV_NAME);
+            var workspaceContext = CreateEnvAndGetWorkspaceService(ENV_NAME);
 
-            string envPath = Path.Combine(workspaceService.CurrentWorkspace.Location, ENV_NAME);
-            var configs = TestTriggerDiscovery(workspaceService, () => Directory.Delete(envPath, true)).ToArray();
+            string envPath = Path.Combine(workspaceContext.Location, ENV_NAME);
+            var configs = TestTriggerDiscovery(workspaceContext, () => Directory.Delete(envPath, true)).ToArray();
 
             Assert.AreEqual(0, configs.Length);
         }
 
         private static IEnumerable<InterpreterConfiguration> TestTriggerDiscovery(
-                IVsFolderWorkspaceService workspaceService,
+                IPythonWorkspaceContext workspaceContext,
                 Action triggerDiscovery,
+                IPythonWorkspaceContextProvider workspaceContextProvider = null,
                 bool useDiscoveryStartedEvent = false
         ) {
-            using (var evt = new AutoResetEvent(false))
-            using (var provider = new WorkspaceInterpreterFactoryProvider(workspaceService)) {
+            workspaceContextProvider = workspaceContextProvider
+                ?? new WorkspaceTestHelper.MockWorkspaceContextProvider(workspaceContext);
+
+            using (var provider = new WorkspaceInterpreterFactoryProvider(workspaceContextProvider))
+            using (var evt = new AutoResetEvent(false)) {
                 // This initializes the provider, discovers the initial set
                 // of factories and starts watching the filesystem.
-                var configs = provider.GetInterpreterConfigurations();
+                provider.GetInterpreterFactories();
 
                 if (useDiscoveryStartedEvent) {
                     provider.DiscoveryStarted += (sender, e) => {
@@ -206,7 +199,7 @@ namespace PythonToolsTests {
             }
         }
 
-        private MockWorkspaceService CreateEnvAndGetWorkspaceService(string envName) {
+        private WorkspaceTestHelper.MockWorkspaceContext CreateEnvAndGetWorkspaceService(string envName) {
             var python = PythonPaths.Python37_x64 ?? PythonPaths.Python37;
 
             var workspacePath = TestData.GetTempPath();
@@ -215,7 +208,7 @@ namespace PythonToolsTests {
 
             CreatePythonVirtualEnv(python.InterpreterPath, workspacePath, envName);
 
-            return new MockWorkspaceService(new MockWorkspace(workspacePath));
+            return new WorkspaceTestHelper.MockWorkspaceContext(new WorkspaceTestHelper.MockWorkspace(workspacePath));
         }
 
         private static void CreatePythonVirtualEnv(string pythonInterpreterPath, string workspacePath, string envName) {
@@ -227,167 +220,6 @@ namespace PythonToolsTests {
                 Assert.AreEqual(0, p.ExitCode);
             }
             Assert.IsTrue(File.Exists(Path.Combine(workspacePath, envName, "scripts", "python.exe")));
-        }
-
-        class MockWorkspaceService : IVsFolderWorkspaceService {
-            public MockWorkspaceService(IWorkspace workspace) {
-                CurrentWorkspace = workspace;
-            }
-
-            public IWorkspace CurrentWorkspace { get; private set; }
-
-            public AsyncEvent<EventArgs> OnActiveWorkspaceChanged { get; set; }
-
-            public void ChangeWorkspace(IWorkspace workspace) {
-                CurrentWorkspace = workspace;
-                OnActiveWorkspaceChanged?.InvokeAsync(this, EventArgs.Empty).DoNotWait();
-            }
-        }
-
-        class MockWorkspace : IWorkspace {
-            private readonly MockWorkspaceSettingsManager _settingsManager;
-
-            public MockWorkspace(string location) {
-                Location = location;
-                _settingsManager = new MockWorkspaceSettingsManager();
-            }
-
-            public MockWorkspace(string location, MockWorkspaceSettingsManager settingsManager) {
-                Location = location;
-                _settingsManager = settingsManager;
-            }
-
-            public string Location { get; private set; }
-
-            public JoinableTaskFactory JTF => throw new NotImplementedException();
-
-            public Task DisposeAsync() {
-                throw new NotImplementedException();
-            }
-
-            public Task<IReadOnlyList<IGrouping<Lazy<IFileContextActionProvider, IFileContextActionProviderMetadata>, IFileContextAction>>> GetActionsForContextsAsync(string filePath, IEnumerable<FileContext> fileContexts, CancellationToken cancellationToken = default(CancellationToken)) {
-                throw new NotImplementedException();
-            }
-
-            public Task<IReadOnlyCollection<string>> GetDirectoriesAsync(string subPath, bool recursive, CancellationToken cancellationToken = default(CancellationToken)) {
-                throw new NotImplementedException();
-            }
-
-            public Task<IReadOnlyList<IGrouping<Lazy<IFileContextActionProvider, IFileContextActionProviderMetadata>, IFileContextAction>>> GetFileContextActionsAsync(string path, IEnumerable<Guid> fileContextTypes, CancellationToken cancellationToken = default(CancellationToken)) {
-                throw new NotImplementedException();
-            }
-
-            public Task<IReadOnlyList<IGrouping<Lazy<IFileContextActionProvider, IFileContextActionProviderMetadata>, IFileContextAction>>> GetFileContextActionsAsync<T>(string path, T context, IEnumerable<Guid> fileContextTypes, CancellationToken cancellationToken = default(CancellationToken)) {
-                throw new NotImplementedException();
-            }
-
-            public Task<IReadOnlyList<IGrouping<Lazy<IFileContextProvider, IFileContextProviderMetadata>, FileContext>>> GetFileContextsAsync(string path, IEnumerable<Guid> fileContextTypes, CancellationToken cancellationToken = default(CancellationToken)) {
-                throw new NotImplementedException();
-            }
-
-            public Task<IReadOnlyList<IGrouping<Lazy<IFileContextProvider, IFileContextProviderMetadata>, FileContext>>> GetFileContextsAsync<T>(string path, T context, IEnumerable<Guid> fileContextTypes, CancellationToken cancellationToken = default(CancellationToken)) {
-                throw new NotImplementedException();
-            }
-
-            public Task<IReadOnlyList<Tuple<Lazy<ILanguageServiceProvider, ILanguageServiceProviderMetadata>, IReadOnlyCollection<FileContext>>>> GetFileContextsForLanguageServicesAsync(string filePath, CancellationToken cancellationToken = default(CancellationToken)) {
-                throw new NotImplementedException();
-            }
-
-            public Task<IReadOnlyCollection<string>> GetFilesAsync(string subPath, bool recursive, CancellationToken cancellationToken = default(CancellationToken)) {
-                throw new NotImplementedException();
-            }
-
-            public object GetService(Type serviceType) {
-                if (serviceType == typeof(IWorkspaceSettingsManager)) {
-                    return _settingsManager;
-                }
-
-                throw new NotImplementedException();
-            }
-
-            public Task<object> GetServiceAsync(Type serviceType) {
-                if (serviceType == typeof(IWorkspaceSettingsManager)) {
-                    return Task.FromResult<object>(_settingsManager);
-                }
-
-                throw new NotImplementedException();
-            }
-
-            public string MakeRelative(string path) {
-                return PathUtils.GetRelativeFilePath(Location, path);
-            }
-
-            public string MakeRooted(string subPath) {
-                return PathUtils.GetAbsoluteFilePath(Location, subPath);
-            }
-        }
-
-        class MockWorkspaceSettingsManager : IWorkspaceSettingsManager {
-            private IWorkspaceSettings _aggregatedSettings;
-
-            public MockWorkspaceSettingsManager() {
-                _aggregatedSettings = new MockWorkspaceSettings();
-            }
-
-            public MockWorkspaceSettingsManager(IWorkspaceSettings aggregatedSettings) {
-                _aggregatedSettings = aggregatedSettings;
-            }
-
-            public AsyncEvent<WorkspaceSettingsChangedEventArgs> OnWorkspaceSettingsChanged { get; set; }
-
-            public IWorkspaceSettings GetAggregatedSettings(string type, string scopePath = null) {
-                return _aggregatedSettings;
-            }
-
-            public Task<IWorkspaceSettingsPersistance> GetPersistanceAsync(bool autoCommit) {
-                throw new NotImplementedException();
-            }
-
-            public IWorkspaceSettingsSource GetSettings(string settingsFile) {
-                throw new NotImplementedException();
-            }
-
-            public void ChangeSettings(IWorkspaceSettings settings) {
-                _aggregatedSettings = settings;
-                OnWorkspaceSettingsChanged.InvokeAsync(this, new WorkspaceSettingsChangedEventArgs(string.Empty, string.Empty)).DoNotWait();
-            }
-        }
-
-        class MockWorkspaceSettings : IWorkspaceSettings {
-            private readonly Dictionary<string, string> _keyValuePairs;
-
-            public MockWorkspaceSettings() {
-                _keyValuePairs = new Dictionary<string, string>();
-            }
-
-            public MockWorkspaceSettings(Dictionary<string, string> keyValuePairs) {
-                _keyValuePairs = keyValuePairs;
-            }
-
-            public string ScopePath => throw new NotImplementedException();
-
-            public IWorkspaceSettings Parent => null;
-
-            public IEnumerable<string> GetKeys() => _keyValuePairs.Keys;
-
-            public WorkspaceSettingsResult GetProperty<T>(string key, out T value, out IWorkspaceSettings originator, T defaultValue = default(T)) {
-                value = defaultValue;
-                originator = this;
-
-                if (typeof(T) != typeof(string)) {
-                    return WorkspaceSettingsResult.Error;
-                }
-
-                if (_keyValuePairs.TryGetValue(key, out string v)) {
-                    value = (T)(object)v;
-                }
-
-                return WorkspaceSettingsResult.Success;
-            }
-
-            public WorkspaceSettingsResult GetProperty<T>(string key, out T value, T defaultValue = default(T)) {
-                return GetProperty(key, out value, out _, defaultValue);
-            }
         }
     }
 }

--- a/Python/Tests/Core/WorkspaceTestHelper.cs
+++ b/Python/Tests/Core/WorkspaceTestHelper.cs
@@ -1,0 +1,385 @@
+﻿// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.PythonTools.Infrastructure;
+using Microsoft.PythonTools.Interpreter;
+using Microsoft.VisualStudio.Threading;
+using Microsoft.VisualStudio.Workspace;
+using Microsoft.VisualStudio.Workspace.Intellisense;
+using Microsoft.VisualStudio.Workspace.Settings;
+using Microsoft.VisualStudio.Workspace.VSIntegration.Contracts;
+using TestUtilities;
+using TestUtilities.Python;
+
+namespace PythonToolsTests {
+    internal class WorkspaceTestHelper {
+        public const string PythonNoId = null;
+        public const string Python27Id = "Global|PythonCore|2.7";
+        public const string Python36Id = "Global|PythonCore|3.6";
+        public const string Python37Id = "Global|PythonCore|3.7";
+        public const string PythonUnavailableId = "Global|PythonCore|2.8";
+
+        private static InterpreterConfiguration Python27Config = new InterpreterConfiguration(Python27Id, "Mock 2.7");
+        private static InterpreterConfiguration Python36Config = new InterpreterConfiguration(Python36Id, "Mock 3.6");
+        private static InterpreterConfiguration Python37Config = new InterpreterConfiguration(Python37Id, "Mock 3.7");
+
+        public static IPythonInterpreterFactory Python27Factory = new MockPythonInterpreterFactory(Python27Config);
+        public static IPythonInterpreterFactory Python36Factory = new MockPythonInterpreterFactory(Python36Config);
+        public static IPythonInterpreterFactory Python37Factory = new MockPythonInterpreterFactory(Python37Config);
+
+        public static IPythonInterpreterFactory DefaultFactory = Python36Factory;
+
+        public static IEnumerable<IPythonInterpreterFactory> AllFactories = new[] {
+            Python27Factory,
+            Python36Factory,
+            Python37Factory,
+        };
+
+        public static MockWorkspace CreateMockWorkspace(string workspaceFolder, string interpreterSetting) {
+            var aggregatedSettings = new MockWorkspaceSettings(
+                new Dictionary<string, string> { { "Interpreter", interpreterSetting } }
+            );
+            var settingsManager = new MockWorkspaceSettingsManager(aggregatedSettings);
+            return new MockWorkspace(workspaceFolder, settingsManager);
+        }
+
+        public static string CreateWorkspaceFolder() {
+            var workspaceFolder = TestData.GetTempPath();
+            Directory.CreateDirectory(workspaceFolder);
+            File.WriteAllText(Path.Combine(workspaceFolder, "app.py"), string.Empty);
+            return workspaceFolder;
+        }
+
+        public class MockOptionsService : IInterpreterOptionsService {
+            public MockOptionsService(IPythonInterpreterFactory factory) {
+                DefaultInterpreter = factory;
+            }
+
+            public IPythonInterpreterFactory DefaultInterpreter { get; set; }
+
+            public string DefaultInterpreterId { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+
+            public event EventHandler DefaultInterpreterChanged;
+
+            public string AddConfigurableInterpreter(string name, InterpreterConfiguration config) {
+                throw new NotImplementedException();
+            }
+
+            public IEnumerable<IPackageManager> GetPackageManagers(IPythonInterpreterFactory factory) {
+                throw new NotImplementedException();
+            }
+
+            public bool IsConfigurable(string id) {
+                throw new NotImplementedException();
+            }
+
+            public void RemoveConfigurableInterpreter(string id) {
+                throw new NotImplementedException();
+            }
+
+            internal void SimulateChangeDefaultInterpreter(IPythonInterpreterFactory factory) {
+                DefaultInterpreter = factory;
+                DefaultInterpreterChanged?.Invoke(this, EventArgs.Empty);
+            }
+        }
+
+        public class MockRegistryService : IInterpreterRegistryService {
+            public MockRegistryService(IEnumerable<IPythonInterpreterFactory> interpreters) {
+                Interpreters = interpreters ?? Enumerable.Empty<IPythonInterpreterFactory>();
+            }
+
+            public IEnumerable<IPythonInterpreterFactory> Interpreters { get; private set; }
+
+            public IEnumerable<InterpreterConfiguration> Configurations => throw new NotImplementedException();
+
+            public IEnumerable<IPythonInterpreterFactory> InterpretersOrDefault => throw new NotImplementedException();
+
+            public IPythonInterpreterFactory NoInterpretersValue => throw new NotImplementedException();
+
+            public event EventHandler InterpretersChanged;
+
+            public void BeginSuppressInterpretersChangedEvent() {
+                throw new NotImplementedException();
+            }
+
+            public void EndSuppressInterpretersChangedEvent() {
+                throw new NotImplementedException();
+            }
+
+            public InterpreterConfiguration FindConfiguration(string id) {
+                throw new NotImplementedException();
+            }
+
+            public IPythonInterpreterFactory FindInterpreter(string id) {
+                return Interpreters.SingleOrDefault(f => f.Configuration.Id == id);
+            }
+
+            public object GetProperty(string id, string propName) {
+                throw new NotImplementedException();
+            }
+
+            public void GetSerializationInfo(IPythonInterpreterFactory factory, out string assembly, out string typeName, out Dictionary<string, object> properties) {
+                throw new NotImplementedException();
+            }
+
+            internal void SimulateChangeInterpreters(IEnumerable<IPythonInterpreterFactory> interpreters) {
+                Interpreters = interpreters ?? Enumerable.Empty<IPythonInterpreterFactory>();
+                InterpretersChanged?.Invoke(this, EventArgs.Empty);
+            }
+        }
+
+        public class MockWorkspaceService : IVsFolderWorkspaceService {
+            public MockWorkspaceService(IWorkspace workspace) {
+                CurrentWorkspace = workspace;
+            }
+
+            public IWorkspace CurrentWorkspace { get; private set; }
+
+            public AsyncEvent<EventArgs> OnActiveWorkspaceChanged { get; set; }
+
+            public void SimulateChangeWorkspace(IWorkspace workspace) {
+                CurrentWorkspace = workspace;
+                OnActiveWorkspaceChanged?.InvokeAsync(this, EventArgs.Empty).DoNotWait();
+            }
+        }
+
+        public class MockWorkspace : IWorkspace {
+            public MockWorkspace(string location) {
+                Location = location;
+                SettingsManager = new MockWorkspaceSettingsManager();
+            }
+
+            public MockWorkspace(string location, MockWorkspaceSettingsManager settingsManager) {
+                Location = location;
+                SettingsManager = settingsManager;
+            }
+
+            internal MockWorkspaceSettingsManager SettingsManager { get; }
+
+            public string Location { get; private set; }
+
+            public JoinableTaskFactory JTF => throw new NotImplementedException();
+
+            public Task DisposeAsync() {
+                throw new NotImplementedException();
+            }
+
+            public Task<IReadOnlyList<IGrouping<Lazy<IFileContextActionProvider, IFileContextActionProviderMetadata>, IFileContextAction>>> GetActionsForContextsAsync(string filePath, IEnumerable<FileContext> fileContexts, CancellationToken cancellationToken = default(CancellationToken)) {
+                throw new NotImplementedException();
+            }
+
+            public Task<IReadOnlyCollection<string>> GetDirectoriesAsync(string subPath, bool recursive, CancellationToken cancellationToken = default(CancellationToken)) {
+                throw new NotImplementedException();
+            }
+
+            public Task<IReadOnlyList<IGrouping<Lazy<IFileContextActionProvider, IFileContextActionProviderMetadata>, IFileContextAction>>> GetFileContextActionsAsync(string path, IEnumerable<Guid> fileContextTypes, CancellationToken cancellationToken = default(CancellationToken)) {
+                throw new NotImplementedException();
+            }
+
+            public Task<IReadOnlyList<IGrouping<Lazy<IFileContextActionProvider, IFileContextActionProviderMetadata>, IFileContextAction>>> GetFileContextActionsAsync<T>(string path, T context, IEnumerable<Guid> fileContextTypes, CancellationToken cancellationToken = default(CancellationToken)) {
+                throw new NotImplementedException();
+            }
+
+            public Task<IReadOnlyList<IGrouping<Lazy<IFileContextProvider, IFileContextProviderMetadata>, FileContext>>> GetFileContextsAsync(string path, IEnumerable<Guid> fileContextTypes, CancellationToken cancellationToken = default(CancellationToken)) {
+                throw new NotImplementedException();
+            }
+
+            public Task<IReadOnlyList<IGrouping<Lazy<IFileContextProvider, IFileContextProviderMetadata>, FileContext>>> GetFileContextsAsync<T>(string path, T context, IEnumerable<Guid> fileContextTypes, CancellationToken cancellationToken = default(CancellationToken)) {
+                throw new NotImplementedException();
+            }
+
+            public Task<IReadOnlyList<Tuple<Lazy<ILanguageServiceProvider, ILanguageServiceProviderMetadata>, IReadOnlyCollection<FileContext>>>> GetFileContextsForLanguageServicesAsync(string filePath, CancellationToken cancellationToken = default(CancellationToken)) {
+                throw new NotImplementedException();
+            }
+
+            public Task<IReadOnlyCollection<string>> GetFilesAsync(string subPath, bool recursive, CancellationToken cancellationToken = default(CancellationToken)) {
+                throw new NotImplementedException();
+            }
+
+            public object GetService(Type serviceType) {
+                if (serviceType == typeof(IWorkspaceSettingsManager)) {
+                    return SettingsManager;
+                }
+
+                throw new NotImplementedException();
+            }
+
+            public Task<object> GetServiceAsync(Type serviceType) {
+                if (serviceType == typeof(IWorkspaceSettingsManager)) {
+                    return Task.FromResult<object>(SettingsManager);
+                }
+
+                throw new NotImplementedException();
+            }
+
+            public string MakeRelative(string path) {
+                return PathUtils.GetRelativeFilePath(Location, path);
+            }
+
+            public string MakeRooted(string subPath) {
+                return PathUtils.GetAbsoluteFilePath(Location, subPath);
+            }
+        }
+
+        public class MockWorkspaceSettingsManager : IWorkspaceSettingsManager {
+            private IWorkspaceSettings _aggregatedSettings;
+
+            public MockWorkspaceSettingsManager() {
+                _aggregatedSettings = new MockWorkspaceSettings();
+            }
+
+            public MockWorkspaceSettingsManager(IWorkspaceSettings aggregatedSettings) {
+                _aggregatedSettings = aggregatedSettings;
+            }
+
+            public AsyncEvent<WorkspaceSettingsChangedEventArgs> OnWorkspaceSettingsChanged { get; set; }
+
+            public IWorkspaceSettings GetAggregatedSettings(string type, string scopePath = null) {
+                return _aggregatedSettings;
+            }
+
+            public Task<IWorkspaceSettingsPersistance> GetPersistanceAsync(bool autoCommit) {
+                throw new NotImplementedException();
+            }
+
+            public IWorkspaceSettingsSource GetSettings(string settingsFile) {
+                throw new NotImplementedException();
+            }
+
+            public void SimulateChangeSettings(IWorkspaceSettings settings) {
+                _aggregatedSettings = settings;
+                OnWorkspaceSettingsChanged.InvokeAsync(this, new WorkspaceSettingsChangedEventArgs(string.Empty, string.Empty)).DoNotWait();
+            }
+        }
+
+        public class MockWorkspaceSettings : IWorkspaceSettings {
+            private readonly Dictionary<string, string> _keyValuePairs;
+
+            public MockWorkspaceSettings() {
+                _keyValuePairs = new Dictionary<string, string>();
+            }
+
+            public MockWorkspaceSettings(Dictionary<string, string> keyValuePairs) {
+                _keyValuePairs = keyValuePairs;
+            }
+
+            public string ScopePath => throw new NotImplementedException();
+
+            public IWorkspaceSettings Parent => null;
+
+            public IEnumerable<string> GetKeys() => _keyValuePairs.Keys;
+
+            public WorkspaceSettingsResult GetProperty<T>(string key, out T value, out IWorkspaceSettings originator, T defaultValue = default(T)) {
+                value = defaultValue;
+                originator = this;
+
+                if (typeof(T) != typeof(string)) {
+                    return WorkspaceSettingsResult.Error;
+                }
+
+                if (_keyValuePairs.TryGetValue(key, out string v)) {
+                    value = (T)(object)v;
+                }
+
+                return WorkspaceSettingsResult.Success;
+            }
+
+            public WorkspaceSettingsResult GetProperty<T>(string key, out T value, T defaultValue = default(T)) {
+                return GetProperty(key, out value, out _, defaultValue);
+            }
+        }
+
+        public class MockWorkspaceContextProvider : IPythonWorkspaceContextProvider {
+            public MockWorkspaceContextProvider(IPythonWorkspaceContext workspaceContext) {
+                Workspace = workspaceContext;
+            }
+
+            public void SimulateChangeWorkspace(IPythonWorkspaceContext context) {
+                WorkspaceClosing?.Invoke(this, new PythonWorkspaceContextEventArgs(Workspace));
+                WorkspaceClosed?.Invoke(this, new PythonWorkspaceContextEventArgs(Workspace));
+                Workspace = context;
+                WorkspaceOpening?.Invoke(this, new PythonWorkspaceContextEventArgs(Workspace));
+                WorkspaceInitialized?.Invoke(this, new PythonWorkspaceContextEventArgs(Workspace));
+            }
+
+            public IPythonWorkspaceContext Workspace { get; private set; }
+
+            public event EventHandler<PythonWorkspaceContextEventArgs> WorkspaceInitialized;
+            public event EventHandler<PythonWorkspaceContextEventArgs> WorkspaceOpening;
+            public event EventHandler<PythonWorkspaceContextEventArgs> WorkspaceClosing;
+            public event EventHandler<PythonWorkspaceContextEventArgs> WorkspaceClosed;
+        }
+
+        public class MockWorkspaceContext : IPythonWorkspaceContext {
+            private readonly WorkspaceTestHelper.MockWorkspace _workspace;
+            private string _interpreterSetting;
+
+            public MockWorkspaceContext(WorkspaceTestHelper.MockWorkspace workspace, string interpreterSetting = null) {
+                _workspace = workspace;
+                _interpreterSetting = interpreterSetting;
+            }
+
+            public string WorkspaceName => throw new NotImplementedException();
+
+            public string Location => _workspace.Location;
+
+            public IPythonInterpreterFactory CurrentFactory => throw new NotImplementedException();
+
+#pragma warning disable CS0067
+            public event EventHandler InterpreterSettingChanged;
+            public event EventHandler SearchPathsSettingChanged;
+            public event EventHandler ActiveInterpreterChanged;
+#pragma warning restore CS0067
+
+            public void Dispose() {
+            }
+
+            public void SimulateChangeInterpreterSetting(string setting) {
+                _interpreterSetting = setting;
+                InterpreterSettingChanged?.Invoke(this, EventArgs.Empty);
+            }
+            public IEnumerable<string> GetAbsoluteSearchPaths() {
+                throw new NotImplementedException();
+            }
+
+            public string GetEnvironmentYmlPath() {
+                throw new NotImplementedException();
+            }
+
+            public string GetRequirementsTxtPath() {
+                throw new NotImplementedException();
+            }
+
+            public string MakeRooted(string path) => PathUtils.GetAbsoluteFilePath(Location, path);
+
+            public string ReadInterpreterSetting() => _interpreterSetting;
+
+            public Task SetInterpreterAsync(string interpreter) {
+                throw new NotImplementedException();
+            }
+
+            public Task SetInterpreterFactoryAsync(IPythonInterpreterFactory factory) {
+                throw new NotImplementedException();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fix #4853 Open Folder: analysis needs to use folder settings

Also:

Automatically restart analyzer when it quits abnormally (for projects as well).
Adds a "SearchPaths" string array setting to PythonSettings.json
Adds a "env" object setting to launch.vs.json
