### PR TITLE
Open folder working directory fixes

### DIFF
--- a/Python/Product/Workspace/PythonLaunchDebugTargetProvider.cs
+++ b/Python/Product/Workspace/PythonLaunchDebugTargetProvider.cs
@@ -124,18 +124,25 @@ namespace Microsoft.PythonTools.Workspace {
                 }
             }
 
-            IProjectLauncher launcher = null;
+            string workingDir = settings.GetValue(WorkingDirectoryKey, string.Empty);
+            if (string.IsNullOrEmpty(workingDir)) {
+                workingDir = workspace.MakeRooted(".");
+            } else if (PathUtils.IsValidPath(workingDir) && !Path.IsPathRooted(workingDir)) {
+                workingDir = workspace.MakeRooted(workingDir);
+            }
+
             var launchConfig = new LaunchConfiguration(config) {
                 InterpreterPath = config == null ? path : null,
                 InterpreterArguments = settings.GetValue(InterpreterArgumentsKey, string.Empty),
                 ScriptName = scriptName,
                 ScriptArguments = settings.GetValue(ScriptArgumentsKey, string.Empty),
-                WorkingDirectory = settings.GetValue(WorkingDirectoryKey, string.Empty),
+                WorkingDirectory = workingDir,
                 SearchPaths = searchPaths,
                 Environment = environment,
             };
             launchConfig.LaunchOptions[PythonConstants.EnableNativeCodeDebugging] = settings.GetValue(NativeDebuggingKey, false).ToString();
 
+            IProjectLauncher launcher = null;
             var browserUrl = settings.GetValue(WebBrowserUrlKey, string.Empty);
             if (!string.IsNullOrEmpty(browserUrl)) {
                 launchConfig.LaunchOptions[PythonConstants.WebBrowserUrlSetting] = browserUrl;


### PR DESCRIPTION
Fix #5054
Allow the working directory setting to be relative path to the root of the workspace and make the default value be the root of the workspace.

Previously, a relative path ended up calculated relative to the VS installer dir (quite wrong) and the default working directory was the running script's parent folder, rather than the root.