### PR TITLE
Fix Python toolbar accessibility

### DIFF
--- a/Python/Product/PythonTools/PythonTools.vsct
+++ b/Python/Product/PythonTools/PythonTools.vsct
@@ -912,11 +912,9 @@ permissions and limitations under the License.
         <CommandFlag>DynamicVisibility</CommandFlag>
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>DefaultDisabled</CommandFlag>
-        <CommandFlag>IconAndText</CommandFlag>
         <CommandFlag>CommandWellOnly</CommandFlag>
         <Strings>
-          <!--<ButtonText>Environment: </ButtonText>-->
-          <ButtonText></ButtonText>
+          <ButtonText>Python Environment</ButtonText>
           <ToolTipText>Current Python environment</ToolTipText>
           <CanonicalName>Python Environment</CanonicalName>
           <LocCanonicalName>Python Environment</LocCanonicalName>
@@ -1176,7 +1174,7 @@ permissions and limitations under the License.
     <KeyBinding guid="guidPythonToolsCmdSet" id="cmdidInterpreterList" key1="K" mod1="Control" key2="VK_OEM_3" editor="guidVSStd97"/>
     <KeyBinding guid="guidPythonToolsCmdSet" id="cmdidInterpreterList" key1="K" mod1="Control" key2="VK_OEM_3" mod2="Control" editor="guidVSStd97"/>
     <KeyBinding guid="guidPythonToolsCmdSet" id="cmdidRemoveImports" key1="K" mod1="Control" key2="J" mod2="Control" editor="guidVSStd97"/>
-    <KeyBinding guid="guidPythonToolsCmdSet" id="comboIdCurrentEnvironment" key1="K" mod1="Control" key2="E" mod2="Control" editor="guidVSStd97"/>
+    <KeyBinding guid="guidPythonToolsCmdSet" id="comboIdCurrentEnvironment" key1="K" mod1="Control" key2="E" editor="guidVSStd97"/>
   </KeyBindings>
 
   <UsedCommands>


### PR DESCRIPTION
Assign a text/automation name to the Python environment combo box.
Change its keyboard shortcut to CTRL-K,E because CTRL-K,CTRL-E was conflicting with another command.

Fixes internal bug 780657