### PR TITLE
Add the IsRequiredForForm automation property to controls in the add environment dialog.

### DIFF
--- a/Common/Product/SharedProject/Wpf/ConfigurationControl.cs
+++ b/Common/Product/SharedProject/Wpf/ConfigurationControl.cs
@@ -28,6 +28,7 @@ namespace Microsoft.VisualStudioTools.Wpf {
         public static readonly DependencyProperty HelpTextProperty = DependencyProperty.Register("HelpText", typeof(string), typeof(ConfigurationTextBoxWithHelp), new PropertyMetadata());
         public static readonly DependencyProperty TextProperty = DependencyProperty.Register("Text", typeof(string), typeof(ConfigurationTextBoxWithHelp), new PropertyMetadata());
         public static readonly DependencyProperty IsReadOnlyProperty = DependencyProperty.Register("IsReadOnly", typeof(bool), typeof(ConfigurationTextBoxWithHelp), new PropertyMetadata());
+        public static readonly DependencyProperty IsRequiredForFormProperty = DependencyProperty.Register("IsRequiredForForm", typeof(bool), typeof(ConfigurationTextBoxWithHelp), new PropertyMetadata());
         public static readonly DependencyProperty BrowseButtonStyleProperty = DependencyProperty.Register("BrowseButtonStyle", typeof(Style), typeof(ConfigurationTextBoxWithHelp), new PropertyMetadata());
         public static readonly DependencyProperty BrowseCommandParameterProperty = DependencyProperty.Register("BrowseCommandParameter", typeof(object), typeof(ConfigurationTextBoxWithHelp), new PropertyMetadata());
         public static readonly DependencyProperty BrowseAutomationNameProperty = DependencyProperty.Register("BrowseAutomationName", typeof(string), typeof(ConfigurationTextBoxWithHelp), new PropertyMetadata());
@@ -52,6 +53,11 @@ namespace Microsoft.VisualStudioTools.Wpf {
         public bool IsReadOnly {
             get { return (bool)GetValue(IsReadOnlyProperty); }
             set { SetValue(IsReadOnlyProperty, value); }
+        }
+
+        public bool IsRequiredForForm {
+            get { return (bool)GetValue(IsRequiredForFormProperty); }
+            set { SetValue(IsRequiredForFormProperty, value); }
         }
 
         public Style BrowseButtonStyle {
@@ -86,6 +92,7 @@ namespace Microsoft.VisualStudioTools.Wpf {
     sealed class ConfigurationComboBoxWithHelp : Control {
         public static readonly DependencyProperty WatermarkProperty = DependencyProperty.Register("Watermark", typeof(string), typeof(ConfigurationComboBoxWithHelp), new PropertyMetadata());
         public static readonly DependencyProperty HelpTextProperty = DependencyProperty.Register("HelpText", typeof(string), typeof(ConfigurationComboBoxWithHelp), new PropertyMetadata());
+        public static readonly DependencyProperty IsRequiredForFormProperty = DependencyProperty.Register("IsRequiredForForm", typeof(bool), typeof(ConfigurationComboBoxWithHelp), new PropertyMetadata());
         public static readonly DependencyProperty ValueProperty = DependencyProperty.Register("Value", typeof(string), typeof(ConfigurationComboBoxWithHelp), new PropertyMetadata());
         public static readonly DependencyProperty ValuesProperty = DependencyProperty.Register("Values", typeof(IList<string>), typeof(ConfigurationComboBoxWithHelp), new PropertyMetadata());
 
@@ -99,6 +106,11 @@ namespace Microsoft.VisualStudioTools.Wpf {
         public string HelpText {
             get { return (string)GetValue(HelpTextProperty); }
             set { SetValue(HelpTextProperty, value); }
+        }
+
+        public bool IsRequiredForForm {
+            get { return (bool)GetValue(IsRequiredForFormProperty); }
+            set { SetValue(IsRequiredForFormProperty, value); }
         }
 
         public string Value {

--- a/Python/Product/PythonTools/PythonTools/Environments/AddCondaEnvironmentControl.xaml
+++ b/Python/Product/PythonTools/PythonTools/Environments/AddCondaEnvironmentControl.xaml
@@ -152,6 +152,7 @@
                         SelectedItem="{Binding Path=SelectedProject}"
                         ItemTemplate="{StaticResource ProjectTemplate}"
                         AutomationProperties.LabeledBy="{Binding ElementName=ProjectLabel}"
+                        AutomationProperties.IsRequiredForForm="{Binding Path=Projects, Converter={x:Static wpf:Converters.NullOrEmptyIsFalse}}"
                         AutomationProperties.AutomationId="Project"
                         Style="{DynamicResource {x:Static ptwpf:ModernStyles.ThemedDialogComboBoxStyleKey}}"/>
 
@@ -169,6 +170,7 @@
                         HorizontalAlignment="Left"
                         Text="{Binding Path=EnvName,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged,ValidatesOnNotifyDataErrors=False}"
                         AutomationProperties.AutomationId="EnvName"
+                        AutomationProperties.IsRequiredForForm="True"
                         AutomationProperties.LabeledBy="{Binding ElementName=EnvNameLabel}"/>
 
                     <Label
@@ -191,6 +193,7 @@
                         Watermark="{x:Static common:Strings.AddCondaEnvironmentFileWatermark}"
                         AutomationProperties.AutomationId="EnvFile"
                         AutomationProperties.LabeledBy="{Binding ElementName=EnvFileRadioButton}"
+                        IsRequiredForForm="{Binding Path=IsEnvFile}"
                         BrowseButtonStyle="{StaticResource BrowseOpenFileButton}"
                         BrowseCommandParameter="{x:Static common:Strings.AddCondaEnvironmentFileBrowseFilter}"
                         BrowseAutomationName="{x:Static common:Strings.AddCondaEnvironmentFileBrowseButton}"/>

--- a/Python/Product/PythonTools/PythonTools/Environments/AddExistingEnvironmentControl.xaml
+++ b/Python/Product/PythonTools/PythonTools/Environments/AddExistingEnvironmentControl.xaml
@@ -69,6 +69,7 @@
                 SelectedItem="{Binding Path=SelectedProject}"
                 ItemTemplate="{StaticResource ProjectTemplate}"
                 AutomationProperties.AutomationId="Project"
+                AutomationProperties.IsRequiredForForm="{Binding Path=Projects, Converter={x:Static wpf:Converters.NullOrEmptyIsFalse}}"
                 AutomationProperties.LabeledBy="{Binding ElementName=ProjectLabel}"/>
 
             <Label
@@ -88,6 +89,7 @@
                 SelectedItem="{Binding Path=SelectedInterpreter}"
                 ItemTemplateSelector="{StaticResource interpreterViewSelector}"
                 AutomationProperties.AutomationId="Interpreter"
+                AutomationProperties.IsRequiredForForm="True"
                 AutomationProperties.LabeledBy="{Binding ElementName=ExistingEnvLabel}">
 
                 <ComboBox.ItemContainerStyle>
@@ -109,6 +111,7 @@
                     Margin="0 0 265 18"
                     Text="{Binding PrefixPath,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged,ValidatesOnNotifyDataErrors=False}"
                     Watermark="{x:Static common:Strings.ConfigurationExtensionPrefixPathWatermark}"
+                    IsRequiredForForm="True"
                     AutomationProperties.LabeledBy="{Binding ElementName=PrefixPathLabel}"
                     AutomationProperties.AutomationId="PrefixPath"
                     BrowseButtonStyle="{StaticResource BrowseFolderButton}"
@@ -141,6 +144,7 @@
                                 Margin="0 0 0 15"
                                 Text="{Binding Description,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged,ValidatesOnNotifyDataErrors=False}"
                                 Watermark="{x:Static common:Strings.ConfigurationExtensionDescriptionWatermark}"
+                                IsRequiredForForm="{Binding Path=RegisterCustomEnv}"
                                 AutomationProperties.AutomationId="Description"
                                 AutomationProperties.LabeledBy="{Binding ElementName=DescriptionLabel}">
                                 <wpf:ConfigurationTextBoxWithHelp.IsReadOnly>
@@ -163,6 +167,7 @@
                                 IsReadOnly="{Binding Path=IsCustomVirtualEnv}"
                                 Text="{Binding InterpreterPath,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged,ValidatesOnNotifyDataErrors=False}"
                                 Watermark="{x:Static common:Strings.ConfigurationExtensionInterpreterPathWatermark}"
+                                IsRequiredForForm="{Binding Path=IsCustomVirtualEnv, Converter={x:Static wpf:Converters.Not}}"
                                 AutomationProperties.LabeledBy="{Binding ElementName=InterpreterPathLabel}"
                                 AutomationProperties.AutomationId="InterpreterPath"
                                 BrowseButtonStyle="{StaticResource BrowseOpenFileButton}"
@@ -181,6 +186,7 @@
                                 IsReadOnly="{Binding Path=IsCustomVirtualEnv}"
                                 Text="{Binding WindowsInterpreterPath,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged,ValidatesOnNotifyDataErrors=False}"
                                 Watermark="{x:Static common:Strings.ConfigurationExtensionWindowedInterpreterPathWatermark}"
+                                IsRequiredForForm="False"
                                 AutomationProperties.LabeledBy="{Binding ElementName=WindowsInterpreterPathLabel}"
                                 AutomationProperties.AutomationId="WindowsInterpreterPath"
                                 BrowseButtonStyle="{StaticResource BrowseOpenFileButton}"
@@ -202,6 +208,7 @@
                                 IsEnabled="{Binding Path=IsCustomVirtualEnv, Converter={x:Static wpf:Converters.Not}}"
                                 Value="{Binding VersionName,Mode=TwoWay,ValidatesOnNotifyDataErrors=False}"
                                 Values="{Binding VersionNames}"
+                                IsRequiredForForm="{Binding Path=IsCustomVirtualEnv, Converter={x:Static wpf:Converters.Not}}"
                                 AutomationProperties.AutomationId="LanguageVersion"
                                 AutomationProperties.LabeledBy="{Binding ElementName=LanguageVersionLabel}"/>
 
@@ -220,6 +227,7 @@
                                 Value="{Binding ArchitectureName,Mode=TwoWay,ValidatesOnNotifyDataErrors=False}"
                                 Values="{Binding ArchitectureNames}"
                                 Watermark="{x:Static common:Strings.ConfigurationExtensionArchitectureWatermark}"
+                                IsRequiredForForm="{Binding Path=IsCustomVirtualEnv, Converter={x:Static wpf:Converters.Not}}"
                                 AutomationProperties.AutomationId="Architecture"
                                 AutomationProperties.LabeledBy="{Binding ElementName=ArchitectureLabel}"/>
 
@@ -235,6 +243,7 @@
                                 IsReadOnly="{Binding Path=IsCustomVirtualEnv}"
                                 Text="{Binding PathEnvironmentVariable,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged,ValidatesOnNotifyDataErrors=False}"
                                 Watermark="{x:Static common:Strings.ConfigurationExtensionPathEnvVarWatermark}"
+                                IsRequiredForForm="False"
                                 AutomationProperties.AutomationId="PathEnvironmentVariable"
                                 AutomationProperties.LabeledBy="{Binding ElementName=PathEnvVarLabel}"/>
                         </StackPanel>

--- a/Python/Product/PythonTools/PythonTools/Environments/AddVirtualEnvironmentControl.xaml
+++ b/Python/Product/PythonTools/PythonTools/Environments/AddVirtualEnvironmentControl.xaml
@@ -79,6 +79,7 @@
                         SelectedItem="{Binding Path=SelectedProject}"
                         ItemTemplate="{StaticResource ProjectTemplate}"
                         AutomationProperties.AutomationId="Project"
+                        AutomationProperties.IsRequiredForForm="{Binding Path=Projects, Converter={x:Static wpf:Converters.NullOrEmptyIsFalse}}"
                         AutomationProperties.LabeledBy="{Binding ElementName=ProjectLabel}"/>
 
                     <Grid>
@@ -103,6 +104,7 @@
                                 HorizontalAlignment="Left"
                                 Text="{Binding Path=VirtualEnvName,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged,ValidatesOnNotifyDataErrors=False}"
                                 AutomationProperties.AutomationId="EnvName"
+                                AutomationProperties.IsRequiredForForm="True"
                                 AutomationProperties.LabeledBy="{Binding ElementName=EnvNameLabel}"/>
                         </StackPanel>
                         <StackPanel Grid.Column="2">
@@ -122,6 +124,7 @@
                                 HorizontalAlignment="Left"
                                 Style="{DynamicResource {x:Static ptwpf:ModernStyles.ThemedDialogComboBoxStyleKey}}"
                                 AutomationProperties.AutomationId="BaseInterpreter"
+                                AutomationProperties.IsRequiredForForm="True"
                                 AutomationProperties.LabeledBy="{Binding ElementName=BaseInterpreterLabel}"
                                 ItemsSource="{Binding Interpreters}"
                                 ItemTemplate="{StaticResource NameTemplate}"
@@ -203,6 +206,7 @@
                         Text="{Binding Path=Description,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged,ValidatesOnNotifyDataErrors=False}"
                         IsEnabled="{Binding Path=IsRegisterCustomEnv}"
                         Watermark="{x:Static common:Strings.AddVirtualEnvironmentDescriptionWatermark}"
+                        IsRequiredForForm="{Binding Path=IsRegisterCustomEnv}"
                         AutomationProperties.AutomationId="Description"
                         AutomationProperties.LabeledBy="{Binding ElementName=RegisterCustomEnvCheckBox}"/>
                 </StackPanel>

--- a/Python/Product/PythonTools/PythonTools/Wpf/ModernStyles.xaml
+++ b/Python/Product/PythonTools/PythonTools/Wpf/ModernStyles.xaml
@@ -1268,6 +1268,7 @@
                                  AutomationProperties.AutomationId="{TemplateBinding AutomationProperties.AutomationId}"
                                  AutomationProperties.Name="{TemplateBinding AutomationProperties.Name}"
                                  AutomationProperties.HelpText="{TemplateBinding HelpText}"
+                                 AutomationProperties.IsRequiredForForm="{TemplateBinding IsRequiredForForm}"
                                  AutomationProperties.LabeledBy="{TemplateBinding AutomationProperties.LabeledBy}"
                                  IsReadOnly="{Binding IsReadOnly,Mode=OneWay,RelativeSource={RelativeSource TemplatedParent}}"
                                  Text="{Binding Text,Mode=TwoWay,RelativeSource={RelativeSource TemplatedParent},UpdateSourceTrigger=PropertyChanged}">
@@ -1338,6 +1339,7 @@
                                   AutomationProperties.AutomationId="{TemplateBinding AutomationProperties.AutomationId}"
                                   AutomationProperties.Name="{TemplateBinding AutomationProperties.Name}"
                                   AutomationProperties.HelpText="{TemplateBinding HelpText}"
+                                  AutomationProperties.IsRequiredForForm="{TemplateBinding IsRequiredForForm}"
                                   AutomationProperties.LabeledBy="{TemplateBinding AutomationProperties.LabeledBy}">
                         </ComboBox>
                     </Grid>


### PR DESCRIPTION
Fix internal bug 790717

FYI @RaymonGulati1 :
`IsRequiredForForm` is used when setting it on our helper control (which consists of multiple controls), it passes it down to the combo or text box
`AutomationProperties.IsRequiredForForm` is used when setting it on the raw combo or text box.