### PR TITLE
Tooltip and automation name fixes for text boxes in add environment dialog

### DIFF
--- a/Python/Product/Common/Strings.Designer.cs
+++ b/Python/Product/Common/Strings.Designer.cs
@@ -88,7 +88,7 @@ namespace Microsoft.PythonTools {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The environment file is typically named environment.yml and specifies the Conda and pip packages to install when creating the Conda environment..
+        ///   Looks up a localized string similar to Path to environment.yml file, which specifies the Conda and pip packages to install when creating the Conda environment..
         /// </summary>
         public static string AddCondaEnvironmentFileHelp {
             get {
@@ -102,6 +102,15 @@ namespace Microsoft.PythonTools {
         public static string AddCondaEnvironmentFileInvalid {
             get {
                 return ResourceManager.GetString("AddCondaEnvironmentFileInvalid", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Environment file path.
+        /// </summary>
+        public static string AddCondaEnvironmentFileName {
+            get {
+                return ResourceManager.GetString("AddCondaEnvironmentFileName", resourceCulture);
             }
         }
         
@@ -215,11 +224,20 @@ namespace Microsoft.PythonTools {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to List of Conda packages to install when creating the Conda environment. Entries should be separated by spaces..
+        ///   Looks up a localized string similar to List of Conda packages to install when creating the Conda environment. Entries should be separated by spaces. Example: numpy pandas.
         /// </summary>
         public static string AddCondaPackagesHelpText {
             get {
                 return ResourceManager.GetString("AddCondaPackagesHelpText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Package names.
+        /// </summary>
+        public static string AddCondaPackagesName {
+            get {
+                return ResourceManager.GetString("AddCondaPackagesName", resourceCulture);
             }
         }
         
@@ -699,6 +717,15 @@ namespace Microsoft.PythonTools {
         public static string AddVirtualEnvironmentChangeLocationLink {
             get {
                 return ResourceManager.GetString("AddVirtualEnvironmentChangeLocationLink", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Environment description.
+        /// </summary>
+        public static string AddVirtualEnvironmentDescriptionName {
+            get {
+                return ResourceManager.GetString("AddVirtualEnvironmentDescriptionName", resourceCulture);
             }
         }
         

--- a/Python/Product/Common/Strings.resx
+++ b/Python/Product/Common/Strings.resx
@@ -2365,6 +2365,9 @@ Expand selection to the full expression?</value>
   <data name="AddVirtualEnvironmentDescriptionWatermark" xml:space="preserve">
     <value>Description for this environment</value>
   </data>
+  <data name="AddVirtualEnvironmentDescriptionName" xml:space="preserve">
+    <value>Environment description</value>
+  </data>
   <data name="AddVirtualEnvironmentPreviewInProgress" xml:space="preserve">
     <value>Building preview...</value>
   </data>
@@ -2420,7 +2423,10 @@ Expand selection to the full expression?</value>
     <value>environment.yml</value>
   </data>
   <data name="AddCondaEnvironmentFileHelp" xml:space="preserve">
-    <value>The environment file is typically named environment.yml and specifies the Conda and pip packages to install when creating the Conda environment.</value>
+    <value>Path to environment.yml file, which specifies the Conda and pip packages to install when creating the Conda environment.</value>
+  </data>
+  <data name="AddCondaEnvironmentFileName" xml:space="preserve">
+    <value>Environment file path</value>
   </data>
   <data name="AddCondaEnvironmentFileBrowseButton" xml:space="preserve">
     <value>Browse for environment file</value>
@@ -2434,11 +2440,14 @@ Expand selection to the full expression?</value>
   <data name="AddCondaPackagesWatermark" xml:space="preserve">
     <value>ex. numpy pandas</value>
   </data>
+  <data name="AddCondaPackagesName" xml:space="preserve">
+    <value>Package names</value>
+  </data>
   <data name="AddCondaPackagesBrowseButton" xml:space="preserve">
     <value>Add packages</value>
   </data>
   <data name="AddCondaPackagesHelpText" xml:space="preserve">
-    <value>List of Conda packages to install when creating the Conda environment. Entries should be separated by spaces.</value>
+    <value>List of Conda packages to install when creating the Conda environment. Entries should be separated by spaces. Example: numpy pandas</value>
   </data>
   <data name="AddEnvironmentSetAsDefaultLabel" xml:space="preserve">
     <value>Set as _default environment for new projects</value>

--- a/Python/Product/PythonTools/PythonTools/Environments/AddCondaEnvironmentControl.xaml
+++ b/Python/Product/PythonTools/PythonTools/Environments/AddCondaEnvironmentControl.xaml
@@ -194,7 +194,6 @@
                         </GroupBox.HeaderTemplate>
                     <StackPanel>
                     <RadioButton
-                        x:Name="EnvFileRadioButton"
                         Margin="16 6 0 3"
                         Content="{x:Static common:Strings.AddCondaEnvironmentFileRadioButton}"
                         IsChecked="{Binding Path=IsEnvFile}"
@@ -207,16 +206,16 @@
                         IsEnabled="{Binding Path=IsEnvFile}"
                         Text="{Binding SelectedEnvFilePath,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged,ValidatesOnNotifyDataErrors=False}"
                         Watermark="{x:Static common:Strings.AddCondaEnvironmentFileWatermark}"
-                        HelpText="{x:Static common:Strings.AddCondaEnvironmentFileWatermark}"
+                        HelpText="{x:Static common:Strings.AddCondaEnvironmentFileHelp}"
+                        ToolTip="{x:Static common:Strings.AddCondaEnvironmentFileHelp}"
                         AutomationProperties.AutomationId="EnvFile"
-                        AutomationProperties.LabeledBy="{Binding ElementName=EnvFileRadioButton}"
+                        AutomationProperties.Name="{x:Static common:Strings.AddCondaEnvironmentFileName}"
                         IsRequiredForForm="{Binding Path=IsEnvFile}"
                         BrowseButtonStyle="{StaticResource BrowseOpenFileButton}"
                         BrowseCommandParameter="{x:Static common:Strings.AddCondaEnvironmentFileBrowseFilter}"
                         BrowseAutomationName="{x:Static common:Strings.AddCondaEnvironmentFileBrowseButton}"/>
 
                     <RadioButton
-                        x:Name="PackagesRadioButton"
                         Margin="16 0 0 3"
                         Content="{x:Static common:Strings.AddCondaPackagesRadioButton}"
                         IsChecked="{Binding Path=IsPackages}"
@@ -231,9 +230,10 @@
                         BrowseButtonStyle="{StaticResource BrowsePackagesButton}"
                         BrowseAutomationName="{x:Static common:Strings.AddCondaPackagesBrowseButton}"
                         Watermark="{x:Static common:Strings.AddCondaPackagesWatermark}"
-                        HelpText="{x:Static common:Strings.AddCondaPackagesWatermark}"
-                        AutomationProperties.AutomationId="Packages"
-                        AutomationProperties.LabeledBy="{Binding ElementName=PackagesRadioButton}"/>
+                        HelpText="{x:Static common:Strings.AddCondaPackagesHelpText}"
+                        ToolTip="{x:Static common:Strings.AddCondaPackagesHelpText}"
+                        AutomationProperties.Name="{x:Static common:Strings.AddCondaPackagesName}"
+                        AutomationProperties.AutomationId="Packages"/>
                     </StackPanel>
                     </GroupBox>
                     

--- a/Python/Product/PythonTools/PythonTools/Environments/AddVirtualEnvironmentControl.xaml
+++ b/Python/Product/PythonTools/PythonTools/Environments/AddVirtualEnvironmentControl.xaml
@@ -195,7 +195,6 @@
 
                     <CheckBox
                         Margin="0 0 0 3"
-                        x:Name="RegisterCustomEnvCheckBox"
                         IsEnabled="{Binding Path=IsRegisterCustomEnvEnabled}"
                         IsChecked="{Binding Path=IsRegisterCustomEnv}"
                         Content="{x:Static common:Strings.AddExistingEnvironmentRegisterGloballyCheckBox}"
@@ -209,8 +208,9 @@
                         Watermark="{x:Static common:Strings.AddVirtualEnvironmentDescriptionWatermark}"
                         IsRequiredForForm="{Binding Path=IsRegisterCustomEnv}"
                         HelpText="{x:Static common:Strings.AddVirtualEnvironmentDescriptionWatermark}"
-                        AutomationProperties.AutomationId="Description"
-                        AutomationProperties.LabeledBy="{Binding ElementName=RegisterCustomEnvCheckBox}"/>
+                        ToolTip="{x:Static common:Strings.AddVirtualEnvironmentDescriptionWatermark}"
+                        AutomationProperties.Name="{x:Static common:Strings.AddVirtualEnvironmentDescriptionName}"
+                        AutomationProperties.AutomationId="Description"/>
                 </StackPanel>
             </ScrollViewer>
 


### PR DESCRIPTION
Fix duplicate automation names and add a tooltip to the textboxes labeled by a checkbox or radio button.

Fix internal bug 790771