### PR TITLE
Resolving Roslyn Analyzer Issues

### DIFF
--- a/Common/Tools/BuildTasks/BuildTasks.csproj
+++ b/Common/Tools/BuildTasks/BuildTasks.csproj
@@ -4,7 +4,7 @@
     <BuildRoot Condition="'$(BuildRoot)' == ''">$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), build.root))</BuildRoot>
   </PropertyGroup>
   <Import Project="$(BuildRoot)\Build\Common.Build.settings" />
-  
+
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
@@ -64,6 +64,7 @@
       <Link>LambdaConverter.cs</Link>
     </Compile>
     <Compile Include="ExtractLambdasFromXaml.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Common/Tools/BuildTasks/ExtractLambdasFromXaml.cs
+++ b/Common/Tools/BuildTasks/ExtractLambdasFromXaml.cs
@@ -20,6 +20,7 @@ using System.CodeDom.Compiler;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Configuration;
+using System.Globalization;
 using System.IO;
 using System.Reflection;
 using System.Xaml;
@@ -117,7 +118,7 @@ namespace Microsoft.VisualStudioTools.BuildTasks {
         }
 
         private void LogError(string source, int line, int code, string text) {
-            string xalCode = string.Format("XAL{0:D4}", code);
+            string xalCode = string.Format(CultureInfo.InvariantCulture, "XAL{0:D4}", code);
 
             if (source == null) {
                 source = ToolName;
@@ -380,7 +381,8 @@ namespace Microsoft.VisualStudioTools.BuildTasks {
         private static readonly string LambdaConverterClrNamespaceWithAssembly = LambdaConverterClrNamespace + ";assembly=";
 
         private static bool IsLambdaNamespace(string ns) {
-            return ns != null && (ns == LambdaConverterClrNamespace || ns.StartsWith(LambdaConverterClrNamespaceWithAssembly));
+            return ns != null && (ns == LambdaConverterClrNamespace ||
+                ns.StartsWith(LambdaConverterClrNamespaceWithAssembly, false, CultureInfo.InvariantCulture));
         }
 
 #if CONSOLE_APP

--- a/Common/Tools/BuildTasks/Properties/AssemblyInfo.cs
+++ b/Common/Tools/BuildTasks/Properties/AssemblyInfo.cs
@@ -22,8 +22,3 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyVersion("1.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
 [assembly: ComVisible(false)]
-
-// The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("861b9a5e-f07e-436b-a737-24072a2e6b55")]
-
-

--- a/Common/Tools/BuildTasks/Properties/AssemblyInfo.cs
+++ b/Common/Tools/BuildTasks/Properties/AssemblyInfo.cs
@@ -1,0 +1,33 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Microsoft.VisualStudioTools.BuildTasks.Properties")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Microsoft.VisualStudioTools.BuildTasks.Properties")]
+[assembly: AssemblyCopyright("Copyright ©  2019")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("861b9a5e-f07e-436b-a737-24072a2e6b55")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+[assembly: AssemblyVersion("1.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Common/Tools/BuildTasks/Properties/AssemblyInfo.cs
+++ b/Common/Tools/BuildTasks/Properties/AssemblyInfo.cs
@@ -1,33 +1,29 @@
-﻿using System.Reflection;
+﻿// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following 
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
-[assembly: AssemblyTitle("Microsoft.VisualStudioTools.BuildTasks.Properties")]
-[assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("Microsoft.VisualStudioTools.BuildTasks.Properties")]
-[assembly: AssemblyCopyright("Copyright ©  2019")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
-
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
+[assembly: AssemblyTitle("Visual Studio - Build Task Tool")]
+[assembly: AssemblyVersion("1.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]
 [assembly: ComVisible(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("861b9a5e-f07e-436b-a737-24072a2e6b55")]
 
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-[assembly: AssemblyVersion("1.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+

--- a/Python/Product/Cookiecutter/Attributes.cs
+++ b/Python/Product/Cookiecutter/Attributes.cs
@@ -27,7 +27,7 @@ namespace Microsoft.CookiecutterTools {
             _name = name;
         }
 
-        public override string DisplayName => Strings.ResourceManager.GetString(_name, CultureInfo.InvariantCulture);
+        public override string DisplayName => Strings.ResourceManager.GetString(_name, Strings.Culture);
     }
 
     [AttributeUsage(AttributeTargets.All)]
@@ -42,7 +42,7 @@ namespace Microsoft.CookiecutterTools {
             get {
                 if (!_replaced) {
                     _replaced = true;
-                    DescriptionValue = Strings.ResourceManager.GetString(base.Description, CultureInfo.InvariantCulture);
+                    DescriptionValue = Strings.ResourceManager.GetString(base.Description, Strings.Culture);
                 }
                 return base.Description;
             }
@@ -56,7 +56,7 @@ namespace Microsoft.CookiecutterTools {
         }
 
         protected override string GetLocalizedString(string value) {
-            return Strings.ResourceManager.GetString(value, CultureInfo.InvariantCulture);
+            return Strings.ResourceManager.GetString(value, Strings.Culture);
         }
     }
 }

--- a/Python/Product/Cookiecutter/Attributes.cs
+++ b/Python/Product/Cookiecutter/Attributes.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.ComponentModel;
+using System.Globalization;
 
 namespace Microsoft.CookiecutterTools {
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Property | AttributeTargets.Field, Inherited = false, AllowMultiple = false)]
@@ -26,7 +27,7 @@ namespace Microsoft.CookiecutterTools {
             _name = name;
         }
 
-        public override string DisplayName => Strings.ResourceManager.GetString(_name);
+        public override string DisplayName => Strings.ResourceManager.GetString(_name, CultureInfo.InvariantCulture);
     }
 
     [AttributeUsage(AttributeTargets.All)]
@@ -41,7 +42,7 @@ namespace Microsoft.CookiecutterTools {
             get {
                 if (!_replaced) {
                     _replaced = true;
-                    DescriptionValue = Strings.ResourceManager.GetString(base.Description);
+                    DescriptionValue = Strings.ResourceManager.GetString(base.Description, CultureInfo.InvariantCulture);
                 }
                 return base.Description;
             }
@@ -55,7 +56,7 @@ namespace Microsoft.CookiecutterTools {
         }
 
         protected override string GetLocalizedString(string value) {
-            return Strings.ResourceManager.GetString(value);
+            return Strings.ResourceManager.GetString(value, CultureInfo.InvariantCulture);
         }
     }
 }

--- a/Python/Product/Cookiecutter/Shared/Interpreters/InterpreterConfiguration.cs
+++ b/Python/Product/Cookiecutter/Shared/Interpreters/InterpreterConfiguration.cs
@@ -96,9 +96,9 @@ namespace Microsoft.CookiecutterTools.Interpreters {
                 return false;
             }
 
-            var cmp = StringComparer.OrdinalIgnoreCase;
+            var cmp = StringComparer.InvariantCultureIgnoreCase;//Should this be OrdinalIgnoreCase???
             return cmp.Equals(PrefixPath, other.PrefixPath) &&
-                string.Equals(Id, other.Id) &&
+                cmp.Equals(Id, other.Id) &&
                 cmp.Equals(InterpreterPath, other.InterpreterPath) &&
                 cmp.Equals(WindowsInterpreterPath, other.WindowsInterpreterPath) &&
                 cmp.Equals(PathEnvironmentVariable, other.PathEnvironmentVariable) &&

--- a/Python/Product/Cookiecutter/Shared/Interpreters/InterpreterConfiguration.cs
+++ b/Python/Product/Cookiecutter/Shared/Interpreters/InterpreterConfiguration.cs
@@ -96,9 +96,9 @@ namespace Microsoft.CookiecutterTools.Interpreters {
                 return false;
             }
 
-            var cmp = StringComparer.InvariantCultureIgnoreCase;//Should this be OrdinalIgnoreCase???
+            var cmp = StringComparer.OrdinalIgnoreCase;
             return cmp.Equals(PrefixPath, other.PrefixPath) &&
-                cmp.Equals(Id, other.Id) &&
+                string.Equals(Id, other.Id, StringComparison.InvariantCultureIgnoreCase) &&
                 cmp.Equals(InterpreterPath, other.InterpreterPath) &&
                 cmp.Equals(WindowsInterpreterPath, other.WindowsInterpreterPath) &&
                 cmp.Equals(PathEnvironmentVariable, other.PathEnvironmentVariable) &&

--- a/Python/Product/Cookiecutter/Shared/Interpreters/InterpreterConfiguration.cs
+++ b/Python/Product/Cookiecutter/Shared/Interpreters/InterpreterConfiguration.cs
@@ -98,7 +98,7 @@ namespace Microsoft.CookiecutterTools.Interpreters {
 
             var cmp = StringComparer.OrdinalIgnoreCase;
             return cmp.Equals(PrefixPath, other.PrefixPath) &&
-                string.Equals(Id, other.Id, StringComparison.InvariantCultureIgnoreCase) &&
+                cmp.Equals(Id, other.Id) &&
                 cmp.Equals(InterpreterPath, other.InterpreterPath) &&
                 cmp.Equals(WindowsInterpreterPath, other.WindowsInterpreterPath) &&
                 cmp.Equals(PathEnvironmentVariable, other.PathEnvironmentVariable) &&

--- a/Python/Product/PythonTools/PythonTools/Project/Attributes.cs
+++ b/Python/Product/PythonTools/PythonTools/Project/Attributes.cs
@@ -29,7 +29,7 @@ namespace Microsoft.PythonTools.Project {
 
         public override string DisplayName {
             get {
-                return Strings.ResourceManager.GetString(_name, CultureInfo.InvariantCulture) ?? VisualStudioTools.Project.SR.GetString(_name);
+                return Strings.ResourceManager.GetString(_name, Strings.Culture) ?? VisualStudioTools.Project.SR.GetString(_name);
             }
         }
     }
@@ -46,7 +46,7 @@ namespace Microsoft.PythonTools.Project {
             get {
                 if (!_replaced) {
                     _replaced = true;
-                    DescriptionValue = Strings.ResourceManager.GetString(base.Description) ??
+                    DescriptionValue = Strings.ResourceManager.GetString(base.Description, Strings.Culture) ??
                         VisualStudioTools.Project.SR.GetString(base.Description);
                 }
                 return base.Description;
@@ -61,7 +61,7 @@ namespace Microsoft.PythonTools.Project {
         }
 
         protected override string GetLocalizedString(string value) {
-            return Strings.ResourceManager.GetString(value) ?? VisualStudioTools.Project.SR.GetString(value);
+            return Strings.ResourceManager.GetString(value, Strings.Culture) ?? VisualStudioTools.Project.SR.GetString(value);
         }
     }
 }

--- a/Python/Product/PythonTools/PythonTools/Project/Attributes.cs
+++ b/Python/Product/PythonTools/PythonTools/Project/Attributes.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.ComponentModel;
+using System.Globalization;
 
 namespace Microsoft.PythonTools.Project {
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Property | AttributeTargets.Field, Inherited = false, AllowMultiple = false)]
@@ -28,7 +29,7 @@ namespace Microsoft.PythonTools.Project {
 
         public override string DisplayName {
             get {
-                return Strings.ResourceManager.GetString(_name) ?? VisualStudioTools.Project.SR.GetString(_name);
+                return Strings.ResourceManager.GetString(_name, CultureInfo.InvariantCulture) ?? VisualStudioTools.Project.SR.GetString(_name);
             }
         }
     }

--- a/Python/Product/VSInterpreters/Interpreter/VisualStudioInterpreterConfiguration.cs
+++ b/Python/Product/VSInterpreters/Interpreter/VisualStudioInterpreterConfiguration.cs
@@ -101,9 +101,9 @@ namespace Microsoft.PythonTools.Interpreter {
                 return false;
             }
 
-            var cmp = StringComparer.OrdinalIgnoreCase;
+            var cmp = StringComparer.InvariantCultureIgnoreCase;//Should this be OrdinalIgnoreCase???
             return cmp.Equals(PrefixPath, other.PrefixPath) &&
-                   string.Equals(Id, other.Id) &&
+                   cmp.Equals(Id, other.Id) &&
                    cmp.Equals(Description, other.Description) &&
                    cmp.Equals(InterpreterPath, other.InterpreterPath) &&
                    cmp.Equals(WindowsInterpreterPath, other.WindowsInterpreterPath) &&

--- a/Python/Product/VSInterpreters/Interpreter/VisualStudioInterpreterConfiguration.cs
+++ b/Python/Product/VSInterpreters/Interpreter/VisualStudioInterpreterConfiguration.cs
@@ -101,9 +101,9 @@ namespace Microsoft.PythonTools.Interpreter {
                 return false;
             }
 
-            var cmp = StringComparer.InvariantCultureIgnoreCase;//Should this be OrdinalIgnoreCase???
+            var cmp = StringComparer.OrdinalIgnoreCase;
             return cmp.Equals(PrefixPath, other.PrefixPath) &&
-                   cmp.Equals(Id, other.Id) &&
+                   string.Equals(Id, other.Id, StringComparison.InvariantCultureIgnoreCase) &&
                    cmp.Equals(Description, other.Description) &&
                    cmp.Equals(InterpreterPath, other.InterpreterPath) &&
                    cmp.Equals(WindowsInterpreterPath, other.WindowsInterpreterPath) &&

--- a/Python/Product/VSInterpreters/Interpreter/VisualStudioInterpreterConfiguration.cs
+++ b/Python/Product/VSInterpreters/Interpreter/VisualStudioInterpreterConfiguration.cs
@@ -103,7 +103,7 @@ namespace Microsoft.PythonTools.Interpreter {
 
             var cmp = StringComparer.OrdinalIgnoreCase;
             return cmp.Equals(PrefixPath, other.PrefixPath) &&
-                   string.Equals(Id, other.Id, StringComparison.InvariantCultureIgnoreCase) &&
+                   cmp.Equals(Id, other.Id) &&
                    cmp.Equals(Description, other.Description) &&
                    cmp.Equals(InterpreterPath, other.InterpreterPath) &&
                    cmp.Equals(WindowsInterpreterPath, other.WindowsInterpreterPath) &&

--- a/Python/Product/VSInterpreters/PackageManager/PipPackageManager.cs
+++ b/Python/Product/VSInterpreters/PackageManager/PipPackageManager.cs
@@ -716,8 +716,10 @@ namespace Microsoft.PythonTools.Interpreter {
         }
 
         private void OnChanged(object sender, FileSystemEventArgs e) {
-            if ((Directory.Exists(e.FullPath) && !"__pycache__".Equals(PathUtils.GetFileOrDirectoryName(e.FullPath))) ||
-                ModulePath.IsPythonFile(e.FullPath, false, true, false)) {
+            if ((Directory.Exists(e.FullPath) && 
+                !PathUtils.GetFileOrDirectoryName(e.FullPath).Equals("__pycache__", StringComparison.InvariantCulture)) ||
+                ModulePath.IsPythonFile(e.FullPath, false, true, false)
+            ) {
                 try {
                     _refreshIsCurrentTrigger.Change(1000, Timeout.Infinite);
                 } catch (ObjectDisposedException) {

--- a/Python/Product/VSInterpreters/PackageManager/PipPackageManager.cs
+++ b/Python/Product/VSInterpreters/PackageManager/PipPackageManager.cs
@@ -717,7 +717,7 @@ namespace Microsoft.PythonTools.Interpreter {
 
         private void OnChanged(object sender, FileSystemEventArgs e) {
             if ((Directory.Exists(e.FullPath) && 
-                !PathUtils.GetFileOrDirectoryName(e.FullPath).Equals("__pycache__", StringComparison.InvariantCulture)) ||
+                !PathUtils.GetFileOrDirectoryName(e.FullPath).Equals("__pycache__", StringComparison.OrdinalIgnoreCase)) ||
                 ModulePath.IsPythonFile(e.FullPath, false, true, false)
             ) {
                 try {

--- a/Python/Product/VSInterpreters/PackageManager/PipRequirementsUtils.cs
+++ b/Python/Product/VSInterpreters/PackageManager/PipRequirementsUtils.cs
@@ -91,7 +91,7 @@ namespace Microsoft.PythonTools.Interpreter {
                 var installedPackage = installed.FirstOrDefault(pkg =>
                     string.Compare(pkg.Name, requirementPackageName, StringComparison.OrdinalIgnoreCase) == 0);
 
-                if (!requirementPackageName.Equals("") && installedPackage == null) {
+                if (!requirementPackageName.Equals("", StringComparison.InvariantCulture) && installedPackage == null) {
                     return true;
                 }
             }

--- a/Python/Product/VSInterpreters/PackageManager/PipRequirementsUtils.cs
+++ b/Python/Product/VSInterpreters/PackageManager/PipRequirementsUtils.cs
@@ -91,7 +91,7 @@ namespace Microsoft.PythonTools.Interpreter {
                 var installedPackage = installed.FirstOrDefault(pkg =>
                     string.Compare(pkg.Name, requirementPackageName, StringComparison.OrdinalIgnoreCase) == 0);
 
-                if (!requirementPackageName.Equals("", StringComparison.InvariantCulture) && installedPackage == null) {
+                if (requirementPackageName.Length > 0 && installedPackage == null) {
                     return true;
                 }
             }


### PR DESCRIPTION
Fix #5005 

Fix BuildTask to include assembly information such as title, name, version. 
Update strings to compare with culturally invariant process
 
