### PR TITLE
Fix outlining

### DIFF
--- a/Build/15.0/packages.config
+++ b/Build/15.0/packages.config
@@ -68,5 +68,5 @@
   <package id="Microsoft.VisualStudio.Editor.Implementation" version="15.8.525" />
   <package id="Microsoft.VisualStudio.Platform.VSEditor" version="15.8.525" />
   <package id="Microsoft.VisualStudio.Text.Internal" version="15.8.525" />
-  <package id="Microsoft.VisualStudio.Python.LanguageServer" version="0.1.28" />
+  <package id="Microsoft.VisualStudio.Python.LanguageServer" version="0.1.29" />
 </packages>

--- a/Build/16.0/packages.config
+++ b/Build/16.0/packages.config
@@ -46,7 +46,7 @@
   <package id="Microsoft.VisualStudio.LanguageServer.Protocol" version="15.9.1" />
   <package id="Microsoft.VisualStudio.Shared.VSCodeDebugProtocol" version="15.8.20719.1"/>
   <package id="Microsoft.VisualStudio.Validation" version="15.3.58" />
-  <package id="Microsoft.VisualStudio.Python.LanguageServer" version="0.1.28" />
+  <package id="Microsoft.VisualStudio.Python.LanguageServer" version="0.1.29" />
 
 
 <!--

--- a/Common/Tests/MockVsTests/MockVsFolderWorkspaceService.cs
+++ b/Common/Tests/MockVsTests/MockVsFolderWorkspaceService.cs
@@ -1,0 +1,29 @@
+﻿// Visual Studio Shared Project
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System;
+using System.ComponentModel.Composition;
+using Microsoft.VisualStudio.Workspace;
+using Microsoft.VisualStudio.Workspace.VSIntegration.Contracts;
+
+namespace Microsoft.VisualStudioTools.MockVsTests {
+    [Export(typeof(IVsFolderWorkspaceService))]
+    class MockVsFolderWorkspaceService : IVsFolderWorkspaceService {
+        public IWorkspace CurrentWorkspace => null;
+
+        public AsyncEvent<EventArgs> OnActiveWorkspaceChanged { get; set; }
+    }
+}

--- a/Common/Tests/MockVsTests/MockVsTests.csproj
+++ b/Common/Tests/MockVsTests/MockVsTests.csproj
@@ -56,6 +56,8 @@
     <Reference Include="Microsoft.VisualStudio.TextManager.Interop, Version=7.1.40304.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
     <Reference Include="Microsoft.VisualStudio.TextManager.Interop.8.0, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
     <Reference Include="Microsoft.VisualStudio.Threading" />
+    <Reference Include="Microsoft.VisualStudio.Workspace, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+    <Reference Include="Microsoft.VisualStudio.Workspace.VSIntegration.Contracts, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="System" />
@@ -140,6 +142,7 @@
     <Compile Include="CachedVsInfo.cs" />
     <Compile Include="CommandTargetExtensions.cs" />
     <Compile Include="IsMockVs.cs" />
+    <Compile Include="MockVsFolderWorkspaceService.cs" />
     <Compile Include="MockClassifierAggregatorService.cs" />
     <Compile Include="MockDTEProperties.cs" />
     <Compile Include="MockDTEProperty.cs" />

--- a/Common/Tests/MockVsTests/MockVsTests.csproj
+++ b/Common/Tests/MockVsTests/MockVsTests.csproj
@@ -56,8 +56,8 @@
     <Reference Include="Microsoft.VisualStudio.TextManager.Interop, Version=7.1.40304.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
     <Reference Include="Microsoft.VisualStudio.TextManager.Interop.8.0, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
     <Reference Include="Microsoft.VisualStudio.Threading" />
-    <Reference Include="Microsoft.VisualStudio.Workspace, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-    <Reference Include="Microsoft.VisualStudio.Workspace.VSIntegration.Contracts, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+    <Reference Include="Microsoft.VisualStudio.Workspace" />
+    <Reference Include="Microsoft.VisualStudio.Workspace.VSIntegration.Contracts" />
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="System" />

--- a/Python/Tests/PythonToolsMockTests/NavigableTests.cs
+++ b/Python/Tests/PythonToolsMockTests/NavigableTests.cs
@@ -185,9 +185,9 @@ print(obj._my_attr_val)
 ";
             using (var helper = new NavigableHelper(code, Version)) {
                 // my_attr
-                await helper.CheckDefinitionLocations(71, 7, Location(4, 5), Location(5, 9), Location(8, 5), Location(9, 9));
-                await helper.CheckDefinitionLocations(128, 7, Location(4, 5), Location(5, 9), Location(8, 5), Location(9, 9));
-                await helper.CheckDefinitionLocations(152, 7, Location(4, 5), Location(5, 9), Location(8, 5), Location(9, 9));
+                await helper.CheckDefinitionLocations(71, 7, Location(4, 5), Location(8, 5), Location(9, 9));
+                await helper.CheckDefinitionLocations(128, 7, Location(4, 5), Location(8, 5), Location(9, 9));
+                await helper.CheckDefinitionLocations(152, 7, Location(4, 5), Location(8, 5), Location(9, 9));
                 await helper.CheckDefinitionLocations(229, 7, Location(4, 5), Location(5, 9), Location(8, 5), Location(9, 9), Location(13, 5));
                 await helper.CheckDefinitionLocations(252, 7, Location(4, 5), Location(5, 9), Location(8, 5), Location(9, 9), Location(13, 5));
 
@@ -202,10 +202,10 @@ print(obj._my_attr_val)
                 await helper.CheckDefinitionLocations(272, 12, Location(2, 5), Location(10, 14));
 
                 // self
-                await helper.CheckDefinitionLocations(79, 4, Location(5, 17));
-                await helper.CheckDefinitionLocations(102, 4, Location(5, 17));
-                await helper.CheckDefinitionLocations(160, 4, Location(9, 17));
-                await helper.CheckDefinitionLocations(181, 4, Location(9, 17));
+                await helper.CheckDefinitionLocations(79, 4, Location(1, 1));
+                await helper.CheckDefinitionLocations(102, 4, Location(1, 1));
+                await helper.CheckDefinitionLocations(160, 4, Location(1, 1));
+                await helper.CheckDefinitionLocations(181, 4, Location(1, 1));
             }
         }
 
@@ -217,7 +217,7 @@ res = my_var * 10
 ";
             using (var helper = new NavigableHelper(code, Version)) {
                 // 2 definitions for my_var
-                await helper.CheckDefinitionLocations(30, 6, Location(1, 1), Location(2, 1));
+                await helper.CheckDefinitionLocations(30, 6, Location(2, 1));
             }
         }
 


### PR DESCRIPTION
Fix #4703 by integrating updated language server

See language server PR at https://github.com/Microsoft/python-language-server/pull/681

Also fixes tests:
- Fix MEF composition error in mock tests.
- Fix go to navigation tests to reflect the updated language server behavior for get definition.