### PR TITLE
Fix narrator behavior in the installed page of the add environment dialog

### DIFF
--- a/Python/Product/Common/Strings.Designer.cs
+++ b/Python/Product/Common/Strings.Designer.cs
@@ -676,6 +676,15 @@ namespace Microsoft.PythonTools {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to (none available).
+        /// </summary>
+        public static string AddInstalledEnvironmentNoneAvailable {
+            get {
+                return ResourceManager.GetString("AddInstalledEnvironmentNoneAvailable", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Python installation.
         /// </summary>
         public static string AddInstalledEnvironmentTabHeader {

--- a/Python/Product/Common/Strings.resx
+++ b/Python/Product/Common/Strings.resx
@@ -2296,6 +2296,9 @@ Expand selection to the full expression?</value>
   <data name="AddInstalledEnvironmentNone" xml:space="preserve">
     <value>(none)</value>
   </data>
+  <data name="AddInstalledEnvironmentNoneAvailable" xml:space="preserve">
+    <value>(none available)</value>
+  </data>
   <data name="AddCondaEnvironmentTabHeader" xml:space="preserve">
     <value>Conda environment</value>
   </data>

--- a/Python/Product/PythonTools/PythonTools/Environments/AddInstalledEnvironmentControl.xaml
+++ b/Python/Product/PythonTools/PythonTools/Environments/AddInstalledEnvironmentControl.xaml
@@ -14,6 +14,11 @@
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="pack://application:,,,/Microsoft.PythonTools;component/PythonTools/Wpf/ModernStyles.xaml" />
                 <ResourceDictionary>
+                    <DataTemplate x:Key="NoneTemplate" DataType="{x:Type l:SetupPackageNoneView}">
+                        <TextBlock
+                            Text="{Binding Path=Text}"
+                            Margin="0 0 0 20"/>
+                    </DataTemplate>
                     <DataTemplate x:Key="InstalledTemplate" DataType="{x:Type l:SetupPackageView}">
                         <TextBlock
                             Text="{Binding Path=Title}"
@@ -26,6 +31,14 @@
                             Margin="0 0 0 10"
                             Style="{DynamicResource {x:Static ptwpf:ModernStyles.ThemedDialogCheckBoxStyleKey}}"/>
                     </DataTemplate>
+                    <l:SetupPackageTemplateSelector
+                        x:Key="InstalledTemplateSelector"
+                        PackageView="{StaticResource InstalledTemplate}"
+                        NoneView="{StaticResource NoneTemplate}"/>
+                    <l:SetupPackageTemplateSelector
+                        x:Key="AvailableTemplateSelector"
+                        PackageView="{StaticResource AvailableTemplate}"
+                        NoneView="{StaticResource NoneTemplate}"/>
                 </ResourceDictionary>
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
@@ -40,15 +53,9 @@
             Text="{x:Static common:Strings.AddInstalledEnvironmentDescription}"
             Margin="0 0 0 20"/>
 
-        <TextBlock
-            Text="{x:Static common:Strings.AddInstalledEnvironmentNone}"
-            Visibility="{Binding Path=AvailableView.IsEmpty, Converter={x:Static wpf:Converters.TrueIsNotCollapsed}}"
-            Margin="0 0 0 20"/>
-
         <ItemsControl
-            ItemsSource="{Binding Path=AvailableView}"
-            ItemTemplate="{StaticResource AvailableTemplate}"
-            Visibility="{Binding Path=AvailableView.IsEmpty, Converter={x:Static wpf:Converters.TrueIsCollapsed}}"
+            ItemsSource="{Binding Path=AvailablePackages}"
+            ItemTemplateSelector="{StaticResource AvailableTemplateSelector}"
             Focusable="False"
             Margin="0 0 0 10"/>
 
@@ -57,15 +64,9 @@
             Content="{x:Static common:Strings.AddInstalledEnvironmentInstalledLabel}"
             Style="{StaticResource ModernLabel}"/>
 
-        <TextBlock
-            Text="{x:Static common:Strings.AddInstalledEnvironmentNone}"
-            Visibility="{Binding Path=InstalledView.IsEmpty, Converter={x:Static wpf:Converters.TrueIsNotCollapsed}}"
-            Margin="0 0 0 20"/>
-
         <ItemsControl
-            ItemsSource="{Binding Path=InstalledView}"
-            ItemTemplate="{StaticResource InstalledTemplate}"
-            Visibility="{Binding Path=InstalledView.IsEmpty, Converter={x:Static wpf:Converters.TrueIsCollapsed}}"
+            ItemsSource="{Binding Path=InstalledPackages}"
+            ItemTemplateSelector="{StaticResource InstalledTemplateSelector}"
             Focusable="False"
             Margin="0 0 0 10"/>
     </StackPanel>


### PR DESCRIPTION
Fix #5179 

Integrates the 'none' entries into the items list as appropriate, so that visibility is controlled by the presence in the list.

Narrator was previously not respecting the visibility of the separate text block control. This works around that.