### PR TITLE
Fix VC debug launcher

### DIFF
--- a/Python/Product/VCDebugLauncher/VCDebugLauncher.csproj
+++ b/Python/Product/VCDebugLauncher/VCDebugLauncher.csproj
@@ -169,28 +169,28 @@
       <VSIXSubPath>.</VSIXSubPath>
     </Content>
     <Content Include="VCTargets\Win32\ImportAfter\Microsoft.PythonTools.Debugger.VCDebugLauncher.targets">
-      <VSIXSubPath>Platforms\Win32\ImportAfter</VSIXSubPath>
-      <InstallRoot>VCTargets</InstallRoot>
+      <VSIXSubPath>Microsoft\VC\v160\Platforms\Win32\ImportAfter</VSIXSubPath>
+      <InstallRoot>MSBuild</InstallRoot>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <IncludeInVSIX>true</IncludeInVSIX>
       <SubType>Designer</SubType>
     </Content>
     <Content Include="VCTargets\Win32\ImportBefore\Microsoft.PythonTools.Debugger.VCDebugLauncher.props">
-      <VSIXSubPath>Platforms\Win32\ImportBefore</VSIXSubPath>
-      <InstallRoot>VCTargets</InstallRoot>
+      <VSIXSubPath>Microsoft\VC\v160\Platforms\Win32\ImportBefore</VSIXSubPath>
+      <InstallRoot>MSBuild</InstallRoot>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
     <Content Include="VCTargets\x64\ImportAfter\Microsoft.PythonTools.Debugger.VCDebugLauncher.targets">
-      <VSIXSubPath>Platforms\x64\ImportAfter</VSIXSubPath>
-      <InstallRoot>VCTargets</InstallRoot>
+      <VSIXSubPath>Microsoft\VC\v160\Platforms\x64\ImportAfter</VSIXSubPath>
+      <InstallRoot>MSBuild</InstallRoot>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <IncludeInVSIX>true</IncludeInVSIX>
       <SubType>Designer</SubType>
     </Content>
     <Content Include="VCTargets\x64\ImportBefore\Microsoft.PythonTools.Debugger.VCDebugLauncher.props">
-      <VSIXSubPath>Platforms\x64\ImportBefore</VSIXSubPath>
-      <InstallRoot>VCTargets</InstallRoot>
+      <VSIXSubPath>Microsoft\VC\v160\Platforms\x64\ImportBefore</VSIXSubPath>
+      <InstallRoot>MSBuild</InstallRoot>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
@@ -226,14 +226,14 @@
   </ItemGroup>
   <ItemGroup>
     <XamlPropertyRule Include="VCTargets\Win32\ImportAfter\Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml">
-      <VSIXSubPath>Platforms\Win32\ImportAfter</VSIXSubPath>
-      <InstallRoot>VCTargets</InstallRoot>
+      <VSIXSubPath>Microsoft\VC\v160\Platforms\Win32\ImportAfter</VSIXSubPath>
+      <InstallRoot>MSBuild</InstallRoot>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <IncludeInVSIX>true</IncludeInVSIX>
     </XamlPropertyRule>
     <Content Include="VCTargets\x64\ImportAfter\Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml">
-      <VSIXSubPath>Platforms\x64\ImportAfter</VSIXSubPath>
-      <InstallRoot>VCTargets</InstallRoot>
+      <VSIXSubPath>Microsoft\VC\v160\Platforms\x64\ImportAfter</VSIXSubPath>
+      <InstallRoot>MSBuild</InstallRoot>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
@@ -260,13 +260,13 @@
         <IncludeInVSIX>true</IncludeInVSIX>
       </LocContent>
       <LocContent Include="$(LocOutputPath)%(VSLanguages.Identity)\VCTargets\Win32\ImportAfter\Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml">
-        <VSIXSubPath>Platforms\Win32\ImportAfter\%(VSLanguages.LCID)</VSIXSubPath>
-        <InstallRoot>VCTargets</InstallRoot>
+        <VSIXSubPath>Microsoft\VC\v160\Platforms\Win32\ImportAfter\%(VSLanguages.LCID)</VSIXSubPath>
+        <InstallRoot>MSBuild</InstallRoot>
         <IncludeInVSIX>true</IncludeInVSIX>
       </LocContent>
       <LocContent Include="$(LocOutputPath)%(VSLanguages.Identity)\VCTargets\x64\ImportAfter\Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml">
-        <VSIXSubPath>Platforms\x64\ImportAfter\%(VSLanguages.LCID)</VSIXSubPath>
-        <InstallRoot>VCTargets</InstallRoot>
+        <VSIXSubPath>Microsoft\VC\v160\Platforms\x64\ImportAfter\%(VSLanguages.LCID)</VSIXSubPath>
+        <InstallRoot>MSBuild</InstallRoot>
         <IncludeInVSIX>true</IncludeInVSIX>
       </LocContent>
     </ItemGroup>

--- a/Python/Templates/NativeDevelopment/ProjectTemplates/VC/Python/PythonExtensionModule/PythonTemplate.vcxproj
+++ b/Python/Templates/NativeDevelopment/ProjectTemplates/VC/Python/PythonExtensionModule/PythonTemplate.vcxproj
@@ -22,32 +22,32 @@
     <ProjectGuid>$guid1$</ProjectGuid>
     <RootNamespace>$safeprojectname$</RootNamespace>
     <PythonVersion>3.7</PythonVersion>
-    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>


### PR DESCRIPTION
Fix #5243 

Update extension module template and VC debug launcher msbuild install location to both use the VC v142 platform toolset. 

FYI platform toolset v142 = VS 2019, v141 = VS 2017, v140 = VS 2015

Update the template to default to use the latest installed Win10 SDK rather than a specific version.

The VCTargets install location has been deprecated. The VC msbuild files now go under the standard MSBuild folder, but now we have to manually specify which platform toolset we want to install into. The v160 folder is for the v142 platform toolset.
