### PR TITLE
Fix the newly detected Roslyn Errors #5197

### DIFF
--- a/Build/Common.Build.CSharp.settings
+++ b/Build/Common.Build.CSharp.settings
@@ -84,6 +84,7 @@
     <SignManifests>false</SignManifests>
     <AssemblyOriginatorKeyFile>$(TargetsPath)\FinalPublicKey.snk</AssemblyOriginatorKeyFile>
     <DelaySign>true</DelaySign>
+    <Features>$(Features);flow-analysis</Features> 
   </PropertyGroup>
 
 </Project>

--- a/Common/Tools/BuildTasks/ExtractLambdasFromXaml.cs
+++ b/Common/Tools/BuildTasks/ExtractLambdasFromXaml.cs
@@ -113,7 +113,7 @@ namespace Microsoft.VisualStudioTools.BuildTasks {
                 return GenerateOutput();
             } catch (Exception ex) {
                 LogError(null, 0, 0, ex.Message);
-                return false;
+                throw;
             }
         }
 


### PR DESCRIPTION
-had to add a workaround msbuild property due to build machine using VS 2017 with msbuild 15.0

first main issue
 ##[error]E:\A\_work\139\s\Python\Product\Cookiecutter\ExtractLambdasFromXaml.cs(114,15): Error CA1031: Modify 'Execute' to catch a more specific exception type, or rethrow the exception. [E:\A\_work\139\s\Common\Tools\BuildTasks\BuildTasks.csproj]
 ExtractLambdasFromXaml.cs(114,15): error CA1031: Modify 'Execute' to catch a more specific exception type, or rethrow the exception. [E:\A\_work\139\s\Common\Tools\BuildTasks\BuildTasks.csproj] [E:\A\_work\139\s\Python\Product\Cookiecutter\Cookiecutter_ljs5eifo_wpftmp.csproj]

second issue with Roslyn itself
"CSC(0,0): Error AD0001: Analyzer 'Microsoft.NetCore.Analyzers.Runtime.DisposableFieldsShouldBeDisposed' threw an exception of type 'System.InvalidOperationException' with message 'Feature 'Flow-Analysis' is disabled.'. [E:\A\_work\529\s\Common\Tools\BuildTasks\BuildTasks.csproj]"


Roslyn Policy run
https://dev.azure.com/mseng/DSTools/_build/results?buildId=9340237&view=logs&s=96ac2280-8cb4-5df5-99de-dd2da759617d