### PR TITLE
Update to ptvsd 4.2.9b0

### DIFF
--- a/Python/Product/Debugger/Debugger.csproj
+++ b/Python/Product/Debugger/Debugger.csproj
@@ -183,7 +183,7 @@
   </ItemGroup>
   <Import Project="..\ProjectAfter.settings" />
   <PropertyGroup>
-    <BundledPTVSDVersion>4.2.8</BundledPTVSDVersion>
+    <BundledPTVSDVersion>4.2.9b0</BundledPTVSDVersion>
   </PropertyGroup>
   <Target Name="_GatherPtvsd" BeforeTargets="_IncludePtvsd" Condition="!Exists('$(IntermediateOutputPath)Packages\ptvsd\__init__.py')">
     <PropertyGroup>


### PR DESCRIPTION
All UI tests passed on both 2.7 and 3.6, except for PendingBreakPointLocation which has unrelated failure (regarding analysis not running).