### PR TITLE
Modify NativeModule.vcxproj for VS2019 16.1 automation tests.

### DIFF
--- a/Python/Tests/TestData/AddProjectReference/NativeModule/NativeModule.vcxproj
+++ b/Python/Tests/TestData/AddProjectReference/NativeModule/NativeModule.vcxproj
@@ -16,7 +16,7 @@
     <PlatformToolset Condition="$(VisualStudioVersion) == '14.0'">v140</PlatformToolset>
     <PlatformToolset Condition="$(VisualStudioVersion) == '12.0'">v120</PlatformToolset>
     <PlatformToolset Condition="$(VisualStudioVersion) == '11.0'">v110</PlatformToolset>
-    <PlatformToolset Condition="$(PlatformToolset) == ''">v141</PlatformToolset>
+    <PlatformToolset Condition="$(PlatformToolset) == ''">v142</PlatformToolset>
     <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/Python/Tests/TestData/AddProjectReference/NativeModule/NativeModule.vcxproj
+++ b/Python/Tests/TestData/AddProjectReference/NativeModule/NativeModule.vcxproj
@@ -17,7 +17,7 @@
     <PlatformToolset Condition="$(VisualStudioVersion) == '12.0'">v120</PlatformToolset>
     <PlatformToolset Condition="$(VisualStudioVersion) == '11.0'">v110</PlatformToolset>
     <PlatformToolset Condition="$(PlatformToolset) == ''">v142</PlatformToolset>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">


### PR DESCRIPTION
Update PlatformToolset and WindowsTargetPlatformVersion for VS2019 automation tests.
  1.Change WindowsTargetPlatformVersion from 10.0.16299.0 to 10.0
  2.Change <PlatformToolset Condition="$(PlatformToolset) == ''">v141</PlatformToolset> to      <PlatformToolset Condition="$(PlatformToolset) == ''">v142</PlatformToolset>