### PR TITLE
Update LiveShare NuGet packages.

### DIFF
--- a/Build/16.0/packages.config
+++ b/Build/16.0/packages.config
@@ -6,8 +6,8 @@
   <package id="EnvDTE90" version="9.0.3" />
   <package id="MicroBuild.Core" version="0.2.0" />
   <package id="Microsoft.DotNet.PlatformAbstractions" version="2.1.0" />
-  <package id="Microsoft.VisualStudio.LiveShare" version="1.0.6" />
-  <package id="Microsoft.VisualStudio.LiveShare.LanguageServices" version="1.0.6" />
+  <package id="Microsoft.VisualStudio.LiveShare" version="1.0.181" />
+  <package id="Microsoft.VisualStudio.LiveShare.LanguageServices" version="1.0.181" />
   <package id="Microsoft.VisualStudio.ComponentModelHost" version="16.0.467" />
   <package id="Microsoft.VisualStudio.Composition" version="16.0.12-beta" />
   <package id="Microsoft.VisualStudio.CoreUtility" version="16.0.467" />


### PR DESCRIPTION
Not required, as there are binding redirects, but I prefer to target the latest available.