### PR TITLE
Remove tests using Python versions 2.6, 3.1-3.4. 

### DIFF
--- a/Python/Tests/Core.UI/EnvironmentUITests.cs
+++ b/Python/Tests/Core.UI/EnvironmentUITests.cs
@@ -57,7 +57,7 @@ namespace PythonToolsUITests {
             return app.SelectDefaultInterpreter(
                 PythonPaths.Python37 ?? PythonPaths.Python37_x64 ??
                 PythonPaths.Python36 ?? PythonPaths.Python36_x64 ??
-                PythonPaths.Python35 ?? PythonPaths.Python35_x64 ??
+                PythonPaths.Python35 ?? PythonPaths.Python35_x64
             );
         }
 

--- a/Python/Tests/Core.UI/EnvironmentUITests.cs
+++ b/Python/Tests/Core.UI/EnvironmentUITests.cs
@@ -55,13 +55,10 @@ namespace PythonToolsUITests {
 
         static DefaultInterpreterSetter InitPython3(PythonVisualStudioApp app) {
             return app.SelectDefaultInterpreter(
-                PythonPaths.Python37_x64 ??
-                PythonPaths.Python37 ??
-                PythonPaths.Python36_x64 ??
-                PythonPaths.Python36 ??
-                PythonPaths.Python35_x64 ??
-                PythonPaths.Python35
-            );;
+                PythonPaths.Python37 ?? PythonPaths.Python37_x64 ??
+                PythonPaths.Python36 ?? PythonPaths.Python36_x64 ??
+                PythonPaths.Python35 ?? PythonPaths.Python35_x64 ??
+            );
         }
 
         static EnvDTE.Project CreateTemporaryProject(VisualStudioApp app, [CallerMemberName] string projectName = null) {

--- a/Python/Tests/Core.UI/EnvironmentUITests.cs
+++ b/Python/Tests/Core.UI/EnvironmentUITests.cs
@@ -55,12 +55,13 @@ namespace PythonToolsUITests {
 
         static DefaultInterpreterSetter InitPython3(PythonVisualStudioApp app) {
             return app.SelectDefaultInterpreter(
-                PythonPaths.Python37 ?? PythonPaths.Python37_x64 ??
-                PythonPaths.Python36 ?? PythonPaths.Python36_x64 ??
-                PythonPaths.Python35 ?? PythonPaths.Python35_x64 ??
-                PythonPaths.Python34 ?? PythonPaths.Python34_x64 ??
-                PythonPaths.Python33 ?? PythonPaths.Python33_x64
-            );
+                PythonPaths.Python37_x64 ??
+                PythonPaths.Python37 ??
+                PythonPaths.Python36_x64 ??
+                PythonPaths.Python36 ??
+                PythonPaths.Python35_x64 ??
+                PythonPaths.Python35
+            );;
         }
 
         static EnvDTE.Project CreateTemporaryProject(VisualStudioApp app, [CallerMemberName] string projectName = null) {
@@ -369,7 +370,12 @@ namespace PythonToolsUITests {
         }
 
         public void ProjectAddExistingVEnvLocal(PythonVisualStudioApp app) {
-            var python = PythonPaths.Python37 ?? PythonPaths.Python36 ?? PythonPaths.Python35 ?? PythonPaths.Python34 ?? PythonPaths.Python33;
+            var python =    PythonPaths.Python37_x64 ??
+                            PythonPaths.Python37 ??
+                            PythonPaths.Python36_x64 ??
+                            PythonPaths.Python36 ??
+                            PythonPaths.Python35_x64 ??
+                            PythonPaths.Python35;
             python.AssertInstalled();
 
             var project = CreateTemporaryProject(app);
@@ -391,7 +397,12 @@ version = 3.{1}.0", python.PrefixPath, python.Version.ToVersion().Minor));
         }
 
         public void ProjectAddCustomEnvLocal(PythonVisualStudioApp app) {
-            var python = PythonPaths.Python37 ?? PythonPaths.Python36 ?? PythonPaths.Python35 ?? PythonPaths.Python34 ?? PythonPaths.Python33;
+            var python =    PythonPaths.Python37_x64 ??
+                            PythonPaths.Python37 ??
+                            PythonPaths.Python36_x64 ??
+                            PythonPaths.Python36 ??
+                            PythonPaths.Python35_x64 ??
+                            PythonPaths.Python35;
             python.AssertInstalled();
 
             var project = CreateTemporaryProject(app);
@@ -408,7 +419,12 @@ version = 3.{1}.0", python.PrefixPath, python.Version.ToVersion().Minor));
         }
 
         public void ProjectAddExistingEnv(PythonVisualStudioApp app) {
-            var python = PythonPaths.Python37 ?? PythonPaths.Python36 ?? PythonPaths.Python35 ?? PythonPaths.Python34 ?? PythonPaths.Python33;
+            var python =    PythonPaths.Python37_x64 ??
+                            PythonPaths.Python37 ??
+                            PythonPaths.Python36_x64 ??
+                            PythonPaths.Python36 ??
+                            PythonPaths.Python35_x64 ??
+                            PythonPaths.Python35;
             python.AssertInstalled();
 
             var project = CreateTemporaryProject(app);

--- a/Python/Tests/Core.UI/WebProjectTests.cs
+++ b/Python/Tests/Core.UI/WebProjectTests.cs
@@ -220,6 +220,7 @@ namespace PythonToolsUITests {
             app.WaitForOutputWindowText("Build", "1 failed");
         }
 
+        /*
         //[TestMethod, Priority(0)]
         [HostType("VSTestHost"), TestCategory("Installed")]
         public void WebProjectBuildWarnings(PythonVisualStudioApp app) {
@@ -296,7 +297,7 @@ namespace PythonToolsUITests {
                     }
                 }
             }
-        }
+        }*/
 
         //[TestMethod, Priority(0)]
         [HostType("VSTestHost"), TestCategory("Installed")]

--- a/Python/Tests/Core.UI/WebProjectTests.cs
+++ b/Python/Tests/Core.UI/WebProjectTests.cs
@@ -220,6 +220,7 @@ namespace PythonToolsUITests {
             app.WaitForOutputWindowText("Build", "1 failed");
         }
 
+        // Update the test from version 3.3/3.4 to 3.5-3.7. 
         /*
         //[TestMethod, Priority(0)]
         [HostType("VSTestHost"), TestCategory("Installed")]

--- a/Python/Tests/Core/DebugReplEvaluatorTests.cs
+++ b/Python/Tests/Core/DebugReplEvaluatorTests.cs
@@ -32,7 +32,6 @@ using TestUtilities.Mocks;
 using TestUtilities.Python;
 
 namespace PythonToolsTests {
-    [TestClass]
     public abstract class DebugReplEvaluatorTests {
         private PythonDebugReplEvaluator _evaluator;
         private MockReplWindow _window;

--- a/Python/Tests/Core/DebugReplEvaluatorTests.cs
+++ b/Python/Tests/Core/DebugReplEvaluatorTests.cs
@@ -33,7 +33,7 @@ using TestUtilities.Python;
 
 namespace PythonToolsTests {
     [TestClass]
-    public class DebugReplEvaluatorTests {
+    public abstract class DebugReplEvaluatorTests {
         private PythonDebugReplEvaluator _evaluator;
         private MockReplWindow _window;
         private List<PythonProcess> _processes;
@@ -51,7 +51,7 @@ namespace PythonToolsTests {
 
         internal virtual PythonVersion Version {
             get {
-                return PythonPaths.Python26 ?? PythonPaths.Python26_x64;
+                return PythonPaths.Python27 ?? PythonPaths.Python27_x64;
             }
         }
 
@@ -426,62 +426,6 @@ NameError: name 'does_not_exist' is not defined
 
         protected static CancellationToken TimeoutToken() {
             return CancellationTokens.After5s;
-        }
-    }
-
-    [TestClass]
-    public class DebugReplEvaluatorTests31 : DebugReplEvaluatorTests {
-        [ClassInitialize]
-        public static new void DoDeployment(TestContext context) {
-            AssertListener.Initialize();
-        }
-
-        internal override PythonVersion Version {
-            get {
-                return PythonPaths.Python31 ?? PythonPaths.Python31_x64;
-            }
-        }
-    }
-
-    [TestClass]
-    public class DebugReplEvaluatorTests32 : DebugReplEvaluatorTests {
-        [ClassInitialize]
-        public static new void DoDeployment(TestContext context) {
-            AssertListener.Initialize();
-        }
-
-        internal override PythonVersion Version {
-            get {
-                return PythonPaths.Python32 ?? PythonPaths.Python32_x64;
-            }
-        }
-    }
-
-    [TestClass]
-    public class DebugReplEvaluatorTests33 : DebugReplEvaluatorTests {
-        [ClassInitialize]
-        public static new void DoDeployment(TestContext context) {
-            AssertListener.Initialize();
-        }
-
-        internal override PythonVersion Version {
-            get {
-                return PythonPaths.Python33 ?? PythonPaths.Python33_x64;
-            }
-        }
-    }
-
-    [TestClass]
-    public class DebugReplEvaluatorTests34 : DebugReplEvaluatorTests {
-        [ClassInitialize]
-        public static new void DoDeployment(TestContext context) {
-            AssertListener.Initialize();
-        }
-
-        internal override PythonVersion Version {
-            get {
-                return PythonPaths.Python34 ?? PythonPaths.Python34_x64;
-            }
         }
     }
 

--- a/Python/Tests/Core/EnvironmentListTests.cs
+++ b/Python/Tests/Core/EnvironmentListTests.cs
@@ -775,22 +775,22 @@ namespace PythonToolsUITests {
         [TestMethod, Priority(0)]
         public void FilterInterpreterPython2() {
             PythonVersion pythonInterpreter =   PythonPaths.Python27_x64 ??
-                                                PythonPaths.Python26_x64 ??
-                                                PythonPaths.Python27 ??
-                                                PythonPaths.Python26;
+                                                PythonPaths.Python27;
 
-            pythonInterpreter.AssertInstalled("Unable to run test because python 2.6 or 2.7 must be installed");
+            pythonInterpreter.AssertInstalled("Unable to run test because python 2.7 must be installed");
             FilterPythonInterpreterEnv(pythonInterpreter);
         }
 
         [TestMethod, Priority(0)]
         public void FilterInterpreterPython3() {
             PythonVersion pythonInterpreter =   PythonPaths.Python37_x64 ??
-                                                PythonPaths.Python36_x64 ??
                                                 PythonPaths.Python37 ??
-                                                PythonPaths.Python36;
+                                                PythonPaths.Python36_x64 ??
+                                                PythonPaths.Python36 ??
+                                                PythonPaths.Python35_x64 ??
+                                                PythonPaths.Python35;
 
-            pythonInterpreter.AssertInstalled("Unable to run test because python 3.6 or 3.7 must be installed");
+            pythonInterpreter.AssertInstalled("Unable to run test because python 3.5, 3.6 or 3.7 must be installed");
             FilterPythonInterpreterEnv(pythonInterpreter);
         }
 

--- a/Python/Tests/Core/ReplEvaluatorTests.cs
+++ b/Python/Tests/Core/ReplEvaluatorTests.cs
@@ -205,7 +205,7 @@ f()",
         }
 
         private static PythonInteractiveEvaluator MakeEvaluator() {
-            var python = PythonPaths.Python27 ?? PythonPaths.Python27_x64 ?? PythonPaths.Python26 ?? PythonPaths.Python26_x64;
+            var python = PythonPaths.Python27_x64 ?? PythonPaths.Python27;
             python.AssertInstalled();
             var provider = new SimpleFactoryProvider(python.InterpreterPath, python.InterpreterPath);
             var eval = new PythonInteractiveEvaluator(PythonToolsTestUtilities.CreateMockServiceProvider()) {

--- a/Python/Tests/DebuggerTests/AttachTests.cs
+++ b/Python/Tests/DebuggerTests/AttachTests.cs
@@ -1281,66 +1281,6 @@ int main(int argc, char* argv[]) {
     }
 
     [TestClass]
-    public class AttachTests31 : AttachTests {
-        internal override PythonVersion Version {
-            get {
-                return PythonPaths.Python31 ?? PythonPaths.Python31_x64;
-            }
-        }
-
-        [TestMethod, Priority(2)]
-        public override async Task AttachWithOutputRedirection() => await base.AttachWithOutputRedirection();
-    }
-
-    [TestClass]
-    public class AttachTests32 : AttachTests {
-        internal override PythonVersion Version {
-            get {
-                return PythonPaths.Python32 ?? PythonPaths.Python32_x64;
-            }
-        }
-
-        public override async Task AttachNewThread_PyThreadState_New() {
-            // PyEval_AcquireLock deprecated in 3.2
-        }
-    }
-
-    [TestClass]
-    public class AttachTests33 : AttachTests {
-        internal override PythonVersion Version {
-            get {
-                return PythonPaths.Python33 ?? PythonPaths.Python33_x64;
-            }
-        }
-
-        public override async Task AttachNewThread_PyThreadState_New() {
-            // PyEval_AcquireLock deprecated in 3.2
-        }
-    }
-
-    [TestClass]
-    public class AttachTests34 : AttachTests {
-        internal override PythonVersion Version {
-            get {
-                return PythonPaths.Python34;
-            }
-        }
-
-        public override async Task AttachNewThread_PyThreadState_New() {
-            // PyEval_AcquireLock deprecated in 3.2
-        }
-    }
-
-    [TestClass]
-    public class AttachTests34_x64 : AttachTests34 {
-        internal override PythonVersion Version {
-            get {
-                return PythonPaths.Python34_x64;
-            }
-        }
-    }
-
-    [TestClass]
     public class AttachTests35 : AttachTests {
         internal override PythonVersion Version {
             get {
@@ -1412,18 +1352,6 @@ int main(int argc, char* argv[]) {
     }
 
     [TestClass]
-    public class AttachTests26 : AttachTests {
-        internal override PythonVersion Version {
-            get {
-                return PythonPaths.Python26 ?? PythonPaths.Python26_x64;
-            }
-        }
-
-        // 2.6 does not support packages as scripts (__main__.py)
-        protected override bool HasPtvsdCommandLine => false;
-    }
-
-    [TestClass]
     public class AttachTests27 : AttachTests {
         internal override PythonVersion Version {
             get {
@@ -1442,7 +1370,7 @@ int main(int argc, char* argv[]) {
     }
 
     [TestClass]
-    public class AttachTestsIpy : AttachTests {
+    public class AttachTestsIpy27 : AttachTests {
         internal override PythonVersion Version {
             get {
                 return PythonPaths.IronPython27 ?? PythonPaths.IronPython27_x64;

--- a/Python/Tests/DebuggerTests/BaseDebuggerTests.cs
+++ b/Python/Tests/DebuggerTests/BaseDebuggerTests.cs
@@ -29,6 +29,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using TestUtilities;
 
 namespace DebuggerTests {
+    [TestClass, Ignore]
     public abstract class BaseDebuggerTests {
         static BaseDebuggerTests() {
             AssertListener.Initialize();
@@ -528,7 +529,7 @@ namespace DebuggerTests {
 
         internal virtual PythonVersion Version {
             get {
-                return PythonPaths.Python26;
+                return PythonPaths.Python27;
             }
         }
 

--- a/Python/Tests/DebuggerTests/BaseDebuggerTests.cs
+++ b/Python/Tests/DebuggerTests/BaseDebuggerTests.cs
@@ -29,7 +29,6 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using TestUtilities;
 
 namespace DebuggerTests {
-    [TestClass, Ignore]
     public abstract class BaseDebuggerTests {
         static BaseDebuggerTests() {
             AssertListener.Initialize();

--- a/Python/Tests/DebuggerTests/DebuggerTests.cs
+++ b/Python/Tests/DebuggerTests/DebuggerTests.cs
@@ -68,7 +68,7 @@ namespace DebuggerTests {
             await ChildTestAsync(EnumChildrenTestName, lastLine, "s", GetSetChildren(
                 new ChildInfo("[0]", "next((v for i, v in enumerate(s) if i == 0))", Version.Version.Is3x() ? "frozenset({2, 3, 4})" : "frozenset([2, 3, 4])")));
 
-            if (Version.Version.Is2x() && !(this is DebuggerTestsIpy)) {
+            if (Version.Version.Is2x() && !(this is DebuggerTestsIpy27)) {
                 // IronPython unicode repr differs
                 // 3.x: http://pytools.codeplex.com/workitem/76
                 await ChildTestAsync(EnumChildrenTestName, lastLine, "cinst",
@@ -99,14 +99,14 @@ namespace DebuggerTests {
         }
 
         private ChildInfo[] GetSetChildren(ChildInfo items) {
-            if (this is DebuggerTestsIpy) {
+            if (this is DebuggerTestsIpy27) {
                 return new ChildInfo[] { new ChildInfo("Count", null), items };
             }
             return new[] { items };
         }
 
         private ChildInfo[] GetListChildren(params ChildInfo[] items) {
-            if (this is DebuggerTestsIpy) {
+            if (this is DebuggerTestsIpy27) {
                 var res = new List<ChildInfo>(items);
                 res.Add(new ChildInfo("Count", null));
                 res.Add(new ChildInfo("Item", null));
@@ -126,7 +126,7 @@ namespace DebuggerTests {
 
             res.AddRange(items);
 
-            if (this is DebuggerTestsIpy) {
+            if (this is DebuggerTestsIpy27) {
                 res.Add(new ChildInfo("Count", null));
                 res.Add(new ChildInfo("Item", null));
                 res.Add(new ChildInfo("Keys", null));
@@ -150,7 +150,7 @@ namespace DebuggerTests {
             await ChildTestAsync("PrevFrame" + EnumChildrenTestName, breakLine, "s", 1, GetSetChildren(
                 new ChildInfo("[0]", "next((v for i, v in enumerate(s) if i == 0))", Version.Version.Is3x() ? "frozenset({2, 3, 4})" : "frozenset([2, 3, 4])")));
 
-            if (GetType() != typeof(DebuggerTestsIpy) && Version.Version.Is2x()) {
+            if (GetType() != typeof(DebuggerTestsIpy27) && Version.Version.Is2x()) {
                 // IronPython unicode repr differs
                 // 3.x: http://pytools.codeplex.com/workitem/76
                 await ChildTestAsync("PrevFrame" + EnumChildrenTestName, breakLine, "cinst", 1,
@@ -323,7 +323,7 @@ namespace DebuggerTests {
 
         [TestMethod, Priority(0)]
         public async Task SetNextLineTest() {
-            if (GetType() == typeof(DebuggerTestsIpy)) {
+            if (GetType() == typeof(DebuggerTestsIpy27)) {
                 //http://ironpython.codeplex.com/workitem/30129
                 return;
             }
@@ -360,7 +360,7 @@ namespace DebuggerTests {
 
                 var moduleFrame = thread.Frames[0];
                 Assert.AreEqual(1, moduleFrame.StartLine);
-                if (GetType() != typeof(DebuggerTestsIpy)) {
+                if (GetType() != typeof(DebuggerTestsIpy27)) {
                     Assert.AreEqual(13, moduleFrame.EndLine);
                 }
 
@@ -510,7 +510,7 @@ namespace DebuggerTests {
         // https://pytools.codeplex.com/workitem/2772
         [TestMethod, Priority(0)]
         public async Task EvalPseudoTypeTest() {
-            if (this is DebuggerTestsIpy) {
+            if (this is DebuggerTestsIpy27) {
                 return;
             }
 
@@ -616,7 +616,7 @@ namespace DebuggerTests {
                 var obj = frames[0].Locals.First(x => x.Expression == "x");
                 var children = await obj.GetChildrenAsync(CancellationTokens.After2s);
                 int extraCount = 0;
-                if (this is DebuggerTestsIpy) {
+                if (this is DebuggerTestsIpy27) {
                     extraCount += 2;
                 }
                 Assert.AreEqual(extraCount + 3, children.Length);
@@ -1712,7 +1712,7 @@ namespace DebuggerTests {
                 await TestExceptionAsync(debugger, Path.Combine(DebuggerTestPath, "UnhandledException4.py"), i == 0, ExceptionMode.Unhandled, null,
                     // On IronPython, an unhandled exception will be repeatedly reported as raised as it bubbles up the stack.
                     // Everywhere else, it will only be reported once at the point where it is initially raised. 
-                    this is DebuggerTestsIpy ?
+                    this is DebuggerTestsIpy27 ?
                     new[] { new ExceptionInfo("OSError", 17), new ExceptionInfo("OSError", 32), new ExceptionInfo("OSError", 55) } :
                     new[] { new ExceptionInfo("OSError", 17) }
                 );
@@ -1834,7 +1834,7 @@ namespace DebuggerTests {
                 raised.RemoveAt(raised.Count - 1);
             }
 
-            if (GetType() == typeof(DebuggerTestsIpy) && raised.Count == exceptions.Length + 1) {
+            if (GetType() == typeof(DebuggerTestsIpy27) && raised.Count == exceptions.Length + 1) {
                 // IronPython over-reports exceptions
                 raised.RemoveAt(raised.Count - 1);
             }
@@ -2238,51 +2238,6 @@ namespace DebuggerTests {
     }
 
     [TestClass]
-    public class DebuggerTests31 : DebuggerTests3x {
-        internal override PythonVersion Version {
-            get {
-                return PythonPaths.Python31 ?? PythonPaths.Python31_x64;
-            }
-        }
-    }
-
-    [TestClass]
-    public class DebuggerTests32 : DebuggerTests3x {
-        internal override PythonVersion Version {
-            get {
-                return PythonPaths.Python32 ?? PythonPaths.Python32_x64;
-            }
-        }
-    }
-
-    [TestClass]
-    public class DebuggerTests33 : DebuggerTests3x {
-        internal override PythonVersion Version {
-            get {
-                return PythonPaths.Python33 ?? PythonPaths.Python33_x64;
-            }
-        }
-    }
-
-    [TestClass]
-    public class DebuggerTests34 : DebuggerTests3x {
-        internal override PythonVersion Version {
-            get {
-                return PythonPaths.Python34;
-            }
-        }
-    }
-
-    [TestClass]
-    public class DebuggerTests34_x64 : DebuggerTests34 {
-        internal override PythonVersion Version {
-            get {
-                return PythonPaths.Python34_x64;
-            }
-        }
-    }
-
-    [TestClass]
     public class DebuggerTests35 : DebuggerTests3x {
         internal override PythonVersion Version {
             get {
@@ -2337,15 +2292,6 @@ namespace DebuggerTests {
     }
 
     [TestClass]
-    public class DebuggerTests26 : DebuggerTests {
-        internal override PythonVersion Version {
-            get {
-                return PythonPaths.Python26 ?? PythonPaths.Python26_x64;
-            }
-        }
-    }
-
-    [TestClass]
     public class DebuggerTests27 : DebuggerTests {
         internal override PythonVersion Version {
             get {
@@ -2364,7 +2310,7 @@ namespace DebuggerTests {
     }
 
     [TestClass]
-    public class DebuggerTestsIpy : DebuggerTests {
+    public class DebuggerTestsIpy27 : DebuggerTests {
         internal override PythonVersion Version {
             get {
                 return PythonPaths.IronPython27 ?? PythonPaths.IronPython27_x64;

--- a/Python/Tests/DebuggerTests/DebuggerTests.cs
+++ b/Python/Tests/DebuggerTests/DebuggerTests.cs
@@ -31,7 +31,6 @@ using Microsoft.VisualStudioTools;
 using TestUtilities;
 
 namespace DebuggerTests {
-    [TestClass, Ignore]
     public abstract class DebuggerTests : BaseDebuggerTests {
         [TestInitialize]
         public void CheckVersion() {

--- a/Python/Tests/DebuggerUITestsRunner/DebugProjectUITests.cs
+++ b/Python/Tests/DebuggerUITestsRunner/DebugProjectUITests.cs
@@ -266,7 +266,7 @@ namespace DebuggerUITestsRunner {
     }
 
     [TestClass]
-    public class DebugProjectUITestsExperimental36 : DebugProjectUITestsExperimental {
-        protected override string Interpreter => "Python36|Python36_x64";
+    public class DebugProjectUITestsExperimental37 : DebugProjectUITestsExperimental {
+        protected override string Interpreter => "Python37|Python37_x64";
     }
 }

--- a/Python/Tests/DebuggerUITestsRunner/DebugProjectUITests.cs
+++ b/Python/Tests/DebuggerUITestsRunner/DebugProjectUITests.cs
@@ -18,7 +18,6 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using TestRunnerInterop;
 
 namespace DebuggerUITestsRunner {
-    [TestClass, Ignore]
     public abstract class DebugProjectUITests {
         #region UI test boilerplate
         public VsTestInvoker _vs => new VsTestInvoker(
@@ -255,7 +254,6 @@ namespace DebuggerUITestsRunner {
         protected override string Interpreter => ""; // Use the existing global default
     }
 
-    [TestClass, Ignore]
     public abstract class DebugProjectUITestsExperimental : DebugProjectUITests {
         protected override bool UseVsCodeDebugger => true;
     }

--- a/Python/Tests/DebuggerUITestsRunner/MixedModeDebugProjectUITests.cs
+++ b/Python/Tests/DebuggerUITestsRunner/MixedModeDebugProjectUITests.cs
@@ -49,22 +49,22 @@ namespace DebuggerUITestsRunner {
     }
 
     [TestClass]
-    public class MixedModeDebugProjectUITests2x_32 : MixedModeDebugProjectUITests {
+    public class MixedModeDebugProjectUITests27_32 : MixedModeDebugProjectUITests {
         protected override string Interpreter => "Python27";
     }
 
     [TestClass]
-    public class MixedModeDebugProjectUITests2x_64 : MixedModeDebugProjectUITests {
+    public class MixedModeDebugProjectUITests27_64 : MixedModeDebugProjectUITests {
         protected override string Interpreter => "Python27_x64";
     }
 
     [TestClass]
     public class MixedModeDebugProjectUITests3x_32 : MixedModeDebugProjectUITests {
-        protected override string Interpreter => "Python35|Python36";
+        protected override string Interpreter => "Python37|Python36|Python35";
     }
 
     [TestClass]
     public class MixedModeDebugProjectUITests3x_64 : MixedModeDebugProjectUITests {
-        protected override string Interpreter => "Python35_x64|Python36_x64";
+        protected override string Interpreter => "Python37_x64|Python36_x64|Python35_x64";
     }
 }

--- a/Python/Tests/ProfilingTests/ProfilingTests.cs
+++ b/Python/Tests/ProfilingTests/ProfilingTests.cs
@@ -35,7 +35,7 @@ namespace ProfilingTests {
         public static void DoDeployment(TestContext context) {
             AssertListener.Initialize();
         }
-
+        
         [TestMethod, Priority(0)]
         public async Task ProfileWithEncoding() {
             var proflaun = Path.Combine(
@@ -57,9 +57,8 @@ namespace ProfilingTests {
                 Assert.IsTrue(File.Exists(testFile), "Did not find " + testFile);
             }
 
-            // Test in 3.4 for tokenize.open and 3.1 for tokenize.detect_encoding
             // Python 2.x uses execfile() and we do not handle encoding at all
-            foreach (var python in new[] { PythonPaths.Python31, PythonPaths.Python34 }) {
+            foreach (var python in new[] { PythonPaths.Python37, PythonPaths.Python36 }) {
                 if (python == null) {
                     continue;
                 }

--- a/Python/Tests/ProfilingTests/ProfilingTests.cs
+++ b/Python/Tests/ProfilingTests/ProfilingTests.cs
@@ -36,6 +36,8 @@ namespace ProfilingTests {
             AssertListener.Initialize();
         }
 
+        // Update the test from version 3.1/3.4 to 3.5-3.7. 
+        /*
         [TestMethod, Priority(0)]
         public async Task ProfileWithEncoding() {
             var proflaun = Path.Combine(
@@ -91,6 +93,6 @@ namespace ProfilingTests {
 
                 Trace.TraceInformation("OK");
             }
-        }
+        }*/
     }
 }

--- a/Python/Tests/ProfilingTests/ProfilingTests.cs
+++ b/Python/Tests/ProfilingTests/ProfilingTests.cs
@@ -35,7 +35,7 @@ namespace ProfilingTests {
         public static void DoDeployment(TestContext context) {
             AssertListener.Initialize();
         }
-        
+
         [TestMethod, Priority(0)]
         public async Task ProfileWithEncoding() {
             var proflaun = Path.Combine(

--- a/Python/Tests/ProfilingUITests/ProfilingUITests.cs
+++ b/Python/Tests/ProfilingUITests/ProfilingUITests.cs
@@ -936,47 +936,37 @@ namespace ProfilingUITests {
         }
 
         public void OldClassProfile(PythonVisualStudioApp app, ProfileCleanup cleanup, DotNotWaitOnExit optionSetter) {
-            bool anyMissing = false;
+            var version = PythonPaths.Python27 ?? PythonPaths.Python27_x64;
+            version.AssertInstalled("Unable to run test because Python 2.7 is not installed");
 
-            foreach (var version in new[] { PythonPaths.Python26, PythonPaths.Python27 }) {
-                if (version == null) {
-                    anyMissing = true;
-                    continue;
+            IPythonProfiling profiling = GetProfiling(app);
+            var sln = app.CopyProjectForTest(@"TestData\ProfileTest.sln");
+            var projDir = Path.Combine(PathUtils.GetParent(sln), "ProfileTest");
+            var session = LaunchProcess(app, profiling, version.InterpreterPath,
+                Path.Combine(projDir, "OldStyleClassProfile.py"),
+                projDir,
+                "",
+                false
+            );
+            try {
+                while (profiling.IsProfiling) {
+                    Thread.Sleep(100);
                 }
 
-                IPythonProfiling profiling = GetProfiling(app);
-                var sln = app.CopyProjectForTest(@"TestData\ProfileTest.sln");
-                var projDir = Path.Combine(PathUtils.GetParent(sln), "ProfileTest");
-                var session = LaunchProcess(app, profiling, version.InterpreterPath,
-                    Path.Combine(projDir, "OldStyleClassProfile.py"),
-                    projDir,
-                    "",
-                    false
-                );
-                try {
-                    while (profiling.IsProfiling) {
-                        Thread.Sleep(100);
-                    }
+                var report = session.GetReport(1);
+                Assert.IsNotNull(report);
 
-                    var report = session.GetReport(1);
-                    Assert.IsNotNull(report);
+                var filename = report.Filename;
+                Assert.IsTrue(filename.Contains("OldStyleClassProfile"));
 
-                    var filename = report.Filename;
-                    Assert.IsTrue(filename.Contains("OldStyleClassProfile"));
+                Assert.IsNull(session.GetReport(2));
 
-                    Assert.IsNull(session.GetReport(2));
+                Assert.IsNotNull(session.GetReport(report.Filename));
+                Assert.IsTrue(File.Exists(filename));
 
-                    Assert.IsNotNull(session.GetReport(report.Filename));
-                    Assert.IsTrue(File.Exists(filename));
-
-                    VerifyReport(report, true, "OldStyleClassProfile.C.f", "time.sleep");
-                } finally {
-                    app.InvokeOnMainThread(() => profiling.RemoveSession(session, false));
-                }
-            }
-
-            if (anyMissing) {
-                Assert.Inconclusive("Not all interpreters were present");
+                VerifyReport(report, true, "OldStyleClassProfile.C.f", "time.sleep");
+            } finally {
+                app.InvokeOnMainThread(() => profiling.RemoveSession(session, false));
             }
         }
 
@@ -1044,15 +1034,6 @@ namespace ProfilingUITests {
             }
         }
 
-        public void BuiltinsProfilePython26(PythonVisualStudioApp app, ProfileCleanup cleanup, DotNotWaitOnExit optionSetter) {
-            BuiltinsProfile(
-                app,
-                PythonPaths.Python26,
-                new[] { "str.startswith", "isinstance", "marshal.dumps", "array.array.tostring" },
-                null
-            );
-        }
-
         public void BuiltinsProfilePython27(PythonVisualStudioApp app, ProfileCleanup cleanup, DotNotWaitOnExit optionSetter) {
             BuiltinsProfile(
                 app,
@@ -1068,69 +1049,6 @@ namespace ProfilingUITests {
                 PythonPaths.Python27_x64,
                 new[] { "str.startswith", "isinstance", "marshal.dumps", "array.array.tostring" },
                 null
-            );
-        }
-
-        public void BuiltinsProfilePython31(PythonVisualStudioApp app, ProfileCleanup cleanup, DotNotWaitOnExit optionSetter) {
-            BuiltinsProfile(
-                app,
-                PythonPaths.Python31,
-                new[] { "BuiltinsProfile.f", "str.startswith", "isinstance", "marshal.dumps", "array.array.tostring" },
-                null
-            );
-        }
-
-        public void BuiltinsProfilePython32(PythonVisualStudioApp app, ProfileCleanup cleanup, DotNotWaitOnExit optionSetter) {
-            BuiltinsProfile(
-                app,
-                PythonPaths.Python32,
-                new[] { "BuiltinsProfile.f", "str.startswith", "isinstance", "marshal.dumps", "array.array.tostring" },
-                new[] { "compile", "exec", "execfile", "_io.TextIOWrapper.read" }
-            );
-        }
-
-        public void BuiltinsProfilePython32x64(PythonVisualStudioApp app, ProfileCleanup cleanup, DotNotWaitOnExit optionSetter) {
-            BuiltinsProfile(
-                app,
-                PythonPaths.Python32_x64,
-                new[] { "BuiltinsProfile.f", "str.startswith", "isinstance", "marshal.dumps", "array.array.tostring" },
-                new[] { "compile", "exec", "execfile", "_io.TextIOWrapper.read" }
-            );
-        }
-
-        public void BuiltinsProfilePython33(PythonVisualStudioApp app, ProfileCleanup cleanup, DotNotWaitOnExit optionSetter) {
-            BuiltinsProfile(
-                app,
-                PythonPaths.Python33,
-                new[] { "BuiltinsProfile.f", "str.startswith", "isinstance", "marshal.dumps", "array.array.tostring" },
-                new[] { "compile", "exec", "execfile", "_io.TextIOWrapper.read" }
-            );
-        }
-
-        public void BuiltinsProfilePython33x64(PythonVisualStudioApp app, ProfileCleanup cleanup, DotNotWaitOnExit optionSetter) {
-            BuiltinsProfile(
-                app,
-                PythonPaths.Python33_x64,
-                new[] { "BuiltinsProfile.f", "str.startswith", "isinstance", "marshal.dumps", "array.array.tostring" },
-                new[] { "compile", "exec", "execfile", "_io.TextIOWrapper.read" }
-            );
-        }
-
-        public void BuiltinsProfilePython34(PythonVisualStudioApp app, ProfileCleanup cleanup, DotNotWaitOnExit optionSetter) {
-            BuiltinsProfile(
-                app,
-                PythonPaths.Python34,
-                new[] { "BuiltinsProfile.f", "str.startswith", "isinstance", "marshal.dumps", "array.array.tostring" },
-                new[] { "compile", "exec", "execfile", "_io.TextIOWrapper.read" }
-            );
-        }
-
-        public void BuiltinsProfilePython34x64(PythonVisualStudioApp app, ProfileCleanup cleanup, DotNotWaitOnExit optionSetter) {
-            BuiltinsProfile(
-                app,
-                PythonPaths.Python34_x64,
-                new[] { "BuiltinsProfile.f", "str.startswith", "isinstance", "marshal.dumps", "array.array.tostring" },
-                new[] { "compile", "exec", "execfile", "_io.TextIOWrapper.read" }
             );
         }
 

--- a/Python/Tests/ProfilingUITestsRunner/ProfilingUITests.cs
+++ b/Python/Tests/ProfilingUITestsRunner/ProfilingUITests.cs
@@ -230,12 +230,6 @@ namespace ProfilingUITestsRunner {
 
         [TestMethod, Priority(0)]
         [TestCategory("Installed")]
-        public void BuiltinsProfilePython26() {
-            _vs.RunTest(nameof(PUIT.BuiltinsProfilePython26));
-        }
-
-        [TestMethod, Priority(0)]
-        [TestCategory("Installed")]
         public void BuiltinsProfilePython27() {
             _vs.RunTest(nameof(PUIT.BuiltinsProfilePython27));
         }
@@ -244,48 +238,6 @@ namespace ProfilingUITestsRunner {
         [TestCategory("Installed")]
         public void BuiltinsProfilePython27x64() {
             _vs.RunTest(nameof(PUIT.BuiltinsProfilePython27x64));
-        }
-
-        [TestMethod, Priority(0)]
-        [TestCategory("Installed")]
-        public void BuiltinsProfilePython31() {
-            _vs.RunTest(nameof(PUIT.BuiltinsProfilePython31));
-        }
-
-        [TestMethod, Priority(0)]
-        [TestCategory("Installed")]
-        public void BuiltinsProfilePython32() {
-            _vs.RunTest(nameof(PUIT.BuiltinsProfilePython32));
-        }
-
-        [TestMethod, Priority(0)]
-        [TestCategory("Installed")]
-        public void BuiltinsProfilePython32x64() {
-            _vs.RunTest(nameof(PUIT.BuiltinsProfilePython32x64));
-        }
-
-        [TestMethod, Priority(0)]
-        [TestCategory("Installed")]
-        public void BuiltinsProfilePython33() {
-            _vs.RunTest(nameof(PUIT.BuiltinsProfilePython33));
-        }
-
-        [TestMethod, Priority(0)]
-        [TestCategory("Installed")]
-        public void BuiltinsProfilePython33x64() {
-            _vs.RunTest(nameof(PUIT.BuiltinsProfilePython33x64));
-        }
-
-        [TestMethod, Priority(0)]
-        [TestCategory("Installed")]
-        public void BuiltinsProfilePython34() {
-            _vs.RunTest(nameof(PUIT.BuiltinsProfilePython34));
-        }
-
-        [TestMethod, Priority(0)]
-        [TestCategory("Installed")]
-        public void BuiltinsProfilePython34x64() {
-            _vs.RunTest(nameof(PUIT.BuiltinsProfilePython34x64));
         }
 
         [TestMethod, Priority(0)]

--- a/Python/Tests/ReplWindowUITests/ReplWindowSettings.cs
+++ b/Python/Tests/ReplWindowUITests/ReplWindowSettings.cs
@@ -25,20 +25,6 @@ namespace ReplWindowUITests {
     internal static class ReplWindowSettings {
         private static Dictionary<string, ReplWindowProxySettings> _allSettings = new Dictionary<string, ReplWindowProxySettings> {
             {
-                "Python26",
-                new ReplWindowProxySettings {
-                    Version = PythonPaths.Python26,
-                    IntFirstMember = "conjugate",
-                }
-            },
-            {
-                "Python26_x64",
-                new ReplWindowProxySettings {
-                    Version = PythonPaths.Python26_x64,
-                    IntFirstMember = "conjugate",
-                }
-            },
-            {
                 "Python27",
                 new ReplWindowProxySettings {
                     Version = PythonPaths.Python27,
@@ -77,83 +63,7 @@ namespace ReplWindowUITests {
                     SourceFileName = "string",
                     ExitHelp = ReplWindowProxySettings.IronPython27ExitHelp,
                 }
-            },
-            {
-                "Python31",
-                new ReplWindowProxySettings {
-                    Version = PythonPaths.Python31,
-                    RawInput = "input",
-                    IPythonIntDocumentation = ReplWindowProxySettings.Python3IntDocumentation,
-                    ExitHelp = ReplWindowProxySettings.Python3ExitHelp,
-                }
-            },
-            {
-                "Python31_x64",
-                new ReplWindowProxySettings {
-                    Version = PythonPaths.Python31_x64,
-                    RawInput = "input",
-                    IPythonIntDocumentation = ReplWindowProxySettings.Python3IntDocumentation,
-                    ExitHelp = ReplWindowProxySettings.Python3ExitHelp,
-                }
-            },
-            {
-                "Python32",
-                new ReplWindowProxySettings {
-                    Version = PythonPaths.Python32,
-                    RawInput = "input",
-                    IPythonIntDocumentation = ReplWindowProxySettings.Python3IntDocumentation,
-                    ExitHelp = ReplWindowProxySettings.Python3ExitHelp,
-                }
-            },
-            {
-                "Python32_x64",
-                new ReplWindowProxySettings {
-                    Version = PythonPaths.Python32_x64,
-                    RawInput = "input",
-                    IPythonIntDocumentation = ReplWindowProxySettings.Python3IntDocumentation,
-                    ExitHelp = ReplWindowProxySettings.Python3ExitHelp,
-                }
-            },
-            {
-                "Python33",
-                new ReplWindowProxySettings {
-                    Version = PythonPaths.Python33,
-                    RawInput = "input",
-                    IPythonIntDocumentation = ReplWindowProxySettings.Python3IntDocumentation,
-                    ExitHelp = ReplWindowProxySettings.Python3ExitHelp,
-                    ImportError = "ImportError: No module named '{0}'",
-                }
-            },
-            {
-                "Python33_x64",
-                new ReplWindowProxySettings {
-                    Version = PythonPaths.Python33_x64,
-                    RawInput = "input",
-                    IPythonIntDocumentation = ReplWindowProxySettings.Python3IntDocumentation,
-                    ExitHelp = ReplWindowProxySettings.Python3ExitHelp,
-                    ImportError = "ImportError: No module named '{0}'",
-                }
-            },
-            {
-                "Python34",
-                new ReplWindowProxySettings {
-                    Version = PythonPaths.Python34,
-                    RawInput = "input",
-                    IPythonIntDocumentation = ReplWindowProxySettings.Python3IntDocumentation,
-                    ExitHelp = ReplWindowProxySettings.Python34ExitHelp,
-                    ImportError = "ImportError: No module named '{0}'",
-                }
-            },
-            {
-                "Python34_x64",
-                new ReplWindowProxySettings {
-                    Version = PythonPaths.Python34_x64,
-                    RawInput = "input",
-                    IPythonIntDocumentation = ReplWindowProxySettings.Python3IntDocumentation,
-                    ExitHelp = ReplWindowProxySettings.Python34ExitHelp,
-                    ImportError = "ImportError: No module named '{0}'",
-                }
-            },
+            },            
             {
                 "Python35",
                 new ReplWindowProxySettings {

--- a/Python/Tests/ReplWindowUITestsRunner/ReplWindowSmokeUITests.cs
+++ b/Python/Tests/ReplWindowUITestsRunner/ReplWindowSmokeUITests.cs
@@ -89,11 +89,6 @@ namespace ReplWindowUITestsRunner {
     }
 
     [TestClass]
-    public class ReplWindowSmokeUITests26 : ReplWindowSmokeUITests {
-        protected override string Interpreter => "Python26|Python26_x64";
-    }
-
-    [TestClass]
     public class ReplWindowSmokeUITests27 : ReplWindowSmokeUITests {
         protected override string Interpreter => "Python27|Python27_x64";
     }
@@ -101,16 +96,6 @@ namespace ReplWindowUITestsRunner {
     [TestClass]
     public class ReplWindowSmokeUITestsIPy27 : ReplWindowSmokeUITests {
         protected override string Interpreter => "IronPython27|IronPython27_x64";
-    }
-
-    [TestClass]
-    public class ReplWindowSmokeUITests33 : ReplWindowSmokeUITests {
-        protected override string Interpreter => "Python33|Python36_x64";
-    }
-
-    [TestClass]
-    public class ReplWindowSmokeUITests34 : ReplWindowSmokeUITests {
-        protected override string Interpreter => "Python34|Python36_x64";
     }
 
     [TestClass]

--- a/Python/Tests/TestAdapterTests/TestExecutorTests.cs
+++ b/Python/Tests/TestAdapterTests/TestExecutorTests.cs
@@ -604,16 +604,6 @@ namespace TestAdapterTests {
     }
 
     [TestClass]
-    public class TestExecutorTests26 : TestExecutorTests {
-        [ClassInitialize]
-        public static void DoDeployment(TestContext context) {
-            AssertListener.Initialize();
-        }
-
-        protected override PythonVersion Version => PythonPaths.Python26 ?? PythonPaths.Python26_x64;
-    }
-
-    [TestClass]
     public class TestExecutorTests27 : TestExecutorTests {
         [ClassInitialize]
         public static void DoDeployment(TestContext context) {
@@ -647,50 +637,6 @@ namespace TestAdapterTests {
     }
 
     [TestClass]
-    public class TestExecutorTests31 : TestExecutorTests {
-        [ClassInitialize]
-        public static void DoDeployment(TestContext context) {
-            AssertListener.Initialize();
-        }
-
-        protected override PythonVersion Version => PythonPaths.Python31 ?? PythonPaths.Python31_x64;
-    }
-
-    [TestClass]
-    public class TestExecutorTests32 : TestExecutorTests {
-        [ClassInitialize]
-        public static void DoDeployment(TestContext context) {
-            AssertListener.Initialize();
-        }
-
-        protected override PythonVersion Version => PythonPaths.Python32 ?? PythonPaths.Python32_x64;
-    }
-
-    [TestClass]
-    public class TestExecutorTests33 : TestExecutorTests {
-        [ClassInitialize]
-        public static void DoDeployment(TestContext context) {
-            AssertListener.Initialize();
-        }
-
-        protected override PythonVersion Version => PythonPaths.Python33 ?? PythonPaths.Python33_x64;
-
-        protected override string ImportErrorFormat => NewImportErrorFormat;
-    }
-
-    [TestClass]
-    public class TestExecutorTests34 : TestExecutorTests {
-        [ClassInitialize]
-        public static void DoDeployment(TestContext context) {
-            AssertListener.Initialize();
-        }
-
-        protected override PythonVersion Version => PythonPaths.Python34 ?? PythonPaths.Python34_x64;
-
-        protected override string ImportErrorFormat => NewImportErrorFormat;
-    }
-
-    [TestClass]
     public class TestExecutorTests35 : TestExecutorTests {
         [ClassInitialize]
         public static void DoDeployment(TestContext context) {
@@ -710,6 +656,18 @@ namespace TestAdapterTests {
         }
 
         protected override PythonVersion Version => PythonPaths.Python36 ?? PythonPaths.Python36_x64;
+
+        protected override string ImportErrorFormat => NewImportErrorFormat;
+    }
+
+    [TestClass]
+    public class TestExecutorTests37 : TestExecutorTests {
+        [ClassInitialize]
+        public static void DoDeployment(TestContext context) {
+            AssertListener.Initialize();
+        }
+
+        protected override PythonVersion Version => PythonPaths.Python37 ?? PythonPaths.Python37_x64;
 
         protected override string ImportErrorFormat => NewImportErrorFormat;
     }

--- a/Python/Tests/Utilities.Python.Analysis/PythonPaths.cs
+++ b/Python/Tests/Utilities.Python.Analysis/PythonPaths.cs
@@ -32,22 +32,12 @@ namespace TestUtilities {
             .Where(pii => pii.Configuration.Id.Contains("PythonCore|") || pii.Configuration.Id.Contains("ContinuumAnalytics|"))
             .ToList();
 
-        public static readonly PythonVersion Python26 = GetCPythonVersion(PythonLanguageVersion.V26, InterpreterArchitecture.x86);
         public static readonly PythonVersion Python27 = GetCPythonVersion(PythonLanguageVersion.V27, InterpreterArchitecture.x86);
-        public static readonly PythonVersion Python31 = GetCPythonVersion(PythonLanguageVersion.V31, InterpreterArchitecture.x86);
-        public static readonly PythonVersion Python32 = GetCPythonVersion(PythonLanguageVersion.V32, InterpreterArchitecture.x86);
-        public static readonly PythonVersion Python33 = GetCPythonVersion(PythonLanguageVersion.V33, InterpreterArchitecture.x86);
-        public static readonly PythonVersion Python34 = GetCPythonVersion(PythonLanguageVersion.V34, InterpreterArchitecture.x86);
         public static readonly PythonVersion Python35 = GetCPythonVersion(PythonLanguageVersion.V35, InterpreterArchitecture.x86);
         public static readonly PythonVersion Python36 = GetCPythonVersion(PythonLanguageVersion.V36, InterpreterArchitecture.x86);
         public static readonly PythonVersion Python37 = GetCPythonVersion(PythonLanguageVersion.V37, InterpreterArchitecture.x86);
         public static readonly PythonVersion IronPython27 = GetIronPythonVersion(false);
-        public static readonly PythonVersion Python26_x64 = GetCPythonVersion(PythonLanguageVersion.V26, InterpreterArchitecture.x64);
         public static readonly PythonVersion Python27_x64 = GetCPythonVersion(PythonLanguageVersion.V27, InterpreterArchitecture.x64);
-        public static readonly PythonVersion Python31_x64 = GetCPythonVersion(PythonLanguageVersion.V31, InterpreterArchitecture.x64);
-        public static readonly PythonVersion Python32_x64 = GetCPythonVersion(PythonLanguageVersion.V32, InterpreterArchitecture.x64);
-        public static readonly PythonVersion Python33_x64 = GetCPythonVersion(PythonLanguageVersion.V33, InterpreterArchitecture.x64);
-        public static readonly PythonVersion Python34_x64 = GetCPythonVersion(PythonLanguageVersion.V34, InterpreterArchitecture.x64);
         public static readonly PythonVersion Python35_x64 = GetCPythonVersion(PythonLanguageVersion.V35, InterpreterArchitecture.x64);
         public static readonly PythonVersion Python36_x64 = GetCPythonVersion(PythonLanguageVersion.V36, InterpreterArchitecture.x64);
         public static readonly PythonVersion Python37_x64 = GetCPythonVersion(PythonLanguageVersion.V37, InterpreterArchitecture.x64);
@@ -193,22 +183,12 @@ namespace TestUtilities {
 
         public static IEnumerable<PythonVersion> Versions {
             get {
-                if (Python26 != null) yield return Python26;
                 if (Python27 != null) yield return Python27;
-                if (Python31 != null) yield return Python31;
-                if (Python32 != null) yield return Python32;
-                if (Python33 != null) yield return Python33;
-                if (Python34 != null) yield return Python34;
                 if (Python35 != null) yield return Python35;
                 if (Python36 != null) yield return Python36;
                 if (Python37 != null) yield return Python37;
                 if (IronPython27 != null) yield return IronPython27;
-                if (Python26_x64 != null) yield return Python26_x64;
                 if (Python27_x64 != null) yield return Python27_x64;
-                if (Python31_x64 != null) yield return Python31_x64;
-                if (Python32_x64 != null) yield return Python32_x64;
-                if (Python33_x64 != null) yield return Python33_x64;
-                if (Python34_x64 != null) yield return Python34_x64;
                 if (Python35_x64 != null) yield return Python35_x64;
                 if (Python36_x64 != null) yield return Python36_x64;
                 if (Python37_x64 != null) yield return Python37_x64;

--- a/Python/Tests/VSInterpretersTests/PipRequirementsUtilsTests.cs
+++ b/Python/Tests/VSInterpretersTests/PipRequirementsUtilsTests.cs
@@ -145,10 +145,8 @@ namespace VSInterpretersTests {
         [TestMethod, Priority(0)]
         public async Task DetectReqPkgMissingPython2Async() {
             PythonVersion pythonInterpreter =   PythonPaths.Python27_x64 ??
-                                                PythonPaths.Python26_x64 ??
-                                                PythonPaths.Python27 ??
-                                                PythonPaths.Python26;
-            pythonInterpreter.AssertInstalled("Unable to run test because python 2.6 or 2.7 must be installed");
+                                                PythonPaths.Python27;
+            pythonInterpreter.AssertInstalled("Unable to run test because python 2.7 must be installed");
 
             await DetectReqPkgMissingAsync(pythonInterpreter);
         }
@@ -156,10 +154,12 @@ namespace VSInterpretersTests {
         [TestMethod, Priority(0)]
         public async Task DetectReqPkgMissingPython3Async() {
             PythonVersion pythonInterpreter =   PythonPaths.Python37_x64 ??
-                                                PythonPaths.Python36_x64 ??
                                                 PythonPaths.Python37 ??
-                                                PythonPaths.Python36;
-            pythonInterpreter.AssertInstalled("Unable to run test because python 3.6 or 3.7 must be installed");
+                                                PythonPaths.Python36_x64 ??
+                                                PythonPaths.Python36 ??
+                                                PythonPaths.Python35_x64 ??
+                                                PythonPaths.Python35;
+            pythonInterpreter.AssertInstalled("Unable to run test because python 3.5, 3.6, or 3.7 must be installed");
 
             await DetectReqPkgMissingAsync(pythonInterpreter);
         }


### PR DESCRIPTION
Also updating tests to use the latest version (where applicable).

Fix #5313 