### PR TITLE
Removing failing tests

### DIFF
--- a/Common/Tests/Utilities/TestExtensions.cs
+++ b/Common/Tests/Utilities/TestExtensions.cs
@@ -24,6 +24,10 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace TestUtilities {
     public static class TestExtensions {
+        public const int P0_FAILING_UNIT_TEST = 11;
+        public const int P2_FAILING_UNIT_TEST = 21;
+        public const int P3_FAILING_UNIT_TEST = 31;
+
         public static void SetStartupFile(this Project project, string name) {
             Assert.IsNotNull(project, "null project");
             Assert.IsNotNull(project.Properties, "null project properties " + project.Name + " " + project.GetType().FullName + " " + project.Kind);

--- a/Python/Tests/Core/CPythonInterpreterTests.cs
+++ b/Python/Tests/Core/CPythonInterpreterTests.cs
@@ -79,7 +79,7 @@ namespace PythonToolsTests {
             }
         }
 
-        [TestMethod, Priority(2)]
+        [TestMethod, Priority(TestExtensions.P2_FAILING_UNIT_TEST)]
         public void ImportFromSearchPath() {
             var analyzer = new PythonAnalysis(PythonLanguageVersion.V35);
             analyzer.AddModule("test-module", "from test_package import *");
@@ -106,7 +106,7 @@ namespace PythonToolsTests {
             AssertUtil.CheckCollection(analyzer.GetAllNames(), new[] { "system" }, new[] { "spam" });
         }
 
-        [TestMethod, Priority(2)] // https://github.com/Microsoft/PTVS/issues/4226
+        [TestMethod, Priority(TestExtensions.P2_FAILING_UNIT_TEST)] // https://github.com/Microsoft/PTVS/issues/4226
         public void ImportFromZipFile() {
             var analyzer = new PythonAnalysis(PythonLanguageVersion.V35);
             analyzer.AddModule("test-module", "from test_package import *; from test_package.sub_package import *");

--- a/Python/Tests/Core/CodeFormatterTests.cs
+++ b/Python/Tests/Core/CodeFormatterTests.cs
@@ -36,7 +36,7 @@ namespace PythonToolsTests {
         [TestCleanup]
         public void TestCleanup() => TestEnvironmentImpl.TestCleanup();
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public async Task TestCodeFormattingSelection() {
             var input = @"print('Hello World')
 
@@ -74,7 +74,7 @@ class Oar(object):
             await CodeFormattingTest(input, selection, expected, "    def say_hello .. method_end", options);
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public async Task TestCodeFormattingMidLineSelection() {
             var input = @"
 def f(x):
@@ -99,7 +99,7 @@ def f(x):
             await CodeFormattingTest(input, selection, expected, " x + 1", options);
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public async Task TestCodeFormattingEndOfFile() {
             var input = @"print('Hello World')
 
@@ -123,7 +123,7 @@ class Oar(object):
             await CodeFormattingTest(input, new Span(input.Length, 0), input, null, options);
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public async Task TestCodeFormattingInMethodExpression() {
             var input = @"print('Hello World')
 
@@ -147,7 +147,7 @@ class Oar(object):
             await CodeFormattingTest(input, "method_end", input, null, options);
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public async Task TestCodeFormattingStartOfMethodSelection() {
             var input = @"print('Hello World')
 
@@ -185,7 +185,7 @@ class Oar(object):
             await CodeFormattingTest(input, selection, expected, "    def say_hello .. ):", options);
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public async Task FormatDocument() {
             var input = @"fob('Hello World')";
             var expected = @"fob( 'Hello World' )";
@@ -194,7 +194,7 @@ class Oar(object):
             await CodeFormattingTest(input, new Span(0, input.Length), expected, null, options, false);
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public async Task FormatDocument2() {
             var input = @"import sys
 import abc

--- a/Python/Tests/Core/CommentBlockTests.cs
+++ b/Python/Tests/Core/CommentBlockTests.cs
@@ -33,7 +33,7 @@ namespace PythonToolsTests {
         [TestCleanup]
         public void TestCleanup() => TestEnvironmentImpl.TestCleanup();
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void TestCommentCurrentLine() {
             var editorTestToolset = new EditorTestToolset();
             var view = editorTestToolset.CreatePythonTextView(@"print 'hello'
@@ -62,7 +62,7 @@ print 'goodbye'
                 view.GetText());
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void TestUnCommentCurrentLine() {
             var editorTestToolset = new EditorTestToolset();
             var view = editorTestToolset.CreatePythonTextView(@"#print 'hello'
@@ -87,7 +87,7 @@ print 'goodbye'",
                 view.GetText());
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void TestComment() {
             var editorTestToolset = new EditorTestToolset();
             var view = editorTestToolset.CreatePythonTextView(@"print 'hello'
@@ -105,7 +105,7 @@ print 'goodbye'
                  view.GetText());
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void TestCommentEmptyLine() {
             var editorTestToolset = new EditorTestToolset();
             var view = editorTestToolset.CreatePythonTextView(@"print 'hello'
@@ -129,7 +129,7 @@ print 'goodbye'
             return new MockTextBuffer(code, PythonCoreConstants.ContentType, "C:\\fob.py");
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void TestCommentWhiteSpaceLine() {
             var editorTestToolset = new EditorTestToolset();
             var view = editorTestToolset.CreatePythonTextView(@"print 'hello'
@@ -149,7 +149,7 @@ print 'goodbye'
                  view.GetText());
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void TestCommentIndented() {
             var editorTestToolset = new EditorTestToolset();
             var view = editorTestToolset.CreatePythonTextView(@"def f():
@@ -170,7 +170,7 @@ print 'goodbye'
                     view.GetText());
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void TestCommentIndentedBlankLine() {
             var editorTestToolset = new EditorTestToolset();
             var view = editorTestToolset.CreatePythonTextView(@"def f():
@@ -194,7 +194,7 @@ print 'goodbye'
                     view.GetText());
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void TestCommentBlankLine() {
             var editorTestToolset = new EditorTestToolset();
             var view = editorTestToolset.CreatePythonTextView(@"print('hi')
@@ -212,7 +212,7 @@ print('bye')",
              view.GetText());
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void TestCommentIndentedWhiteSpaceLine() {
             var editorTestToolset = new EditorTestToolset();
             var view = editorTestToolset.CreatePythonTextView(@"def f():
@@ -236,7 +236,7 @@ print('bye')",
                     view.GetText());
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void TestUnCommentIndented() {
             var editorTestToolset = new EditorTestToolset();
             var view = editorTestToolset.CreatePythonTextView(@"def f():
@@ -257,7 +257,7 @@ print('bye')",
                     view.GetText());
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void TestUnComment() {
             var editorTestToolset = new EditorTestToolset();
             var view = editorTestToolset.CreatePythonTextView(@"#print 'hello'
@@ -276,7 +276,7 @@ print 'goodbye'";
         /// <summary>
         /// http://pytools.codeplex.com/workitem/814
         /// </summary>
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void TestCommentStartOfLastLine() {
             var editorTestToolset = new EditorTestToolset();
             var view = editorTestToolset.CreatePythonTextView(@"print 'hello'
@@ -293,7 +293,7 @@ print 'goodbye'";
             Assert.AreEqual(expected, view.GetText());
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void TestCommentAfterCodeIsNotUncommented() {
             var editorTestToolset = new EditorTestToolset();
             var view = editorTestToolset.CreatePythonTextView(@"print 'hello' #comment that should stay a comment

--- a/Python/Tests/Core/CondaEnvironmentManagerTests.cs
+++ b/Python/Tests/Core/CondaEnvironmentManagerTests.cs
@@ -162,7 +162,7 @@ namespace PythonToolsUITests {
             AssertCondaMetaFiles(envPath, "cookies-2.2.1*.json", "python-*.json");
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         [TestCategory("10s")]
         public async Task CreateEnvironmentByPathFromEnvironmentFileCondaAndPip() {
             var mgr = CreateEnvironmentManager();

--- a/Python/Tests/Core/DebugReplEvaluatorTests.cs
+++ b/Python/Tests/Core/DebugReplEvaluatorTests.cs
@@ -156,7 +156,7 @@ NameError: name 'does_not_exist' is not defined
             Assert.AreEqual("1", variables[0].StringRepr);
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public async Task AvailableScopes() {
             await AttachAsync("DebugReplTest1.py", 3);
 
@@ -185,7 +185,7 @@ NameError: name 'does_not_exist' is not defined
             }
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public virtual async Task ChangeModule() {
             await AttachAsync("DebugReplTest1.py", 3);
 
@@ -215,7 +215,7 @@ NameError: name 'does_not_exist' is not defined
             Assert.AreEqual("'hello'", ExecuteText("a"));
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public virtual async Task ChangeFrame() {
             await AttachAsync("DebugReplTest2.py", 13);
 
@@ -279,7 +279,7 @@ NameError: name 'does_not_exist' is not defined
             Assert.AreEqual("'thread1'", ExecuteText("t1_val"));
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public virtual async Task ChangeProcess() {
             await AttachAsync("DebugReplTest4A.py", 3);
             await AttachAsync("DebugReplTest4B.py", 3);
@@ -319,7 +319,7 @@ NameError: name 'does_not_exist' is not defined
             Assert.AreEqual("Abort is not supported.", _window.Error.TrimEnd());
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public async Task StepInto() {
             // Make sure that we don't step into the internal repl code
             // http://pytools.codeplex.com/workitem/777

--- a/Python/Tests/Core/DebugReplEvaluatorTests.cs
+++ b/Python/Tests/Core/DebugReplEvaluatorTests.cs
@@ -98,7 +98,7 @@ namespace PythonToolsTests {
             Assert.AreEqual("'hello'", ExecuteText("a"));
         }
 
-        [TestMethod, Priority(3)]
+        [TestMethod, Priority(TestExtensions.P3_FAILING_UNIT_TEST)]
         public async Task DisplayFunctionLocalsAndGlobals() {
             await AttachAsync("DebugReplTest2.py", 13);
 
@@ -106,7 +106,7 @@ namespace PythonToolsTests {
             Assert.AreEqual("5", ExecuteText("print(global_val)"));
         }
 
-        [TestMethod, Priority(3)]
+        [TestMethod, Priority(TestExtensions.P3_FAILING_UNIT_TEST)]
         public async Task ErrorInInput() {
             await AttachAsync("DebugReplTest2.py", 13);
 
@@ -117,7 +117,7 @@ NameError: name 'does_not_exist' is not defined
 ".Replace("\r\n", "\n"), _window.Error.Replace("\r\n", "\n"));
         }
 
-        [TestMethod, Priority(3)]
+        [TestMethod, Priority(TestExtensions.P3_FAILING_UNIT_TEST)]
         public async Task ChangeVariables() {
             await AttachAsync("DebugReplTest2.py", 13);
 
@@ -125,7 +125,7 @@ NameError: name 'does_not_exist' is not defined
             Assert.AreEqual("1", ExecuteText("print(innermost_val)"));
         }
 
-        [TestMethod, Priority(3)]
+        [TestMethod, Priority(TestExtensions.P3_FAILING_UNIT_TEST)]
         public async Task ChangeVariablesAndRefreshFrames() {
             // This is really a test for PythonProcess' RefreshFramesAsync
             // but it's convenient to have it here, as this is the exact
@@ -249,7 +249,7 @@ NameError: name 'does_not_exist' is not defined
             Assert.AreEqual("1", ExecuteCommand(new DebugReplFrameCommand(), ""));
         }
 
-        [TestMethod, Priority(3)]
+        [TestMethod, Priority(TestExtensions.P3_FAILING_UNIT_TEST)]
         [TestCategory("10s")]
         public async Task ChangeThread() {
             await AttachAsync("DebugReplTest3.py", 39);
@@ -306,7 +306,7 @@ NameError: name 'does_not_exist' is not defined
             Assert.AreEqual("60", ExecuteText("b2"));
         }
 
-        [TestMethod, Priority(3)]
+        [TestMethod, Priority(TestExtensions.P3_FAILING_UNIT_TEST)]
         [TestCategory("10s")]
         public async Task Abort() {
             await AttachAsync("DebugReplTest5.py", 3);

--- a/Python/Tests/Core/DebugReplEvaluatorTests.cs
+++ b/Python/Tests/Core/DebugReplEvaluatorTests.cs
@@ -90,7 +90,7 @@ namespace PythonToolsTests {
             }
         }
 
-        [TestMethod, Priority(2)]
+        [TestMethod, Priority(TestExtensions.P2_FAILING_UNIT_TEST)]
         public async Task DisplayVariables() {
             await AttachAsync("DebugReplTest1.py", 3);
 
@@ -497,13 +497,13 @@ NameError: name 'does_not_exist' is not defined
             }
         }
 
-        [TestMethod, Priority(2)]
+        [TestMethod, Priority(TestExtensions.P2_FAILING_UNIT_TEST)]
         public override async Task ChangeFrame() => await base.ChangeFrame();
 
-        [TestMethod, Priority(2)]
+        [TestMethod, Priority(TestExtensions.P2_FAILING_UNIT_TEST)]
         public override async Task ChangeModule() => await base.ChangeModule();
 
-        [TestMethod, Priority(2)]
+        [TestMethod, Priority(TestExtensions.P2_FAILING_UNIT_TEST)]
         public override async Task ChangeProcess() => await base.ChangeProcess();
     }
 }

--- a/Python/Tests/Core/EnvironmentListTests.cs
+++ b/Python/Tests/Core/EnvironmentListTests.cs
@@ -558,7 +558,7 @@ namespace PythonToolsUITests {
             }
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void ChangeDefault() {
             bool changed = false;
             var container = CreateCompositionContainer();

--- a/Python/Tests/Core/ExtractMethodTests.cs
+++ b/Python/Tests/Core/ExtractMethodTests.cs
@@ -669,7 +669,7 @@ def f():
         /// Test cases which make sure we have the right ranges for each statement when doing extract method
         /// and that we don't mess up the code before/after the statement.
         /// </summary>
-        [TestMethod, Priority(2)] // https://github.com/Microsoft/PTVS/issues/4088
+        [TestMethod, Priority(TestExtensions.P2_FAILING_UNIT_TEST)] // https://github.com/Microsoft/PTVS/issues/4088
         public async Task StatementTests() {
             await SuccessTest("b",
 @"def f():

--- a/Python/Tests/Core/ExtractMethodTests.cs
+++ b/Python/Tests/Core/ExtractMethodTests.cs
@@ -52,7 +52,7 @@ namespace PythonToolsTests {
         [TestCleanup]
         public void TestCleanup() => TestEnvironmentImpl.TestCleanup();
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public async Task TestGlobalNonLocalVars() {
             await SuccessTest("ABC = 42",
 @"def f():
@@ -104,7 +104,7 @@ def f():
 
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public async Task TestDefinitions() {
             await SuccessTest("x = .. = h()",
 @"def f():
@@ -163,7 +163,7 @@ def f(): pass",
 f = g()");
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public async Task TestLeadingComment() {
             await SuccessTest("x = 41",
 @"# fob
@@ -176,7 +176,7 @@ def g():
 x = g()");
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public async Task AssignInIfStatementReadAfter() {
             await ExtractMethodTest(@"class C:
     def fob(self):
@@ -240,7 +240,7 @@ x = g()");
 
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public async Task ExtractMethodIndexExpr() {
             await ExtractMethodTest(@"class C:
     def process_kinect_event(self, e):
@@ -258,7 +258,7 @@ x = g()");
  ), scopeName: "C");
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public async Task TestExtractLambda() {
             // lambda is present in the code
             await ExtractMethodTest(
@@ -287,7 +287,7 @@ def f():
     abc = g()"));
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public async Task TestExtractGenerator() {
             var code = @"def f(imp = imp):
     yield 42";
@@ -301,7 +301,7 @@ def f(imp = g()):
     yield 42"));
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public async Task TestExtractDefaultValue() {
             var code = @"def f(imp = imp):
     pass";
@@ -315,14 +315,14 @@ def f(imp = g()):
     pass"));
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public async Task TestFromImportStar() {
             await ExtractMethodTest(
 @"def f():
     from sys import *", "from sys import *", TestResult.Error(ErrorImportStar));
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public async Task TestExtractDefiniteAssignmentAfter() {
             await SuccessTest("x = 42",
 @"def f():
@@ -340,7 +340,7 @@ def f():
         print x, y");
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public async Task TestExtractDefiniteAssignmentAfterStmtList() {
             await SuccessTest("x = 42",
 @"def f():
@@ -361,7 +361,7 @@ def f():
 
 
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public async Task TestExtractDefiniteAssignmentAfterStmtListRead() {
             await SuccessTest("x = 100",
 @"def f():
@@ -380,7 +380,7 @@ def f():
         print (x, y)");
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         [TestCategory("10s")]
         public async Task TestAllNodes() {
             var prefixes = new string[] { " # fob\r\n", "" };
@@ -500,7 +500,7 @@ def f():
             }
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public async Task TestExtractDefiniteAssignmentAfterStmtListMultipleAssign() {
             await SuccessTest("x = 100; x = 200",
 @"def f():
@@ -521,7 +521,7 @@ def f():
 
 
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public async Task TestExtractFromClass() {
             await ExtractMethodTest(
 @"class C:
@@ -529,7 +529,7 @@ def f():
     oar = 100", "abc .. 100", TestResult.Error(ErrorExtractFromClass));
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public async Task TestExtractSuiteWhiteSpace() {
             await SuccessTest("x .. 200",
 @"def f():
@@ -565,7 +565,7 @@ def f():
         /// <summary>
         /// Test cases that verify we correctly identify when not all paths contain return statements.
         /// </summary>
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public async Task TestNotAllCodePathsReturn() {            
             await TestMissingReturn("for i .. 23", @"def f(x):
     for i in xrange(100):
@@ -625,7 +625,7 @@ def f():
         }
 
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public async Task TestReturnWithOutputVars() {
             await TestReturnWithOutputs("if x .. 100", @"def f(x):
     if x:
@@ -637,7 +637,7 @@ def f():
 ");
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public async Task TestCannotRefactorYield() {
             await TestBadYield("yield 42", @"def f(x):
     yield 42
@@ -649,7 +649,7 @@ def f():
 ");
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public async Task TestContinueWithoutLoop() {
             await TestBadContinue("continue", @"def f(x):
     for i in xrange(100):
@@ -657,7 +657,7 @@ def f():
 ");
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public async Task TestBreakWithoutLoop() {
             await TestBadBreak("break", @"def f(x):
     for i in xrange(100):
@@ -1108,7 +1108,7 @@ class C:
         g()");
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public async Task ClassTests() {
             await SuccessTest("x = fob",
 @"class C(object):
@@ -1218,7 +1218,7 @@ class C:
 
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public async Task TestComprehensions() {
             await SuccessTest("i % 2 == 0", @"def f():
     x = [i for i in range(100) if i % 2 == 0]", @"def g(i):
@@ -1249,7 +1249,7 @@ def f():
     x = {k:v for k,v in range(100) if g(k, v)}", version: new Version(3, 2));
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public async Task SuccessfulTests() {
             await SuccessTest("x .. 100",
 @"def f():
@@ -1603,7 +1603,7 @@ def f(x):
     return (g())");
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public async Task ExtractAsyncFunction() {
             // Ensure extracted bodies that use await generate async functions
 

--- a/Python/Tests/Core/PythonProjectTests.cs
+++ b/Python/Tests/Core/PythonProjectTests.cs
@@ -181,7 +181,7 @@ namespace PythonToolsTests {
         }
 
 
-        [TestMethod, Priority(2)]
+        [TestMethod, Priority(TestExtensions.P2_FAILING_UNIT_TEST)]
         public async Task AnalyzeBadEgg() {
             var factories = new[] { InterpreterFactoryCreator.CreateAnalysisInterpreterFactory(new Version(3, 4)) };
             var services = PythonToolsTestUtilities.CreateMockServiceProvider().GetEditorServices();

--- a/Python/Tests/Core/PythonProjectTests.cs
+++ b/Python/Tests/Core/PythonProjectTests.cs
@@ -118,7 +118,7 @@ namespace PythonToolsTests {
             }
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public async Task LoadAndUnloadModule() {
             var services = PythonToolsTestUtilities.CreateMockServiceProvider().GetEditorServices();
             using (var are = new AutoResetEvent(false))

--- a/Python/Tests/Core/PythonWorkspaceContextProviderTests.cs
+++ b/Python/Tests/Core/PythonWorkspaceContextProviderTests.cs
@@ -28,7 +28,7 @@ namespace PythonToolsTests {
             AssertListener.Initialize();
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void AlreadyOpenedWorkspace() {
             var workspaceFolder = WorkspaceTestHelper.CreateWorkspaceFolder();
             var workspace = WorkspaceTestHelper.CreateMockWorkspace(workspaceFolder, WorkspaceTestHelper.PythonNoId);
@@ -45,7 +45,7 @@ namespace PythonToolsTests {
             Assert.AreEqual(WorkspaceTestHelper.DefaultFactory, provider.Workspace.CurrentFactory);
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void LoadWorkspace() {
             var workspaceFolder = WorkspaceTestHelper.CreateWorkspaceFolder();
             var workspace = WorkspaceTestHelper.CreateMockWorkspace(workspaceFolder, WorkspaceTestHelper.PythonNoId);
@@ -81,7 +81,7 @@ namespace PythonToolsTests {
             }
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void CloseWorkspace() {
             var workspaceFolder = WorkspaceTestHelper.CreateWorkspaceFolder();
             var workspace = WorkspaceTestHelper.CreateMockWorkspace(workspaceFolder, WorkspaceTestHelper.PythonNoId);
@@ -117,7 +117,7 @@ namespace PythonToolsTests {
             }
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void SwitchWorkspace() {
             var workspaceFolder1 = WorkspaceTestHelper.CreateWorkspaceFolder();
             var workspaceFolder2 = WorkspaceTestHelper.CreateWorkspaceFolder();

--- a/Python/Tests/Core/PythonWorkspaceContextTests.cs
+++ b/Python/Tests/Core/PythonWorkspaceContextTests.cs
@@ -30,7 +30,7 @@ namespace PythonToolsTests {
             AssertListener.Initialize();
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void DefaultInterpreter() {
             var data = PrepareWorkspace(WorkspaceTestHelper.PythonNoId);
 
@@ -42,7 +42,7 @@ namespace PythonToolsTests {
             Assert.AreEqual(WorkspaceTestHelper.DefaultFactory, workspaceContext.CurrentFactory);
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void InstalledInterpreter() {
             var data = PrepareWorkspace(WorkspaceTestHelper.Python27Id);
 
@@ -54,7 +54,7 @@ namespace PythonToolsTests {
             Assert.AreEqual(WorkspaceTestHelper.Python27Factory, workspaceContext.CurrentFactory);
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void UnavailableInterpreter() {
             var data = PrepareWorkspace(WorkspaceTestHelper.PythonUnavailableId);
 
@@ -66,7 +66,7 @@ namespace PythonToolsTests {
             Assert.AreEqual(WorkspaceTestHelper.DefaultFactory, workspaceContext.CurrentFactory);
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void ChangeInterpreterSetting() {
             var data = PrepareWorkspace(WorkspaceTestHelper.Python27Id);
 
@@ -101,7 +101,7 @@ namespace PythonToolsTests {
             }
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void RemoveInterpreterSetting() {
             var data = PrepareWorkspace(WorkspaceTestHelper.Python27Id);
 
@@ -136,7 +136,7 @@ namespace PythonToolsTests {
             }
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void RemoveInterpreterSettingAlreadyDefault() {
             var data = PrepareWorkspace(WorkspaceTestHelper.DefaultFactory.Configuration.Id);
 
@@ -171,7 +171,7 @@ namespace PythonToolsTests {
             }
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void ChangeDefaultInterpreterInUse() {
             var data = PrepareWorkspace(WorkspaceTestHelper.PythonNoId);
 
@@ -197,7 +197,7 @@ namespace PythonToolsTests {
             }
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void ChangeDefaultInterpreterNotInUse() {
             // We don't use the global default
             var data = PrepareWorkspace(WorkspaceTestHelper.Python27Id);
@@ -224,7 +224,7 @@ namespace PythonToolsTests {
             }
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void RemoveInterpreterInUse() {
             var data = PrepareWorkspace(WorkspaceTestHelper.Python27Id);
 
@@ -252,7 +252,7 @@ namespace PythonToolsTests {
             }
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void RemoveInterpreterNotInUse() {
             var data = PrepareWorkspace(WorkspaceTestHelper.Python27Id);
 

--- a/Python/Tests/Core/ReplEvaluatorTests.cs
+++ b/Python/Tests/Core/ReplEvaluatorTests.cs
@@ -40,7 +40,7 @@ namespace PythonToolsTests {
             AssertListener.Initialize();
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void ExecuteTest() {
             using (var evaluator = MakeEvaluator()) {
                 var window = new MockReplWindow(evaluator);
@@ -83,7 +83,7 @@ namespace PythonToolsTests {
             }
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void TestCanExecute() {
             using (var evaluator = MakeEvaluator()) {
                 Assert.IsTrue(evaluator.CanExecuteCode("print 'hello'"));
@@ -129,7 +129,7 @@ namespace PythonToolsTests {
             }
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void ReplSplitCodeTest() {
             // http://pytools.codeplex.com/workitem/606
 
@@ -318,7 +318,7 @@ f()",
             }
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public async Task NoInterpreterPath() {
             // http://pytools.codeplex.com/workitem/662
 
@@ -335,7 +335,7 @@ f()",
             );
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void BadInterpreterPath() {
             // http://pytools.codeplex.com/workitem/662
 

--- a/Python/Tests/Core/ReplEvaluatorTests.cs
+++ b/Python/Tests/Core/ReplEvaluatorTests.cs
@@ -59,7 +59,7 @@ namespace PythonToolsTests {
             }
         }
 
-        [TestMethod, Priority(3)]
+        [TestMethod, Priority(TestExtensions.P3_FAILING_UNIT_TEST)]
         public void TestAbort() {
             using (var evaluator = MakeEvaluator()) {
                 var window = new MockReplWindow(evaluator);
@@ -107,7 +107,7 @@ namespace PythonToolsTests {
             }
         }
 
-        [TestMethod, Priority(3)]
+        [TestMethod, Priority(TestExtensions.P3_FAILING_UNIT_TEST)]
         public async Task TestGetAllMembers() {
             using (var evaluator = MakeEvaluator()) {
                 var window = new MockReplWindow(evaluator);

--- a/Python/Tests/Core/WorkspaceInterpreterFactoryTests.cs
+++ b/Python/Tests/Core/WorkspaceInterpreterFactoryTests.cs
@@ -32,7 +32,7 @@ namespace PythonToolsTests {
             AssertListener.Initialize();
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void WatchWorkspaceFolderChanged() {
             var workspaceFolder1 = TestData.GetTempPath();
             Directory.CreateDirectory(workspaceFolder1);
@@ -60,7 +60,7 @@ namespace PythonToolsTests {
             }
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void WatchWorkspaceSettingsChanged() {
             var workspaceFolder = TestData.GetTempPath();
             Directory.CreateDirectory(workspaceFolder);
@@ -77,7 +77,7 @@ namespace PythonToolsTests {
             TestTriggerDiscovery(workspaceContext, triggerDiscovery, null, true);
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void WatchWorkspaceVirtualEnvCreated() {
             var python = PythonPaths.Python37_x64 ?? PythonPaths.Python37;
 
@@ -104,7 +104,7 @@ namespace PythonToolsTests {
             Assert.AreEqual("Workspace|Workspace|env", configs[0].Id);
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void DetectLocalEnvOutsideWorkspace() {
             var python = PythonPaths.Python37_x64 ?? PythonPaths.Python37;
 
@@ -143,7 +143,7 @@ namespace PythonToolsTests {
             }
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void WatchWorkspaceVirtualEnvRenamed() {
             const string ENV_NAME = "env";
             var workspaceContext = CreateEnvAndGetWorkspaceService(ENV_NAME);
@@ -157,7 +157,7 @@ namespace PythonToolsTests {
             Assert.AreEqual("Workspace|Workspace|env1", configs[0].Id);
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void WatchWorkspaceVirtualEnvDeleted() {
             const string ENV_NAME = "env";
             var workspaceContext = CreateEnvAndGetWorkspaceService(ENV_NAME);

--- a/Python/Tests/DebuggerTests/AttachTests.cs
+++ b/Python/Tests/DebuggerTests/AttachTests.cs
@@ -770,7 +770,7 @@ int main(int argc, char* argv[]) {
             }
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         [TestCategory("10s")]
         public virtual async Task AttachWithOutputRedirection() {
             var expectedOutput = new[] { "stdout", "stderr" };

--- a/Python/Tests/DebuggerTests/AttachTests.cs
+++ b/Python/Tests/DebuggerTests/AttachTests.cs
@@ -143,7 +143,7 @@ namespace DebuggerTests {
             }
         }
 
-        [TestMethod, Priority(2)]
+        [TestMethod, Priority(TestExtensions.P2_FAILING_UNIT_TEST)]
         [TestCategory("10s"), TestCategory("60s")]
         public virtual async Task AttachReattach() {
             Process p = Process.Start(Version.InterpreterPath, "-B \"" + TestData.GetPath(@"TestData\DebuggerProject\InfiniteRun.py") + "\"");
@@ -328,7 +328,7 @@ namespace DebuggerTests {
             }
         }
 
-        [TestMethod, Priority(2)]
+        [TestMethod, Priority(TestExtensions.P2_FAILING_UNIT_TEST)]
         [TestCategory("10s")]
         public virtual async Task AttachTimeout() {
             string cast = "(PyCodeObject*)";
@@ -370,7 +370,7 @@ int main(int argc, char* argv[]) {
         /// <summary>
         /// Attempts to attach w/ code only running on new threads which are initialized using PyGILState_Ensure
         /// </summary>
-        [TestMethod, Priority(2)]
+        [TestMethod, Priority(TestExtensions.P2_FAILING_UNIT_TEST)]
         [TestCategory("10s")]
         public virtual async Task AttachNewThread_PyGILState_Ensure() {
             var hostCode = @"#include <Python.h>
@@ -493,7 +493,7 @@ void main()
         /// <summary>
         /// Attempts to attach w/ code only running on new threads which are initialized using PyThreadState_New
         /// </summary>
-        [TestMethod, Priority(2)]
+        [TestMethod, Priority(TestExtensions.P2_FAILING_UNIT_TEST)]
         [TestCategory("10s")]
         public virtual async Task AttachNewThread_PyThreadState_New() {
             var hostCode = @"#include <Windows.h>
@@ -621,7 +621,7 @@ void main()
             }
         }
 
-        [TestMethod, Priority(2)]
+        [TestMethod, Priority(TestExtensions.P2_FAILING_UNIT_TEST)]
         [TestCategory("10s")]
         public virtual async Task AttachTimeoutThreadsInitialized() {
             string cast = "(PyCodeObject*)";
@@ -1151,7 +1151,7 @@ int main(int argc, char* argv[]) {
         }
 
         // https://github.com/Microsoft/PTVS/issues/2842
-        [TestMethod, Priority(2)]
+        [TestMethod, Priority(TestExtensions.P2_FAILING_UNIT_TEST)]
         public virtual async Task AttachPtvsdAndStopDebugging() {
             if (!HasPtvsdCommandLine) {
                 return;

--- a/Python/Tests/DebuggerTests/AttachTests.cs
+++ b/Python/Tests/DebuggerTests/AttachTests.cs
@@ -1011,22 +1011,22 @@ int main(int argc, char* argv[]) {
             AssertUtil.ArrayEquals(expectedOutput, actualOutput);
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public async Task AttachPtvsdImport() {
             await TestPtvsdImport("secret=None", new Uri("tcp://localhost"));
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public async Task AttachPtvsdCommandLine() {
             await TestPtvsdCommandLine("--wait", new Uri("tcp://localhost"));
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public async Task AttachPtvsdImportSecret() {
             await TestPtvsdImport("secret='secret'", new Uri("tcp://secret@localhost"));
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public async Task AttachPtvsdCommandLineSecret() {
             await TestPtvsdCommandLine("--wait --secret secret", new Uri("tcp://secret@localhost"));
         }
@@ -1047,18 +1047,18 @@ int main(int argc, char* argv[]) {
             return ip;
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public async Task AttachPtvsdImportAddress() {
             var ip = GetNetworkInterface();
             await TestPtvsdImport("secret=None, address=('" + ip + "', 8765)", new Uri("tcp://" + ip + ":8765"));
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public async Task AttachPtvsdCommandLinePort() {
             await TestPtvsdCommandLine("--wait --port 8765", new Uri("tcp://localhost:8765"));
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public async Task AttachPtvsdCommandLineInterface() {
             var ip = GetNetworkInterface();
             await TestPtvsdCommandLine("--wait --interface " + ip, new Uri("tcp://" + ip));

--- a/Python/Tests/DebuggerTests/AttachTests.cs
+++ b/Python/Tests/DebuggerTests/AttachTests.cs
@@ -1100,7 +1100,7 @@ int main(int argc, char* argv[]) {
             });
         }
 
-        [TestMethod, Priority(3)]
+        [TestMethod, Priority(TestExtensions.P3_FAILING_UNIT_TEST)]
         public async Task AttachPtvsdCommandLineNoWait() {
             if (!HasPtvsdCommandLine) {
                 return;

--- a/Python/Tests/DebuggerTests/DebuggerTests.cs
+++ b/Python/Tests/DebuggerTests/DebuggerTests.cs
@@ -1239,7 +1239,7 @@ namespace DebuggerTests {
             }.RunAsync();
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public async Task TestBreakpointHitOtherThreadStackTrace() {
             // http://pytools.codeplex.com/workitem/483
 
@@ -1907,7 +1907,7 @@ namespace DebuggerTests {
             );
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public async Task TestExceptionHandlers() {
             var debugger = new PythonDebugger();
 

--- a/Python/Tests/DebuggerTests/DebuggerTests.cs
+++ b/Python/Tests/DebuggerTests/DebuggerTests.cs
@@ -2001,7 +2001,7 @@ namespace DebuggerTests {
 
         #region Exit Code Tests
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         [TestCategory("10s")]
         public async Task TestStartup() {
             var debugger = new PythonDebugger();
@@ -2019,7 +2019,7 @@ namespace DebuggerTests {
             await TestExitCodeAsync(debugger, Path.Combine(DebuggerTestPath, "CheckNameAndFile.py"), 0);
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         [TestCategory("10s")]
         public async Task TestWindowsStartup() {
             var debugger = new PythonDebugger();

--- a/Python/Tests/DebuggerUITestsRunner/AttachUITests.cs
+++ b/Python/Tests/DebuggerUITestsRunner/AttachUITests.cs
@@ -57,13 +57,13 @@ namespace DebuggerUITestsRunner {
             _vs.RunTest(nameof(DebuggerUITests.AttachUITests.AttachUserSetsBreakpoint));
         }
 
-        [TestMethod, Priority(2)]
+        [TestMethod, Priority(VsTestContext.P2_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void AttachThreadsBreakAllAndSetExitFlag() {
             _vs.RunTest(nameof(DebuggerUITests.AttachUITests.AttachThreadsBreakAllAndSetExitFlag));
         }
 
-        [TestMethod, Priority(2)]
+        [TestMethod, Priority(VsTestContext.P2_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void AttachThreadsBreakOneAndSetExitFlag() {
             _vs.RunTest(nameof(DebuggerUITests.AttachUITests.AttachThreadsBreakOneAndSetExitFlag));

--- a/Python/Tests/DebuggerUITestsRunner/DebugProjectUITests.cs
+++ b/Python/Tests/DebuggerUITestsRunner/DebugProjectUITests.cs
@@ -132,7 +132,7 @@ namespace DebuggerUITestsRunner {
             _vs.RunTest(nameof(DebuggerUITests.DebugProjectUITests.MainThread), UseVsCodeDebugger, Interpreter);
         }
 
-        [TestMethod, Priority(2)]
+        [TestMethod, Priority(VsTestContext.P2_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void ExpressionEvaluation() {
             _vs.RunTest(nameof(DebuggerUITests.DebugProjectUITests.ExpressionEvaluation), UseVsCodeDebugger, Interpreter);

--- a/Python/Tests/DebuggerUITestsRunner/DebugProjectUITests.cs
+++ b/Python/Tests/DebuggerUITestsRunner/DebugProjectUITests.cs
@@ -42,7 +42,7 @@ namespace DebuggerUITestsRunner {
 
         protected abstract string Interpreter { get; }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(VsTestContext.P0_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void DebugPythonProject() {
             _vs.RunTest(nameof(DebuggerUITests.DebugProjectUITests.DebugPythonProject), UseVsCodeDebugger, Interpreter);
@@ -114,7 +114,7 @@ namespace DebuggerUITestsRunner {
             _vs.RunTest(nameof(DebuggerUITests.DebugProjectUITests.SetNextLine), UseVsCodeDebugger, Interpreter);
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(VsTestContext.P0_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void TerminateProcess() {
             _vs.RunTest(nameof(DebuggerUITests.DebugProjectUITests.TerminateProcess), UseVsCodeDebugger, Interpreter);
@@ -181,7 +181,7 @@ namespace DebuggerUITestsRunner {
         }
 
         [Ignore] // Not reliable enough right now
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(VsTestContext.P0_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void LaunchWithErrorsDontRun() {
             _vs.RunTest(nameof(DebuggerUITests.DebugProjectUITests.LaunchWithErrorsDontRun), UseVsCodeDebugger, Interpreter);
@@ -205,7 +205,7 @@ namespace DebuggerUITestsRunner {
             _vs.RunTest(nameof(DebuggerUITests.DebugProjectUITests.StartWithDebuggingNotInProject), UseVsCodeDebugger, Interpreter);
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(VsTestContext.P0_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void StartWithoutDebuggingNotInProject() {
             _vs.RunTest(nameof(DebuggerUITests.DebugProjectUITests.StartWithoutDebuggingNotInProject), UseVsCodeDebugger, Interpreter);
@@ -223,7 +223,7 @@ namespace DebuggerUITestsRunner {
             _vs.RunTest(nameof(DebuggerUITests.DebugProjectUITests.StartWithDebuggingSubfolderInProject), UseVsCodeDebugger, Interpreter);
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(VsTestContext.P0_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void StartWithoutDebuggingInProject() {
             _vs.RunTest(nameof(DebuggerUITests.DebugProjectUITests.StartWithoutDebuggingInProject), UseVsCodeDebugger, Interpreter);
@@ -241,7 +241,7 @@ namespace DebuggerUITestsRunner {
             _vs.RunTest(nameof(DebuggerUITests.DebugProjectUITests.StartWithoutDebuggingNoScript), UseVsCodeDebugger, Interpreter);
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(VsTestContext.P0_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void WebProjectLauncherNoStartupFile() {
             _vs.RunTest(nameof(DebuggerUITests.DebugProjectUITests.WebProjectLauncherNoStartupFile), UseVsCodeDebugger, Interpreter);

--- a/Python/Tests/DebuggerUITestsRunner/MixedModeDebugProjectUITests.cs
+++ b/Python/Tests/DebuggerUITestsRunner/MixedModeDebugProjectUITests.cs
@@ -41,7 +41,7 @@ namespace DebuggerUITestsRunner {
         public static void ClassCleanup() => VsTestContext.Instance.Dispose();
         #endregion
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(VsTestContext.P0_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void DebugPurePythonProject() {
             _vs.RunTest(nameof(DebuggerUITests.MixedModeDebugProjectUITests.DebugPurePythonProject), Interpreter);

--- a/Python/Tests/DjangoTests/DjangoAnalyzerTests.cs
+++ b/Python/Tests/DjangoTests/DjangoAnalyzerTests.cs
@@ -62,7 +62,7 @@ namespace DjangoTests {
             TestSingleRenderVariable("test_render_to_response.html");
         }
 
-        [TestMethod, Priority(2)] // https://github.com/Microsoft/PTVS/issues/4144
+        [TestMethod, Priority(TestExtensions.P2_FAILING_UNIT_TEST)] // https://github.com/Microsoft/PTVS/issues/4144
         public void TestCustomFilter() {
             var proj = AnalyzerTest(TestData.GetPath("TestData\\DjangoAnalysisTestApp"), out var langVersion);
 
@@ -90,7 +90,7 @@ namespace DjangoTests {
             );
         }
 
-        [TestMethod, Priority(2)] // https://github.com/Microsoft/PTVS/issues/4144
+        [TestMethod, Priority(TestExtensions.P2_FAILING_UNIT_TEST)] // https://github.com/Microsoft/PTVS/issues/4144
         public void TestCustomTag() {
             var proj = AnalyzerTest(TestData.GetPath("TestData\\DjangoAnalysisTestApp"), out var langVersion);
 

--- a/Python/Tests/DjangoTests/DjangoAnalyzerTests.cs
+++ b/Python/Tests/DjangoTests/DjangoAnalyzerTests.cs
@@ -52,12 +52,12 @@ namespace DjangoTests {
             Assert.AreEqual(value, values.Single().GetConstantValueAsString());
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void TestRender() {
             TestSingleRenderVariable("test_render.html");
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void TestRenderToResponse() {
             TestSingleRenderVariable("test_render_to_response.html");
         }
@@ -122,7 +122,7 @@ namespace DjangoTests {
             );
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void TestListView() {
             var proj = AnalyzerTest(TestData.GetPath("TestData\\DjangoAnalysisTestApp"), out _);
             var templates = TestData.GetPath("TestData\\DjangoAnalysisTestApp\\myapp\\templates\\myapp\\");
@@ -132,7 +132,7 @@ namespace DjangoTests {
             AssertUtil.ContainsExactly(detailsVars.Keys, "latest_poll_list");
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void TestDetailsView() {
             var proj = AnalyzerTest(TestData.GetPath("TestData\\DjangoAnalysisTestApp"), out _);
             var templates = TestData.GetPath("TestData\\DjangoAnalysisTestApp\\myapp\\templates\\myapp\\");

--- a/Python/Tests/DjangoTests/DjangoDebuggerTests.cs
+++ b/Python/Tests/DjangoTests/DjangoDebuggerTests.cs
@@ -101,7 +101,7 @@ namespace DjangoTests {
             }
         }
 
-        [TestMethod, Priority(3)]
+        [TestMethod, Priority(TestExtensions.P3_FAILING_UNIT_TEST)]
         [TestCategory("10s"), TestCategory("60s")]
         public async Task TemplateStepping() {
             Init(DbState.OarApp);
@@ -163,7 +163,7 @@ namespace DjangoTests {
             );
         }
 
-        [TestMethod, Priority(3)]
+        [TestMethod, Priority(TestExtensions.P3_FAILING_UNIT_TEST)]
         [TestCategory("10s")]
         public async Task BreakInTemplate() {
             Init(DbState.OarApp);
@@ -186,7 +186,7 @@ namespace DjangoTests {
             }.RunAsync();
         }
 
-        [TestMethod, Priority(3)]
+        [TestMethod, Priority(TestExtensions.P3_FAILING_UNIT_TEST)]
         public async Task TemplateLocals() {
             Init(DbState.OarApp);
 

--- a/Python/Tests/DjangoUITestsRunner/DjangoAzureProjectUITests.cs
+++ b/Python/Tests/DjangoUITestsRunner/DjangoAzureProjectUITests.cs
@@ -39,7 +39,7 @@ namespace DjangoUITestsRunner {
         public static void ClassCleanup() => VsTestContext.Instance.Dispose();
         #endregion
 
-        [TestMethod, Priority(2)]
+        [TestMethod, Priority(VsTestContext.P2_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void AddCloudProject() {
             _vs.RunTest(nameof(DjangoUITests.DjangoAzureProjectUITests.AddCloudProject));

--- a/Python/Tests/DjangoUITestsRunner/DjangoEditingUITests.cs
+++ b/Python/Tests/DjangoUITestsRunner/DjangoEditingUITests.cs
@@ -39,13 +39,13 @@ namespace DjangoUITestsRunner {
         public static void ClassCleanup() => VsTestContext.Instance.Dispose();
         #endregion
 
-        [TestMethod, Priority(2)]
+        [TestMethod, Priority(VsTestContext.P2_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void Classifications() {
             _vs.RunTest(nameof(DjangoUITests.DjangoEditingUITests.Classifications));
         }
 
-        [TestMethod, Priority(2)]
+        [TestMethod, Priority(VsTestContext.P2_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void Insertion1() {
             _vs.RunTest(nameof(DjangoUITests.DjangoEditingUITests.Insertion1));
@@ -58,73 +58,73 @@ namespace DjangoUITestsRunner {
             _vs.RunTest(nameof(DjangoUITests.DjangoEditingUITests.Insertion2));
         }
 
-        [TestMethod, Priority(2)]
+        [TestMethod, Priority(VsTestContext.P2_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void Insertion3() {
             _vs.RunTest(nameof(DjangoUITests.DjangoEditingUITests.Insertion3));
         }
 
-        [TestMethod, Priority(2)]
+        [TestMethod, Priority(VsTestContext.P2_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void Insertion4() {
             _vs.RunTest(nameof(DjangoUITests.DjangoEditingUITests.Insertion4));
         }
 
-        [TestMethod, Priority(2)]
+        [TestMethod, Priority(VsTestContext.P2_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void Insertion5() {
             _vs.RunTest(nameof(DjangoUITests.DjangoEditingUITests.Insertion5));
         }
 
-        [TestMethod, Priority(2)]
+        [TestMethod, Priority(VsTestContext.P2_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void Insertion6() {
             _vs.RunTest(nameof(DjangoUITests.DjangoEditingUITests.Insertion6));
         }
 
-        [TestMethod, Priority(2)]
+        [TestMethod, Priority(VsTestContext.P2_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void Insertion7() {
             _vs.RunTest(nameof(DjangoUITests.DjangoEditingUITests.Insertion7));
         }
 
-        [TestMethod, Priority(2)]
+        [TestMethod, Priority(VsTestContext.P2_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void Insertion8() {
             _vs.RunTest(nameof(DjangoUITests.DjangoEditingUITests.Insertion8));
         }
 
-        [TestMethod, Priority(2)]
+        [TestMethod, Priority(VsTestContext.P2_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void Insertion9() {
             _vs.RunTest(nameof(DjangoUITests.DjangoEditingUITests.Insertion9));
         }
 
-        [TestMethod, Priority(2)]
+        [TestMethod, Priority(VsTestContext.P2_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void Insertion10() {
             _vs.RunTest(nameof(DjangoUITests.DjangoEditingUITests.Insertion10));
         }
 
-        [TestMethod, Priority(2)]
+        [TestMethod, Priority(VsTestContext.P2_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void Insertion11() {
             _vs.RunTest(nameof(DjangoUITests.DjangoEditingUITests.Insertion11));
         }
 
-        [TestMethod, Priority(2)]
+        [TestMethod, Priority(VsTestContext.P2_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void Insertion12() {
             _vs.RunTest(nameof(DjangoUITests.DjangoEditingUITests.Insertion12));
         }
 
-        [TestMethod, Priority(2)]
+        [TestMethod, Priority(VsTestContext.P2_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void Deletion1() {
             _vs.RunTest(nameof(DjangoUITests.DjangoEditingUITests.Deletion1));
         }
 
-        [TestMethod, Priority(2)]
+        [TestMethod, Priority(VsTestContext.P2_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void Paste1() {
             _vs.RunTest(nameof(DjangoUITests.DjangoEditingUITests.Paste1));
@@ -166,91 +166,91 @@ namespace DjangoUITestsRunner {
             _vs.RunTest(nameof(DjangoUITests.DjangoEditingUITests.SelectAllText));
         }
 
-        [TestMethod, Priority(2)]
+        [TestMethod, Priority(VsTestContext.P2_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void CutUndo() {
             _vs.RunTest(nameof(DjangoUITests.DjangoEditingUITests.CutUndo));
         }
 
-        [TestMethod, Priority(2)]
+        [TestMethod, Priority(VsTestContext.P2_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void IntellisenseCompletions() {
             _vs.RunTest(nameof(DjangoUITests.DjangoEditingUITests.IntellisenseCompletions));
         }
 
-        [TestMethod, Priority(2)]
+        [TestMethod, Priority(VsTestContext.P2_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void IntellisenseCompletions2() {
             _vs.RunTest(nameof(DjangoUITests.DjangoEditingUITests.IntellisenseCompletions2));
         }
 
-        [TestMethod, Priority(2)]
+        [TestMethod, Priority(VsTestContext.P2_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void IntellisenseCompletions4() {
             _vs.RunTest(nameof(DjangoUITests.DjangoEditingUITests.IntellisenseCompletions4));
         }
 
-        [TestMethod, Priority(2)]
+        [TestMethod, Priority(VsTestContext.P2_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void IntellisenseCompletions5() {
             _vs.RunTest(nameof(DjangoUITests.DjangoEditingUITests.IntellisenseCompletions5));
         }
 
-        [TestMethod, Priority(2)]
+        [TestMethod, Priority(VsTestContext.P2_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void IntellisenseCompletions6() {
             _vs.RunTest(nameof(DjangoUITests.DjangoEditingUITests.IntellisenseCompletions6));
         }
 
-        [TestMethod, Priority(2)]
+        [TestMethod, Priority(VsTestContext.P2_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void IntellisenseCompletions7() {
             _vs.RunTest(nameof(DjangoUITests.DjangoEditingUITests.IntellisenseCompletions7));
         }
 
-        [TestMethod, Priority(2)]
+        [TestMethod, Priority(VsTestContext.P2_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void IntellisenseCompletions8() {
             _vs.RunTest(nameof(DjangoUITests.DjangoEditingUITests.IntellisenseCompletions8));
         }
 
-        [TestMethod, Priority(2)]
+        [TestMethod, Priority(VsTestContext.P2_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void IntellisenseCompletions9() {
             _vs.RunTest(nameof(DjangoUITests.DjangoEditingUITests.IntellisenseCompletions9));
         }
 
-        [TestMethod, Priority(2)]
+        [TestMethod, Priority(VsTestContext.P2_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void IntellisenseCompletions10() {
             _vs.RunTest(nameof(DjangoUITests.DjangoEditingUITests.IntellisenseCompletions10));
         }
 
-        [TestMethod, Priority(2)]
+        [TestMethod, Priority(VsTestContext.P2_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void IntellisenseCompletions11() {
             _vs.RunTest(nameof(DjangoUITests.DjangoEditingUITests.IntellisenseCompletions11));
         }
 
-        [TestMethod, Priority(2)]
+        [TestMethod, Priority(VsTestContext.P2_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void IntellisenseCompletions12() {
             _vs.RunTest(nameof(DjangoUITests.DjangoEditingUITests.IntellisenseCompletions12));
         }
 
-        [TestMethod, Priority(2)]
+        [TestMethod, Priority(VsTestContext.P2_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void IntellisenseCompletionsHtml() {
             _vs.RunTest(nameof(DjangoUITests.DjangoEditingUITests.IntellisenseCompletionsHtml));
         }
 
-        [TestMethod, Priority(2)]
+        [TestMethod, Priority(VsTestContext.P2_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void IntellisenseCompletionsCss() {
             _vs.RunTest(nameof(DjangoUITests.DjangoEditingUITests.IntellisenseCompletionsCss));
         }
 
-        [TestMethod, Priority(2)]
+        [TestMethod, Priority(VsTestContext.P2_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void IntellisenseCompletionsJS() {
             _vs.RunTest(nameof(DjangoUITests.DjangoEditingUITests.IntellisenseCompletionsJS));

--- a/Python/Tests/DjangoUITestsRunner/DjangoProjectUITests.cs
+++ b/Python/Tests/DjangoUITestsRunner/DjangoProjectUITests.cs
@@ -57,7 +57,7 @@ namespace DjangoUITestsRunner {
             _vs.RunTest(nameof(DjangoUITests.DjangoProjectUITests.DjangoCollectStaticFilesCommand));
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(VsTestContext.P0_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void DjangoShellCommand() {
             _vs.RunTest(nameof(DjangoUITests.DjangoProjectUITests.DjangoShellCommand));
@@ -88,7 +88,7 @@ namespace DjangoUITestsRunner {
         }
 
         [Ignore] // https://devdiv.visualstudio.com/DevDiv/_workitems?id=433488
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(VsTestContext.P0_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void DebugProjectProperties() {
             _vs.RunTest(nameof(DjangoUITests.DjangoProjectUITests.DebugProjectProperties));

--- a/Python/Tests/DjangoUITestsRunner/DjangoProjectUITests.cs
+++ b/Python/Tests/DjangoUITestsRunner/DjangoProjectUITests.cs
@@ -69,7 +69,7 @@ namespace DjangoUITestsRunner {
             _vs.RunTest(nameof(DjangoUITests.DjangoProjectUITests.DjangoCommandsNonDjangoApp));
         }
 
-        [TestMethod, Priority(2)]
+        [TestMethod, Priority(VsTestContext.P2_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void StartNewApp() {
             _vs.RunTest(nameof(DjangoUITests.DjangoProjectUITests.StartNewApp));

--- a/Python/Tests/FastCgi/FastCgiTests2x.cs
+++ b/Python/Tests/FastCgi/FastCgiTests2x.cs
@@ -66,7 +66,7 @@ namespace FastCgiTests {
             }
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         [TestCategory("10s")]
         public void DjangoHelloWorld() {
             using (var site = ConfigureIISForDjango(AppCmdPath, InterpreterPath, "DjangoTestApp.settings")) {
@@ -102,7 +102,7 @@ namespace FastCgiTests {
             }
         }*/
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void LargeResponse() {
             using (var site = ConfigureIISForDjango(AppCmdPath, InterpreterPath, "DjangoTestApp.settings")) {
                 site.StartServer();
@@ -125,7 +125,7 @@ namespace FastCgiTests {
             }
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         [TestCategory("10s")]
         public void DjangoHelloWorldParallel() {
             using (var site = ConfigureIISForDjango(AppCmdPath, InterpreterPath, "DjangoTestApp.settings")) {
@@ -435,7 +435,7 @@ namespace FastCgiTests {
 
         #region Test Cases
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void TestDjangoNewApp() {
             EnsureDjango();
             IisExpressTest(
@@ -444,7 +444,7 @@ namespace FastCgiTests {
             );
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void TestDjangoNewAppUrlRewrite() {
             EnsureDjango();
             IisExpressTest(
@@ -472,7 +472,7 @@ namespace FastCgiTests {
         /// <summary>
         /// Handler doesn't exist in imported module
         /// </summary>
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void TestBadHandler() {
             IisExpressTest(
                 TestData.GetPath("TestData", "WFastCgi", "BadHandler"),
@@ -566,7 +566,7 @@ namespace FastCgiTests {
         /// <summary>
         /// Validates wfastcgi exits when changes to .py or .config files are detected
         /// </summary>
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         [TestCategory("10s")]
         public void TestFileSystemChanges() {
             var location = TestData.GetTempPath();
@@ -596,7 +596,7 @@ namespace FastCgiTests {
         /// <summary>
         /// Validates wfastcgi exits when changes to .py files in a subdirectory are detected
         /// </summary>
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void TestFileSystemChangesPackage() {
             var location = TestData.GetTempPath();
             FileUtils.CopyDirectory(TestData.GetPath(@"TestData\WFastCgi\FileSystemChangesPackage"), location);
@@ -620,7 +620,7 @@ namespace FastCgiTests {
         /// <summary>
         /// Validates wfastcgi exits when changes to a file pattern specified in web.config changes.
         /// </summary>
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void TestFileSystemChangesCustomRegex() {
             var location = TestData.GetTempPath();
             FileUtils.CopyDirectory(TestData.GetPath(@"TestData\WFastCgi\FileSystemChangesCustomRegex"), location);
@@ -666,7 +666,7 @@ namespace FastCgiTests {
         /// <summary>
         /// Validates that we can setup IIS to serve static files properly
         /// </summary>
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void TestStaticFiles() {
             EnsureDjango();
             IisExpressTest(
@@ -683,7 +683,7 @@ namespace FastCgiTests {
         /// <summary>
         /// Validates that we can setup IIS to serve static files properly
         /// </summary>
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void TestStaticFilesUrlRewrite() {
             EnsureDjango();
             IisExpressTest(
@@ -741,7 +741,7 @@ namespace FastCgiTests {
         /// <summary>
         /// Tests that we send portions of the response as they are given to us.
         /// </summary>
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void TestDjangoQueryString() {
             EnsureDjango();
             IisExpressTest(
@@ -756,7 +756,7 @@ namespace FastCgiTests {
         /// <summary>
         /// Tests that we can post values to Django and it gets them 
         /// </summary>
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void TestDjangoPost() {
             EnsureDjango();
             IisExpressTest(
@@ -773,7 +773,7 @@ namespace FastCgiTests {
         /// <summary>
         /// Tests that we send portions of the response as they are given to us.
         /// </summary>
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void TestDjangoPath() {
             EnsureDjango();
             IisExpressTest(
@@ -788,7 +788,7 @@ namespace FastCgiTests {
         /// <summary>
         /// Tests that we send portions of the response as they are given to us.
         /// </summary>
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void TestDjangoQueryStringUrlRewrite() {
             EnsureDjango();
             IisExpressTest(
@@ -803,7 +803,7 @@ namespace FastCgiTests {
         /// <summary>
         /// Tests that we can post values to Django and it gets them when using URL rewriting
         /// </summary>
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void TestDjangoPostUrlRewrite() {
             EnsureDjango();
             IisExpressTest(
@@ -820,7 +820,7 @@ namespace FastCgiTests {
         /// <summary>
         /// Tests that we send portions of the response as they are given to us.
         /// </summary>
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void TestDjangoPathUrlRewrite() {
             EnsureDjango();
             IisExpressTest(

--- a/Python/Tests/IronPython/IronPythonAnalysisTest.cs
+++ b/Python/Tests/IronPython/IronPythonAnalysisTest.cs
@@ -55,7 +55,7 @@ namespace IronPythonTests {
 
         #region Test Cases
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void Generics() {
             var text = @"
 import clr
@@ -70,7 +70,7 @@ zzz = y.ReturnsGenericParam()
             AssertUtil.ContainsExactly(entry.GetMemberNames("zzz", 1), "GetEnumerator", "__doc__", "__iter__", "__repr__");
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void Constructors() {
             var text = @"
 from System import AccessViolationException
@@ -94,7 +94,7 @@ n = AccessViolationException.__new__
                 ")";
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void ImportClr() {
             var text = @"
 import clr
@@ -104,7 +104,7 @@ x = 'abc'
             entry.AssertHasAttr("x", "Length");
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void ClrAddReference() {
             var text = @"
 import clr
@@ -117,7 +117,7 @@ from System.Drawing import Point
             Assert.AreEqual(35, members.Count);
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void ClrAddReferenceByName() {
             var text = @"
 import clr
@@ -128,7 +128,7 @@ from Microsoft.Scripting import SourceUnit
             Assert.AreEqual(40, entry.GetMemberNames("SourceUnit", text.IndexOf("from Microsoft.")).ToList().Count);
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void Enum() {
             var entry = ProcessText(@"
 import System
@@ -140,7 +140,7 @@ x = System.StringComparison.OrdinalIgnoreCase
             Assert.AreEqual(x.MemberType, PythonMemberType.EnumInstance);
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void Color() {
 
             var entry = ProcessText(@"
@@ -165,7 +165,7 @@ b = a.some_color
             AssertUtil.ContainsExactly(entry.GetTypes("b", 1).Select(x => x.Name), "Color");
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void BuiltinTypeSignatures() {
             var entry = ProcessText(@"
 import System
@@ -228,7 +228,7 @@ a.fob += EventHandler(f)
                 new VariableLocation(5, 23, VariableType.Reference));
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void SystemFromImport() {
             var text = @"
 from System import Environment
@@ -238,7 +238,7 @@ Environment.GetCommandLineArgs()
             Assert.IsTrue(entry.GetMemberNames("Environment", 1).Any(s => s == "CommandLine"));
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void ImportAsIpy() {
             var text = @"
 import System.Collections as coll
@@ -247,7 +247,7 @@ import System.Collections as coll
             Assert.IsTrue(entry.GetMemberNames("coll", 1).Any(s => s == "ArrayList"));
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void SystemImport() {
             var text = @"
 import System
@@ -264,7 +264,7 @@ x = System.Environment
             AssertUtil.Contains(entry.GetMemberNames("x", 1), "GetEnvironmentVariables");
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void SystemMembers() {
             var text = @"
 import System
@@ -280,7 +280,7 @@ args = x.GetCommandLineArgs()
             Assert.IsTrue(entry.GetMemberNames("args", text.IndexOf("args =")).Any(s => s == "AsReadOnly"));
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void NamespaceMembers() {
             var text = @"
 import System
@@ -292,7 +292,7 @@ x = System.Collections
             Assert.IsTrue(x.Contains("ArrayList"));
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void GenericIndexing() {
             // indexing into a generic type should know how the type info
             // flows through
@@ -308,7 +308,7 @@ x = List[int]()
             Assert.IsTrue(self.Contains("AddRange"));
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void ReturnTypesCollapsing() {
             // indexing into a generic type should know how the type info
             // flows through
@@ -329,7 +329,7 @@ mod.
 #endif
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void IronPythonMro() {
             var text = @"
 from System import DivideByZeroException
@@ -352,7 +352,7 @@ from System import DivideByZeroException
                 "object");
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void AssignEvent() {
             var text = @"
 import System
@@ -366,7 +366,7 @@ System.AppDomain.CurrentDomain.AssemblyLoad += f
             Assert.IsTrue(entry.GetMemberNames("args", text.IndexOf("pass")).Any(s => s == "LoadedAssembly"));
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void EventMemberType() {
             var text = @"from System import AppDomain";
             var entry = ProcessText(text);
@@ -385,7 +385,7 @@ y = System.Environment.CurrentDirectory()
             ProcessText(text);
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void QuickInfoClr() {
             var text = @"
 import System
@@ -413,7 +413,7 @@ def g():
             //AssertUtil.ContainsExactly(entry.GetVariableDescriptionsByIndex("System.AppDomain.DomainUnload", 1), "event of type System.EventHandler");
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void BuiltinMethodSignaturesClr() {
             var entry = ProcessText(@"
 import clr
@@ -432,7 +432,7 @@ constructed = str().Contains
 
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void BuiltinMethodDocumentationClr() {
             var entry = ProcessText(@"
 import wpf
@@ -465,7 +465,7 @@ class MyArrayList(System.Collections.ArrayList):
         /// <summary>
         /// Verify importing wpf will add a reference to the WPF assemblies
         /// </summary>
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void WpfReferences() {
             var entry = ProcessText(@"
 import wpf
@@ -582,7 +582,7 @@ f(x=42, y = 'abc')
             entry.AssertIsInstance("z", code.IndexOf("pass"), BuiltinTypeId.Int, BuiltinTypeId.Str);
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void TestPackageImportStar() {
             var analyzer = CreateAnalyzer();
 
@@ -656,7 +656,7 @@ y = f()
         /// Slicing should assume the incoming type
         /// https://pytools.codeplex.com/workitem/1581
         /// </summary>
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void TestBuiltinOperatorsFallback() {
             var code = @"import array
 
@@ -709,7 +709,7 @@ w = f(a='p', p=1, q='abc')
             entry.AssertIsInstance("w", BuiltinTypeId.Str, BuiltinTypeId.Int);
         }
 
-        [TestMethod, Priority(0), Timeout(5000)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST), Timeout(5000)]
         public void RecursiveListComprehensionV32() {
             var code = @"
 def f(x):
@@ -892,7 +892,7 @@ y = f('fob', 'oar')";
         //            entry.AssertIsInstance("y", BuiltinTypeId.Int, BuiltinTypeId.Float);
         //        }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void ImportAs() {
             var entry = ProcessTextV2(@"import sys as s, array as a");
 
@@ -967,7 +967,7 @@ s = y['x']['y']['value']
             entry.AssertIsInstance("s", BuiltinTypeId.Str);
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void RecursiveTuples() {
             var code = @"class A(object):
     def __init__(self):
@@ -1040,7 +1040,7 @@ y = x[0]
             entry.AssertIsInstance("y", BuiltinTypeId.List, BuiltinTypeId.Int, BuiltinTypeId.Float, BuiltinTypeId.Str);
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void ImportStar() {
             var entry = ProcessText(@"
 from nt import *
@@ -1059,7 +1059,7 @@ from nt import *
             }
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void ImportTrailingComma() {
             var entry = ProcessText(@"
 import nt,
@@ -1328,7 +1328,7 @@ class D(C):
             entry.AssertHasAttr("self", code.IndexOf("self.fob"), "abc");
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void Mro() {
             // Successful: MRO is A B C D E F object
             var code = @"
@@ -1469,7 +1469,7 @@ class Test_test2(Test_test1):
             );
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void Iterator() {
             var entry = ProcessText(@"
 A = [1, 2, 3]
@@ -1533,7 +1533,7 @@ c = next(iC)
             entry.AssertIsInstance("c", BuiltinTypeId.Int);
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void Generator2x() {
             var entry = ProcessText(@"
 def f():
@@ -1592,7 +1592,7 @@ d = a.__next__()";
             AssertUtil.ContainsExactly(entry.GetTypeIds("d", 1));
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void Generator3x() {
             var entry = ProcessTextV2(@"
 def f():
@@ -1676,7 +1676,7 @@ def f(abc):
                 new VariableLocation(5, 2, VariableType.Reference));
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void LambdaInComprehension() {
             var text = "x = [(lambda a:[a**i for i in range(a+1)])(j) for j in range(5)]";
 
@@ -1690,7 +1690,7 @@ def f(abc):
             entry.AssertIsInstance("x", BuiltinTypeId.List);
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void Comprehensions() {
             var text = @"
 x = 10; g = (i for i in range(x)); x = 5
@@ -1723,7 +1723,7 @@ exec b in a
             entry.AssertReferences("b", new VariableLocation(3, 1, VariableType.Definition), new VariableLocation(4, 6, VariableType.Reference));
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void PrivateMemberReferences() {
             string text = @"
 class C:
@@ -1746,7 +1746,7 @@ class C:
                 new VariableLocation(10, 14, VariableType.Reference));
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void GeneratorComprehensions() {
             var text = @"
 x = [2,3,4]
@@ -1819,7 +1819,7 @@ for some_str, some_int, some_bool in x:
             entry.AssertIsInstance("some_bool", BuiltinTypeId.Bool);
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void ForIterator() {
             var code = @"
 class X(object):
@@ -1897,7 +1897,7 @@ b = x.b
             entry.AssertIsInstance("b", BuiltinTypeId.Float);
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void NoGetAttrForSlots() {
             var code = @"class A(object):
     def __getattr__(self, key):
@@ -1942,7 +1942,7 @@ v = x[0]
             entry.AssertIsInstance("v", BuiltinTypeId.Str);
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void BuiltinSpecializations() {
             var entry = CreateAnalyzer();
             entry.AddModule("test-module", @"
@@ -2258,7 +2258,7 @@ class CInheritedInit(CNewStyleInit):
             Assert.AreEqual("new-style init doc", result[0].Documentation);
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void Ellipsis() {
             var entry = ProcessText(@"
 x = ...
@@ -2343,7 +2343,7 @@ def g():
             entry.AssertIsInstance("e2", text.IndexOf(", e2"), "MyException");
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void ConstantMath() {
 
             var text2x = @"
@@ -2424,7 +2424,7 @@ oar2 = fob2 % (42, )";
             entry.AssertIsInstance("oar2", BuiltinTypeId.Unicode);
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void StringFormattingV36() {
             var text = @"
 y = f'abc {42}'
@@ -2491,7 +2491,7 @@ oar2 = 100 * fob2";
             entry.AssertIsInstance("oar2", BuiltinTypeId.Unicode);
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void NotOperator() {
             var text = @"
 
@@ -2541,7 +2541,7 @@ b = {1}{1}C()
             }
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void TrueDividePython3x() {
             var text = @"
 class C:
@@ -2560,7 +2560,7 @@ c = 'abc' / a
             AssertUtil.ContainsExactly(entry.GetShortDescriptions("c", text.IndexOf("c =")), "float");
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void BinaryOperators() {
             var operators = new[] {
                 new { Method = "add", Operator = "+", Version = PythonLanguageVersion.V27 },
@@ -2659,7 +2659,7 @@ y3v = y3[0]
             entry.AssertIsInstance("y3v", BuiltinTypeId.Int, BuiltinTypeId.Float);
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void SequenceMultiply() {
             var text = @"
 x = ()
@@ -2787,7 +2787,7 @@ class C(object):
                 new VariableLocation(9, 20, VariableType.Reference));
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void References() {
             // instance variables
             var text = @"
@@ -3361,7 +3361,7 @@ g = f()");
             );
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void ReferencesGeneratorsV3() {
             var text = @"
 [f for f in x]
@@ -3459,7 +3459,7 @@ def m(x = math.atan2(1, 0)): pass
             }
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void SpecialDictMethodsCrossUnitAnalysis() {
             // dict methods which return lists
             foreach (var method in new[] { "x.itervalues()", "x.keys()", "x.iterkeys()", "x.values()" }) {
@@ -3639,7 +3639,7 @@ y_xor_x_0 = next(iter(y_xor_x))
 
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void GetVariablesDictionaryGet() {
             var entry = ProcessText(@"x = {42:'abc'}");
             entry.AssertDescription("x.get", "bound built-in method get");
@@ -3968,7 +3968,7 @@ f = x().g";
             }
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void ForwardRef() {
             var text = @"
 
@@ -4088,7 +4088,7 @@ if y is not None:
             entry.AssertIsInstance("b", text.IndexOf("x, y"));
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void SimpleGlobals() {
             var text = @"
 class x(object):
@@ -4176,7 +4176,7 @@ abc.Cmeth(['fob'], 'oar')
         }
 
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void FunctionOverloads() {
             var text = @"
 def f(a, b, c=0):
@@ -4224,7 +4224,7 @@ f('a', 'b', 1)
         /// <summary>
         /// http://pytools.codeplex.com/workitem/799
         /// </summary>
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void OverrideCompletions() {
             var text = @"
 class oar(list):
@@ -4335,7 +4335,7 @@ b = a[42]
         /// <summary>
         /// We shouldn't use instance members when invoking special methods
         /// </summary>
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void IterNoInstance() {
             var text = @"
 class me(object):
@@ -4432,7 +4432,7 @@ for i in range(5):
             entry.AssertIsInstance("i", BuiltinTypeId.Int);
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void BuiltinImport() {
             var text = @"
 import sys
@@ -4442,7 +4442,7 @@ import sys
             entry.AssertHasAttr("sys", "winver");
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void BuiltinImportInFunc() {
             var text = @"
 def f():
@@ -4453,7 +4453,7 @@ def f():
             entry.AssertHasAttr("sys", text.IndexOf("sys"), "winver");
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void BuiltinImportInClass() {
             var text = @"
 class C:
@@ -4544,7 +4544,7 @@ val = next(it)
             entry.AssertIsInstance("val", "S0");
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void ForwardRefVars() {
             var text = @"
 class x(object):
@@ -4620,7 +4620,7 @@ fob = a.abc
             entry.AssertHasAttrExact("a", "abc", "func", "__doc__", "__class__");
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void MemberAssign2() {
             var text = @"
 class D:
@@ -4640,7 +4640,7 @@ fob = D().func2()
             Assert.Inconclusive("Test not yet implemented");
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void AnnotatedAssign() {
             var text = @"
 x : int = 42
@@ -4920,7 +4920,7 @@ b = y.ClassMethod()
             }
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void UserDescriptor() {
             var text = @"
 class mydesc(object):
@@ -5109,7 +5109,7 @@ class C(object):
             }
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void Package() {
             var src1 = "";
 
@@ -5149,7 +5149,7 @@ abc = 42
             }
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void PackageRelativeImportPep328() {
             var imports = new Dictionary<string, string>() {
                 { "from .moduleY import spam", "spam"},
@@ -5240,7 +5240,7 @@ class MyClass(object):
         }
 
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void DecoratorFlow() {
             var text1 = @"
 import mod2
@@ -5653,7 +5653,7 @@ a = X(2)
             entry.AssertIsInstance("a.value", BuiltinTypeId.Int);
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void Global() {
             var text = @"
 x = None
@@ -5675,7 +5675,7 @@ a, b = f()
             entry.AssertIsInstance("y", BuiltinTypeId.NoneType, BuiltinTypeId.Int);
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void Nonlocal() {
             var text = @"
 def f():
@@ -5727,7 +5727,7 @@ a = f(None)
             entry.AssertIsInstance("a", BuiltinTypeId.NoneType, BuiltinTypeId.Int);
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void IsInstance() {
             var text = @"
 x = None
@@ -5960,7 +5960,7 @@ r2 = fn(123, None, 4.5)
             }
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void IsInstanceAndLambdaScopes() {
             // https://github.com/Microsoft/PTVS/issues/2801
             var text = @"if isinstance(p, dict):
@@ -5981,7 +5981,7 @@ r2 = fn(123, None, 4.5)
   <statements>", dump);
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void IsInstanceReferences() {
             var text = @"def fob():
     oar = get_b()
@@ -6062,7 +6062,7 @@ n1 = g(1)";
             );
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void QuickInfo() {
             var text = @"
 import sys
@@ -6207,7 +6207,7 @@ def g():
             AssertUtil.Contains(entry.GetCompletionDocumentation("", "min", 1).First(), "min(");
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void MemberType() {
             var text = @"
 import sys
@@ -6259,7 +6259,7 @@ d[0] = d
         /// <summary>
         /// Variable is refered to in the base class, defined in the derived class, we should know the type information.
         /// </summary>
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void BaseReferencedDerivedDefined() {
             var text = @"
 class Base(object):
@@ -6353,7 +6353,7 @@ tyt = tuple(t)
 #endif
 
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void SubclassFindAllRefs() {
             string text = @"
 class Base(object):
@@ -6480,7 +6480,7 @@ class D(object):
             entry.AssertHasParameters("cls.inst_method", i, "self");
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void MetaClassesV3() {
             var text = @"class C(type):
     def f(self):
@@ -6653,7 +6653,7 @@ class Derived3(object):
             }
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void ParameterAnnotation() {
             var text = @"
 s = None
@@ -6667,7 +6667,7 @@ def f(s: s = 123):
             entry.AssertIsInstance("s", text.IndexOf("return"), BuiltinTypeId.Int, BuiltinTypeId.NoneType);
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void ParameterAnnotationLambda() {
             var text = @"
 s = None
@@ -6681,7 +6681,7 @@ def f(s: lambda s: s > 0 = 123):
             entry.AssertIsInstance("s", text.IndexOf("return"), BuiltinTypeId.Int);
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void ReturnAnnotation() {
             var text = @"
 s = None
@@ -6695,7 +6695,7 @@ def f(s = 123) -> s:
             entry.AssertIsInstance("s", text.IndexOf("return"), BuiltinTypeId.Int);
         }
         
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void FunctoolsWraps() {
             var text = @"
 from functools import wraps, update_wrapper
@@ -6759,7 +6759,7 @@ test1_result = test1()
             );
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void SysModulesGetSpecialization() {
             var code = @"import sys
 modules = sys.modules
@@ -6817,7 +6817,7 @@ x = A().wg");
             Assert.IsNotNull(entry);
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void Coroutine() {
             var code = @"
 async def g():
@@ -6835,7 +6835,7 @@ async def f():
             entry.AssertIsInstance("g2", code.IndexOf("x ="), BuiltinTypeId.Generator);
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void AsyncWithStatement() {
             var text = @"
 class X(object):
@@ -6860,7 +6860,7 @@ async def f():
             entry.AssertIsInstance("y", text.IndexOf("pass #y"), BuiltinTypeId.Int);
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void AsyncForIterator() {
             var code = @"
 class X:
@@ -6921,7 +6921,7 @@ def f():
             }
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void DefaultModuleAttributes() {
             var entry3 = ProcessTextV2("x = 1");
             AssertUtil.ContainsExactly(entry3.GetNamesNoBuiltins(), "__builtins__", "__file__", "__name__", "__package__", "__cached__", "__spec__", "x");
@@ -6958,7 +6958,7 @@ x = ClsB.x");
             analyzer.AssertIsInstance(entryB, "x", BuiltinTypeId.Int);
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void UndefinedVariableDiagnostic() {
             PythonAnalysis entry;
             string code;
@@ -7013,7 +7013,7 @@ with f() as v2:
             entry.AssertDiagnostics();
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void UncallableObjectDiagnostic() {
             var code = @"class MyClass:
     pass
@@ -7035,7 +7035,7 @@ y = mcc()
             );
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void OsPathMembers() {
             var code = @"import os.path as P
 ";
@@ -7050,7 +7050,7 @@ y = mcc()
             AssertUtil.ContainsAtLeast(entry.GetMemberNames("P"), "abspath", "dirname");
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void UnassignedClassMembers() {
             var code = @"
 from typing import NamedTuple

--- a/Python/Tests/IronPython/IronPythonAnalysisTest.cs
+++ b/Python/Tests/IronPython/IronPythonAnalysisTest.cs
@@ -6004,7 +6004,7 @@ r2 = fn(123, None, 4.5)
             }
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void FunctoolsDecoratorReferences() {
             var text = @"from functools import wraps
 

--- a/Python/Tests/IronPython/IronPythonAnalysisTest.cs
+++ b/Python/Tests/IronPython/IronPythonAnalysisTest.cs
@@ -724,7 +724,7 @@ def f(x):
             // If we complete processing then we have succeeded
         }
 
-        [TestMethod, Priority(2)]
+        [TestMethod, Priority(TestExtensions.P2_FAILING_UNIT_TEST)]
         [TestCategory("ExpectFail")]
         public void CartesianStarArgs() {
             // TODO: Figure out whether this is useful behaviour
@@ -3196,7 +3196,7 @@ abc()
             );
         }
 
-        [TestMethod, Priority(2), TestCategory("ExpectFail")]
+        [TestMethod, Priority(TestExtensions.P2_FAILING_UNIT_TEST), TestCategory("ExpectFail")]
         public void SuperclassMemberReferencesCrossModule() {
             // https://github.com/Microsoft/PTVS/issues/2271
 

--- a/Python/Tests/IronPython/ReplEvaluatorTests.cs
+++ b/Python/Tests/IronPython/ReplEvaluatorTests.cs
@@ -46,7 +46,7 @@ namespace IronPythonTests {
             }
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void IronPythonModuleName() {
             using (var replEval = Evaluator) {
                 var replWindow = new MockReplWindow(replEval);
@@ -60,7 +60,7 @@ namespace IronPythonTests {
             }
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void IronPythonSignatures() {
             using (var replEval = Evaluator) {
                 var replWindow = new MockReplWindow(replEval);
@@ -79,7 +79,7 @@ namespace IronPythonTests {
             }
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void IronPythonCommentInput() {
             // http://pytools.codeplex.com/workitem/649
             using (var replEval = Evaluator) {
@@ -91,7 +91,7 @@ namespace IronPythonTests {
             }
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void ConsoleWriteLineTest() {
             // http://pytools.codeplex.com/workitem/649
             using (var replEval = Evaluator) {
@@ -118,7 +118,7 @@ namespace IronPythonTests {
             }
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void GenericMethodCompletions() {
             // http://pytools.codeplex.com/workitem/661
             using (var replEval = Evaluator) {
@@ -152,7 +152,7 @@ namespace IronPythonTests {
             }
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public async Task NoTraceFunction() {
             // http://pytools.codeplex.com/workitem/662
             using (var replEval = Evaluator) {
@@ -168,7 +168,7 @@ namespace IronPythonTests {
             }
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void CommentFollowedByBlankLine() {
             // http://pytools.codeplex.com/workitem/659
             using (var replEval = Evaluator) {
@@ -183,7 +183,7 @@ namespace IronPythonTests {
 
 
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void AttachSupportMultiThreaded() {
             // http://pytools.codeplex.com/workitem/663
             using (var replEval = Evaluator) {

--- a/Python/Tests/ProfilingUITestsRunner/ProfilingUITests.cs
+++ b/Python/Tests/ProfilingUITestsRunner/ProfilingUITests.cs
@@ -40,13 +40,13 @@ namespace ProfilingUITestsRunner {
         public static void ClassCleanup() => VsTestContext.Instance.Dispose();
         #endregion
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(VsTestContext.P0_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void DefaultInterpreterSelected() {
             _vs.RunTest(nameof(PUIT.DefaultInterpreterSelected));
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(VsTestContext.P0_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void StartupProjectSelected() {
             _vs.RunTest(nameof(PUIT.StartupProjectSelected));
@@ -58,13 +58,13 @@ namespace ProfilingUITestsRunner {
             _vs.RunTest(nameof(PUIT.NewProfilingSession));
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(VsTestContext.P0_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void DeleteMultipleSessions() {
             _vs.RunTest(nameof(PUIT.DeleteMultipleSessions));
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(VsTestContext.P0_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void NewProfilingSessionOpenSolution() {
             _vs.RunTest(nameof(PUIT.NewProfilingSessionOpenSolution));
@@ -124,13 +124,13 @@ namespace ProfilingUITestsRunner {
             _vs.RunTest(nameof(PUIT.SaveDirtySession));
         }
 
-        [TestMethod, Priority(2)]
+        [TestMethod, Priority(VsTestContext.P0_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void DeleteReport() {
             _vs.RunTest(nameof(PUIT.DeleteReport));
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(VsTestContext.P0_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void CompareReports() {
             _vs.RunTest(nameof(PUIT.CompareReports));
@@ -162,19 +162,19 @@ namespace ProfilingUITestsRunner {
             _vs.RunTest(nameof(PUIT.TargetPropertiesForProject));
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(VsTestContext.P0_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void TargetPropertiesForInterpreter() {
             _vs.RunTest(nameof(PUIT.TargetPropertiesForInterpreter));
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(VsTestContext.P0_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void TargetPropertiesForExecutable() {
             _vs.RunTest(nameof(PUIT.TargetPropertiesForExecutable));
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(VsTestContext.P0_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void StopProfiling() {
             _vs.RunTest(nameof(PUIT.StopProfiling));
@@ -198,67 +198,67 @@ namespace ProfilingUITestsRunner {
             _vs.RunTest(nameof(PUIT.MultipleReports));
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(VsTestContext.P0_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void LaunchExecutable() {
             _vs.RunTest(nameof(PUIT.LaunchExecutable));
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(VsTestContext.P0_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void ClassProfile() {
             _vs.RunTest(nameof(PUIT.ClassProfile));
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(VsTestContext.P0_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void OldClassProfile() {
             _vs.RunTest(nameof(PUIT.OldClassProfile));
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(VsTestContext.P0_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void DerivedProfile() {
             _vs.RunTest(nameof(PUIT.DerivedProfile));
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(VsTestContext.P0_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void Pystone() {
             _vs.RunTest(nameof(PUIT.Pystone));
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(VsTestContext.P0_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void BuiltinsProfilePython27() {
             _vs.RunTest(nameof(PUIT.BuiltinsProfilePython27));
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(VsTestContext.P0_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void BuiltinsProfilePython27x64() {
             _vs.RunTest(nameof(PUIT.BuiltinsProfilePython27x64));
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(VsTestContext.P0_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void BuiltinsProfilePython35() {
             _vs.RunTest(nameof(PUIT.BuiltinsProfilePython35));
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(VsTestContext.P0_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void BuiltinsProfilePython35x64() {
             _vs.RunTest(nameof(PUIT.BuiltinsProfilePython35x64));
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(VsTestContext.P0_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void BuiltinsProfilePython36() {
             _vs.RunTest(nameof(PUIT.BuiltinsProfilePython36));
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(VsTestContext.P0_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void BuiltinsProfilePython36x64() {
             _vs.RunTest(nameof(PUIT.BuiltinsProfilePython36x64));
@@ -276,7 +276,7 @@ namespace ProfilingUITestsRunner {
             _vs.RunTest(nameof(PUIT.BuiltinsProfilePython37x64));
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(VsTestContext.P0_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void LaunchExecutableUsingInterpreterGuid() {
             _vs.RunTest(nameof(PUIT.LaunchExecutableUsingInterpreterGuid));

--- a/Python/Tests/ProfilingUITestsRunner/ProfilingUITests.cs
+++ b/Python/Tests/ProfilingUITestsRunner/ProfilingUITests.cs
@@ -70,7 +70,7 @@ namespace ProfilingUITestsRunner {
             _vs.RunTest(nameof(PUIT.NewProfilingSessionOpenSolution));
         }
 
-        [TestMethod, Priority(2)]
+        [TestMethod, Priority(VsTestContext.P2_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void LaunchPythonProfilingWizard() {
             _vs.RunTest(nameof(PUIT.LaunchPythonProfilingWizard));
@@ -180,13 +180,13 @@ namespace ProfilingUITestsRunner {
             _vs.RunTest(nameof(PUIT.StopProfiling));
         }
 
-        [TestMethod, Priority(2)]
+        [TestMethod, Priority(VsTestContext.P2_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void MultipleTargets() {
             _vs.RunTest(nameof(PUIT.MultipleTargets));
         }
 
-        [TestMethod, Priority(2)]
+        [TestMethod, Priority(VsTestContext.P2_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void MultipleTargetsWithProjectHome() {
             _vs.RunTest(nameof(PUIT.MultipleTargetsWithProjectHome));

--- a/Python/Tests/PythonToolsMockTests/ClassifierTests.cs
+++ b/Python/Tests/PythonToolsMockTests/ClassifierTests.cs
@@ -228,7 +228,7 @@ async def f():
             }
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void ReturnAnnotationClassifications() {
             var code = @"
 def f() -> int:
@@ -252,7 +252,7 @@ def f() -> int:
             }
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void RegexClassifications() {
             var code = @"import re as R
 R.compile('pattern', 'str')

--- a/Python/Tests/PythonToolsMockTests/ClassifierTests.cs
+++ b/Python/Tests/PythonToolsMockTests/ClassifierTests.cs
@@ -184,7 +184,7 @@ e'''";
             }
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void TrueFalseClassification() {
             var code = "True False";
 

--- a/Python/Tests/PythonToolsMockTests/CompletionTests.cs
+++ b/Python/Tests/PythonToolsMockTests/CompletionTests.cs
@@ -264,7 +264,7 @@ print
             }
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void ExceptionCompletions() {
             using (var vs = new MockVs()) {
                 foreach (var ver in new[] { PythonLanguageVersion.V36, PythonLanguageVersion.V27 }) {
@@ -444,7 +444,7 @@ f(1, 2, 3, 4,")) {
             }
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void ImportCompletions() {
             using (var view = new PythonEditor()) {
                 view.Text = "import  ";
@@ -547,7 +547,7 @@ f(1, 2, 3, 4,")) {
         }
 
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void FromOSPathImportCompletions2x() {
             using (var vs = new MockVs()) {
                 var factory = vs.Invoke(() => vs.GetPyService().InterpreterRegistryService.Interpreters.LastOrDefault(p => p.Configuration.Version.Major == 2));
@@ -555,7 +555,7 @@ f(1, 2, 3, 4,")) {
             }
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void FromOSPathImportCompletions3x() {
             using (var vs = new MockVs()) {
                 var factory = vs.Invoke(() => vs.GetPyService().InterpreterRegistryService.Interpreters.LastOrDefault(p => p.Configuration.Version.Major == 3));
@@ -641,7 +641,7 @@ sys.
             }
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void GotoDefinition() {
             using (var vs = new MockVs()) {
                 string code = @"
@@ -809,7 +809,7 @@ class Baz(Fob, Oar):
             }
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void BuiltinOverrideCompletions() {
             AssertOverrideInsertionContains(PythonLanguageVersion.V27, "str", "capitalize", "capitalize(self):\r\n        return super(Fob, self).capitalize()");
             AssertOverrideInsertionContains(PythonLanguageVersion.V33, "str", "capitalize", "capitalize(self):\r\n        return super().capitalize()");
@@ -1030,7 +1030,7 @@ x = m.f(";
             }
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void YieldFromExpressionCompletion() {
             const string code = @"
 def f():
@@ -1059,7 +1059,7 @@ def g():
             }
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void AwaitExpressionCompletion() {
             const string code = @"
 async def f():

--- a/Python/Tests/PythonToolsMockTests/CompletionTests.cs
+++ b/Python/Tests/PythonToolsMockTests/CompletionTests.cs
@@ -158,7 +158,7 @@ namespace PythonToolsMockTests {
             }
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void KeywordOrIdentifierCompletions() {
             // http://pytools.codeplex.com/workitem/560
             string code = @"

--- a/Python/Tests/PythonToolsMockTests/CompletionTests.cs
+++ b/Python/Tests/PythonToolsMockTests/CompletionTests.cs
@@ -206,7 +206,7 @@ l(42)
             }
         }
 
-        [TestMethod, Priority(2)]
+        [TestMethod, Priority(TestExtensions.P2_FAILING_UNIT_TEST)]
         public void TrueFalseNoneCompletions() {
             // http://pytools.codeplex.com/workitem/1905
             foreach (var version in new[] { PythonLanguageVersion.V27, PythonLanguageVersion.V33 }) {
@@ -476,7 +476,7 @@ f(1, 2, 3, 4,")) {
             }
         }
 
-        [TestMethod, Priority(2)]
+        [TestMethod, Priority(TestExtensions.P2_FAILING_UNIT_TEST)]
         public void FromImportCompletions() {
             using (var view = new PythonEditor()) {
                 IEnumerable<string> completions = null;
@@ -660,7 +660,7 @@ C().fff";
             }
         }
 
-        [TestMethod, Priority(2)]
+        [TestMethod, Priority(TestExtensions.P2_FAILING_UNIT_TEST)]
         public void QuickInfo() {
             string code = @"
 x = ""ABCDEFGHIJKLMNOPQRSTUVWYXZ""
@@ -716,7 +716,7 @@ e): <unknown type>");
             }
         }
 
-        [TestMethod, Priority(2)]
+        [TestMethod, Priority(TestExtensions.P2_FAILING_UNIT_TEST)]
         public void NormalOverrideCompletions() {
             using (var view2 = new PythonEditor(version: PythonLanguageVersion.V27))
             using (var view3 = new PythonEditor(version: PythonLanguageVersion.V33)) {
@@ -905,7 +905,7 @@ class B(dict):
             }
         }
 
-        [TestMethod, Priority(2)]
+        [TestMethod, Priority(TestExtensions.P2_FAILING_UNIT_TEST)]
         public void CompletionWithLongDocString() {
             using (var vs = new MockVs()) {
                 var docString = GenerateText(100, 72, "    ").ToArray();

--- a/Python/Tests/PythonToolsMockTests/EditorTests.cs
+++ b/Python/Tests/PythonToolsMockTests/EditorTests.cs
@@ -109,7 +109,7 @@ namespace PythonToolsMockTests {
             }
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void DotCompletes() {
             using (var view = new PythonEditor()) {
                 view.TypeAndWaitForAnalysis("min");

--- a/Python/Tests/PythonToolsMockTests/NavigableTests.cs
+++ b/Python/Tests/PythonToolsMockTests/NavigableTests.cs
@@ -62,7 +62,7 @@ namespace PythonToolsMockTests {
             }
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public async Task ModuleImportDefinition() {
             var code = @"import sys
 

--- a/Python/Tests/PythonToolsMockTests/ProjectTests.cs
+++ b/Python/Tests/PythonToolsMockTests/ProjectTests.cs
@@ -40,7 +40,7 @@ namespace PythonToolsMockTests {
     public class ProjectTests {
         static PythonProjectGenerator Generator = PythonProjectGenerator.CreateStatic();
 
-        [TestMethod, Priority(2)]
+        [TestMethod, Priority(TestExtensions.P2_FAILING_UNIT_TEST)]
         public void BasicProjectTest() {
             var sln = Generator.Project(
                 "HelloWorld",
@@ -97,7 +97,7 @@ namespace PythonToolsMockTests {
             }
         }
 
-        [TestMethod, Priority(2)]
+        [TestMethod, Priority(TestExtensions.P2_FAILING_UNIT_TEST)]
         [TestCategory("Installed")]
         public void ShouldWarnOnRun() {
             var sln = Generator.Project(
@@ -141,7 +141,7 @@ namespace PythonToolsMockTests {
             }
         }
 
-        [TestMethod, Priority(2)]
+        [TestMethod, Priority(TestExtensions.P2_FAILING_UNIT_TEST)]
         [TestCategory("Installed")] // Requires .targets file to be installed
         public void OAProjectMustBeRightType() {
             var sln = Generator.Project(

--- a/Python/Tests/PythonToolsMockTests/RefactorRenameTests.cs
+++ b/Python/Tests/PythonToolsMockTests/RefactorRenameTests.cs
@@ -274,7 +274,7 @@ namespace PythonToolsMockTests {
             );
         }
 
-        [TestMethod, Priority(2)]
+        [TestMethod, Priority(TestExtensions.P2_FAILING_UNIT_TEST)]
         public void SanityClassField() {
             RefactorTest("xyz", "abc",
                 new[] {
@@ -824,7 +824,7 @@ abc = 200
             );
         }
 
-        [TestMethod, Priority(2)]
+        [TestMethod, Priority(TestExtensions.P2_FAILING_UNIT_TEST)]
         public void SanityLocal() {
             RefactorTest("xyz", "abc",
                 new[] {
@@ -885,7 +885,7 @@ def h(abc):
 
         }
 
-        [TestMethod, Priority(2)]
+        [TestMethod, Priority(TestExtensions.P2_FAILING_UNIT_TEST)]
         public void SanityClosure() {
             RefactorTest("xyz", "abc",
                 new[] {
@@ -945,7 +945,7 @@ abc = 200
             );
         }
 
-        [TestMethod, Priority(2)]
+        [TestMethod, Priority(TestExtensions.P2_FAILING_UNIT_TEST)]
         public void SanityLambda() {
             RefactorTest("xyz", "abc",
                 new[] {
@@ -1678,7 +1678,7 @@ xyz = 100
             );
         }
 
-        [TestMethod, Priority(2)]
+        [TestMethod, Priority(TestExtensions.P2_FAILING_UNIT_TEST)]
         public void DelNonLocal() {
             RefactorTest("xyz", "abc", version: new Version(3, 2),
             inputs: new[] {
@@ -2161,7 +2161,7 @@ f(abc)
             );
         }
 
-        [TestMethod, Priority(2)]
+        [TestMethod, Priority(TestExtensions.P2_FAILING_UNIT_TEST)]
         public void ImportAsStatement() {
             RefactorTest("xyz", "abc",
             new[] {

--- a/Python/Tests/PythonToolsMockTests/RefactorRenameTests.cs
+++ b/Python/Tests/PythonToolsMockTests/RefactorRenameTests.cs
@@ -512,7 +512,7 @@ abc = 200
             );
         }
 
-        [TestMethod, Priority(3)]
+        [TestMethod, Priority(TestExtensions.P3_FAILING_UNIT_TEST)]
         public void RenameGeneratorVariable() {
             // http://pytools.codeplex.com/workitem/454
             RefactorTest("xyz", "abc",

--- a/Python/Tests/PythonToolsMockTests/RefactorRenameTests.cs
+++ b/Python/Tests/PythonToolsMockTests/RefactorRenameTests.cs
@@ -464,7 +464,7 @@ abc = 200
             );
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void InheritedClassField() {
 
             RefactorTest("xyz", "abc",
@@ -1262,7 +1262,7 @@ xyz = 100
             );
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void SanityNonLocal() {
             RefactorTest("xyz", "abc", version: new Version(3, 2),
             inputs: new[] {
@@ -2313,7 +2313,7 @@ abc = 200
 
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void NestedFunctions() {
             RefactorTest("h", "g",
                 new[] {

--- a/Python/Tests/PythonToolsMockTests/SquiggleTests.cs
+++ b/Python/Tests/PythonToolsMockTests/SquiggleTests.cs
@@ -58,7 +58,7 @@ namespace PythonToolsMockTests {
         }
 
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public async Task UnresolvedImportSquiggle() {
             List<string> squiggles;
 

--- a/Python/Tests/PythonToolsMockTests/SquiggleTests.cs
+++ b/Python/Tests/PythonToolsMockTests/SquiggleTests.cs
@@ -95,7 +95,7 @@ namespace PythonToolsMockTests {
             }
         }
 
-        [TestMethod, Priority(2)]
+        [TestMethod, Priority(TestExtensions.P2_FAILING_UNIT_TEST)]
         public async Task HandledImportSquiggle() {
             var testCases = new List<Tuple<string, string[]>>();
             testCases.Add(Tuple.Create(

--- a/Python/Tests/PythonToolsUITestsRunner/AddImportTests.cs
+++ b/Python/Tests/PythonToolsUITestsRunner/AddImportTests.cs
@@ -57,13 +57,13 @@ namespace PythonToolsUITestsRunner {
             _vs.RunTest(nameof(PythonToolsUITests.AddImportTests.DocStringFuture));
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(VsTestContext.P0_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void ImportFunctionFrom() {
             _vs.RunTest(nameof(PythonToolsUITests.AddImportTests.ImportFunctionFrom));
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(VsTestContext.P0_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void ImportFunctionFromSubpackage() {
             _vs.RunTest(nameof(PythonToolsUITests.AddImportTests.ImportFunctionFromSubpackage));
@@ -81,49 +81,49 @@ namespace PythonToolsUITestsRunner {
             _vs.RunTest(nameof(PythonToolsUITests.AddImportTests.ImportBuiltinFunction));
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(VsTestContext.P0_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void ImportFunctionFromExistingFromImport() {
             _vs.RunTest(nameof(PythonToolsUITests.AddImportTests.ImportFunctionFromExistingFromImport));
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(VsTestContext.P0_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void ImportFunctionFromExistingFromImportAsName() {
             _vs.RunTest(nameof(PythonToolsUITests.AddImportTests.ImportFunctionFromExistingFromImportAsName));
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(VsTestContext.P0_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void ImportFunctionFromExistingFromImportParens() {
             _vs.RunTest(nameof(PythonToolsUITests.AddImportTests.ImportFunctionFromExistingFromImportParens));
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(VsTestContext.P0_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void ImportFunctionFromExistingFromImportParensAsName() {
             _vs.RunTest(nameof(PythonToolsUITests.AddImportTests.ImportFunctionFromExistingFromImportParensAsName));
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(0VsTestContext.P0_FAILING_UI_TEST]
         [TestCategory("Installed")]
         public void ImportFunctionFromExistingFromImportParensAsNameTrailingComma() {
             _vs.RunTest(nameof(PythonToolsUITests.AddImportTests.ImportFunctionFromExistingFromImportParensAsNameTrailingComma));
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(VsTestContext.P0_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void ImportFunctionFromExistingFromImportParensTrailingComma() {
             _vs.RunTest(nameof(PythonToolsUITests.AddImportTests.ImportFunctionFromExistingFromImportParensTrailingComma));
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(VsTestContext.P0_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void ImportPackage() {
             _vs.RunTest(nameof(PythonToolsUITests.AddImportTests.ImportPackage));
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(VsTestContext.P0_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void ImportSubPackage() {
             _vs.RunTest(nameof(PythonToolsUITests.AddImportTests.ImportSubPackage));

--- a/Python/Tests/PythonToolsUITestsRunner/AddImportTests.cs
+++ b/Python/Tests/PythonToolsUITestsRunner/AddImportTests.cs
@@ -39,19 +39,19 @@ namespace PythonToolsUITestsRunner {
         public static void ClassCleanup() => VsTestContext.Instance.Dispose();
         #endregion
 
-        [TestMethod, Priority(2)]
+        [TestMethod, Priority(VsTestContext.P2_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void DocString() {
             _vs.RunTest(nameof(PythonToolsUITests.AddImportTests.DocString));
         }
 
-        [TestMethod, Priority(2)]
+        [TestMethod, Priority(VsTestContext.P2_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void UnicodeDocString() {
             _vs.RunTest(nameof(PythonToolsUITests.AddImportTests.UnicodeDocString));
         }
 
-        [TestMethod, Priority(2)]
+        [TestMethod, Priority(VsTestContext.P2_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void DocStringFuture() {
             _vs.RunTest(nameof(PythonToolsUITests.AddImportTests.DocStringFuture));
@@ -75,7 +75,7 @@ namespace PythonToolsUITestsRunner {
             _vs.RunTest(nameof(PythonToolsUITests.AddImportTests.ImportWithErrors));
         }
 
-        [TestMethod, Priority(2)]
+        [TestMethod, Priority(VsTestContext.P2_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void ImportBuiltinFunction() {
             _vs.RunTest(nameof(PythonToolsUITests.AddImportTests.ImportBuiltinFunction));
@@ -105,7 +105,7 @@ namespace PythonToolsUITestsRunner {
             _vs.RunTest(nameof(PythonToolsUITests.AddImportTests.ImportFunctionFromExistingFromImportParensAsName));
         }
 
-        [TestMethod, Priority(0VsTestContext.P0_FAILING_UI_TEST]
+        [TestMethod, Priority(VsTestContext.P0_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void ImportFunctionFromExistingFromImportParensAsNameTrailingComma() {
             _vs.RunTest(nameof(PythonToolsUITests.AddImportTests.ImportFunctionFromExistingFromImportParensAsNameTrailingComma));
@@ -129,7 +129,7 @@ namespace PythonToolsUITestsRunner {
             _vs.RunTest(nameof(PythonToolsUITests.AddImportTests.ImportSubPackage));
         }
 
-        [TestMethod, Priority(2)]
+        [TestMethod, Priority(VsTestContext.P2_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void Parameters() {
             _vs.RunTest(nameof(PythonToolsUITests.AddImportTests.Parameters));

--- a/Python/Tests/PythonToolsUITestsRunner/BasicProjectTests.cs
+++ b/Python/Tests/PythonToolsUITestsRunner/BasicProjectTests.cs
@@ -191,7 +191,7 @@ namespace PythonToolsUITestsRunner {
         }
 
         [Ignore] // TODO: fix this test
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(VsTestContext.P0_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void DotNetSearchPathReferences() {
             _vs.RunTest(nameof(PythonToolsUITests.BasicProjectTests.DotNetSearchPathReferences));
@@ -280,7 +280,7 @@ namespace PythonToolsUITestsRunner {
             _vs.RunTest(nameof(PythonToolsUITests.BasicProjectTests.CopyFolderWithMultipleItems));
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(VsTestContext.P0_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void OpenInteractiveFromSolutionExplorer() {
             _vs.RunTest(nameof(PythonToolsUITests.BasicProjectTests.OpenInteractiveFromSolutionExplorer));

--- a/Python/Tests/PythonToolsUITestsRunner/BuildTasksUITests.cs
+++ b/Python/Tests/PythonToolsUITestsRunner/BuildTasksUITests.cs
@@ -41,7 +41,7 @@ namespace PythonToolsUITestsRunner {
 
         #region Python 2.7 tests
 
-        [TestMethod, Priority(2)]
+        [TestMethod, Priority(VsTestContext.P2_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void CustomCommandsAdded_27() {
             _vs.RunTest(nameof(PythonToolsUITests.BuildTasksUITests.CustomCommandsAdded), "2.7");
@@ -71,7 +71,7 @@ namespace PythonToolsUITestsRunner {
             _vs.RunTest(nameof(PythonToolsUITests.BuildTasksUITests.CustomCommandsRunProcessInRepl), "2.7");
         }
 
-        [TestMethod, Priority(2)]
+        [TestMethod, Priority(VsTestContext.P2_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void CustomCommandsRunProcessInOutput_27() {
             _vs.RunTest(nameof(PythonToolsUITests.BuildTasksUITests.CustomCommandsRunProcessInOutput), "2.7");
@@ -89,13 +89,13 @@ namespace PythonToolsUITestsRunner {
             _vs.RunTest(nameof(PythonToolsUITests.BuildTasksUITests.CustomCommandsErrorList), "2.7");
         }
 
-        [TestMethod, Priority(2)]
+        [TestMethod, Priority(VsTestContext.P2_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void CustomCommandsRequiredPackages_27() {
             _vs.RunTest(nameof(PythonToolsUITests.BuildTasksUITests.CustomCommandsRequiredPackages), "2.7");
         }
 
-        [TestMethod, Priority(2)]
+        [TestMethod, Priority(VsTestContext.P2_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void CustomCommandsSearchPath_27() {
             _vs.RunTest(nameof(PythonToolsUITests.BuildTasksUITests.CustomCommandsSearchPath), "2.7");
@@ -105,7 +105,7 @@ namespace PythonToolsUITestsRunner {
 
         #region Python 3.5 tests
 
-        [TestMethod, Priority(2)]
+        [TestMethod, Priority(VsTestContext.P2_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void CustomCommandsAdded_35() {
             _vs.RunTest(nameof(PythonToolsUITests.BuildTasksUITests.CustomCommandsAdded), "3.5");
@@ -135,7 +135,7 @@ namespace PythonToolsUITestsRunner {
             _vs.RunTest(nameof(PythonToolsUITests.BuildTasksUITests.CustomCommandsRunProcessInRepl), "3.5");
         }
 
-        [TestMethod, Priority(2)]
+        [TestMethod, Priority(VsTestContext.P2_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void CustomCommandsRunProcessInOutput_35() {
             _vs.RunTest(nameof(PythonToolsUITests.BuildTasksUITests.CustomCommandsRunProcessInOutput), "3.5");
@@ -153,13 +153,13 @@ namespace PythonToolsUITestsRunner {
             _vs.RunTest(nameof(PythonToolsUITests.BuildTasksUITests.CustomCommandsErrorList), "3.5");
         }
 
-        [TestMethod, Priority(2)]
+        [TestMethod, Priority(VsTestContext.P2_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void CustomCommandsRequiredPackages_35() {
             _vs.RunTest(nameof(PythonToolsUITests.BuildTasksUITests.CustomCommandsRequiredPackages), "3.5");
         }
 
-        [TestMethod, Priority(2)]
+        [TestMethod, Priority(VsTestContext.P2_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void CustomCommandsSearchPath_35() {
             _vs.RunTest(nameof(PythonToolsUITests.BuildTasksUITests.CustomCommandsSearchPath), "3.5");

--- a/Python/Tests/PythonToolsUITestsRunner/BuildTasksUITests.cs
+++ b/Python/Tests/PythonToolsUITestsRunner/BuildTasksUITests.cs
@@ -47,7 +47,7 @@ namespace PythonToolsUITestsRunner {
             _vs.RunTest(nameof(PythonToolsUITests.BuildTasksUITests.CustomCommandsAdded), "2.7");
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(VsTestContext.P0_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void CustomCommandsWithResourceLabel_27() {
             _vs.RunTest(nameof(PythonToolsUITests.BuildTasksUITests.CustomCommandsWithResourceLabel), "2.7");
@@ -59,7 +59,7 @@ namespace PythonToolsUITestsRunner {
             _vs.RunTest(nameof(PythonToolsUITests.BuildTasksUITests.CustomCommandsReplWithResourceLabel), "2.7");
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(VsTestContext.P0_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void CustomCommandsRunInRepl_27() {
             _vs.RunTest(nameof(PythonToolsUITests.BuildTasksUITests.CustomCommandsRunInRepl), "2.7");
@@ -83,7 +83,7 @@ namespace PythonToolsUITestsRunner {
             _vs.RunTest(nameof(PythonToolsUITests.BuildTasksUITests.CustomCommandsRunProcessInConsole), "2.7");
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(VsTestContext.P0_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void CustomCommandsErrorList_27() {
             _vs.RunTest(nameof(PythonToolsUITests.BuildTasksUITests.CustomCommandsErrorList), "2.7");
@@ -111,19 +111,19 @@ namespace PythonToolsUITestsRunner {
             _vs.RunTest(nameof(PythonToolsUITests.BuildTasksUITests.CustomCommandsAdded), "3.5");
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(VsTestContext.P0_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void CustomCommandsWithResourceLabel_35() {
             _vs.RunTest(nameof(PythonToolsUITests.BuildTasksUITests.CustomCommandsWithResourceLabel), "3.5");
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(VsTestContext.P0_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void CustomCommandsReplWithResourceLabel_35() {
             _vs.RunTest(nameof(PythonToolsUITests.BuildTasksUITests.CustomCommandsReplWithResourceLabel), "3.5");
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(VsTestContext.P0_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void CustomCommandsRunInRepl_35() {
             _vs.RunTest(nameof(PythonToolsUITests.BuildTasksUITests.CustomCommandsRunInRepl), "3.5");

--- a/Python/Tests/PythonToolsUITestsRunner/EditorTests.cs
+++ b/Python/Tests/PythonToolsUITestsRunner/EditorTests.cs
@@ -90,7 +90,7 @@ namespace PythonToolsUITestsRunner {
             _vs.RunTest(nameof(PythonToolsUITests.EditorTests.ClassificationMultiLineStringTest2));
         }
 
-        [TestMethod, Priority(2)]
+        [TestMethod, Priority(VsTestContext.P2_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void SignaturesTest() {
             _vs.RunTest(nameof(PythonToolsUITests.EditorTests.SignaturesTest));
@@ -102,7 +102,7 @@ namespace PythonToolsUITestsRunner {
             _vs.RunTest(nameof(PythonToolsUITests.EditorTests.MultiLineSignaturesTest));
         }
 
-        [TestMethod, Priority(2)]
+        [TestMethod, Priority(VsTestContext.P2_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void CompletionsCaseSensitive() {
             _vs.RunTest(nameof(PythonToolsUITests.EditorTests.CompletionsCaseSensitive));
@@ -126,7 +126,7 @@ namespace PythonToolsUITestsRunner {
             _vs.RunTest(nameof(PythonToolsUITests.EditorTests.TypingTest));
         }
 
-        [TestMethod, Priority(2)]
+        [TestMethod, Priority(VsTestContext.P2_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void CompletionTests() {
             _vs.RunTest(nameof(PythonToolsUITests.EditorTests.CompletionTests));
@@ -168,7 +168,7 @@ namespace PythonToolsUITestsRunner {
             _vs.RunTest(nameof(PythonToolsUITests.EditorTests.ImportSelf));
         }
 
-        [TestMethod, Priority(2), TestCategory("Squiggle")]
+        [TestMethod, Priority(VsTestContext.P2_FAILING_UI_TEST), TestCategory("Squiggle")]
         [TestCategory("Installed")]
         public void ImportMissingThenAddThenExcludeFile() {
             _vs.RunTest(nameof(PythonToolsUITests.EditorTests.ImportMissingThenAddThenExcludeFile));

--- a/Python/Tests/PythonToolsUITestsRunner/EditorTests.cs
+++ b/Python/Tests/PythonToolsUITestsRunner/EditorTests.cs
@@ -57,7 +57,7 @@ namespace PythonToolsUITestsRunner {
             _vs.RunTest(nameof(PythonToolsUITests.EditorTests.OutliningTest));
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(VsTestContext.P0_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void OutlineNestedFuncDef() {
             _vs.RunTest(nameof(PythonToolsUITests.EditorTests.OutlineNestedFuncDef));
@@ -120,7 +120,7 @@ namespace PythonToolsUITestsRunner {
             _vs.RunTest(nameof(PythonToolsUITests.EditorTests.AutoIndentExisting));
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(VsTestContext.P0_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void TypingTest() {
             _vs.RunTest(nameof(PythonToolsUITests.EditorTests.TypingTest));
@@ -156,7 +156,7 @@ namespace PythonToolsUITestsRunner {
             _vs.RunTest(nameof(PythonToolsUITests.EditorTests.IndentationInconsistencyIgnore));
         }
 
-        [TestMethod, Priority(0), TestCategory("Squiggle")]
+        [TestMethod, Priority(VsTestContext.P0_FAILING_UI_TEST), TestCategory("Squiggle")]
         [TestCategory("Installed")]
         public void ImportPresent() {
             _vs.RunTest(nameof(PythonToolsUITests.EditorTests.ImportPresent));

--- a/Python/Tests/PythonToolsUITestsRunner/EnvironmentUITests.cs
+++ b/Python/Tests/PythonToolsUITestsRunner/EnvironmentUITests.cs
@@ -64,19 +64,19 @@ namespace PythonToolsUITestsRunner {
             _vs.RunTest(nameof(PythonToolsUITests.EnvironmentUITests.LoadVEnv));
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(VsTestContext.P0_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void ActivateVEnv() {
             _vs.RunTest(nameof(PythonToolsUITests.EnvironmentUITests.ActivateVEnv));
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(VsTestContext.P0_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void RemoveVEnv() {
             _vs.RunTest(nameof(PythonToolsUITests.EnvironmentUITests.RemoveVEnv));
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(VsTestContext.P0_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void DeleteVEnv() {
             _vs.RunTest(nameof(PythonToolsUITests.EnvironmentUITests.DeleteVEnv));
@@ -94,19 +94,19 @@ namespace PythonToolsUITestsRunner {
             _vs.RunTest(nameof(PythonToolsUITests.EnvironmentUITests.ProjectCreateVEnv));
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(VsTestContext.P0_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void ProjectCreateCondaEnvFromPackages() {
             _vs.RunTest(nameof(PythonToolsUITests.EnvironmentUITests.ProjectCreateCondaEnvFromPackages));
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(VsTestContext.P0_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void ProjectCreateCondaEnvFromEnvFile() {
             _vs.RunTest(nameof(PythonToolsUITests.EnvironmentUITests.ProjectCreateCondaEnvFromEnvFile));
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(VsTestContext.P0_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void ProjectAddExistingVEnvLocal() {
             _vs.RunTest(nameof(PythonToolsUITests.EnvironmentUITests.ProjectAddExistingVEnvLocal));
@@ -118,7 +118,7 @@ namespace PythonToolsUITestsRunner {
             _vs.RunTest(nameof(PythonToolsUITests.EnvironmentUITests.ProjectAddCustomEnvLocal));
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(VsTestContext.P0_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void ProjectAddExistingEnv() {
             _vs.RunTest(nameof(PythonToolsUITests.EnvironmentUITests.ProjectAddExistingEnv));
@@ -130,19 +130,19 @@ namespace PythonToolsUITestsRunner {
             _vs.RunTest(nameof(PythonToolsUITests.EnvironmentUITests.WorkspaceCreateVEnv));
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(VsTestContext.P0_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void WorkspaceCreateCondaEnvFromEnvFile() {
             _vs.RunTest(nameof(PythonToolsUITests.EnvironmentUITests.WorkspaceCreateCondaEnvFromEnvFile));
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(VsTestContext.P0_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void WorkspaceCreateCondaEnvFromPackages() {
             _vs.RunTest(nameof(PythonToolsUITests.EnvironmentUITests.WorkspaceCreateCondaEnvFromPackages));
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(VsTestContext.P0_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void WorkspaceCreateCondaEnvFromNoPackages() {
             _vs.RunTest(nameof(PythonToolsUITests.EnvironmentUITests.WorkspaceCreateCondaEnvFromNoPackages));
@@ -178,7 +178,7 @@ namespace PythonToolsUITestsRunner {
             _vs.RunTest(nameof(PythonToolsUITests.EnvironmentUITests.VirtualEnvironmentReplWorkingDirectory));
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(VsTestContext.P0_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void SwitcherSingleProject() {
             _vs.RunTest(nameof(PythonToolsUITests.EnvironmentUITests.SwitcherSingleProject));

--- a/Python/Tests/PythonToolsUITestsRunner/ErrorListTaskListTests.cs
+++ b/Python/Tests/PythonToolsUITestsRunner/ErrorListTaskListTests.cs
@@ -45,13 +45,13 @@ namespace PythonToolsUITestsRunner {
             _vs.RunTest(nameof(PythonToolsUITests.ErrorListTaskListTests.ErrorList));
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(VsTestContext.P0_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void CommentTaskList() {
             _vs.RunTest(nameof(PythonToolsUITests.ErrorListTaskListTests.CommentTaskList));
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(VsTestContext.P0_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void ErrorListAndTaskListAreClearedWhenProjectIsDeleted() {
             _vs.RunTest(nameof(PythonToolsUITests.ErrorListTaskListTests.ErrorListAndTaskListAreClearedWhenProjectIsDeleted));
@@ -69,13 +69,13 @@ namespace PythonToolsUITestsRunner {
             _vs.RunTest(nameof(PythonToolsUITests.ErrorListTaskListTests.ErrorListAndTaskListAreClearedWhenProjectWithMultipleFilesIsUnloaded));
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(VsTestContext.P0_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void ErrorListAndTaskListAreClearedWhenFileIsDeleted() {
             _vs.RunTest(nameof(PythonToolsUITests.ErrorListTaskListTests.ErrorListAndTaskListAreClearedWhenFileIsDeleted));
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(VsTestContext.P0_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void ErrorListAndTaskListAreClearedWhenOpenFileIsDeleted() {
             _vs.RunTest(nameof(PythonToolsUITests.ErrorListTaskListTests.ErrorListAndTaskListAreClearedWhenOpenFileIsDeleted));

--- a/Python/Tests/PythonToolsUITestsRunner/ErrorListTaskListTests.cs
+++ b/Python/Tests/PythonToolsUITestsRunner/ErrorListTaskListTests.cs
@@ -39,7 +39,7 @@ namespace PythonToolsUITestsRunner {
         public static void ClassCleanup() => VsTestContext.Instance.Dispose();
         #endregion
 
-        [TestMethod, Priority(2)]
+        [TestMethod, Priority(VsTestContext.P2_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void ErrorList() {
             _vs.RunTest(nameof(PythonToolsUITests.ErrorListTaskListTests.ErrorList));

--- a/Python/Tests/PythonToolsUITestsRunner/FormattingUITests.cs
+++ b/Python/Tests/PythonToolsUITestsRunner/FormattingUITests.cs
@@ -45,7 +45,7 @@ namespace PythonToolsUITestsRunner {
             _vs.RunTest(nameof(PythonToolsUITests.FormattingUITests.ToggleableOptionTest));
         }
 
-        [TestMethod, Priority(2)]
+        [TestMethod, Priority(VsTestContext.P2_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void FormatDocument() {
             _vs.RunTest(nameof(PythonToolsUITests.FormattingUITests.FormatDocument));
@@ -57,7 +57,7 @@ namespace PythonToolsUITestsRunner {
             _vs.RunTest(nameof(PythonToolsUITests.FormattingUITests.FormatAsyncDocument));
         }
 
-        [TestMethod, Priority(2)]
+        [TestMethod, Priority(VsTestContext.P2_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void FormatSelection() {
             _vs.RunTest(nameof(PythonToolsUITests.FormattingUITests.FormatSelection));
@@ -69,7 +69,7 @@ namespace PythonToolsUITestsRunner {
             _vs.RunTest(nameof(PythonToolsUITests.FormattingUITests.FormatSelectionNoSelection));
         }
 
-        [TestMethod, Priority(2)]
+        [TestMethod, Priority(VsTestContext.P2_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void FormatReduceLines() {
             _vs.RunTest(nameof(PythonToolsUITests.FormattingUITests.FormatReduceLines));

--- a/Python/Tests/PythonToolsUITestsRunner/PublishTest.cs
+++ b/Python/Tests/PythonToolsUITestsRunner/PublishTest.cs
@@ -39,13 +39,13 @@ namespace PythonToolsUITestsRunner {
         public static void ClassCleanup() => VsTestContext.Instance.Dispose();
         #endregion
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(VsTestContext.P0_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void TestPublishFiles() {
             _vs.RunTest(nameof(PythonToolsUITests.PublishTest.TestPublishFiles));
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(VsTestContext.P0_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void TestPublishReadOnlyFiles() {
             _vs.RunTest(nameof(PythonToolsUITests.PublishTest.TestPublishReadOnlyFiles));

--- a/Python/Tests/PythonToolsUITestsRunner/RemoveImportTests.cs
+++ b/Python/Tests/PythonToolsUITestsRunner/RemoveImportTests.cs
@@ -69,7 +69,7 @@ namespace PythonToolsUITestsRunner {
             _vs.RunTest(nameof(PythonToolsUITests.RemoveImportTests.FromImportParensTrailingComma1));
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(VsTestContext.P0_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void FromImportParensTrailingComma2() {
             _vs.RunTest(nameof(PythonToolsUITests.RemoveImportTests.FromImportParensTrailingComma2));

--- a/Python/Tests/PythonToolsUITestsRunner/SnippetsTests.cs
+++ b/Python/Tests/PythonToolsUITestsRunner/SnippetsTests.cs
@@ -40,43 +40,43 @@ namespace PythonToolsUITestsRunner {
         #endregion
 
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(VsTestContext.P0_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void TestBasicSnippetsTab() {
             _vs.RunTest(nameof(PythonToolsUITests.SnippetsTests.TestBasicSnippetsTab));
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(VsTestContext.P0_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void TestPassSelected() {
             _vs.RunTest(nameof(PythonToolsUITests.SnippetsTests.TestPassSelected));
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(VsTestContext.P0_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void TestPassSelectedIndented() {
             _vs.RunTest(nameof(PythonToolsUITests.SnippetsTests.TestPassSelectedIndented));
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(VsTestContext.P0_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void TestSurroundWith() {
             _vs.RunTest(nameof(PythonToolsUITests.SnippetsTests.TestSurroundWith));
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(VsTestContext.P0_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void TestSurroundWithMultiline() {
             _vs.RunTest(nameof(PythonToolsUITests.SnippetsTests.TestSurroundWithMultiline));
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(VsTestContext.P0_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void TestInsertSnippet() {
             _vs.RunTest(nameof(PythonToolsUITests.SnippetsTests.TestInsertSnippet));
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(VsTestContext.P0_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void TestInsertSnippetEmptySelectionNonEmptyLine() {
             _vs.RunTest(nameof(PythonToolsUITests.SnippetsTests.TestInsertSnippetEmptySelectionNonEmptyLine));
@@ -109,7 +109,7 @@ namespace PythonToolsUITestsRunner {
         /// <summary>
         /// Starting a nested session should dismiss the initial session
         /// </summary>
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(VsTestContext.P0_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void TestNestedSession() {
             _vs.RunTest(nameof(PythonToolsUITests.SnippetsTests.TestNestedSession));

--- a/Python/Tests/PythonToolsUITestsRunner/SnippetsTests.cs
+++ b/Python/Tests/PythonToolsUITestsRunner/SnippetsTests.cs
@@ -82,25 +82,25 @@ namespace PythonToolsUITestsRunner {
             _vs.RunTest(nameof(PythonToolsUITests.SnippetsTests.TestInsertSnippetEmptySelectionNonEmptyLine));
         }
 
-        [TestMethod, Priority(2)]
+        [TestMethod, Priority(VsTestContext.P2_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void TestTestClassSnippet() {
             _vs.RunTest(nameof(PythonToolsUITests.SnippetsTests.TestTestClassSnippet));
         }
 
-        [TestMethod, Priority(2)]
+        [TestMethod, Priority(VsTestContext.P2_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void TestTestClassSnippetBadImport() {
             _vs.RunTest(nameof(PythonToolsUITests.SnippetsTests.TestTestClassSnippetBadImport));
         }
 
-        [TestMethod, Priority(2)]
+        [TestMethod, Priority(VsTestContext.P2_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void TestTestClassSnippetImportAs() {
             _vs.RunTest(nameof(PythonToolsUITests.SnippetsTests.TestTestClassSnippetImportAs));
         }
 
-        [TestMethod, Priority(2)]
+        [TestMethod, Priority(VsTestContext.P2_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void TestTestClassSnippetUnitTestImported() {
             _vs.RunTest(nameof(PythonToolsUITests.SnippetsTests.TestTestClassSnippetUnitTestImported));

--- a/Python/Tests/PythonToolsUITestsRunner/TestExplorerTests.cs
+++ b/Python/Tests/PythonToolsUITestsRunner/TestExplorerTests.cs
@@ -39,7 +39,7 @@ namespace PythonToolsUITestsRunner {
         public static void ClassCleanup() => VsTestContext.Instance.Dispose();
         #endregion
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(VsTestContext.P0_FAILING_UI_TEST)]
         [TestCategory("Installed")]
         public void RunAll() {
             _vs.RunTest(nameof(PythonToolsUITests.TestExplorerTests.RunAll));

--- a/Python/Tests/TestAdapterTests/TestDiscovererTests.cs
+++ b/Python/Tests/TestAdapterTests/TestDiscovererTests.cs
@@ -98,7 +98,7 @@ namespace TestAdapterTests {
             return TestAnalyzer.GetTestCasesFromAst(m, null);
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void DecoratedTests() {
             using (var analyzer = MakeTestAnalyzer()) {
                 var code = @"import unittest
@@ -186,7 +186,7 @@ class MyTest3(TestBase):
             }
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void TestCaseRunTests() {
             using (var analyzer = MakeTestAnalyzer()) {
                 var code = @"import unittest
@@ -213,7 +213,7 @@ class TestBase(unittest.TestCase):
         /// <summary>
         /// If we have test* and runTest we shouldn't discover runTest
         /// </summary>
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void TestCaseRunTestsWithTest() {
             using (var analyzer = MakeTestAnalyzer()) {
                 var code = @"import unittest

--- a/Python/Tests/TestAdapterTests/TestDiscovererTests.cs
+++ b/Python/Tests/TestAdapterTests/TestDiscovererTests.cs
@@ -138,7 +138,7 @@ class MyTest(unittest.TestCase):
             }
         }
 
-        [TestMethod, Priority(2)]
+        [TestMethod, Priority(TestExtensions.P2_FAILING_UNIT_TEST)]
         public void TestCaseSubclasses() {
             using (var analyzer = MakeTestAnalyzer()) {
                 var entry1 = AddModule(analyzer, "Pkg.SubPkg", @"import unittest

--- a/Python/Tests/TestAdapterTests/TestExecutorTests.cs
+++ b/Python/Tests/TestAdapterTests/TestExecutorTests.cs
@@ -219,7 +219,7 @@ namespace TestAdapterTests {
             )), testCases);
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         [TestCategory("10s")]
         public void TestRun() {
             var executor = new TestExecutor();

--- a/Python/Tests/TestAdapterTests/TestExecutorTests.cs
+++ b/Python/Tests/TestAdapterTests/TestExecutorTests.cs
@@ -612,7 +612,7 @@ namespace TestAdapterTests {
 
         protected override PythonVersion Version => PythonPaths.Python27 ?? PythonPaths.Python27_x64;
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         [TestCategory("10s")]
         public void TestExtensionReference() {
             // This test uses a 32-bit Python 2.7 .pyd

--- a/Python/Tests/TestRunnerInterop/VsTestContext.cs
+++ b/Python/Tests/TestRunnerInterop/VsTestContext.cs
@@ -22,6 +22,10 @@ using System.Threading;
 
 namespace TestRunnerInterop {
     public sealed class VsTestContext : IDisposable {
+        public const int P0_FAILING_UI_TEST = 12;
+        public const int P2_FAILING_UI_TEST = 22;
+        public const int P3_FAILING_UI_TEST = 32;
+
         private readonly string _testDataRoot;
         private VsInstance _vs;
         private string _devenvExe;

--- a/Python/Tests/VSInterpretersTests/VSInterpretersTests.cs
+++ b/Python/Tests/VSInterpretersTests/VSInterpretersTests.cs
@@ -99,7 +99,7 @@ namespace FactoryProviderSuccess {
             }
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void ProviderLoadLog_Success() {
             var path = FactoryProviderTypeLoadErrorPath;
 
@@ -183,7 +183,7 @@ namespace FactoryProviderSuccess {
             }
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void ProviderLoadLog_CorruptImage() {
             var catalogLog = new MockLogger();
 
@@ -245,7 +245,7 @@ namespace FactoryProviderTypeLoadException {
             }
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void ProviderLoadLog_TypeLoadException() {
             var path = FactoryProviderTypeLoadErrorPath;
 
@@ -277,7 +277,7 @@ namespace FactoryProviderTypeLoadException {
             Assert.IsNotNull(registry.Configurations.FirstOrDefault());
         }
 
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
         public void ProviderLoadLog_SuccessAndFailure() {
             var path = FactoryProviderTypeLoadErrorPath;
 


### PR DESCRIPTION
Fix #5355 

Changing the priorities on failing P0, P2, and P3 tests so they can be easily filtered out. 

Due to the unreliability of P2 and P3 tests, there may be some tests which are still failing but they not been filtered out. The primary purpose of this issue is to find and filter failing P0 tests. 

There may be some P0 UI tests that pass on a dev machine but fail on pipeline. They are being investigated. 