### PR TITLE
Add test window ouput logs for discovery command line variables 

### DIFF
--- a/Python/Product/TestAdapter.Executor/Services/DiscoveryService.cs
+++ b/Python/Product/TestAdapter.Executor/Services/DiscoveryService.cs
@@ -52,6 +52,11 @@ namespace Microsoft.PythonTools.TestAdapter.Services {
                     visible: false,
                     new StreamRedirector(writer)
                 )) {
+
+                    DebugInfo("cd " + projSettings.WorkingDirectory);
+                    DebugInfo("set " + projSettings.PathEnv + "=" + env[projSettings.PathEnv]);
+                    DebugInfo(proc.Arguments);
+
                     // If there's an error in the launcher script,
                     // it will terminate without connecting back.
                     WaitHandle.WaitAny(new WaitHandle[] { proc.WaitHandle });
@@ -112,6 +117,11 @@ namespace Microsoft.PythonTools.TestAdapter.Services {
                 paths.Where(Directory.Exists).Distinct(StringComparer.OrdinalIgnoreCase)
             );
             return searchPaths;
+        }
+
+        [Conditional("DEBUG")]
+        private void DebugInfo(string message) {
+            _logger.SendMessage(TestMessageLevel.Informational, message);
         }
 
         private void Error(string message) {


### PR DESCRIPTION
helps with debugging issues.  already have these logs in test execution.

![image](https://user-images.githubusercontent.com/1946977/61091704-fee23d00-a3f7-11e9-8802-b9ee548a0770.png)
