### PR TITLE
Add UI tests for pytest

### DIFF
--- a/Python/Tests/Core.UI/TestExplorerTests.cs
+++ b/Python/Tests/Core.UI/TestExplorerTests.cs
@@ -15,54 +15,172 @@
 // permissions and limitations under the License.
 
 using System;
+using System.IO;
 using System.Linq;
-using EnvDTE;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using TestUtilities;
+using TestUtilities.Python;
 using TestUtilities.UI;
 using TestUtilities.UI.Python;
 
 namespace PythonToolsUITests {
     public class TestExplorerTests {
-        public void RunAll(PythonVisualStudioApp app) {
-            var sln = app.CopyProjectForTest(@"TestData\TestExplorer.sln");
-            var project = app.OpenProject(sln);
+        private static TestInfo[] AllPytests = new TestInfo[] {
+            // test_pt.py
+            new TestInfo("test_pt_fail", "test_pt", "test_pt", "test_pt.py", 4, "Failed", "assert False"),
+            new TestInfo("test_pt_pass", "test_pt", "test_pt", "test_pt.py", 1, "Passed"),
+            new TestInfo("test_method_pass", "test_pt", "TestClassPT", "test_pt.py", 8, "Passed"),
 
+            // test_ut.py
+            new TestInfo("test_ut_fail", "test_ut", "TestClassUT", "test_ut.py", 4, "Failed", "AssertionError: Not implemented"),
+            new TestInfo("test_ut_pass", "test_ut", "TestClassUT", "test_ut.py", 7, "Passed"),
+
+            // test_mark.py
+            new TestInfo("test_webtest", "test_mark", "test_mark", "test_mark.py", 5, "Passed"),
+            new TestInfo("test_skip", "test_mark", "test_mark", "test_mark.py", 9, "Skipped", "skip unconditionally"),
+            new TestInfo("test_skipif_not_skipped", "test_mark", "test_mark", "test_mark.py", 17, "Passed"),
+            new TestInfo("test_skipif_skipped", "test_mark", "test_mark", "test_mark.py", 13, "Skipped", "skip VAL == 1"),
+
+            // test_fixture.py
+            new TestInfo("test_data[0]", "test_fixture", "test_fixture", "test_fixture.py", 7, "Passed"),
+            new TestInfo("test_data[1]", "test_fixture", "test_fixture", "test_fixture.py", 7, "Passed"),
+            new TestInfo("test_data[3]", "test_fixture", "test_fixture", "test_fixture.py", 7, "Failed", "assert 3 != 3"),
+        };
+
+        // TODO: when new unittest support is ready, reimplement this (and add test for workspace)
+        //public void RunAllUnittestProject(PythonVisualStudioApp app) {
+        //    var sln = app.CopyProjectForTest(@"TestData\TestExplorer.sln");
+        //    var project = app.OpenProject(sln);
+
+        //    var testExplorer = app.OpenTestExplorer();
+        //    Assert.IsNotNull(testExplorer, "Could not open test explorer");
+
+        //    testExplorer.GroupByProjectNamespaceClass();
+
+        //    var successTest = testExplorer.WaitForPythonTest("test1.py", "Test_test1", "test_success", PythonTestExplorer.TestState.NotRun);
+        //    var failedTest = testExplorer.WaitForPythonTest("test1.py", "Test_test1", "test_failure", PythonTestExplorer.TestState.NotRun);
+
+        //    Console.WriteLine("Running all tests");
+        //    testExplorer.RunAll(TimeSpan.FromSeconds(5));
+
+        //    successTest = testExplorer.WaitForPythonTest("test1.py", "Test_test1", "test_success", PythonTestExplorer.TestState.Passed);
+        //    failedTest = testExplorer.WaitForPythonTest("test1.py", "Test_test1", "test_failure", PythonTestExplorer.TestState.Failed);
+
+        //    failedTest.Select();
+        //    testExplorer.Summary.WaitForDetails("test_failure");
+
+        //    // Check the stack trace for helper() and test_failure() methods
+        //    var stack = testExplorer.Summary.StrackTraceList;
+        //    Assert.AreEqual(2, stack.Items.Count);
+        //    var frame0 = stack.GetFrame(0);
+        //    var frame1 = stack.GetFrame(1);
+        //    Assert.AreEqual("Test_test1.helper", frame0.Name);
+        //    Assert.AreEqual("Test_test1.test_failure", frame1.Name);
+
+        //    // Click on helper() method in call stack to navigate to code
+        //    Assert.IsNotNull(frame0.Hyperlink, "Link not found for helper() frame");
+        //    frame0.Hyperlink.Invoke();
+
+        //    // Validate that editor selection is in helper() method
+        //    var doc = app.Dte.ActiveDocument;
+        //    Assert.IsNotNull(doc, "Active document is null");
+        //    var selection = doc.Selection as TextSelection;
+        //    Assert.IsNotNull(selection, "Selection is null");
+        //    Assert.AreEqual("test1.py", doc.Name);
+        //    Assert.AreEqual(11, selection.CurrentLine);
+        //}
+
+        public void RunAllPytestProject(PythonVisualStudioApp app) {
+            var defaultSetter = new InterpreterWithPackageSetter(app.ServiceProvider, "pytest");
+            using (defaultSetter) {
+                var sln = app.CopyProjectForTest(@"TestData\TestExplorerPytest.sln");
+                var project = app.OpenProject(sln);
+
+                RunAllPytest(app);
+            }
+        }
+
+        public void RunAllPytestWorkspace(PythonVisualStudioApp app) {
+            var defaultSetter = new InterpreterWithPackageSetter(app.ServiceProvider, "pytest");
+            using (defaultSetter) {
+                // Create a workspace folder with pytest enabled and with the
+                // same set of test files used for the project-based test.
+                var workspaceFolderPath = Path.Combine(TestData.GetTempPath(), "TestExplorerPytest");
+                Directory.CreateDirectory(workspaceFolderPath);
+
+                var pythonSettingsJson = "{\"PyTestEnabled\": true,\"PyTestPath\": \"pytest\"}";
+                File.WriteAllText(Path.Combine(workspaceFolderPath, "PythonSettings.json"), pythonSettingsJson);
+
+                var sourceProjectFolderPath = TestData.GetPath("TestData", "TestExplorerPytest");
+                foreach (var filePath in Directory.GetFiles(sourceProjectFolderPath, "*.py")) {
+                    var destFilePath = Path.Combine(workspaceFolderPath, Path.GetFileName(filePath));
+                    File.Copy(filePath, destFilePath, true);
+                }
+
+                app.OpenFolder(workspaceFolderPath);
+
+                RunAllPytest(app);
+            }
+        }
+
+        private static void RunAllPytest(PythonVisualStudioApp app) {
             var testExplorer = app.OpenTestExplorer();
             Assert.IsNotNull(testExplorer, "Could not open test explorer");
 
-            testExplorer.GroupByNamespace();
+            Console.WriteLine("Waiting for tests discovery");
+            app.WaitForOutputWindowText("Tests", "Discovery finished: 12 tests found", 15_000);
 
-            var successTest = testExplorer.WaitForPythonTest("test1.py", "Test_test1", "test_success", PythonTestExplorer.TestState.NotRun);
-            var failedTest = testExplorer.WaitForPythonTest("test1.py", "Test_test1", "test_failure", PythonTestExplorer.TestState.NotRun);
+            testExplorer.GroupByProjectNamespaceClass();
+
+            foreach (var test in AllPytests) {
+                var item = testExplorer.WaitForItem(test.Path);
+                Assert.IsNotNull(item, $"Coult not find {string.Join(":", test.Path)}");
+            }
 
             Console.WriteLine("Running all tests");
-            testExplorer.RunAll(TimeSpan.FromSeconds(5));
+            testExplorer.RunAll(TimeSpan.FromSeconds(10));
+            app.WaitForOutputWindowText("Tests", "Run finished: 12 tests run", 10_000);
 
-            successTest = testExplorer.WaitForPythonTest("test1.py", "Test_test1", "test_success", PythonTestExplorer.TestState.Passed);
-            failedTest = testExplorer.WaitForPythonTest("test1.py", "Test_test1", "test_failure", PythonTestExplorer.TestState.Failed);
+            foreach (var test in AllPytests) {
+                var item = testExplorer.WaitForItem(test.Path);
+                Assert.IsNotNull(item, $"Coult not find {string.Join(":", test.Path)}");
 
-            failedTest.Select();
-            testExplorer.Summary.WaitForDetails("test_failure");
+                item.Select();
+                item.SetFocus();
 
-            // Check the stack trace for helper() and test_failure() methods
-            var stack = testExplorer.Summary.StrackTraceList;
-            Assert.AreEqual(2, stack.Items.Count);
-            var frame0 = stack.GetFrame(0);
-            var frame1 = stack.GetFrame(1);
-            Assert.AreEqual("Test_test1.helper", frame0.Name);
-            Assert.AreEqual("Test_test1.test_failure", frame1.Name);
+                var details = testExplorer.GetDetailsWithRetry();
 
-            // Click on helper() method in call stack to navigate to code
-            Assert.IsNotNull(frame0.Hyperlink, "Link not found for helper() frame");
-            frame0.Hyperlink.Invoke();
+                AssertUtil.Contains(details, $"Test Name:	{test.Name}");
+                AssertUtil.Contains(details, $"Test Outcome:	{test.Outcome}");
+                AssertUtil.Contains(details, $"{test.SourceFile} : line {test.SourceLine}");
 
-            // Validate that editor selection is in helper() method
-            var doc = app.Dte.ActiveDocument;
-            Assert.IsNotNull(doc, "Active document is null");
-            var selection = doc.Selection as TextSelection;
-            Assert.IsNotNull(selection, "Selection is null");
-            Assert.AreEqual("test1.py", doc.Name);
-            Assert.AreEqual(11, selection.CurrentLine);
+                if (test.ResultMessage != null) {
+                    AssertUtil.Contains(details, $"Result Message:	{test.ResultMessage}");
+                }
+            }
+        }
+
+        class TestInfo {
+            public TestInfo(string name, string project, string classOrModule, string sourceFile, int sourceLine, string outcome, string resultMessage = null) {
+                Name = name;
+                Project = project;
+                ClassOrModule = classOrModule;
+                SourceFile = sourceFile;
+                SourceLine = sourceLine;
+                Outcome = outcome;
+                ResultMessage = resultMessage;
+
+                Path = new string[] { Project, SourceFile, ClassOrModule, Name };
+            }
+
+            public string Name { get; }
+            public string Project { get; }
+            public string ClassOrModule { get; }
+            public string SourceFile { get; }
+            public int SourceLine { get; }
+            public string Outcome { get; }
+            public string ResultMessage { get; }
+            public string[] Path { get; }
         }
     }
 }

--- a/Python/Tests/PythonToolsUITestsRunner/TestExplorerTests.cs
+++ b/Python/Tests/PythonToolsUITestsRunner/TestExplorerTests.cs
@@ -39,10 +39,22 @@ namespace PythonToolsUITestsRunner {
         public static void ClassCleanup() => VsTestContext.Instance.Dispose();
         #endregion
 
-        [TestMethod, Priority(VsTestContext.P0_FAILING_UI_TEST)]
+        //[TestMethod, Priority(VsTestContext.P0_FAILING_UI_TEST)]
+        //[TestCategory("Installed")]
+        //public void RunAllUnittestProject() {
+        //    _vs.RunTest(nameof(PythonToolsUITests.TestExplorerTests.RunAllUnittestProject));
+        //}
+
+        [TestMethod, Priority(0)]
         [TestCategory("Installed")]
-        public void RunAll() {
-            _vs.RunTest(nameof(PythonToolsUITests.TestExplorerTests.RunAll));
+        public void RunAllPytestProject() {
+            _vs.RunTest(nameof(PythonToolsUITests.TestExplorerTests.RunAllPytestProject));
+        }
+
+        [TestMethod, Priority(0)]
+        [TestCategory("Installed")]
+        public void RunAllPytestWorkspace() {
+            _vs.RunTest(nameof(PythonToolsUITests.TestExplorerTests.RunAllPytestWorkspace));
         }
     }
 }

--- a/Python/Tests/TestData/TestExplorerPytest.sln
+++ b/Python/Tests/TestData/TestExplorerPytest.sln
@@ -1,0 +1,23 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29109.77
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{888888A0-9F3D-457C-B088-3A5042F75D52}") = "TestExplorerPytest", "TestExplorerPytest\TestExplorerPytest.pyproj", "{74C7265E-E4ED-4F27-8384-3CA6E36603D9}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{74C7265E-E4ED-4F27-8384-3CA6E36603D9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{74C7265E-E4ED-4F27-8384-3CA6E36603D9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {AC7A18AE-6972-4CB7-8709-2B7AAE3B7814}
+	EndGlobalSection
+EndGlobal

--- a/Python/Tests/TestData/TestExplorerPytest/TestExplorerPytest.pyproj
+++ b/Python/Tests/TestData/TestExplorerPytest/TestExplorerPytest.pyproj
@@ -1,0 +1,42 @@
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>74c7265e-e4ed-4f27-8384-3ca6e36603d9</ProjectGuid>
+    <ProjectHome>.</ProjectHome>
+    <StartupFile>
+    </StartupFile>
+    <SearchPath>
+    </SearchPath>
+    <WorkingDirectory>.</WorkingDirectory>
+    <OutputPath>.</OutputPath>
+    <Name>TestExplorerPytest</Name>
+    <RootNamespace>TestExplorerPytest</RootNamespace>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
+    <DebugSymbols>true</DebugSymbols>
+    <EnableUnmanagedDebugging>false</EnableUnmanagedDebugging>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+    <DebugSymbols>true</DebugSymbols>
+    <EnableUnmanagedDebugging>false</EnableUnmanagedDebugging>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="test_ut.py" />
+    <Compile Include="test_pt.py" />
+    <Compile Include="test_fixture.py" />
+    <Compile Include="test_mark.py" />
+  </ItemGroup>
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\Python Tools\Microsoft.PythonTools.targets" />
+  <PropertyGroup>
+    <PyTestEnabled>True</PyTestEnabled>
+  </PropertyGroup>
+  <!-- Uncomment the CoreCompile target to enable the Build command in
+       Visual Studio and specify your pre- and post-build commands in
+       the BeforeBuild and AfterBuild targets below. -->
+  <!--<Target Name="CoreCompile" />-->
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+</Project>

--- a/Python/Tests/TestData/TestExplorerPytest/test_fixture.py
+++ b/Python/Tests/TestData/TestExplorerPytest/test_fixture.py
@@ -1,0 +1,8 @@
+import pytest
+
+@pytest.fixture(params=[0, 1, 3])
+def data_set(request):
+    return request.param
+
+def test_data(data_set):
+    assert data_set != 3

--- a/Python/Tests/TestData/TestExplorerPytest/test_mark.py
+++ b/Python/Tests/TestData/TestExplorerPytest/test_mark.py
@@ -1,0 +1,19 @@
+import pytest
+
+VAL = 1 
+
+@pytest.mark.webtest
+def test_webtest():
+    pass
+
+@pytest.mark.skip(reason="skip unconditionally")
+def test_skip():
+    pass
+
+@pytest.mark.skipif(VAL == 1, reason="skip VAL == 1")
+def test_skipif_skipped():
+    pass
+
+@pytest.mark.skipif(VAL == 0, reason="skip VAL == 0")
+def test_skipif_not_skipped():
+    pass

--- a/Python/Tests/TestData/TestExplorerPytest/test_pt.py
+++ b/Python/Tests/TestData/TestExplorerPytest/test_pt.py
@@ -1,0 +1,9 @@
+def test_pt_pass():
+    assert True
+
+def test_pt_fail():
+    assert False
+
+class TestClassPT(object):
+    def test_method_pass(self):
+        pass

--- a/Python/Tests/TestData/TestExplorerPytest/test_ut.py
+++ b/Python/Tests/TestData/TestExplorerPytest/test_ut.py
@@ -1,0 +1,11 @@
+import unittest
+
+class TestClassUT(unittest.TestCase):
+    def test_ut_fail(self):
+        self.fail("Not implemented")
+
+    def test_ut_pass(self):
+        pass
+
+if __name__ == '__main__':
+    unittest.main()

--- a/Python/Tests/Utilities.Python/PythonTestExplorerGridView.cs
+++ b/Python/Tests/Utilities.Python/PythonTestExplorerGridView.cs
@@ -1,0 +1,99 @@
+﻿// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Windows.Automation;
+
+namespace TestUtilities.UI {
+    public class PythonTestExplorerGridView : ListView {
+        public PythonTestExplorerGridView(AutomationElement element) : base(element) { }
+
+        /// <summary>
+        /// Waits for the item in the tree to be available for up to a specified timeout.
+        /// </summary>
+        protected AutomationElement WaitForItemHelper(Func<string[], AutomationElement> getItem, string[] path, TimeSpan timeout) {
+            AutomationElement item = null;
+            var stopWatch = new Stopwatch();
+            stopWatch.Start();
+            while (stopWatch.Elapsed < timeout) {
+                item = getItem(path);
+                if (item != null) {
+                    break;
+                }
+                Thread.Sleep(250);
+            }
+
+            if (item == null) {
+                Console.WriteLine("Failed to find {0} within {1} ms", String.Join("\\", path), timeout.TotalMilliseconds);
+                DumpElement(Element);
+            }
+            return item;
+        }
+
+        /// <summary>
+        /// Waits for the item in the tree to be available for up to 10 seconds.
+        /// </summary>
+        public AutomationElement WaitForItem(params string[] path) {
+            return WaitForItemHelper(FindItem, path);
+        }
+
+        protected AutomationElement WaitForItemHelper(Func<string[], AutomationElement> getItem, string[] path) {
+            return WaitForItemHelper(getItem, path, TimeSpan.FromSeconds(10));
+        }
+
+        public void CollapseAll() {
+            foreach (AutomationElement child in Element.FindAll(TreeScope.Children, Condition.TrueCondition)) {
+                if (child.TryGetCurrentPattern(ExpandCollapsePattern.Pattern, out var pattern)) {
+                    ((ExpandCollapsePattern)pattern).Collapse();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Finds the specified item in the tree and returns it.
+        /// </summary>
+        /// <param name="path"></param>
+        /// <returns></returns>
+        public AutomationElement FindItem(params string[] path) {
+            return FindNode(Element.FindAll(TreeScope.Children, Condition.TrueCondition), path, 0);
+        }
+
+        protected static AutomationElement FindNode(AutomationElementCollection nodes, string[] splitPath, int depth) {
+            for (int i = 0; i < nodes.Count; i++) {
+                var node = nodes[i];
+                var name = node.GetCurrentPropertyValue(AutomationElement.NameProperty) as string;
+
+                if (name.Equals(splitPath[depth], StringComparison.CurrentCulture)) {
+                    if (depth == splitPath.Length - 1) {
+                        return node;
+                    }
+
+                    // ensure the node is expanded...
+                    try {
+                        EnsureExpanded(node);
+                    } catch (InvalidOperationException) {
+                        // handle race w/ items being removed...
+                        Console.WriteLine("Failed to expand {0}", splitPath[depth]);
+                    }
+                    return FindNode(node.FindAll(TreeScope.Children, Condition.TrueCondition), splitPath, depth + 1);
+                }
+            }
+            return null;
+        }
+    }
+}

--- a/Python/Tests/Utilities.Python/TestUtilities.Python.csproj
+++ b/Python/Tests/Utilities.Python/TestUtilities.Python.csproj
@@ -137,6 +137,7 @@
     <Compile Include="PythonProjectGenerator.cs" />
     <Compile Include="PythonProjectProcessor.cs" />
     <Compile Include="PythonTestDefinitions.cs" />
+    <Compile Include="PythonTestExplorerGridView.cs" />
     <Compile Include="PythonToolsOptionsImporter.cs" />
     <Compile Include="PythonToolsTestUtilities.cs" />
     <Compile Include="EditorWindowExtensions.cs" />


### PR DESCRIPTION
Fix #5400 

Add end-to-end test for both project and workspace scenarios.

I've commented out the old one for unittest, we can work on that when support is ready. I filed a separate issue for it https://github.com/microsoft/PTVS/issues/5431

Note that the test relies on grouping to be set to Project, Namespace, Class. Unfortunately, I can't change it via automation. It's the default, so unless you've changed it at some point, it should work.
