### PR TITLE
Bschnurr/unittest discovery

### DIFF
--- a/Python/Product/PythonTools/PythonConstants.cs
+++ b/Python/Product/PythonTools/PythonConstants.cs
@@ -125,9 +125,15 @@ namespace Microsoft.PythonTools {
         public const string PyTestEnabledSetting = "PyTestEnabled";
         public const string PyTestPathSetting = "PyTestPath";
         public const string PyTestArgsSetting = "PyTestArgs";
+        public const string UnitTestArgsSetting = "UnitTestArgs";
+        public const string TestframeworkSetting = "TestFramework";
 
 
-
+        public enum TestframeworkType {
+            None = 0,
+            Pytest = 1,
+            UnitTest = 2
+        }
         /// <summary>
         /// Specifies port to which to open web browser on launch.
         /// </summary>

--- a/Python/Product/PythonTools/PythonConstants.cs
+++ b/Python/Product/PythonTools/PythonConstants.cs
@@ -17,6 +17,12 @@
 using System;
 
 namespace Microsoft.PythonTools {
+    public enum TestFrameworkType {
+        None = 0,
+        Pytest = 1,
+        UnitTest = 2
+    }
+
     static class PythonConstants {
         //Language name
         public const string LanguageName = "Python";
@@ -126,14 +132,8 @@ namespace Microsoft.PythonTools {
         public const string PyTestPathSetting = "PyTestPath";
         public const string PyTestArgsSetting = "PyTestArgs";
         public const string UnitTestArgsSetting = "UnitTestArgs";
-        public const string TestframeworkSetting = "TestFramework";
+        public const string TestFrameworkSetting = "TestFramework";
 
-
-        public enum TestframeworkType {
-            None = 0,
-            Pytest = 1,
-            UnitTest = 2
-        }
         /// <summary>
         /// Specifies port to which to open web browser on launch.
         /// </summary>
@@ -181,6 +181,7 @@ namespace Microsoft.PythonTools {
         public const string DontShowUpgradeDialogAgainCollection = "PythonTools\\Dialogs";
 
         internal const string PythonToolsProcessIdEnvironmentVariable = "_PTVS_PID";
+        internal const string UnitTestExecutorUriString = "executor://PythonUnitTestExecutor/v1";
         internal const string TestExecutorUriString = "executor://PythonTestExecutor/v1";
         internal const string WSTestExecutorUriString = "executor://PythonWorkspaceTestExecutor/v1";
         

--- a/Python/Product/PythonTools/PythonTools/Project/PythonTestPropertyPageControl.Designer.cs
+++ b/Python/Product/PythonTools/PythonTools/Project/PythonTestPropertyPageControl.Designer.cs
@@ -30,6 +30,9 @@ namespace Microsoft.PythonTools.Project {
             this._unitTestArgs = new System.Windows.Forms.TextBox();
             this._testFrameworkLabel = new System.Windows.Forms.Label();
             this._testFramework = new System.Windows.Forms.ComboBox();
+            this.label1 = new System.Windows.Forms.Label();
+            this._unitTestPattern = new System.Windows.Forms.TextBox();
+            this._mixedMode = new System.Windows.Forms.CheckBox();
             this.tableLayoutPanel1.SuspendLayout();
             this.tableLayoutPanel.SuspendLayout();
             this.SuspendLayout();
@@ -43,11 +46,15 @@ namespace Microsoft.PythonTools.Project {
             // tableLayoutPanel
             // 
             resources.ApplyResources(this.tableLayoutPanel, "tableLayoutPanel");
+            this.tableLayoutPanel.Controls.Add(this.label1, 0, 5);
             this.tableLayoutPanel.Controls.Add(this._unitTestArgsLabel, 0, 1);
             this.tableLayoutPanel.Controls.Add(this._unitTestArgs, 1, 1);
             this.tableLayoutPanel.Controls.Add(this._testFrameworkLabel, 0, 0);
             this.tableLayoutPanel.Controls.Add(this._testFramework, 1, 0);
+            this.tableLayoutPanel.Controls.Add(this._unitTestPattern, 1, 5);
+            this.tableLayoutPanel.Controls.Add(this._mixedMode, 0, 6);
             this.tableLayoutPanel.Name = "tableLayoutPanel";
+            this.tableLayoutPanel.Paint += new System.Windows.Forms.PaintEventHandler(this.TableLayoutPanel_Paint);
             // 
             // _unitTestArgsLabel
             // 
@@ -77,7 +84,25 @@ namespace Microsoft.PythonTools.Project {
             resources.GetString("_testFramework.Items1"),
             resources.GetString("_testFramework.Items2")});
             this._testFramework.Name = "_testFramework";
-            this._testFramework.SelectedIndexChanged += new System.EventHandler(this.TestFrameworkSelectedIndexChanged);             // 
+            this._testFramework.SelectedIndexChanged += new System.EventHandler(this.TestFrameworkSelectedIndexChanged);
+            // 
+            // label1
+            // 
+            resources.ApplyResources(this.label1, "label1");
+            this.label1.AutoEllipsis = true;
+            this.label1.Name = "label1";
+            // 
+            // _unitTestPattern
+            // 
+            resources.ApplyResources(this._unitTestPattern, "_unitTestPattern");
+            this._unitTestPattern.Name = "_unitTestPattern";
+            // 
+            // _mixedMode
+            // 
+            resources.ApplyResources(this._mixedMode, "_mixedMode");
+            this._mixedMode.Name = "_mixedMode";
+            this._mixedMode.UseVisualStyleBackColor = true;
+            // 
             // PythonTestPropertyPageControl
             // 
             resources.ApplyResources(this, "$this");
@@ -100,5 +125,8 @@ namespace Microsoft.PythonTools.Project {
         private System.Windows.Forms.TextBox _unitTestArgs;
         private System.Windows.Forms.Label _testFrameworkLabel;
         private System.Windows.Forms.ComboBox _testFramework;
+        private System.Windows.Forms.Label label1;
+        private System.Windows.Forms.TextBox _unitTestPattern;
+        private System.Windows.Forms.CheckBox _mixedMode;
     }
 }

--- a/Python/Product/PythonTools/PythonTools/Project/PythonTestPropertyPageControl.Designer.cs
+++ b/Python/Product/PythonTools/PythonTools/Project/PythonTestPropertyPageControl.Designer.cs
@@ -24,102 +24,81 @@ namespace Microsoft.PythonTools.Project {
         /// </summary>
         private void InitializeComponent() {
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(PythonTestPropertyPageControl));
-            this._pytestGroup = new System.Windows.Forms.GroupBox();
-            this.tableLayoutPanel2 = new System.Windows.Forms.TableLayoutPanel();
-            this._pytestPathLabel = new System.Windows.Forms.Label();
-            this._pytestPath = new System.Windows.Forms.TextBox();
-            this._argumentsLabel = new System.Windows.Forms.Label();
-            this._arguments = new System.Windows.Forms.TextBox();
-            this._pytestEnabled = new System.Windows.Forms.CheckBox();
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
-            this._pytestGroup.SuspendLayout();
-            this.tableLayoutPanel2.SuspendLayout();
+            this.tableLayoutPanel = new System.Windows.Forms.TableLayoutPanel();
+            this._unitTestArgsLabel = new System.Windows.Forms.Label();
+            this._unitTestArgs = new System.Windows.Forms.TextBox();
+            this._testFrameworkLabel = new System.Windows.Forms.Label();
+            this._testFramework = new System.Windows.Forms.ComboBox();
             this.tableLayoutPanel1.SuspendLayout();
+            this.tableLayoutPanel.SuspendLayout();
             this.SuspendLayout();
-            // 
-            // _pytestGroup
-            // 
-            resources.ApplyResources(this._pytestGroup, "_pytestGroup");
-            this._pytestGroup.Controls.Add(this.tableLayoutPanel2);
-            this._pytestGroup.Name = "_pytestGroup";
-            this._pytestGroup.TabStop = false;
-            this._pytestGroup.Enter += new System.EventHandler(this._applicationGroup_Enter);
-            // 
-            // tableLayoutPanel2
-            // 
-            resources.ApplyResources(this.tableLayoutPanel2, "tableLayoutPanel2");
-            this.tableLayoutPanel2.Controls.Add(this._pytestPath, 1, 0);
-            this.tableLayoutPanel2.Controls.Add(this._pytestPathLabel, 0, 0);
-            this.tableLayoutPanel2.Controls.Add(this._argumentsLabel, 0, 1);
-            this.tableLayoutPanel2.Controls.Add(this._arguments, 1, 1);
-            this.tableLayoutPanel2.Controls.Add(this._pytestEnabled, 0, 2);
-            this.tableLayoutPanel2.Name = "tableLayoutPanel2";
-            this.tableLayoutPanel2.Paint += new System.Windows.Forms.PaintEventHandler(this.TableLayoutPanel2_Paint);
-            // 
-            // _pytestPathLabel
-            // 
-            resources.ApplyResources(this._pytestPathLabel, "_pytestPathLabel");
-            this._pytestPathLabel.AutoEllipsis = true;
-            this._pytestPathLabel.Name = "_pytestPathLabel";
-            // 
-            // _pytestPath
-            // 
-            resources.ApplyResources(this._pytestPath, "_pytestPath");
-            this._pytestPath.Name = "_pytestPath";
-            this._pytestPath.TextChanged += new System.EventHandler(this.Changed);
-            // 
-            // _argumentsLabel
-            // 
-            resources.ApplyResources(this._argumentsLabel, "_argumentsLabel");
-            this._argumentsLabel.AutoEllipsis = true;
-            this._argumentsLabel.Name = "_argumentsLabel";
-            // 
-            // _arguments
-            // 
-            resources.ApplyResources(this._arguments, "_arguments");
-            this._arguments.Name = "_arguments";
-            this._arguments.TextChanged += new System.EventHandler(this.Changed);
-            // 
-            // _pytestEnabled
-            // 
-            resources.ApplyResources(this._pytestEnabled, "_pytestEnabled");
-            this.tableLayoutPanel2.SetColumnSpan(this._pytestEnabled, 2);
-            this._pytestEnabled.Name = "_pytestEnabled";
-            this._pytestEnabled.UseVisualStyleBackColor = true;
-            this._pytestEnabled.CheckedChanged += new System.EventHandler(this.Changed);
             // 
             // tableLayoutPanel1
             // 
             resources.ApplyResources(this.tableLayoutPanel1, "tableLayoutPanel1");
-            this.tableLayoutPanel1.Controls.Add(this._pytestGroup, 0, 0);
+            this.tableLayoutPanel1.Controls.Add(this.tableLayoutPanel, 0, 0);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
             // 
+            // tableLayoutPanel
+            // 
+            resources.ApplyResources(this.tableLayoutPanel, "tableLayoutPanel");
+            this.tableLayoutPanel.Controls.Add(this._unitTestArgsLabel, 0, 1);
+            this.tableLayoutPanel.Controls.Add(this._unitTestArgs, 1, 1);
+            this.tableLayoutPanel.Controls.Add(this._testFrameworkLabel, 0, 0);
+            this.tableLayoutPanel.Controls.Add(this._testFramework, 1, 0);
+            this.tableLayoutPanel.Name = "tableLayoutPanel";
+            // 
+            // _unitTestArgsLabel
+            // 
+            resources.ApplyResources(this._unitTestArgsLabel, "_unitTestArgsLabel");
+            this._unitTestArgsLabel.AutoEllipsis = true;
+            this._unitTestArgsLabel.Name = "_unitTestArgsLabel";
+            // 
+            // _unitTestArgs
+            // 
+            resources.ApplyResources(this._unitTestArgs, "_unitTestArgs");
+            this._unitTestArgs.Name = "_unitTestArgs";
+            this._unitTestArgs.TextChanged += new System.EventHandler(this.Changed);
+            // 
+            // _testFrameworkLabel
+            // 
+            resources.ApplyResources(this._testFrameworkLabel, "_testFrameworkLabel");
+            this._testFrameworkLabel.AutoEllipsis = true;
+            this._testFrameworkLabel.Name = "_testFrameworkLabel";
+            // 
+            // _testFramework
+            // 
+            resources.ApplyResources(this._testFramework, "_testFramework");
+            this._testFramework.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this._testFramework.FormattingEnabled = true;
+            this._testFramework.Items.AddRange(new object[] {
+            resources.GetString("_testFramework.Items"),
+            resources.GetString("_testFramework.Items1"),
+            resources.GetString("_testFramework.Items2")});
+            this._testFramework.Name = "_testFramework";
+            this._testFramework.SelectedIndexChanged += new System.EventHandler(this.TestFrameworkSelectedIndexChanged);             // 
             // PythonTestPropertyPageControl
             // 
             resources.ApplyResources(this, "$this");
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.Controls.Add(this.tableLayoutPanel1);
             this.Name = "PythonTestPropertyPageControl";
-            this._pytestGroup.ResumeLayout(false);
-            this._pytestGroup.PerformLayout();
-            this.tableLayoutPanel2.ResumeLayout(false);
-            this.tableLayoutPanel2.PerformLayout();
             this.tableLayoutPanel1.ResumeLayout(false);
             this.tableLayoutPanel1.PerformLayout();
+            this.tableLayoutPanel.ResumeLayout(false);
+            this.tableLayoutPanel.PerformLayout();
             this.ResumeLayout(false);
             this.PerformLayout();
 
         }
 
         #endregion
-
-        private System.Windows.Forms.GroupBox _pytestGroup;
-        private System.Windows.Forms.Label _pytestPathLabel;
-        private System.Windows.Forms.TextBox _pytestPath;
-        private System.Windows.Forms.TextBox _arguments;
-        private System.Windows.Forms.Label _argumentsLabel;
-        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel2;
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
-        private System.Windows.Forms.CheckBox _pytestEnabled;
+        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel;
+        private System.Windows.Forms.Label _unitTestArgsLabel;
+        private System.Windows.Forms.TextBox _unitTestArgs;
+        private System.Windows.Forms.Label _testFrameworkLabel;
+        private System.Windows.Forms.ComboBox _testFramework;
     }
 }

--- a/Python/Product/PythonTools/PythonTools/Project/PythonTestPropertyPageControl.cs
+++ b/Python/Product/PythonTools/PythonTools/Project/PythonTestPropertyPageControl.cs
@@ -41,9 +41,9 @@ namespace Microsoft.PythonTools.Project {
             _service = _propPage.Project.Site.GetComponentModel().GetService<IInterpreterRegistryService>();
 
             UnitTestArgs = _propPage.Project.GetProjectProperty(PythonConstants.UnitTestArgsSetting, false);
-            string testFrameworkStr = _propPage.Project.GetProjectProperty(PythonConstants.TestframeworkSetting, false);
-            TestFramework = PythonConstants.TestframeworkType.None; 
-            if(Enum.TryParse<PythonConstants.TestframeworkType>(testFrameworkStr, out PythonConstants.TestframeworkType parsedFramworked)) {
+            string testFrameworkStr = _propPage.Project.GetProjectProperty(PythonConstants.TestFrameworkSetting, false);
+            TestFramework = TestFrameworkType.None; 
+            if(Enum.TryParse<TestFrameworkType>(testFrameworkStr, ignoreCase:true, out TestFrameworkType parsedFramworked)) {
                 TestFramework = parsedFramworked;
             }
         }
@@ -52,13 +52,13 @@ namespace Microsoft.PythonTools.Project {
             _service = _propPage.Project.Site.GetComponentModel().GetService<IInterpreterRegistryService>();
 
             _propPage.Project.SetProjectProperty(PythonConstants.UnitTestArgsSetting, UnitTestArgs);
-            _propPage.Project.SetProjectProperty(PythonConstants.TestframeworkSetting, TestFramework.ToString());
+            _propPage.Project.SetProjectProperty(PythonConstants.TestFrameworkSetting, TestFramework.ToString());
         }
 
 
-        internal PythonConstants.TestframeworkType TestFramework {
+        internal TestFrameworkType TestFramework {
             get {
-                return (PythonConstants.TestframeworkType)_testFramework.SelectedIndex;
+                return (TestFrameworkType)_testFramework.SelectedIndex;
             }
             set {
                 _testFramework.SelectedIndex = (int)value;
@@ -79,8 +79,8 @@ namespace Microsoft.PythonTools.Project {
             UpdateLayout(TestFramework);
         }
 
-        private void UpdateLayout(PythonConstants.TestframeworkType framework) {
-            if (framework == PythonConstants.TestframeworkType.UnitTest) {
+        private void UpdateLayout(TestFrameworkType framework) {
+            if (framework == TestFrameworkType.UnitTest) {
                 _unitTestArgs.Visible = true;
                 _unitTestArgsLabel.Visible = true;
             } else {

--- a/Python/Product/PythonTools/PythonTools/Project/PythonTestPropertyPageControl.cs
+++ b/Python/Product/PythonTools/PythonTools/Project/PythonTestPropertyPageControl.cs
@@ -37,51 +37,57 @@ namespace Microsoft.PythonTools.Project {
             _propPage = newPage;
         }
 
-        
-        internal void SaveSettings() {
-            _service = _propPage.Project.Site.GetComponentModel().GetService<IInterpreterRegistryService>();
-           
-            _propPage.Project.SetProjectProperty(PythonConstants.PyTestArgsSetting, PytestArgs);
-            _propPage.Project.SetProjectProperty(PythonConstants.PyTestPathSetting, PytestPath);
-            _propPage.Project.SetProjectProperty(PythonConstants.PyTestEnabledSetting, PytestEnabled.ToString());
-        }
-
         internal void LoadSettings() {
             _service = _propPage.Project.Site.GetComponentModel().GetService<IInterpreterRegistryService>();
-           
-            PytestArgs = _propPage.Project.GetProjectProperty(PythonConstants.PyTestArgsSetting, false);
-            PytestPath = _propPage.Project.GetProjectProperty(PythonConstants.PyTestPathSetting, false);
-            if (string.IsNullOrEmpty(PytestPath)) {
-                PytestPath = "pytest";
+
+            UnitTestArgs = _propPage.Project.GetProjectProperty(PythonConstants.UnitTestArgsSetting, false);
+            string testFrameworkStr = _propPage.Project.GetProjectProperty(PythonConstants.TestframeworkSetting, false);
+            TestFramework = PythonConstants.TestframeworkType.None; 
+            if(Enum.TryParse<PythonConstants.TestframeworkType>(testFrameworkStr, out PythonConstants.TestframeworkType parsedFramworked)) {
+                TestFramework = parsedFramworked;
             }
-            PytestEnabled = Convert.ToBoolean(_propPage.Project.GetProjectProperty(PythonConstants.PyTestEnabledSetting, false));
         }
 
-        public string PytestPath {
-            get { return _pytestPath.Text; }
-            set { _pytestPath.Text = value; }
+        internal void SaveSettings() {
+            _service = _propPage.Project.Site.GetComponentModel().GetService<IInterpreterRegistryService>();
+
+            _propPage.Project.SetProjectProperty(PythonConstants.UnitTestArgsSetting, UnitTestArgs);
+            _propPage.Project.SetProjectProperty(PythonConstants.TestframeworkSetting, TestFramework.ToString());
         }
 
-        public string PytestArgs {
-            get { return _arguments.Text; }
-            set { _arguments.Text = value; }
+
+        internal PythonConstants.TestframeworkType TestFramework {
+            get {
+                return (PythonConstants.TestframeworkType)_testFramework.SelectedIndex;
+            }
+            set {
+                _testFramework.SelectedIndex = (int)value;
+            }
         }
 
-        public bool PytestEnabled {
-            get { return _pytestEnabled.Checked; }
-            set { _pytestEnabled.Checked = value; }
+        public string UnitTestArgs {
+            get { return _unitTestArgs.Text; }
+            set { _unitTestArgs.Text = value; }
         }
 
         private void Changed(object sender, EventArgs e) {
             _propPage.IsDirty = true;
         }
 
-        private void TableLayoutPanel2_Paint(object sender, PaintEventArgs e) {
-
+        private void TestFrameworkSelectedIndexChanged(object sender, EventArgs e) {
+            _propPage.IsDirty = true;
+            UpdateLayout(TestFramework);
         }
 
-        private void _applicationGroup_Enter(object sender, EventArgs e) {
-
+        private void UpdateLayout(PythonConstants.TestframeworkType framework) {
+            if (framework == PythonConstants.TestframeworkType.UnitTest) {
+                _unitTestArgs.Visible = true;
+                _unitTestArgsLabel.Visible = true;
+            } else {
+                _unitTestArgs.Visible = false;
+                _unitTestArgsLabel.Visible = false;
+            }
         }
+
     }
 }

--- a/Python/Product/PythonTools/PythonTools/Project/PythonTestPropertyPageControl.cs
+++ b/Python/Product/PythonTools/PythonTools/Project/PythonTestPropertyPageControl.cs
@@ -89,5 +89,8 @@ namespace Microsoft.PythonTools.Project {
             }
         }
 
+        private void TableLayoutPanel_Paint(object sender, PaintEventArgs e) {
+
+        }
     }
 }

--- a/Python/Product/PythonTools/PythonTools/Project/PythonTestPropertyPageControl.resx
+++ b/Python/Product/PythonTools/PythonTools/Project/PythonTestPropertyPageControl.resx
@@ -118,259 +118,199 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="_pytestGroup.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="_pytestGroup.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
-    <value>GrowAndShrink</value>
-  </data>
-  <data name="tableLayoutPanel2.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="tableLayoutPanel2.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
-    <value>GrowAndShrink</value>
-  </data>
-  <data name="tableLayoutPanel2.ColumnCount" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="_pytestPath.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Left, Right</value>
-  </data>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-  <data name="_pytestPath.Location" type="System.Drawing.Point, System.Drawing">
-    <value>117, 3</value>
-  </data>
-  <data name="_pytestPath.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 3, 6, 3</value>
-  </data>
-  <data name="_pytestPath.MinimumSize" type="System.Drawing.Size, System.Drawing">
-    <value>50, 4</value>
-  </data>
-  <data name="_pytestPath.Size" type="System.Drawing.Size, System.Drawing">
-    <value>310, 22</value>
-  </data>
-  <data name="_pytestPath.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;_pytestPath.Name" xml:space="preserve">
-    <value>_pytestPath</value>
-  </data>
-  <data name="&gt;&gt;_pytestPath.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;_pytestPath.Parent" xml:space="preserve">
-    <value>tableLayoutPanel2</value>
-  </data>
-  <data name="&gt;&gt;_pytestPath.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="_pytestPathLabel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Left</value>
-  </data>
-  <data name="_pytestPathLabel.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="_pytestPathLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 7</value>
-  </data>
-  <data name="_pytestPathLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 0, 6, 0</value>
-  </data>
-  <data name="_pytestPathLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>63, 13</value>
-  </data>
-  <data name="_pytestPathLabel.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="_pytestPathLabel.Text" xml:space="preserve">
-    <value>Pytest Path</value>
-  </data>
-  <data name="_pytestPathLabel.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-    <value>MiddleLeft</value>
-  </data>
-  <data name="&gt;&gt;_pytestPathLabel.Name" xml:space="preserve">
-    <value>_pytestPathLabel</value>
-  </data>
-  <data name="&gt;&gt;_pytestPathLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;_pytestPathLabel.Parent" xml:space="preserve">
-    <value>tableLayoutPanel2</value>
-  </data>
-  <data name="&gt;&gt;_pytestPathLabel.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="_argumentsLabel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Left</value>
-  </data>
-  <data name="_argumentsLabel.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="_argumentsLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 35</value>
-  </data>
-  <data name="_argumentsLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 0, 6, 0</value>
-  </data>
-  <data name="_argumentsLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>99, 13</value>
-  </data>
-  <data name="_argumentsLabel.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="_argumentsLabel.Text" xml:space="preserve">
-    <value>Pytest Arguments:</value>
-  </data>
-  <data name="_argumentsLabel.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-    <value>MiddleLeft</value>
-  </data>
-  <data name="&gt;&gt;_argumentsLabel.Name" xml:space="preserve">
-    <value>_argumentsLabel</value>
-  </data>
-  <data name="&gt;&gt;_argumentsLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;_argumentsLabel.Parent" xml:space="preserve">
-    <value>tableLayoutPanel2</value>
-  </data>
-  <data name="&gt;&gt;_argumentsLabel.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="_arguments.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Left, Right</value>
-  </data>
-  <data name="_arguments.Location" type="System.Drawing.Point, System.Drawing">
-    <value>117, 31</value>
-  </data>
-  <data name="_arguments.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 3, 6, 3</value>
-  </data>
-  <data name="_arguments.MinimumSize" type="System.Drawing.Size, System.Drawing">
-    <value>50, 4</value>
-  </data>
-  <data name="_arguments.Size" type="System.Drawing.Size, System.Drawing">
-    <value>310, 22</value>
-  </data>
-  <data name="_arguments.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;_arguments.Name" xml:space="preserve">
-    <value>_arguments</value>
-  </data>
-  <data name="&gt;&gt;_arguments.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;_arguments.Parent" xml:space="preserve">
-    <value>tableLayoutPanel2</value>
-  </data>
-  <data name="&gt;&gt;_arguments.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="_pytestEnabled.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Left</value>
-  </data>
-  <data name="_pytestEnabled.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="_pytestEnabled.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="_pytestEnabled.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 59</value>
-  </data>
-  <data name="_pytestEnabled.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 3, 6, 3</value>
-  </data>
-  <data name="_pytestEnabled.Size" type="System.Drawing.Size, System.Drawing">
-    <value>101, 17</value>
-  </data>
-  <data name="_pytestEnabled.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
-  </data>
-  <data name="_pytestEnabled.Text" xml:space="preserve">
-    <value>Pytest Enabled</value>
-  </data>
-  <data name="&gt;&gt;_pytestEnabled.Name" xml:space="preserve">
-    <value>_pytestEnabled</value>
-  </data>
-  <data name="&gt;&gt;_pytestEnabled.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;_pytestEnabled.Parent" xml:space="preserve">
-    <value>tableLayoutPanel2</value>
-  </data>
-  <data name="&gt;&gt;_pytestEnabled.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="tableLayoutPanel2.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="tableLayoutPanel2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 23</value>
-  </data>
-  <data name="tableLayoutPanel2.RowCount" type="System.Int32, mscorlib">
-    <value>4</value>
-  </data>
-  <data name="tableLayoutPanel2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>433, 79</value>
-  </data>
-  <data name="tableLayoutPanel2.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;tableLayoutPanel2.Name" xml:space="preserve">
-    <value>tableLayoutPanel2</value>
-  </data>
-  <data name="&gt;&gt;tableLayoutPanel2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tableLayoutPanel2.Parent" xml:space="preserve">
-    <value>_pytestGroup</value>
-  </data>
-  <data name="&gt;&gt;tableLayoutPanel2.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="tableLayoutPanel2.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="_pytestPath" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="_pytestPathLabel" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_argumentsLabel" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_arguments" Row="1" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="_pytestEnabled" Row="2" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
-  </data>
-  <data name="_pytestGroup.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="_pytestGroup.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 8</value>
-  </data>
-  <data name="_pytestGroup.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 8, 6, 8</value>
-  </data>
-  <data name="_pytestGroup.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 8, 6, 8</value>
-  </data>
-  <data name="_pytestGroup.Size" type="System.Drawing.Size, System.Drawing">
-    <value>445, 110</value>
-  </data>
-  <data name="_pytestGroup.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="_pytestGroup.Text" xml:space="preserve">
-    <value>Pytest Settings</value>
-  </data>
-  <data name="&gt;&gt;_pytestGroup.Name" xml:space="preserve">
-    <value>_pytestGroup</value>
-  </data>
-  <data name="&gt;&gt;_pytestGroup.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;_pytestGroup.Parent" xml:space="preserve">
-    <value>tableLayoutPanel1</value>
-  </data>
-  <data name="&gt;&gt;_pytestGroup.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
   <data name="tableLayoutPanel1.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
   <data name="tableLayoutPanel1.ColumnCount" type="System.Int32, mscorlib">
     <value>1</value>
+  </data>
+  <data name="tableLayoutPanel.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="tableLayoutPanel.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
+    <value>GrowAndShrink</value>
+  </data>
+  <data name="tableLayoutPanel.ColumnCount" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="_unitTestArgsLabel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Left</value>
+  </data>
+  <data name="_unitTestArgsLabel.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="_unitTestArgsLabel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="_unitTestArgsLabel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 34</value>
+  </data>
+  <data name="_unitTestArgsLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>6, 0, 6, 0</value>
+  </data>
+  <data name="_unitTestArgsLabel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>110, 13</value>
+  </data>
+  <data name="_unitTestArgsLabel.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="_unitTestArgsLabel.Text" xml:space="preserve">
+    <value>Unittest Arguments:</value>
+  </data>
+  <data name="_unitTestArgsLabel.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleLeft</value>
+  </data>
+  <data name="&gt;&gt;_unitTestArgsLabel.Name" xml:space="preserve">
+    <value>_unitTestArgsLabel</value>
+  </data>
+  <data name="&gt;&gt;_unitTestArgsLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;_unitTestArgsLabel.Parent" xml:space="preserve">
+    <value>tableLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;_unitTestArgsLabel.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="_unitTestArgs.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Left, Right</value>
+  </data>
+  <data name="_unitTestArgs.Location" type="System.Drawing.Point, System.Drawing">
+    <value>128, 30</value>
+  </data>
+  <data name="_unitTestArgs.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>6, 3, 6, 3</value>
+  </data>
+  <data name="_unitTestArgs.MinimumSize" type="System.Drawing.Size, System.Drawing">
+    <value>50, 4</value>
+  </data>
+  <data name="_unitTestArgs.Size" type="System.Drawing.Size, System.Drawing">
+    <value>310, 22</value>
+  </data>
+  <data name="_unitTestArgs.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;_unitTestArgs.Name" xml:space="preserve">
+    <value>_unitTestArgs</value>
+  </data>
+  <data name="&gt;&gt;_unitTestArgs.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;_unitTestArgs.Parent" xml:space="preserve">
+    <value>tableLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;_unitTestArgs.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="_testFrameworkLabel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Left</value>
+  </data>
+  <data name="_testFrameworkLabel.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="_testFrameworkLabel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="_testFrameworkLabel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 7</value>
+  </data>
+  <data name="_testFrameworkLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>6, 0, 6, 0</value>
+  </data>
+  <data name="_testFrameworkLabel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>90, 13</value>
+  </data>
+  <data name="_testFrameworkLabel.TabIndex" type="System.Int32, mscorlib">
+    <value>8</value>
+  </data>
+  <data name="_testFrameworkLabel.Text" xml:space="preserve">
+    <value>Test Framework:</value>
+  </data>
+  <data name="_testFrameworkLabel.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleLeft</value>
+  </data>
+  <data name="&gt;&gt;_testFrameworkLabel.Name" xml:space="preserve">
+    <value>_testFrameworkLabel</value>
+  </data>
+  <data name="&gt;&gt;_testFrameworkLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;_testFrameworkLabel.Parent" xml:space="preserve">
+    <value>tableLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;_testFrameworkLabel.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="_testFramework.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Left, Right</value>
+  </data>
+  <data name="_testFramework.Items" xml:space="preserve">
+    <value>none</value>
+  </data>
+  <data name="_testFramework.Items1" xml:space="preserve">
+    <value>pytest</value>
+  </data>
+  <data name="_testFramework.Items2" xml:space="preserve">
+    <value>unittest</value>
+  </data>
+  <data name="_testFramework.Location" type="System.Drawing.Point, System.Drawing">
+    <value>128, 3</value>
+  </data>
+  <data name="_testFramework.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>6, 3, 6, 3</value>
+  </data>
+  <data name="_testFramework.MinimumSize" type="System.Drawing.Size, System.Drawing">
+    <value>50, 0</value>
+  </data>
+  <data name="_testFramework.Size" type="System.Drawing.Size, System.Drawing">
+    <value>310, 21</value>
+  </data>
+  <data name="_testFramework.TabIndex" type="System.Int32, mscorlib">
+    <value>7</value>
+  </data>
+  <data name="&gt;&gt;_testFramework.Name" xml:space="preserve">
+    <value>_testFramework</value>
+  </data>
+  <data name="&gt;&gt;_testFramework.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;_testFramework.Parent" xml:space="preserve">
+    <value>tableLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;_testFramework.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="tableLayoutPanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="tableLayoutPanel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 3</value>
+  </data>
+  <data name="tableLayoutPanel.RowCount" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
+  <data name="tableLayoutPanel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>444, 55</value>
+  </data>
+  <data name="tableLayoutPanel.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel.Name" xml:space="preserve">
+    <value>tableLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="tableLayoutPanel.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="_unitTestArgsLabel" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_unitTestArgs" Row="1" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="_testFrameworkLabel" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_testFramework" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <data name="tableLayoutPanel1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
@@ -385,7 +325,7 @@
     <value>2</value>
   </data>
   <data name="tableLayoutPanel1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>457, 126</value>
+    <value>450, 61</value>
   </data>
   <data name="tableLayoutPanel1.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -403,7 +343,7 @@
     <value>0</value>
   </data>
   <data name="tableLayoutPanel1.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="_pytestGroup" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,Percent,50" /&gt;&lt;/TableLayoutSettings&gt;</value>
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="tableLayoutPanel" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,Percent,50" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
@@ -424,7 +364,7 @@
     <value>6, 8, 6, 8</value>
   </data>
   <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
-    <value>457, 126</value>
+    <value>450, 61</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>PythonTestPropertyPageControl</value>

--- a/Python/Product/PythonTools/PythonTools/Project/PythonTestPropertyPageControl.resx
+++ b/Python/Product/PythonTools/PythonTools/Project/PythonTestPropertyPageControl.resx
@@ -134,6 +134,46 @@
   <data name="tableLayoutPanel.ColumnCount" type="System.Int32, mscorlib">
     <value>2</value>
   </data>
+  <data name="label1.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Left</value>
+  </data>
+  <data name="label1.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label1.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="label1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 62</value>
+  </data>
+  <data name="label1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>6, 0, 6, 0</value>
+  </data>
+  <data name="label1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>47, 13</value>
+  </data>
+  <data name="label1.TabIndex" type="System.Int32, mscorlib">
+    <value>9</value>
+  </data>
+  <data name="label1.Text" xml:space="preserve">
+    <value>Pattern:</value>
+  </data>
+  <data name="label1.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleLeft</value>
+  </data>
+  <data name="&gt;&gt;label1.Name" xml:space="preserve">
+    <value>label1</value>
+  </data>
+  <data name="&gt;&gt;label1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label1.Parent" xml:space="preserve">
+    <value>tableLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;label1.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
   <data name="_unitTestArgsLabel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Left</value>
   </data>
@@ -143,7 +183,6 @@
   <data name="_unitTestArgsLabel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="_unitTestArgsLabel.Location" type="System.Drawing.Point, System.Drawing">
     <value>6, 34</value>
   </data>
@@ -151,13 +190,13 @@
     <value>6, 0, 6, 0</value>
   </data>
   <data name="_unitTestArgsLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>110, 13</value>
+    <value>84, 13</value>
   </data>
   <data name="_unitTestArgsLabel.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
   </data>
   <data name="_unitTestArgsLabel.Text" xml:space="preserve">
-    <value>Unittest Arguments:</value>
+    <value>Root Directory:</value>
   </data>
   <data name="_unitTestArgsLabel.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
     <value>MiddleLeft</value>
@@ -172,13 +211,13 @@
     <value>tableLayoutPanel</value>
   </data>
   <data name="&gt;&gt;_unitTestArgsLabel.ZOrder" xml:space="preserve">
-    <value>0</value>
+    <value>1</value>
   </data>
   <data name="_unitTestArgs.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Left, Right</value>
   </data>
   <data name="_unitTestArgs.Location" type="System.Drawing.Point, System.Drawing">
-    <value>128, 30</value>
+    <value>108, 30</value>
   </data>
   <data name="_unitTestArgs.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>6, 3, 6, 3</value>
@@ -202,7 +241,7 @@
     <value>tableLayoutPanel</value>
   </data>
   <data name="&gt;&gt;_unitTestArgs.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>2</value>
   </data>
   <data name="_testFrameworkLabel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Left</value>
@@ -241,7 +280,7 @@
     <value>tableLayoutPanel</value>
   </data>
   <data name="&gt;&gt;_testFrameworkLabel.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>3</value>
   </data>
   <data name="_testFramework.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Left, Right</value>
@@ -256,7 +295,7 @@
     <value>unittest</value>
   </data>
   <data name="_testFramework.Location" type="System.Drawing.Point, System.Drawing">
-    <value>128, 3</value>
+    <value>108, 3</value>
   </data>
   <data name="_testFramework.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>6, 3, 6, 3</value>
@@ -280,7 +319,76 @@
     <value>tableLayoutPanel</value>
   </data>
   <data name="&gt;&gt;_testFramework.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>4</value>
+  </data>
+  <data name="_unitTestPattern.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Left, Right</value>
+  </data>
+  <data name="_unitTestPattern.Location" type="System.Drawing.Point, System.Drawing">
+    <value>108, 58</value>
+  </data>
+  <data name="_unitTestPattern.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>6, 3, 6, 3</value>
+  </data>
+  <data name="_unitTestPattern.MinimumSize" type="System.Drawing.Size, System.Drawing">
+    <value>50, 4</value>
+  </data>
+  <data name="_unitTestPattern.Size" type="System.Drawing.Size, System.Drawing">
+    <value>310, 22</value>
+  </data>
+  <data name="_unitTestPattern.TabIndex" type="System.Int32, mscorlib">
+    <value>10</value>
+  </data>
+  <data name="_unitTestPattern.Text" xml:space="preserve">
+    <value>test*.py </value>
+  </data>
+  <data name="&gt;&gt;_unitTestPattern.Name" xml:space="preserve">
+    <value>_unitTestPattern</value>
+  </data>
+  <data name="&gt;&gt;_unitTestPattern.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;_unitTestPattern.Parent" xml:space="preserve">
+    <value>tableLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;_unitTestPattern.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="_mixedMode.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Left, Right</value>
+  </data>
+  <data name="_mixedMode.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="_mixedMode.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="_mixedMode.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 86</value>
+  </data>
+  <data name="_mixedMode.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>6, 3, 6, 3</value>
+  </data>
+  <data name="_mixedMode.Size" type="System.Drawing.Size, System.Drawing">
+    <value>90, 17</value>
+  </data>
+  <data name="_mixedMode.TabIndex" type="System.Int32, mscorlib">
+    <value>11</value>
+  </data>
+  <data name="_mixedMode.Text" xml:space="preserve">
+    <value>Verbose</value>
+  </data>
+  <data name="&gt;&gt;_mixedMode.Name" xml:space="preserve">
+    <value>_mixedMode</value>
+  </data>
+  <data name="&gt;&gt;_mixedMode.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;_mixedMode.Parent" xml:space="preserve">
+    <value>tableLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;_mixedMode.ZOrder" xml:space="preserve">
+    <value>6</value>
   </data>
   <data name="tableLayoutPanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
@@ -289,10 +397,10 @@
     <value>3, 3</value>
   </data>
   <data name="tableLayoutPanel.RowCount" type="System.Int32, mscorlib">
-    <value>5</value>
+    <value>7</value>
   </data>
   <data name="tableLayoutPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>444, 55</value>
+    <value>424, 106</value>
   </data>
   <data name="tableLayoutPanel.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -310,7 +418,7 @@
     <value>0</value>
   </data>
   <data name="tableLayoutPanel.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="_unitTestArgsLabel" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_unitTestArgs" Row="1" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="_testFrameworkLabel" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_testFramework" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="label1" Row="5" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_unitTestArgsLabel" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_unitTestArgs" Row="1" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="_testFrameworkLabel" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_testFramework" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="_unitTestPattern" Row="5" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="_mixedMode" Row="6" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <data name="tableLayoutPanel1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
@@ -325,7 +433,7 @@
     <value>2</value>
   </data>
   <data name="tableLayoutPanel1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>450, 61</value>
+    <value>430, 112</value>
   </data>
   <data name="tableLayoutPanel1.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -364,7 +472,7 @@
     <value>6, 8, 6, 8</value>
   </data>
   <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
-    <value>450, 61</value>
+    <value>430, 112</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>PythonTestPropertyPageControl</value>

--- a/Python/Product/TestAdapter.Executor/Config/PythonProjectSettings.cs
+++ b/Python/Product/TestAdapter.Executor/Config/PythonProjectSettings.cs
@@ -1,16 +1,19 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Windows.Forms;
 
 namespace Microsoft.PythonTools.TestAdapter.Config {
     public class PythonProjectSettings : IEquatable<PythonProjectSettings> {
-        public readonly string ProjectName, ProjectHome, WorkingDirectory, InterpreterPath, PathEnv, PytestPath, PytestArgs;
+        public readonly string ProjectName, ProjectHome, WorkingDirectory, InterpreterPath, PathEnv;
         public readonly bool EnableNativeCodeDebugging;
-        public readonly bool PytestEnabled = false;
         public readonly List<string> SearchPath;
         public readonly Dictionary<string, string> Environment;
         public readonly List<string> Sources;
         public readonly bool IsWorkspace;
         public readonly bool UseLegacyDebugger;
+        public readonly TestFrameworkType TestFramwork;
+
+       
 
         public PythonProjectSettings(string projectName,
             string projectHome,
@@ -18,25 +21,22 @@ namespace Microsoft.PythonTools.TestAdapter.Config {
             string interpreter,
             string pathEnv,
             bool nativeDebugging,
-            string pytestPath,
-            string pytestArgs,
-            bool pytestEnabled,
             bool isWorkspace,
-            bool useLegacyDebugger) {
+            bool useLegacyDebugger,
+            string testFramework) {
             ProjectName = projectName;
             ProjectHome = projectHome;
             WorkingDirectory = workingDir;
             InterpreterPath = interpreter;
             PathEnv = pathEnv;
             EnableNativeCodeDebugging = nativeDebugging;
-            PytestEnabled = pytestEnabled;
-            PytestPath = pytestPath;
-            PytestArgs = pytestArgs;
             SearchPath = new List<string>();
             Environment = new Dictionary<string, string>();
             Sources = new List<string>();
             IsWorkspace = isWorkspace;
             UseLegacyDebugger = useLegacyDebugger;
+            TestFramwork = TestFrameworkType.None;
+            Enum.TryParse<TestFrameworkType>(testFramework, ignoreCase:true, out TestFramwork);
         }
 
         public override bool Equals(object obj) {
@@ -60,8 +60,8 @@ namespace Microsoft.PythonTools.TestAdapter.Config {
                 PathEnv == other.PathEnv &&
                 EnableNativeCodeDebugging == other.EnableNativeCodeDebugging &&
                 IsWorkspace == other.IsWorkspace &&
-                PytestEnabled == other.PytestEnabled &&
-                UseLegacyDebugger == other.UseLegacyDebugger) {
+                UseLegacyDebugger == other.UseLegacyDebugger &&
+                TestFramwork == other.TestFramwork) {
                 if (SearchPath.Count == other.SearchPath.Count &&
                     Environment.Count == other.Environment.Count) {
                     for (int i = 0; i < SearchPath.Count; i++) {

--- a/Python/Product/TestAdapter.Executor/Config/RunSettingsUtil.cs
+++ b/Python/Product/TestAdapter.Executor/Config/RunSettingsUtil.cs
@@ -21,11 +21,9 @@ namespace Microsoft.PythonTools.TestAdapter.Config {
                     project.GetAttribute("interpreter", ""),
                     project.GetAttribute("pathEnv", ""),
                     project.GetAttribute("nativeDebugging", "").IsTrue(),
-                    project.GetAttribute("pytestPath", ""),
-                    project.GetAttribute("pytestArgs", ""),
-                    project.GetAttribute("pytestEnabled", "").IsTrue(),
                     project.GetAttribute("isWorkspace", "").IsTrue(),
-                    project.GetAttribute("useLegacyDebugger", "").IsTrue()
+                    project.GetAttribute("useLegacyDebugger", "").IsTrue(),
+                    project.GetAttribute("testFramework", "")
                 ); 
 
                 foreach (XPathNavigator environment in project.Select("Environment/Variable")) {

--- a/Python/Product/TestAdapter.Executor/Services/DiscoveryServiceFactory.cs
+++ b/Python/Product/TestAdapter.Executor/Services/DiscoveryServiceFactory.cs
@@ -1,0 +1,21 @@
+﻿
+using Microsoft.PythonTools.TestAdapter.Config;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
+using System;
+
+namespace Microsoft.PythonTools.TestAdapter.Services {
+    internal class DiscovererFactory {
+
+        public static IPythonTestDiscoverer GetDiscoverer(PythonProjectSettings settings) {
+            switch (settings.TestFramwork) {
+                case TestFrameworkType.Pytest:
+                    return new TestDiscovererPytest(settings);
+                case TestFrameworkType.UnitTest:
+                    return new TestDiscovererUnitTest(settings);
+                case TestFrameworkType.None:
+                default:
+                    throw new NotImplementedException($"CreateDiscoveryService TestFrameworkType:{settings.TestFramwork.ToString()} not supported");
+            }
+        }
+    }
+}

--- a/Python/Product/TestAdapter.Executor/Services/ExecutorService.cs
+++ b/Python/Product/TestAdapter.Executor/Services/ExecutorService.cs
@@ -68,14 +68,11 @@ namespace Microsoft.PythonTools.TestAdapter.Services {
             var arguments = new List<string> {
                 TestLauncherPath,
                 projSettings.WorkingDirectory,
-                projSettings.PytestPath,
+                "pytest", 
                 _debugSecret,
                 _debugPort.ToString(),
                 String.Format("--junitxml={0}", outputfile)
             };
-
-            if (!String.IsNullOrEmpty(projSettings.PytestArgs))
-                arguments.Add(projSettings.PytestArgs);
 
             foreach (TestCase test in tests) {
                 var executionTestPath = test.GetPropertyValue<string>(Pytest.Constants.PytestTestExecutionPathPropertery, default);

--- a/Python/Product/TestAdapter.Executor/Services/IPythonTestDiscoverer.cs
+++ b/Python/Product/TestAdapter.Executor/Services/IPythonTestDiscoverer.cs
@@ -1,0 +1,10 @@
+﻿using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
+using System.Collections.Generic;
+
+
+namespace Microsoft.PythonTools.TestAdapter.Services {
+    interface IPythonTestDiscoverer {
+        void DiscoverTests(IEnumerable<string> sources, IMessageLogger logger, ITestCaseDiscoverySink discoverySink);
+    }
+}

--- a/Python/Product/TestAdapter.Executor/TestAdapter.Executor.csproj
+++ b/Python/Product/TestAdapter.Executor/TestAdapter.Executor.csproj
@@ -91,13 +91,18 @@
     <Compile Include="Config\RunSettingsUtil.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Pytest\PytestDiscoveryReader.cs" />
-    <Compile Include="Services\DiscoveryService.cs" />
+    <Compile Include="Pytest\TestDiscovererPytest.cs" />
+    <Compile Include="Services\DiscoveryServiceFactory.cs" />
     <Compile Include="Services\ExecutorService.cs" />
     <Compile Include="Pytest\TestResultParser.cs" />
+    <Compile Include="Services\IPythonTestDiscoverer.cs" />
+    <Compile Include="TestCollection.cs" />
     <Compile Include="TestDiscoverer.cs" />
     <Compile Include="TestExecutor.cs" />
     <Compile Include="TestProtocol.cs" />
     <Compile Include="TestReader.cs" />
+    <Compile Include="UnitTest\TestExecutorUnitTest.cs" />
+    <Compile Include="UnitTest\TestDiscovererUnitTest.cs" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="PythonFiles\testing_tools\adapter\discovery.py">
@@ -153,7 +158,9 @@
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <Folder Include="Interface\" />
+  </ItemGroup>
   <Import Project="..\ProjectAfter.settings" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Python/Product/TestAdapter.Executor/TestCollection.cs
+++ b/Python/Product/TestAdapter.Executor/TestCollection.cs
@@ -1,0 +1,15 @@
+﻿using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.PythonTools.TestAdapter {
+    class TestCollection : ITestCaseDiscoverySink {
+
+        public List<TestCase> Tests;
+
+        public void SendTestCase(TestCase discoveredTest) {
+            Tests.Add(discoveredTest);
+        }
+    }
+}

--- a/Python/Product/TestAdapter.Executor/TestExecutor.cs
+++ b/Python/Product/TestAdapter.Executor/TestExecutor.cs
@@ -167,19 +167,8 @@ namespace Microsoft.PythonTools.TestAdapter {
 
         private void RunTestGroup(IGrouping<PythonProjectSettings, TestCase> testGroup, IRunContext runContext, IFrameworkHandle frameworkHandle) {
             PythonProjectSettings settings = testGroup.Key;
-            if (settings.TestFramwork == TestFrameworkType.None) {
+            if (settings.TestFramwork != TestFrameworkType.Pytest) {
                 return;
-            }
-
-            switch (settings.TestFramwork) {
-                case TestFrameworkType.None:
-                    break;
-                case TestFrameworkType.Pytest:
-                    break;
-                case TestFrameworkType.UnitTest:
-                    break;
-                default:
-                    break;
             }
 
             using (var executor = new ExecutorService(frameworkHandle, runContext)) {

--- a/Python/Product/TestAdapter.Executor/UnitTest/TestDiscovererUnitTest.cs
+++ b/Python/Product/TestAdapter.Executor/UnitTest/TestDiscovererUnitTest.cs
@@ -1,0 +1,130 @@
+﻿using Microsoft.PythonTools.Analysis;
+using Microsoft.PythonTools.Infrastructure;
+using Microsoft.PythonTools.TestAdapter.Config;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+
+
+namespace Microsoft.PythonTools.TestAdapter.Services {
+    internal class TestDiscovererUnitTest : IPythonTestDiscoverer {
+        private readonly PythonProjectSettings _settings;
+        private IMessageLogger _logger;
+        private static readonly string DiscoveryAdapterPath = PythonToolsInstallPath.GetFile("PythonFiles\\testing_tools\\run_adapter.py");
+
+        public TestDiscovererUnitTest(PythonProjectSettings settings) {
+            _settings = settings;
+        }
+
+        public void DiscoverTests(IEnumerable<string> sources, IMessageLogger logger, ITestCaseDiscoverySink discoverySink) {
+            _logger = logger;
+            throw new NotImplementedException("TestExecutorUnitTest::DiscoverTests");
+
+            //var discoveryResults = new List<PytestDiscoveryResults>();
+
+            //try {
+            //    var env = InitializeEnvironment(sources, _settings);
+            //    var arguments = GetArguments(sources);
+
+            //    using (var outputStream = new MemoryStream())
+            //    using (var writer = new StreamWriter(outputStream, encoding: new UTF8Encoding(true), 4096, leaveOpen: true))
+            //    using (var proc = ProcessOutput.Run(
+            //        _settings.InterpreterPath,
+            //        arguments,
+            //        _settings.WorkingDirectory,
+            //        env,
+            //        visible: false,
+            //        new StreamRedirector(writer)
+            //    )) {
+
+            //        DebugInfo("cd " + _settings.WorkingDirectory);
+            //        DebugInfo("set " + _settings.PathEnv + "=" + env[_settings.PathEnv]);
+            //        DebugInfo(proc.Arguments);
+
+            //        // If there's an error in the launcher script,
+            //        // it will terminate without connecting back.
+            //        WaitHandle.WaitAny(new WaitHandle[] { proc.WaitHandle });
+
+            //        outputStream.Flush();
+            //        outputStream.Seek(0, SeekOrigin.Begin);
+            //        var json = new StreamReader(outputStream).ReadToEnd();
+
+            //        try {
+            //            discoveryResults = JsonConvert.DeserializeObject<List<PytestDiscoveryResults>>(json);
+            //        } catch (InvalidOperationException ex) {
+            //            Error("Failed to parse: {0}".FormatInvariant(ex.Message));
+            //            Error(json);
+            //        } catch (JsonException ex) {
+            //            Error("Failed to parse: {0}".FormatInvariant(ex.Message));
+            //            Error(json);
+            //        }
+            //    }
+            //} catch (Exception ex) {
+            //    Error(ex.Message);
+            //}
+        }
+
+        public string[] GetArguments(IEnumerable<string> sources) {
+            var arguments = new List<string>();
+            arguments.Add(DiscoveryAdapterPath);
+            arguments.Add("discover");
+            arguments.Add("unittest");
+            arguments.Add("--");
+
+            foreach (var s in sources) {
+                arguments.Add(s);
+            }
+            return arguments.ToArray();
+        }
+
+        private Dictionary<string, string> InitializeEnvironment(IEnumerable<string> sources, PythonProjectSettings projSettings) {
+            var pythonPathVar = projSettings.PathEnv;
+            var pythonPath = GetSearchPaths(sources, projSettings);
+            var env = new Dictionary<string, string>();
+
+            if (!string.IsNullOrWhiteSpace(pythonPathVar)) {
+                env[pythonPathVar] = pythonPath;
+            }
+
+            foreach (var envVar in projSettings.Environment) {
+                env[envVar.Key] = envVar.Value;
+            }
+
+            return env;
+        }
+
+        private string GetSearchPaths(IEnumerable<string> sources, PythonProjectSettings settings) {
+            var paths = settings.SearchPath;
+
+            HashSet<string> knownModulePaths = new HashSet<string>();
+            foreach (var source in sources) {
+                string testFilePath = PathUtils.GetAbsoluteFilePath(settings.ProjectHome, source);
+                var modulePath = ModulePath.FromFullPath(testFilePath);
+                if (knownModulePaths.Add(modulePath.LibraryPath)) {
+                    paths.Insert(0, modulePath.LibraryPath);
+                }
+            }
+
+            paths.Insert(0, settings.WorkingDirectory);
+
+            string searchPaths = string.Join(
+                ";",
+                paths.Where(Directory.Exists).Distinct(StringComparer.OrdinalIgnoreCase)
+            );
+            return searchPaths;
+        }
+
+        [Conditional("DEBUG")]
+        private void DebugInfo(string message) {
+            _logger?.SendMessage(TestMessageLevel.Informational, message);
+        }
+
+        private void Error(string message) {
+            _logger?.SendMessage(TestMessageLevel.Error, message);
+        }
+    }
+}

--- a/Python/Product/TestAdapter.Executor/UnitTest/TestExecutorUnitTest.cs
+++ b/Python/Product/TestAdapter.Executor/UnitTest/TestExecutorUnitTest.cs
@@ -1,4 +1,4 @@
-// Python Tools for Visual Studio
+﻿// Python Tools for Visual Studio
 // Copyright(c) Microsoft Corporation
 // All rights reserved.
 //
@@ -21,46 +21,28 @@ using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Net;
+using System.Net.NetworkInformation;
 using System.Net.Sockets;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Windows.Forms;
+using System.Xml;
 using System.Xml.XPath;
 using Microsoft.PythonTools.Analysis;
 using Microsoft.PythonTools.Infrastructure;
 using Microsoft.PythonTools.Ipc.Json;
-using Microsoft.PythonTools.TestAdapter.Config;
-using Microsoft.PythonTools.TestAdapter.Pytest;
-using Microsoft.PythonTools.TestAdapter.Services;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
 using TP = Microsoft.PythonTools.TestAdapter.TestProtocol;
 
 namespace Microsoft.PythonTools.TestAdapter {
-
-    [ExtensionUri(PythonConstants.TestExecutorUriString)]
-    public class PytestProjectTestExecutor : TestExecutor {
-
-        public PytestProjectTestExecutor() : base() {
-
-        }
-
-    }
-
-    [ExtensionUri(PythonConstants.WSTestExecutorUriString)]
-    public class PytestWorkspaceTestExecutor : TestExecutor {
-        public PytestWorkspaceTestExecutor() : base() {
-
-        }
-    }
-
     [SuppressMessage("Microsoft.Design", "CA1001:TypesThatOwnDisposableFieldsShouldBeDisposable",
         Justification = "object owned by VS")]
-    public class TestExecutor : ITestExecutor {
+    [ExtensionUri(PythonConstants.UnitTestExecutorUriString)]
+    class TestExecutorUnitTest : ITestExecutor {
         private static readonly Guid PythonRemoteDebugPortSupplierUnsecuredId = new Guid("{FEB76325-D127-4E02-B59D-B16D93D46CF5}");
         private static readonly Guid PythonDebugEngineGuid = new Guid("EC1375B7-E2CE-43E8-BF75-DC638DE1F1F9");
         private static readonly Guid NativeDebugEngineGuid = new Guid("3B476D35-A401-11D2-AAD4-00C04F990171");
@@ -72,7 +54,7 @@ namespace Microsoft.PythonTools.TestAdapter {
 
         private readonly VisualStudioProxy _app;
 
-        public TestExecutor() {
+        public TestExecutorUnitTest() {
             _app = VisualStudioProxy.FromEnvironmentVariable(PythonConstants.PythonToolsProcessIdEnvironmentVariable);
         }
 
@@ -80,10 +62,13 @@ namespace Microsoft.PythonTools.TestAdapter {
             _cancelRequested.Set();
         }
 
+        private static XPathDocument Read(string xml) {
+            var settings = new XmlReaderSettings();
+            settings.XmlResolver = null;
+            return new XPathDocument(XmlReader.Create(new StringReader(xml), settings));
+        }
+
         public void RunTests(IEnumerable<string> sources, IRunContext runContext, IFrameworkHandle frameworkHandle) {
-
-            //MessageBox.Show("Hello1: " + Process.GetCurrentProcess().Id);
-
             if (sources == null) {
                 throw new ArgumentNullException(nameof(sources));
             }
@@ -98,34 +83,64 @@ namespace Microsoft.PythonTools.TestAdapter {
 
             _cancelRequested.Reset();
 
-            var sourceToProjSettings = RunSettingsUtil.GetSourceToProjSettings(runContext.RunSettings);
-
-            var testColletion = new TestCollection();
-
-            foreach (var testGroup in sources.GroupBy(x => sourceToProjSettings[x])) {
-                var settings = testGroup.Key;
-
-                try {
-                    var discovery = DiscovererFactory.GetDiscoverer(settings);
-                    discovery.DiscoverTests(testGroup, frameworkHandle, testColletion);
-                } catch (Exception ex) {
-                    frameworkHandle.SendMessage(TestMessageLevel.Error, ex.Message);
-                }
-                
-                if (_cancelRequested.WaitOne(0)) {
-                    return;
-                }
+            var executorUri = new Uri(PythonConstants.TestExecutorUriString);
+            var tests = new List<TestCase>();
+            var doc = Read(runContext.RunSettings.SettingsXml);
+            foreach (var t in TestReader.ReadTests(doc, new HashSet<string>(sources, StringComparer.OrdinalIgnoreCase), m => {
+                frameworkHandle?.SendMessage(TestMessageLevel.Warning, m);
+            })) {
+                tests.Add(new TestCase(t.FullyQualifiedName, executorUri, t.SourceFile) {
+                    DisplayName = t.DisplayName,
+                    LineNumber = t.LineNo,
+                    CodeFilePath = t.SourceFile
+                });
             }
 
-            RunPytest(testColletion.Tests, runContext, frameworkHandle);
+            if (_cancelRequested.WaitOne(0)) {
+                return;
+            }
+
+            RunTestCases(tests, runContext, frameworkHandle);
         }
 
-       
+        private Dictionary<string, PythonProjectSettings> GetSourceToSettings(IRunSettings settings) {
+            var doc = Read(settings.SettingsXml);
+            XPathNodeIterator nodes = doc.CreateNavigator().Select("/RunSettings/Python/TestCases/Project");
+            Dictionary<string, PythonProjectSettings> res = new Dictionary<string, PythonProjectSettings>();
+
+            foreach (XPathNavigator project in nodes) {
+                PythonProjectSettings projSettings = new PythonProjectSettings(
+                    project.GetAttribute("home", ""),
+                    project.GetAttribute("workingDir", ""),
+                    project.GetAttribute("interpreter", ""),
+                    project.GetAttribute("pathEnv", ""),
+                    project.GetAttribute("nativeDebugging", "").IsTrue(),
+                    project.GetAttribute("useLegacyDebugger", "").IsTrue()
+                );
+
+                foreach (XPathNavigator environment in project.Select("Environment/Variable")) {
+                    projSettings.Environment[environment.GetAttribute("name", "")] = environment.GetAttribute("value", "");
+                }
+
+                string djangoSettings = project.GetAttribute("djangoSettingsModule", "");
+                if (!String.IsNullOrWhiteSpace(djangoSettings)) {
+                    projSettings.Environment["DJANGO_SETTINGS_MODULE"] = djangoSettings;
+                }
+
+                foreach (XPathNavigator searchPath in project.Select("SearchPaths/Search")) {
+                    projSettings.SearchPath.Add(searchPath.GetAttribute("value", ""));
+                }
+
+                foreach (XPathNavigator test in project.Select("Test")) {
+                    string testFile = test.GetAttribute("file", "");
+                    Debug.Assert(!string.IsNullOrWhiteSpace(testFile));
+                    res[testFile] = projSettings;
+                }
+            }
+            return res;
+        }
 
         public void RunTests(IEnumerable<TestCase> tests, IRunContext runContext, IFrameworkHandle frameworkHandle) {
-        
-            //MessageBox.Show("Hello1: " + Process.GetCurrentProcess().Id);
-
             if (tests == null) {
                 throw new ArgumentNullException(nameof(tests));
             }
@@ -138,62 +153,9 @@ namespace Microsoft.PythonTools.TestAdapter {
                 throw new ArgumentNullException(nameof(frameworkHandle));
             }
 
-            RunPytest(tests, runContext, frameworkHandle);
-
             _cancelRequested.Reset();
-        }
 
-
-        private void RunPytest(
-            IEnumerable<TestCase> tests,
-            IRunContext runContext,
-            IFrameworkHandle frameworkHandle
-        ) {
-            var sourceToProjSettings = RunSettingsUtil.GetSourceToProjSettings(runContext.RunSettings);
-
-            foreach (var testGroup in tests.GroupBy(t => sourceToProjSettings.TryGetValue(t.CodeFilePath, out PythonProjectSettings proj) ? proj : null)) {
-                if (testGroup.Key == null) {
-                    Debug.WriteLine("Missing projectSettings for TestCases:");
-                    Debug.WriteLine(String.Join(",\n", testGroup));
-                }
-
-                if (_cancelRequested.WaitOne(0)) {
-                    break;
-                }
-
-                RunTestGroup(testGroup, runContext, frameworkHandle);
-            }
-        }
-
-        private void RunTestGroup(IGrouping<PythonProjectSettings, TestCase> testGroup, IRunContext runContext, IFrameworkHandle frameworkHandle) {
-            PythonProjectSettings settings = testGroup.Key;
-            if (settings.TestFramwork == TestFrameworkType.None) {
-                return;
-            }
-
-            switch (settings.TestFramwork) {
-                case TestFrameworkType.None:
-                    break;
-                case TestFrameworkType.Pytest:
-                    break;
-                case TestFrameworkType.UnitTest:
-                    break;
-                default:
-                    break;
-            }
-
-            using (var executor = new ExecutorService(frameworkHandle, runContext)) {
-                var resultsXML = executor.Run(settings, testGroup);
-
-                var testResults = TestResultParser.Parse(resultsXML, testGroup);
-                foreach (var result in testResults) {
-
-                    if (_cancelRequested.WaitOne(0)) {
-                        break;
-                    }
-                    frameworkHandle.RecordResult(result);
-                }
-            }
+            RunTestCases(tests, runContext, frameworkHandle);
         }
 
         private void RunTestCases(
@@ -201,14 +163,13 @@ namespace Microsoft.PythonTools.TestAdapter {
             IRunContext runContext,
             IFrameworkHandle frameworkHandle
         ) {
-
             bool codeCoverage = EnableCodeCoverage(runContext);
             string covPath = null;
             if (codeCoverage) {
                 covPath = GetCoveragePath(tests);
             }
             // .py file path -> project settings
-            var sourceToSettings = RunSettingsUtil.GetSourceToProjSettings(runContext.RunSettings);
+            var sourceToSettings = GetSourceToSettings(runContext.RunSettings);
 
             foreach (var testGroup in tests.GroupBy(x => sourceToSettings[x.CodeFilePath])) {
                 if (_cancelRequested.WaitOne(0)) {
@@ -328,7 +289,7 @@ namespace Microsoft.PythonTools.TestAdapter {
         }
 
         private static bool EnableCodeCoverage(IRunContext runContext) {
-            var doc = RunSettingsUtil.Read(runContext.RunSettings.SettingsXml);
+            var doc = Read(runContext.RunSettings.SettingsXml);
             XPathNodeIterator nodes = doc.CreateNavigator().Select("/RunSettings/Python/EnableCoverage");
             bool enableCoverage;
             if (nodes.MoveNext()) {
@@ -344,7 +305,7 @@ namespace Microsoft.PythonTools.TestAdapter {
         /// &lt;DryRun value="true" /&gt; element under RunSettings/Python.
         /// </summary>
         private static bool IsDryRun(IRunSettings settings) {
-            var doc = RunSettingsUtil.Read(settings.SettingsXml);
+            var doc = Read(settings.SettingsXml);
             try {
                 var node = doc.CreateNavigator().SelectSingleNode("/RunSettings/Python/DryRun[@value='true']");
                 return node != null;
@@ -360,7 +321,7 @@ namespace Microsoft.PythonTools.TestAdapter {
         /// RunSettings/Python.
         /// </summary>
         private static bool ShouldShowConsole(IRunSettings settings) {
-            var doc = RunSettingsUtil.Read(settings.SettingsXml);
+            var doc = Read(settings.SettingsXml);
             try {
                 var node = doc.CreateNavigator().SelectSingleNode("/RunSettings/Python/ShowConsole[@value='false']");
                 return node == null;
@@ -857,7 +818,73 @@ namespace Microsoft.PythonTools.TestAdapter {
             }
         }
 
-       
+        sealed class PythonProjectSettings : IEquatable<PythonProjectSettings> {
+            public readonly string ProjectHome, WorkingDirectory, InterpreterPath, PathEnv;
+            public readonly bool EnableNativeCodeDebugging;
+            public readonly bool UseLegacyDebugger;
+            public readonly List<string> SearchPath;
+            public readonly Dictionary<string, string> Environment;
+
+            public PythonProjectSettings(
+                string projectHome,
+                string workingDir,
+                string interpreter,
+                string pathEnv,
+                bool nativeDebugging,
+                bool useLegacyDebugger
+            ) {
+                ProjectHome = projectHome;
+                WorkingDirectory = workingDir;
+                InterpreterPath = interpreter;
+                PathEnv = pathEnv;
+                EnableNativeCodeDebugging = nativeDebugging;
+                UseLegacyDebugger = useLegacyDebugger;
+                SearchPath = new List<string>();
+                Environment = new Dictionary<string, string>();
+            }
+
+            public override bool Equals(object obj) {
+                return Equals(obj as PythonProjectSettings);
+            }
+            public override int GetHashCode() {
+                return ProjectHome.GetHashCode() ^
+                    WorkingDirectory.GetHashCode() ^
+                    InterpreterPath.GetHashCode();
+            }
+            public bool Equals(PythonProjectSettings other) {
+                if (other == null) {
+                    return false;
+                }
+
+                if (ProjectHome == other.ProjectHome &&
+                    WorkingDirectory == other.WorkingDirectory &&
+                    InterpreterPath == other.InterpreterPath &&
+                    PathEnv == other.PathEnv &&
+                    EnableNativeCodeDebugging == other.EnableNativeCodeDebugging &&
+                    UseLegacyDebugger == other.UseLegacyDebugger) {
+                    if (SearchPath.Count == other.SearchPath.Count &&
+                        Environment.Count == other.Environment.Count) {
+                        for (int i = 0; i < SearchPath.Count; i++) {
+                            if (SearchPath[i] != other.SearchPath[i]) {
+                                return false;
+                            }
+                        }
+
+                        foreach (var keyValue in Environment) {
+                            string value;
+                            if (!other.Environment.TryGetValue(keyValue.Key, out value) ||
+                                value != keyValue.Value) {
+                                return false;
+                            }
+                        }
+
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+        }
 
         enum PythonDebugMode {
             None,

--- a/Python/Product/TestAdapter/PythonRunSettings.cs
+++ b/Python/Product/TestAdapter/PythonRunSettings.cs
@@ -140,8 +140,7 @@ namespace Microsoft.PythonTools.TestAdapter {
                             writer.WriteStartElement("Project");
                             writer.WriteAttributeString("home", container.Project);
 
-                            string nativeCode = "", djangoSettings = "", pytestPath = "", pytestArgs = "", projectName = "";
-                            bool pytestEnabled = false;
+                            string nativeCode = "", djangoSettings = "", projectName = "", testFramework = "";
                             bool isWorkspace = false;
                             ProjectInfo projInfo = null;
                             LaunchConfiguration config = null;
@@ -166,9 +165,7 @@ namespace Microsoft.PythonTools.TestAdapter {
                                     }
                                     nativeCode = projInfo.GetProperty(PythonConstants.EnableNativeCodeDebugging);
                                     djangoSettings = projInfo.GetProperty("DjangoSettingsModule");
-                                    pytestEnabled = projInfo.GetBoolProperty(PythonConstants.PyTestEnabledSetting).GetValueOrDefault(false);
-                                    pytestPath = projInfo.GetProperty(PythonConstants.PyTestPathSetting);
-                                    pytestArgs = projInfo.GetProperty(PythonConstants.PyTestArgsSetting);
+                                    testFramework = projInfo.GetProperty(PythonConstants.TestFrameworkSetting);
                                     projectName = projInfo.ProjectName;
                                 }
                             });
@@ -185,11 +182,7 @@ namespace Microsoft.PythonTools.TestAdapter {
                             writer.WriteAttributeString("useLegacyDebugger", UseLegacyDebugger ? "1" : "0");
                             writer.WriteAttributeString("nativeDebugging", nativeCode);
                             writer.WriteAttributeString("djangoSettingsModule", djangoSettings);
-
-                            writer.WriteAttributeString("pytestEnabled", pytestEnabled.ToString());
-                            writer.WriteAttributeString("pytestPath", pytestPath);
-                            writer.WriteAttributeString("pytestArgs", pytestArgs);
-
+                            writer.WriteAttributeString("testFramework", testFramework);
                             writer.WriteAttributeString("workingDir", config.WorkingDirectory);
                             writer.WriteAttributeString("interpreter", config.GetInterpreterPath());
                             writer.WriteAttributeString("pathEnv", config.Interpreter.PathEnvironmentVariable);

--- a/Python/Product/VSInterpreters/Interpreter/PythonWorkspaceContext.cs
+++ b/Python/Product/VSInterpreters/Interpreter/PythonWorkspaceContext.cs
@@ -29,9 +29,7 @@ namespace Microsoft.PythonTools.Interpreter {
         private const string PythonSettingsType = "PythonSettings";
         private const string InterpreterProperty = "Interpreter";
         private const string SearchPathsProperty = "SearchPaths";
-        private const string PytestArgProperty = "PyTestArgs";
-        private const string PytestEnabledProperty = "PyTestEnabled";
-        private const string PytestPathProperty = "PyTestPath";
+        private const string TestFrameworkProperty = "TestFramework";
 
         private readonly IWorkspace _workspace;
         private readonly IInterpreterOptionsService _optionsService;
@@ -46,9 +44,7 @@ namespace Microsoft.PythonTools.Interpreter {
         private object _cacheLock = new object();
         private string[] _searchPaths;
         private string _interpreter;
-        private string[] _pytestArgs;
-        private bool _pytestEnabled;
-        private string _pytestPath;
+        private string _testFramework;
 
 
         // These are set in initialize
@@ -101,9 +97,7 @@ namespace Microsoft.PythonTools.Interpreter {
         public void Initialize() {
             _interpreter = ReadInterpreterSetting();
             _searchPaths = ReadSearchPathsSetting();
-            _pytestArgs = ReadPytestArgSetting();
-            _pytestEnabled = GetBoolProperty(PytestEnabledProperty) ?? false;
-            _pytestPath = GetStringProperty(PytestPathProperty) ?? "pytest";
+            _testFramework = GetStringProperty(TestFrameworkProperty);
 
             RefreshCurrentFactory();
 
@@ -150,15 +144,6 @@ namespace Microsoft.PythonTools.Interpreter {
             var searchPaths = settings.UnionPropertyArray<string>(SearchPathsProperty);
 
             return searchPaths.ToArray();
-        }
-
-        private string[] ReadPytestArgSetting()
-        {
-            var settingsMgr = _workspace.GetSettingsManager();
-            var settings = settingsMgr.GetAggregatedSettings(PythonSettingsType);
-            var pytestarg = settings.UnionPropertyArray<string>(PytestArgProperty);
-
-            return pytestarg.ToArray();
         }
 
         public IEnumerable<string> GetAbsoluteSearchPaths() {
@@ -287,14 +272,9 @@ namespace Microsoft.PythonTools.Interpreter {
                 searchPathsChanged = !oldSearchPaths.SequenceEqual(_searchPaths);
                 _searchPaths = ReadSearchPathsSetting();
 
-                var oldPytestArgs = _pytestArgs;
-                var oldPytestEnabled = _pytestEnabled;
-                var oldPytestPath = _pytestPath;
-
-                _pytestArgs = ReadPytestArgSetting();
-                _pytestEnabled = GetBoolProperty(PytestEnabledProperty).GetValueOrDefault(false);
-                _pytestPath = GetStringProperty(PytestPathProperty) ?? "pytest";
-                testSettingsChanged = !oldPytestArgs.SequenceEqual(_pytestArgs) || oldPytestEnabled != _pytestEnabled || !String.Equals(oldPytestPath, _pytestPath);
+                var oldTestFramework = _testFramework;
+                _testFramework = GetStringProperty(TestFrameworkProperty);
+                testSettingsChanged = !String.Equals(oldTestFramework, _testFramework);
             }
 
             if (interpreterChanged) {

--- a/Python/Tests/TestAdapterTests/TestDiscovererTests.cs
+++ b/Python/Tests/TestAdapterTests/TestDiscovererTests.cs
@@ -55,7 +55,7 @@ namespace TestAdapterTests {
 
             const string projectPath = @"C:\Visual Studio 2015\Projects\PythonApplication107\PythonApplication107\PythonApplication107.pyproj";
             const string testFilePath = @"C:\Visual Studio 2015\Projects\PythonApplication107\PythonApplication107\test1.py";
-            new ProjectTestDiscover().DiscoverTests(
+            new PythonTestDiscoverer().DiscoverTests(
                 new[] { testFilePath },
                 ctx,
                 logger,


### PR DESCRIPTION
Fixing up TestFramework property to switch between pytest and unittest
fixing workspace TestFramework settings
Adding placeholder discoverer for unittest
Moving unit test executor code to TestExecutorUnitTest
Refactor TestDiscoverer to choose between pytest and unittest