### PR TITLE
Bschnurr/fix import pytest

### DIFF
--- a/Python/Product/TestAdapter.Executor/PythonFiles/testing_tools/adapter/__main__.py
+++ b/Python/Product/TestAdapter.Executor/PythonFiles/testing_tools/adapter/__main__.py
@@ -46,7 +46,7 @@ TOOLS = {
     }
 
 REPORTERS = {
-     'pytest': {
+    'pytest': {
         'discover': report.report_discovered,
         },
     'unittest': {


### PR DESCRIPTION

Unittest framework test discovery should not require installing pytest  …
- Still needed to add parse options for pytest event if it wasn't installed so that the user wouldn't see an error that would drive them to convert to unittest.
run_adapter.py discover: error: argument tool: invalid choice: 'pytest' (choose from 'unittest')

now the error they will see is:

"C:\USERS\BSCHNURR\APPDATA\LOCAL\MICROSOFT\VISUALSTUDIO\16.0_FE4FEA96EXP\EXTENSIONS\MICROSOFT CORPORATION\PYTHON\16.0.0\PythonFiles\testing_tools\adapter\pytest\_discovery.py", line 9, in <module>
    import pytest
ModuleNotFoundError: No module named 'pytest'

related bug #5454