### PR TITLE
Few test improvements

### DIFF
--- a/Python/Tests/TestAdapterTests/TestDiscovererTests.cs
+++ b/Python/Tests/TestAdapterTests/TestDiscovererTests.cs
@@ -19,6 +19,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using Microsoft.PythonTools.Parsing;
 using Microsoft.PythonTools.TestAdapter;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -251,7 +252,12 @@ namespace TestAdapterTests {
             Assert.AreEqual(0, discoverySink.Tests.Count);
 
             var errors = string.Join(Environment.NewLine, logger.GetErrors());
-            AssertUtil.Contains(errors, "ModuleNotFoundError: No module named 'pytest'");
+            AssertUtil.Contains(
+                errors,
+                Version.Version <= PythonLanguageVersion.V27
+                    ? "ImportError: No module named pytest"
+                    : "ModuleNotFoundError: No module named 'pytest'"
+            );
         }
 
         [TestMethod, Priority(0)]


### PR DESCRIPTION
Now that we can discover unittest without pytest being installed, I've adjusted the test to make sure 'pytest' is not installed in the environment when testing 'unittest' support. Also fix for Python 2.7 error validation.