### PR TITLE
fix for Unittest discovery not working on Python 2.7

### DIFF
--- a/Python/Product/TestAdapter.Executor/PythonFiles/testing_tools/adapter/unittest/_discovery.py
+++ b/Python/Product/TestAdapter.Executor/PythonFiles/testing_tools/adapter/unittest/_discovery.py
@@ -49,7 +49,7 @@ def discover(pytestargs=None, hidestdio=False,
                             pass
 
                     if (isinstance(obj, types.FunctionType) or
-                        isinstance(obj, types.UnboundMethodType)):
+                        ((sys.version_info[0] < 3) and isinstance(obj, types.UnboundMethodType))):
                         _, lineno = inspect.getsourcelines(obj)
                         setattr(test, 'lineno', lineno)
             except:

--- a/Python/Product/TestAdapter.Executor/PythonFiles/testing_tools/adapter/unittest/_discovery.py
+++ b/Python/Product/TestAdapter.Executor/PythonFiles/testing_tools/adapter/unittest/_discovery.py
@@ -40,7 +40,7 @@ def discover(pytestargs=None, hidestdio=False,
 
                     filename = inspect.getsourcefile(module)
                     setattr(test, 'source', filename)
-
+                    
                     obj = module
                     for part in parts:
                         try:
@@ -48,7 +48,8 @@ def discover(pytestargs=None, hidestdio=False,
                         except AttributeError as e:
                             pass
 
-                    if isinstance(obj, types.FunctionType):
+                    if (isinstance(obj, types.FunctionType) or
+                        isinstance(obj, types.UnboundMethodType)):
                         _, lineno = inspect.getsourcelines(obj)
                         setattr(test, 'lineno', lineno)
             except:


### PR DESCRIPTION
fix bug #5462