### PR TITLE
Fix version number in vsix/swix

### DIFF
--- a/Python/Setup/swix/Microsoft.PythonTools.vsmanproj
+++ b/Python/Setup/swix/Microsoft.PythonTools.vsmanproj
@@ -8,7 +8,7 @@
     <FinalizeManifest>true</FinalizeManifest>
     <FinalizeSkipLayout>true</FinalizeSkipLayout>
 
-    <BuildNumber>$(VSTarget).$(BuildNumber)</BuildNumber>
+    <BuildNumber>$(FileVersion)</BuildNumber>
 
     <TargetName>$(MSBuildProjectName)</TargetName>
   </PropertyGroup>

--- a/Python/Setup/swix/swix.generate.targets
+++ b/Python/Setup/swix/swix.generate.targets
@@ -4,7 +4,7 @@
     <SwrFile>$(IntermediateOutputPath)package.g.swr</SwrFile>
     <SwrFile Condition="$(OutputLocalized)">$(IntermediateOutputPath)package.g.$(lang).swr</SwrFile>
     <SwixPackageType Condition="$(SwixPackageType) == ''">component</SwixPackageType>
-    <SwixVersion Condition="$(SwixVersion) == ''">$(VSTarget).$(BuildNumber)</SwixVersion>
+    <SwixVersion Condition="$(SwixVersion) == ''">$(FileVersion)</SwixVersion>
     <Python Condition="$(Python) == ''">"$(PackagesPath)python\tools\python.exe"</Python>
   </PropertyGroup>
 


### PR DESCRIPTION
Fix #5457 

Confirmed that the vsix manifest.json built on the build machine now is 16.2.<build> instead of 16.0.<build> previously, so I think this is good to go.