### PR TITLE
Unit test discovery assert when test in sub folder bug #5477

### DIFF
--- a/Python/Product/TestAdapter.Executor/PythonFiles/testing_tools/adapter/unittest/_discovery.py
+++ b/Python/Product/TestAdapter.Executor/PythonFiles/testing_tools/adapter/unittest/_discovery.py
@@ -20,38 +20,44 @@ def discover(pytestargs=None, hidestdio=False,
         for cls in suite._tests:
             try:
                 for test in cls._tests:
-                    #Find source, lineno from TestId and add them to test object
-                    parts = test.id().split('.')
-                    error_case, error_message = None, None
+                    try:    
+                        #Find source, lineno from TestId and add them to test object
+                        parts = test.id().split('.')
+                        error_case, error_message = None, None
                     
-                    #Used loadTestsFromName(..) as an example of finding source of a function
-                    #https://github.com/python/cpython/blob/master/Lib/unittest/loader.py
+                        #Used loadTestsFromName(..) as an example of finding source of a function
+                        #https://github.com/python/cpython/blob/master/Lib/unittest/loader.py
 
-                    parts_copy = parts[:]
-                    while parts_copy:
-                        try:
-                            module_name = '.'.join(parts_copy)
-                            module = __import__(module_name)
-                            break
-                        except ImportError:
-                            next_attribute = parts_copy.pop()
+                        parts_copy = parts[:]
+                        while parts_copy:
+                            try:
+                                module_name = '.'.join(parts_copy)
+                                module = __import__(module_name)
+                                break
+                            except ImportError:
+                                next_attribute = parts_copy.pop()
                             
-                    parts = parts[1:]
-
-                    filename = inspect.getsourcefile(module)
-                    setattr(test, 'source', filename)
+                        parts = parts[1:]
                     
-                    obj = module
-                    for part in parts:
-                        try:
-                            parent, obj = obj, getattr(obj, part)
-                        except AttributeError as e:
-                            pass
+                        obj = module
+                        for part in parts:
+                            try:
+                                parent, obj = obj, getattr(obj, part)
+                            except AttributeError as e:
+                                pass
 
-                    if (isinstance(obj, types.FunctionType) or
-                        ((sys.version_info[0] < 3) and isinstance(obj, types.UnboundMethodType))):
-                        _, lineno = inspect.getsourcelines(obj)
-                        setattr(test, 'lineno', lineno)
+                        if (isinstance(obj, types.FunctionType) or
+                            ((sys.version_info[0] < 3) and isinstance(obj, types.UnboundMethodType))):
+                        
+                            #workaround for decorators on functions return the source of decorator and not the actual function
+                            #We return the finename of our parent which should be the class, works even if class also has a decorator
+                            filename = inspect.getsourcefile(parent)
+                            setattr(test, 'source', filename)
+
+                            _, lineno = inspect.getsourcelines(obj)
+                            setattr(test, 'lineno', lineno)
+                    except:
+                        pass
             except:
                 pass
     return (

--- a/Python/Tests/TestAdapterTests/TestDiscovererTests.cs
+++ b/Python/Tests/TestAdapterTests/TestDiscovererTests.cs
@@ -282,7 +282,54 @@ namespace TestAdapterTests {
             DiscoverTests(testEnv, new[] { testFilePath }, runSettings, expectedTests);
         }
 
-        [Ignore] // TODO: is this a bug in product? this is not returning any result
+        [TestMethod, Priority(0)]
+        [TestCategory("10s")]
+        
+        public void DiscoverUnittestDecoratorsIgnoreLineNumbers() {
+            var testEnv = TestEnvironment.Create(Version, FrameworkUnittest);
+
+            var testFilePath = Path.Combine(testEnv.SourceFolderPath, "test_decorators_ut.py");
+            File.Copy(TestData.GetPath("TestData", "TestDiscoverer", "Decorators", "test_decorators_ut.py"), testFilePath);
+
+            var expectedTests = new[] {
+                new TestInfo("test_ut_fail", "test_decorators_ut.py::TestClassDecoratorsUT::test_ut_fail", testFilePath, 5),
+                //note: Currently unittest/_discovery.py is returning decorators line number
+                new TestInfo("test_ut_pass", "test_decorators_ut.py::TestClassDecoratorsUT::test_ut_pass", testFilePath, 8), 
+            };
+
+            var runSettings = new MockRunSettings(
+                new MockRunSettingsXmlBuilder(testEnv.TestFramework, testEnv.InterpreterPath, testEnv.ResultsFolderPath, testEnv.SourceFolderPath)
+                    .WithTestFilesFromFolder(testEnv.SourceFolderPath)
+                    .ToXml()
+            );
+
+            DiscoverTests(testEnv, new[] { testFilePath }, runSettings, expectedTests);
+        }
+
+        [Ignore] //note: Add when we fix: Unittest discovery returns off by one line number for decorated functions #5497
+        [TestMethod, Priority(0)]
+        [TestCategory("10s")]
+        public void DiscoverUnittestDecoratorsCorrectLineNumbers() {
+            var testEnv = TestEnvironment.Create(Version, FrameworkUnittest);
+
+            var testFilePath = Path.Combine(testEnv.SourceFolderPath, "test_decorators_ut.py");
+            File.Copy(TestData.GetPath("TestData", "TestDiscoverer", "Decorators", "test_decorators_ut.py"), testFilePath);
+
+            var expectedTests = new[] {
+                new TestInfo("test_ut_fail", "test_decorators_ut.py::TestClassDecoratorsUT::test_ut_fail", testFilePath, 5),
+                //bschnurr note: currently unittest/_discovery.py is returning decorators line number
+                new TestInfo("test_ut_pass", "test_decorators_ut.py::TestClassDecoratorsUT::test_ut_pass", testFilePath, 9),
+            };
+
+            var runSettings = new MockRunSettings(
+                new MockRunSettingsXmlBuilder(testEnv.TestFramework, testEnv.InterpreterPath, testEnv.ResultsFolderPath, testEnv.SourceFolderPath)
+                    .WithTestFilesFromFolder(testEnv.SourceFolderPath)
+                    .ToXml()
+            );
+
+            DiscoverTests(testEnv, new[] { testFilePath }, runSettings, expectedTests);
+        }
+
         [TestMethod, Priority(0)]
         [TestCategory("10s")]
         public void DiscoverUnittestRelativeImport() {
@@ -295,7 +342,7 @@ namespace TestAdapterTests {
             var expectedTests = new[] {
                 new TestInfo(
                     "test_relative_import",
-                    "test_relative_import.py::RelativeImportTests::test_relative_import",
+                    "relativeimportpackage\\test_relative_import.py::RelativeImportTests::test_relative_import",
                     testFilePath,
                     5
                 ),

--- a/Python/Tests/TestData/TestDiscoverer/Decorators/test_decorators_ut.py
+++ b/Python/Tests/TestData/TestDiscoverer/Decorators/test_decorators_ut.py
@@ -1,0 +1,13 @@
+import unittest
+
+@unittest.skip("Skip over the entire test class")
+class TestClassDecoratorsUT(unittest.TestCase):
+    def test_ut_fail(self):
+        self.fail("Not implemented")
+   
+    @unittest.skip("Skip over the entire test routine")
+    def test_ut_pass(self):
+        pass
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
-now we append the last two elements from the testId which should be classname and functionname to the module relative path.

-Gathering the source file of the test proved difficult. Previous version was using the module file but for anything in a package it was returning __init__.py.

Then trying getsourcefile on the test object would return the wrong file is the test was decorated.
My solution is to call getsourcefile on the test's parent, which should be the class object, which still returns the correct filename even if the class is decorated.

Fix #5477 