### PR TITLE
Add error handling in environment window.

### DIFF
--- a/Python/Product/Common/Strings.Designer.cs
+++ b/Python/Product/Common/Strings.Designer.cs
@@ -3389,11 +3389,29 @@ namespace Microsoft.PythonTools {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to An error occurred opening command prompt..
+        /// </summary>
+        public static string ErrorOpeningCommandPrompt {
+            get {
+                return ResourceManager.GetString("ErrorOpeningCommandPrompt", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to An error occurred opening this interactive window..
         /// </summary>
         public static string ErrorOpeningInteractiveWindow {
             get {
                 return ResourceManager.GetString("ErrorOpeningInteractiveWindow", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to An error occurred opening PowerShell..
+        /// </summary>
+        public static string ErrorOpeningPowershell {
+            get {
+                return ResourceManager.GetString("ErrorOpeningPowershell", resourceCulture);
             }
         }
         
@@ -3416,6 +3434,15 @@ namespace Microsoft.PythonTools {
         public static string ErrorStartingInteractiveProcess {
             get {
                 return ResourceManager.GetString("ErrorStartingInteractiveProcess", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to An error occurred starting this interpreter..
+        /// </summary>
+        public static string ErrorStartingInterpreter {
+            get {
+                return ResourceManager.GetString("ErrorStartingInterpreter", resourceCulture);
             }
         }
         

--- a/Python/Product/Common/Strings.resx
+++ b/Python/Product/Common/Strings.resx
@@ -537,6 +537,15 @@ The web.config file will be configured to resolve URIs matching this pattern to 
   <data name="ErrorOpeningInteractiveWindow" xml:space="preserve">
     <value>An error occurred opening this interactive window.</value>
   </data>
+  <data name="ErrorStartingInterpreter" xml:space="preserve">
+    <value>An error occurred starting this interpreter.</value>
+  </data>
+  <data name="ErrorOpeningCommandPrompt" xml:space="preserve">
+    <value>An error occurred opening command prompt.</value>
+  </data>
+  <data name="ErrorOpeningPowershell" xml:space="preserve">
+    <value>An error occurred opening PowerShell.</value>
+  </data>
   <data name="ErrorStartingInteractiveProcess" xml:space="preserve">
     <value>Failed to start interactive process:
 {0}


### PR DESCRIPTION
Fix #5511 

Added some try/catch, as well as some `?.Dispose` which we've started doing elsewhere as a precaution, since `Process.Start` can return `null`.