### PR TITLE
fix for Tooltips in package manager search results slows down VS, bec…

### DIFF
--- a/Python/Product/EnvironmentsList/PipPackageView.cs
+++ b/Python/Product/EnvironmentsList/PipPackageView.cs
@@ -45,17 +45,18 @@ namespace Microsoft.PythonTools.EnvironmentsList {
             }
 
             try {
-                var oldDescription = _package.Description;
                 var p = await _provider.GetInstallablePackageAsync(_package, CancellationToken.None);
                 if (p.IsValid) {
                     if (!p.ExactVersion.IsEmpty && (!_upgradeVersion.HasValue || !_upgradeVersion.Value.Equals(p.ExactVersion))) {
                         _upgradeVersion = p.ExactVersion;
                         OnPropertyChanged("UpgradeVersion");
                     }
-                    if (p.Description != _package.Description) {
+                    
+                    if (!String.IsNullOrEmpty(p.Description) && p.Description != _package.Description) {
                         _package.Description = p.Description;
                         OnPropertyChanged("Description");
-                    } else if (string.IsNullOrEmpty(p.Description)) {
+                    }
+                    else if (_package.Description == null) {
                         _package.Description = string.Empty;
                         OnPropertyChanged("Description");
                     }


### PR DESCRIPTION
…omes unusable fix #5518

circular triggering when p.Description was null.
package.description was first  null

then retriggered
then package.description was set to empty.string
then hit the first if again.