### PR TITLE
Fix for pytest discovery in workspace mode not working on ptvsd

### DIFF
--- a/Python/Product/PythonTools/PythonTools/WorkspaceInfoBarManager.cs
+++ b/Python/Product/PythonTools/PythonTools/WorkspaceInfoBarManager.cs
@@ -114,6 +114,7 @@ namespace Microsoft.PythonTools {
                    PathUtils.IsValidPath(filePath) &&
                    File.Exists(filePath) &&
                    ModulePath.IsPythonSourceFile(filePath) &&
+                   _pythonWorkspaceService.Workspace != null &&
                    PathUtils.IsSubpathOf(_pythonWorkspaceService.Workspace.Location, filePath);
         }
 

--- a/Python/Product/TestAdapter.Executor/Pytest/PytestExtensions.cs
+++ b/Python/Product/TestAdapter.Executor/Pytest/PytestExtensions.cs
@@ -53,6 +53,13 @@ namespace Microsoft.PythonTools.TestAdapter.Pytest {
             tc.SetPropertyValue(Constants.PytestIdProperty, test.Id);
             tc.SetPropertyValue(Constants.PyTestXmlClassNameProperty, CreateXmlClassName(test, parentMap));
             tc.SetPropertyValue(Constants.PytestTestExecutionPathPropertery, GetAbsoluteTestExecutionPath(fullSourcePathNormalized, test.Id));
+
+            if (test.Markers != null) {
+                foreach (var marker in test.Markers) {
+                    tc.Traits.Add(new Trait(marker.ToString(), String.Empty));
+                }
+            }
+
             return tc;
         }
 

--- a/Python/Product/TestAdapter.Executor/Pytest/TestDiscovererPytest.cs
+++ b/Python/Product/TestAdapter.Executor/Pytest/TestDiscovererPytest.cs
@@ -48,7 +48,7 @@ namespace Microsoft.PythonTools.TestAdapter.Pytest {
 
             try {
                 var env = InitializeEnvironment(sources, _settings);
-                var arguments = GetArguments(sources);
+                var arguments = GetArguments(sources, _settings);
                 DebugInfo("cd " + _settings.WorkingDirectory);
                 DebugInfo("set " + _settings.PathEnv + "=" + env[_settings.PathEnv]);
                 DebugInfo($"{_settings.InterpreterPath} {string.Join(" ", arguments)}");
@@ -96,7 +96,7 @@ namespace Microsoft.PythonTools.TestAdapter.Pytest {
             }
         }
 
-        public string[] GetArguments(IEnumerable<string> sources) {
+        public string[] GetArguments(IEnumerable<string> sources, PythonProjectSettings projSettings) {
             var arguments = new List<string>();
             arguments.Add(DiscoveryAdapterPath);
             arguments.Add("discover");
@@ -104,8 +104,10 @@ namespace Microsoft.PythonTools.TestAdapter.Pytest {
             arguments.Add("--");
             arguments.Add("--cache-clear");
 
-            foreach (var s in sources) {
-                arguments.Add(s);
+            if (!projSettings.IsWorkspace) {
+                foreach (var s in sources) {
+                    arguments.Add(s);
+                }
             }
             return arguments.ToArray();
         }
@@ -129,15 +131,6 @@ namespace Microsoft.PythonTools.TestAdapter.Pytest {
 
         private string GetSearchPaths(IEnumerable<string> sources, PythonProjectSettings settings) {
             var paths = settings.SearchPath;
-
-            HashSet<string> knownModulePaths = new HashSet<string>();
-            foreach (var source in sources) {
-                string testFilePath = PathUtils.GetAbsoluteFilePath(settings.ProjectHome, source);
-                var modulePath = ModulePath.FromFullPath(testFilePath);
-                if (knownModulePaths.Add(modulePath.LibraryPath)) {
-                    paths.Insert(0, modulePath.LibraryPath);
-                }
-            }
 
             paths.Insert(0, settings.WorkingDirectory);
 

--- a/Python/Product/TestAdapter.Executor/Services/ExecutorService.cs
+++ b/Python/Product/TestAdapter.Executor/Services/ExecutorService.cs
@@ -138,6 +138,8 @@ namespace Microsoft.PythonTools.TestAdapter.Services {
 
         private string GetSearchPaths(IEnumerable<TestCase> tests, PythonProjectSettings settings) {
             var paths = settings.SearchPath;
+            paths.Insert(0, settings.WorkingDirectory);
+
             string searchPaths = string.Join(
                 ";",
                 paths.Where(Directory.Exists).Distinct(StringComparer.OrdinalIgnoreCase)

--- a/Python/Product/TestAdapter.Executor/Services/ExecutorService.cs
+++ b/Python/Product/TestAdapter.Executor/Services/ExecutorService.cs
@@ -92,7 +92,7 @@ namespace Microsoft.PythonTools.TestAdapter.Services {
             };
 
             foreach (TestCase test in tests) {
-                var executionTestPath = test.GetPropertyValue<string>(Pytest.Constants.PytestTestExecutionPathPropertery, default);
+                var executionTestPath = test.GetPropertyValue<string>(Pytest.Constants.PytestIdProperty, default);
                 if (String.IsNullOrEmpty(executionTestPath)) {
                     Debug.WriteLine("Pytest execution path missing for testcase {0}", test.FullyQualifiedName);
                     continue;
@@ -138,16 +138,6 @@ namespace Microsoft.PythonTools.TestAdapter.Services {
 
         private string GetSearchPaths(IEnumerable<TestCase> tests, PythonProjectSettings settings) {
             var paths = settings.SearchPath;
-
-            HashSet<string> knownModulePaths = new HashSet<string>();
-            foreach (var test in tests) {
-                string testFilePath = PathUtils.GetAbsoluteFilePath(settings.ProjectHome, test.CodeFilePath);
-                var modulePath = ModulePath.FromFullPath(testFilePath);
-                if (knownModulePaths.Add(modulePath.LibraryPath)) {
-                    paths.Insert(0, modulePath.LibraryPath);
-                }
-            }
-
             string searchPaths = string.Join(
                 ";",
                 paths.Where(Directory.Exists).Distinct(StringComparer.OrdinalIgnoreCase)
@@ -188,9 +178,8 @@ namespace Microsoft.PythonTools.TestAdapter.Services {
                                     }
                                  }
                             }
-                           
-                            WaitHandle.WaitAny(new WaitHandle[] { proc.WaitHandle });
-                            proc.Wait(TimeSpan.FromMilliseconds(1000));
+
+                            proc.Wait();
                         } catch (COMException ex) {
                             Error(Strings.Test_ErrorConnecting);
                             DebugError(ex.ToString());

--- a/Python/Product/TestAdapter.Executor/UnitTest/TestDiscovererUnitTest.cs
+++ b/Python/Product/TestAdapter.Executor/UnitTest/TestDiscovererUnitTest.cs
@@ -140,16 +140,6 @@ namespace Microsoft.PythonTools.TestAdapter.UnitTest {
 
         private string GetSearchPaths(IEnumerable<string> sources, PythonProjectSettings settings) {
             var paths = settings.SearchPath;
-
-            HashSet<string> knownModulePaths = new HashSet<string>();
-            foreach (var source in sources) {
-                string testFilePath = PathUtils.GetAbsoluteFilePath(settings.ProjectHome, source);
-                var modulePath = ModulePath.FromFullPath(testFilePath);
-                if (knownModulePaths.Add(modulePath.LibraryPath)) {
-                    paths.Insert(0, modulePath.LibraryPath);
-                }
-            }
-
             paths.Insert(0, settings.WorkingDirectory);
 
             string searchPaths = string.Join(

--- a/Python/Tests/TestAdapterTests/TestExecutorTests.cs
+++ b/Python/Tests/TestAdapterTests/TestExecutorTests.cs
@@ -604,6 +604,11 @@ namespace TestAdapterTests {
                 };
 
                 string id = ".\\" + ti.FullyQualifiedName;
+                if (testEnv.TestFramework == FrameworkPytest) {
+                    var classParts = ti.PytestXmlClassName.Split('.');
+                    id = (classParts.Length > 1) ? ".\\" + ti.FullyQualifiedName : ".\\" + Path.GetFileName(ti.FilePath) + "::" + ti.DisplayName;
+                }
+             
                 string xmlClassName = ti.PytestXmlClassName;
 
                 // FullyQualifiedName as exec path suffix only works for test class case,


### PR DESCRIPTION
Fix improved runing pytests in ptvsd. Now passing just pytestId instead of path+pytestId
Fix missing traits on pytests. Removed by mistake in a previous change.
since currently we only support running tests under the project/workspace folder.
Currently it works up to 318 tests from ptvsd

auto adding search paths were messing up pytest's discovery

however we needed to manually add /src folder to the search paths for everything to work
ie.

PythonSettings.json
{
    "TestFramework": "pytest",
    "SearchPaths": [ "D:\\dev\\ptvsd\\src\\" ]

}