### PR TITLE
Fix dynamic project file generation in tests to force ToolsVersion="4.0"

### DIFF
--- a/Common/Tests/Utilities/SharedProject/SolutionFile.cs
+++ b/Common/Tests/Utilities/SharedProject/SolutionFile.cs
@@ -131,6 +131,15 @@ EndGlobal
             collection.UnloadAllProjects();
             collection.Dispose();
 
+            // MSBuild.Project doesn't want to save ToolsVersion as 4.0,
+            // (passing it to MSBuild.Project ctor does nothing)
+            // so manually replace it here.
+            foreach (var proj in projects) {
+                var text = File.ReadAllText(proj.FullPath, Encoding.UTF8);
+                text = text.Replace("ToolsVersion=\"Current\"", "ToolsVersion=\"4.0\"");
+                File.WriteAllText(proj.FullPath, text, Encoding.UTF8);
+            }
+
             var slnFilename = Path.Combine(location, solutionName + ".sln");
             File.WriteAllText(slnFilename, slnFile.ToString().Replace("\\t", "\t"), Encoding.UTF8);
             return new SolutionFile(slnFilename, toGenerate);


### PR DESCRIPTION
UI tests that used dynamic project generation were causing a project upgrade when the project was loaded. This was due to ToolsVersion being incorrect. This forces it after the MSBuild has saved the file, since we couldn't figure out how to get msbuild to set the version in the first place.