### PR TITLE
fix for pytest execution hitting 32k command line limt.

### DIFF
--- a/Python/Product/TestAdapter.Executor/Services/ExecutorService.cs
+++ b/Python/Product/TestAdapter.Executor/Services/ExecutorService.cs
@@ -76,7 +76,7 @@ namespace Microsoft.PythonTools.TestAdapter.Services {
         }
 
         public void Dispose() {
-          
+
         }
 
         public string[] GetArguments(IEnumerable<TestCase> tests, string outputfile) {
@@ -94,12 +94,11 @@ namespace Microsoft.PythonTools.TestAdapter.Services {
             // a test list on disk so that we do not overflow the 
             // 32K argument limit.
             var testIds = tests.Select(t => t.GetPropertyValue<string>(Pytest.Constants.PytestIdProperty, default));
-            if (testIds.Count() > 5 ) {
-                var testListFilePath = TestUtils.CreateTestList(testIds);
+            if (testIds.Count() > 5) {
+                var testListFilePath = TestUtils.CreateTestListFile(testIds);
                 arguments.Add(testListFilePath);
-            }
-            else {
-                arguments.Add("blankTestList");
+            } else {
+                arguments.Add("dummyfilename"); //expected not to exist, but script excepts something
                 foreach (var testId in testIds) {
                     arguments.Add(testId);
                 }
@@ -116,7 +115,7 @@ namespace Microsoft.PythonTools.TestAdapter.Services {
             debugPort = 0;
 
             if (_debugMode == PythonDebugMode.PythonOnly) {
-                if(_projectSettings.UseLegacyDebugger) {
+                if (_projectSettings.UseLegacyDebugger) {
                     var secretBuffer = new byte[24];
                     RandomNumberGenerator.Create().GetNonZeroBytes(secretBuffer);
                     debugSecret = Convert.ToBase64String(secretBuffer)
@@ -132,7 +131,7 @@ namespace Microsoft.PythonTools.TestAdapter.Services {
         private Dictionary<string, string> InitializeEnvironment(IEnumerable<TestCase> tests) {
             var pythonPathVar = _projectSettings.PathEnv;
             var pythonPath = GetSearchPaths(tests, _projectSettings);
-            var env  = new Dictionary<string, string>();
+            var env = new Dictionary<string, string>();
 
             if (!string.IsNullOrWhiteSpace(pythonPathVar)) {
                 env[pythonPathVar] = pythonPath;
@@ -187,7 +186,7 @@ namespace Microsoft.PythonTools.TestAdapter.Services {
                                     if (proc.Wait(TimeSpan.FromMilliseconds(500))) {
                                         break;
                                     }
-                                 }
+                                }
                             }
 
                             proc.Wait();
@@ -205,7 +204,7 @@ namespace Microsoft.PythonTools.TestAdapter.Services {
             } catch (Exception e) {
                 Error(e.ToString());
             }
-            
+
             return ouputFile;
         }
 

--- a/Python/Product/TestAdapter.Executor/TestAdapter.Executor.csproj
+++ b/Python/Product/TestAdapter.Executor/TestAdapter.Executor.csproj
@@ -106,6 +106,7 @@
     <Compile Include="UnitTest\TestDiscovererUnitTest.cs" />
     <Compile Include="UnitTest\UnitTestDiscoveryResults.cs" />
     <Compile Include="UnitTest\UnitTestExtensions.cs" />
+    <Compile Include="Utils\TestUtils.cs" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="PythonFiles\testing_tools\adapter\discovery.py">

--- a/Python/Product/TestAdapter.Executor/UnitTest/TestExecutorUnitTest.cs
+++ b/Python/Product/TestAdapter.Executor/UnitTest/TestExecutorUnitTest.cs
@@ -508,7 +508,7 @@ namespace Microsoft.PythonTools.TestAdapter {
                     // a test list on disk so that we do not overflow the 
                     // 32K argument limit.
                     if (_tests.Length > 5) {
-                        testList = TestUtils.CreateTestList(GetTestCases().Select( pair => pair.Key));
+                        testList = TestUtils.CreateTestListFile(GetTestCases().Select( pair => pair.Key));
                     }
                     var arguments = GetArguments(testList);
 

--- a/Python/Product/TestAdapter.Executor/UnitTest/TestExecutorUnitTest.cs
+++ b/Python/Product/TestAdapter.Executor/UnitTest/TestExecutorUnitTest.cs
@@ -34,6 +34,7 @@ using Microsoft.PythonTools.Infrastructure;
 using Microsoft.PythonTools.Ipc.Json;
 using Microsoft.PythonTools.TestAdapter.Config;
 using Microsoft.PythonTools.TestAdapter.Services;
+using Microsoft.PythonTools.TestAdapter.Utils;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
@@ -507,7 +508,7 @@ namespace Microsoft.PythonTools.TestAdapter {
                     // a test list on disk so that we do not overflow the 
                     // 32K argument limit.
                     if (_tests.Length > 5) {
-                        testList = CreateTestList();
+                        testList = TestUtils.CreateTestList(GetTestCases().Select( pair => pair.Key));
                     }
                     var arguments = GetArguments(testList);
 

--- a/Python/Product/TestAdapter.Executor/Utils/TestUtils.cs
+++ b/Python/Product/TestAdapter.Executor/Utils/TestUtils.cs
@@ -21,18 +21,10 @@ using System.Text;
 namespace Microsoft.PythonTools.TestAdapter.Utils {
     static class TestUtils {
 
-        // For a small set of tests, we'll pass them on the command
-        // line. Once we exceed a certain (arbitrary) number, create
-        // a test list on disk so that we do not overflow the 
-        // 32K argument limit.
-        internal static string CreateTestList(IEnumerable<string> tests) {
-            var testList = Path.GetTempFileName();
-            using (var writer = new StreamWriter(testList, false, new UTF8Encoding(false))) {
-                foreach (var test in tests) {
-                    writer.WriteLine(test);
-                }
-            }
-            return testList;
+        internal static string CreateTestListFile(IEnumerable<string> tests) {
+            var testListFilePath = Path.GetTempFileName();
+            File.WriteAllLines(testListFilePath, tests, new UTF8Encoding(false));
+            return testListFilePath;
         }
     }
 }

--- a/Python/Product/TestAdapter.Executor/Utils/TestUtils.cs
+++ b/Python/Product/TestAdapter.Executor/Utils/TestUtils.cs
@@ -1,0 +1,38 @@
+﻿// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace Microsoft.PythonTools.TestAdapter.Utils {
+    static class TestUtils {
+
+        // For a small set of tests, we'll pass them on the command
+        // line. Once we exceed a certain (arbitrary) number, create
+        // a test list on disk so that we do not overflow the 
+        // 32K argument limit.
+        internal static string CreateTestList(IEnumerable<string> tests) {
+            var testList = Path.GetTempFileName();
+            using (var writer = new StreamWriter(testList, false, new UTF8Encoding(false))) {
+                foreach (var test in tests) {
+                    writer.WriteLine(test);
+                }
+            }
+            return testList;
+        }
+    }
+}

--- a/Python/Product/TestAdapter/testlauncher.py
+++ b/Python/Product/TestAdapter/testlauncher.py
@@ -19,11 +19,11 @@ import sys
 import traceback
 
 def main():
-    cwd, testRunner, secret, port, debugger_search_path, args = parse_argv()
+    cwd, testRunner, secret, port, debugger_search_path, test_file, args = parse_argv()
     sys.path[0] = os.getcwd()
     os.chdir(cwd)
     load_debugger(secret, port, debugger_search_path)
-    run(testRunner, args)
+    run(testRunner,test_file, args)
 
 def parse_argv():
     """Parses arguments for use with the test launcher.
@@ -33,10 +33,11 @@ def parse_argv():
     3. debugSecret
     4. debugPort
     5. Debugger search path
-    6. Rest of the arguments are passed into the test runner.
+    6. TestFile List
+    7. Rest of the arguments are passed into the test runner.
     """
 
-    return (sys.argv[1], sys.argv[2], sys.argv[3], int(sys.argv[4]), sys.argv[5], sys.argv[6:])
+    return (sys.argv[1], sys.argv[2], sys.argv[3], int(sys.argv[4]), sys.argv[5], sys.argv[6], sys.argv[7:])
 
 def load_debugger(secret, port, debugger_search_path):
     # Load the debugger package
@@ -73,11 +74,20 @@ Press Enter to close. . .''')
             input()
         sys.exit(1)
 
-def run(testRunner, args):
+def run(testRunner,test_list, args):
     """Runs the test
     testRunner -- test runner to be used `pytest` or `nose`
     args -- arguments passed into the test runner
     """
+
+    all_tests = []
+    if test_list and os.path.exists(test_list):
+        with open(test_list, 'r', encoding='utf-8') as tests:
+            all_tests.extend(t.strip() for t in tests)
+
+
+    if all_tests:
+        args.extend(all_tests)
 
     try:
         if testRunner == 'pytest':

--- a/Python/Product/TestAdapter/testlauncher.py
+++ b/Python/Product/TestAdapter/testlauncher.py
@@ -33,7 +33,7 @@ def parse_argv():
     3. debugSecret
     4. debugPort
     5. Debugger search path
-    6. TestFile List
+    6. TestFile, with a list of testIds to run
     7. Rest of the arguments are passed into the test runner.
     """
 

--- a/Python/Product/TestAdapter/testlauncher.py
+++ b/Python/Product/TestAdapter/testlauncher.py
@@ -23,7 +23,7 @@ def main():
     sys.path[0] = os.getcwd()
     os.chdir(cwd)
     load_debugger(secret, port, debugger_search_path)
-    run(testRunner,test_file, args)
+    run(testRunner, test_file, args)
 
 def parse_argv():
     """Parses arguments for use with the test launcher.
@@ -74,20 +74,15 @@ Press Enter to close. . .''')
             input()
         sys.exit(1)
 
-def run(testRunner,test_list, args):
+def run(testRunner, test_file, args):
     """Runs the test
     testRunner -- test runner to be used `pytest` or `nose`
     args -- arguments passed into the test runner
     """
 
-    all_tests = []
-    if test_list and os.path.exists(test_list):
-        with open(test_list, 'r', encoding='utf-8') as tests:
-            all_tests.extend(t.strip() for t in tests)
-
-
-    if all_tests:
-        args.extend(all_tests)
+    if test_file and os.path.exists(test_file):
+        with open(test_file, 'r', encoding='utf-8') as tests:
+            args.extend(t.strip() for t in tests)
 
     try:
         if testRunner == 'pytest':


### PR DESCRIPTION
- now passing pytestIds to run in a file just like unittest execution
- testlaunch.py now parses out testids from any testlist file