### PR TITLE
Bschnurr/fix pytest discovery limits

### DIFF
--- a/Python/Product/TestAdapter.Executor/Pytest/TestDiscovererPytest.cs
+++ b/Python/Product/TestAdapter.Executor/Pytest/TestDiscovererPytest.cs
@@ -108,7 +108,7 @@ namespace Microsoft.PythonTools.TestAdapter.Pytest {
             bool useTestList = sources.Count() > 5;
             if (!projSettings.IsWorkspace &&
                 useTestList) {
-                var testListFilePath = TestUtils.CreateTestList(sources);
+                var testListFilePath = TestUtils.CreateTestListFile(sources);
                 arguments.Add("--test-list");
                 arguments.Add(testListFilePath);
             }

--- a/Python/Product/TestAdapter.Executor/PythonFiles/testing_tools/adapter/__main__.py
+++ b/Python/Product/TestAdapter.Executor/PythonFiles/testing_tools/adapter/__main__.py
@@ -2,13 +2,12 @@
 # Licensed under the MIT License.
 
 from __future__ import absolute_import
-
+import os
 import argparse
 import sys
 
 from . import report, unittest
 from .errors import UnsupportedToolError, UnsupportedCommandError
-
 
 def default_subparser(cmd, name, parent):
     parser = parent.add_parser(name)
@@ -84,6 +83,7 @@ def parse_args(
                 subsub.add_argument('--no-hide-stdio', dest='hidestdio',
                                     action='store_false')
                 subsub.add_argument('--pretty', action='store_true')
+                subsub.add_argument('--test-list',  metavar='<file>', type=str, help='read tests from this file')
 
     # Parse the args!
     if '--' in argv:
@@ -95,6 +95,11 @@ def parse_args(
     args = parser.parse_args(argv)
     ns = vars(args)
 
+    # Append tests pass by file test_list to toolargs
+    if args.test_list and os.path.exists(args.test_list):
+        with open(args.test_list, 'r', encoding='utf-8') as tests:
+            toolargs.extend(t.strip() for t in tests)
+   
     cmd = ns.pop('cmd')
     if not cmd:
         parser.error('missing command')

--- a/Python/Product/TestAdapter.Executor/UnitTest/TestDiscovererUnitTest.cs
+++ b/Python/Product/TestAdapter.Executor/UnitTest/TestDiscovererUnitTest.cs
@@ -34,7 +34,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using Microsoft.PythonTools.Analysis;
 using Microsoft.PythonTools.Infrastructure;
 using Microsoft.PythonTools.TestAdapter.Config;
 using Microsoft.PythonTools.TestAdapter.Services;
@@ -112,8 +111,8 @@ namespace Microsoft.PythonTools.TestAdapter.UnitTest {
             arguments.Add(DiscoveryAdapterPath);
             arguments.Add("discover");
             arguments.Add("unittest");
+            //Note unittest specific options go after this separator
             arguments.Add("--");
-
             arguments.Add(_settings.UnitTestRootDir);
             arguments.Add(_settings.UnitTestPattern);
 


### PR DESCRIPTION

fix for pytest execution hitting 32k command line limt.  …
- now passing pytestIds to run in a file just like unittest execution
- testlaunch.py now parses out testids from any testlist file