### PR TITLE
Fix reading of test file on Python 2.7.

### DIFF
--- a/Python/Product/TestAdapter.Executor/PythonFiles/testing_tools/adapter/__main__.py
+++ b/Python/Product/TestAdapter.Executor/PythonFiles/testing_tools/adapter/__main__.py
@@ -2,8 +2,9 @@
 # Licensed under the MIT License.
 
 from __future__ import absolute_import
-import os
+import io
 import argparse
+import os
 import sys
 
 from . import report, unittest
@@ -97,7 +98,7 @@ def parse_args(
 
     # Append tests pass by file test_list to toolargs
     if args.test_list and os.path.exists(args.test_list):
-        with open(args.test_list, 'r', encoding='utf-8') as tests:
+        with io.open(args.test_list, 'r', encoding='utf-8') as tests:
             toolargs.extend(t.strip() for t in tests)
    
     cmd = ns.pop('cmd')

--- a/Python/Product/TestAdapter.Executor/UnitTest/TestExecutorUnitTest.cs
+++ b/Python/Product/TestAdapter.Executor/UnitTest/TestExecutorUnitTest.cs
@@ -508,7 +508,7 @@ namespace Microsoft.PythonTools.TestAdapter {
                     // a test list on disk so that we do not overflow the 
                     // 32K argument limit.
                     if (_tests.Length > 5) {
-                        testList = TestUtils.CreateTestListFile(GetTestCases().Select( pair => pair.Key));
+                        testList = TestUtils.CreateTestListFile(GetTestCases().Select(pair => pair.Key));
                     }
                     var arguments = GetArguments(testList);
 

--- a/Python/Product/TestAdapter/testlauncher.py
+++ b/Python/Product/TestAdapter/testlauncher.py
@@ -14,6 +14,7 @@
 # See the Apache Version 2.0 License for specific language governing
 # permissions and limitations under the License.
 
+import io
 import os
 import sys
 import traceback
@@ -81,7 +82,7 @@ def run(testRunner, test_file, args):
     """
 
     if test_file and os.path.exists(test_file):
-        with open(test_file, 'r', encoding='utf-8') as tests:
+        with io.open(test_file, 'r', encoding='utf-8') as tests:
             args.extend(t.strip() for t in tests)
 
     try:

--- a/Python/Product/TestAdapter/visualstudio_py_testlauncher.py
+++ b/Python/Product/TestAdapter/visualstudio_py_testlauncher.py
@@ -19,6 +19,7 @@ from __future__ import with_statement
 __author__ = "Microsoft Corporation <ptvshelp@microsoft.com>"
 __version__ = "3.0.0.0"
 
+import io
 import os.path
 import sys
 import json
@@ -38,13 +39,6 @@ try:
 except:
     from unittest import _TextTestResult as TextTestResult
     _IS_OLD_UNITTEST = True
-
-if sys.version_info[0] < 3:
-    if sys.version_info[:2] < (2, 6):
-        from codecs import open
-    else:
-        from io import open
-
 
 class _TestOutput(object):
     """file like object which redirects output to the repl window."""
@@ -296,7 +290,7 @@ def main():
 
     all_tests = list(opts.tests or [])
     if opts.test_list:
-        with open(opts.test_list, 'r', encoding='utf-8') as test_list:
+        with io.open(opts.test_list, 'r', encoding='utf-8') as test_list:
             all_tests.extend(t.strip() for t in test_list)
 
     if opts.dry_run:

--- a/Python/Tests/TestAdapterTests/Mocks/MockRunSettingsXmlBuilder.cs
+++ b/Python/Tests/TestAdapterTests/Mocks/MockRunSettingsXmlBuilder.cs
@@ -37,7 +37,7 @@ namespace TestAdapterTests.Mocks {
         // {5} is one or more formatted _runSettingEnvironment lines
         // {6} is one or more formatted _runSettingSearch lines
 
-        private const string _runSettingProject = @"<Project name=""{0}"" home=""{1}"" nativeDebugging="""" djangoSettingsModule="""" workingDir=""{1}"" interpreter=""{2}"" pathEnv=""PYTHONPATH"" testFramework= ""{3}"" discoveryWaitTime= ""{7}""><Environment>{5}</Environment><SearchPaths>{6}</SearchPaths>
+        private const string _runSettingProject = @"<Project name=""{0}"" home=""{1}"" nativeDebugging="""" djangoSettingsModule="""" workingDir=""{1}"" interpreter=""{2}"" pathEnv=""PYTHONPATH"" testFramework= ""{3}"" discoveryWaitTime= ""{7}"" isWorkspace=""{8}""><Environment>{5}</Environment><SearchPaths>{6}</SearchPaths>
 {4}
 </Project>";
 
@@ -56,11 +56,12 @@ namespace TestAdapterTests.Mocks {
         private string _testDir;
         private string _interpreterPath;
         private int _discoveryWaitTimeInSeconds;
+        private bool _isWorkspace;
         private StringBuilder _environmentLines = new StringBuilder();
         private StringBuilder _searchLines = new StringBuilder();
         private StringBuilder _testLines = new StringBuilder();
 
-        public MockRunSettingsXmlBuilder(string testFramework, string interpreterPath, string resultsDir, string testDir, int discoveryWaitTimeInSeconds = -1 ) {
+        public MockRunSettingsXmlBuilder(string testFramework, string interpreterPath, string resultsDir, string testDir, int discoveryWaitTimeInSeconds = -1, bool isWorkspace = true) {
             _environmentLines = new StringBuilder();
             _searchLines = new StringBuilder();
             _testLines = new StringBuilder();
@@ -69,6 +70,7 @@ namespace TestAdapterTests.Mocks {
             _resultsDir = resultsDir;
             _testDir = testDir;
             _discoveryWaitTimeInSeconds = discoveryWaitTimeInSeconds;
+            _isWorkspace = isWorkspace;
         }
 
         public MockRunSettingsXmlBuilder WithEnvironmentVariable(string name, string val) {
@@ -106,7 +108,8 @@ namespace TestAdapterTests.Mocks {
                     _testLines.ToString(),
                     _environmentLines.ToString(),
                     _searchLines.ToString(),
-                    _discoveryWaitTimeInSeconds < 0 ? string.Empty : _discoveryWaitTimeInSeconds.ToString()
+                    _discoveryWaitTimeInSeconds < 0 ? string.Empty : _discoveryWaitTimeInSeconds.ToString(),
+                    _isWorkspace
                 ),
                 "false",
                 "false"

--- a/Python/Tests/TestAdapterTests/TestDiscovererTests.cs
+++ b/Python/Tests/TestAdapterTests/TestDiscovererTests.cs
@@ -20,7 +20,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Microsoft.PythonTools;
-using Microsoft.PythonTools.Parsing;
 using Microsoft.PythonTools.TestAdapter;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -72,6 +71,39 @@ namespace TestAdapterTests {
             );
 
             DiscoverTests(testEnv, new[] { testFilePath }, runSettings, expectedTests);
+        }
+
+        [TestMethod, Priority(0)]
+        [TestCategory("10s")]
+        public void DiscoverPytestLargeProject() {
+            var testEnv = TestEnvironment.GetOrCreate(Version, FrameworkPytest);
+
+            // Test that we don't try passing 1000 files via command line arguments
+            // since that would exceed the 32k limit and fail.
+            var isWorkspace = false;
+            var expectedTests = new List<TestInfo>();
+            for (int i = 0; i < 1000; i ++) {
+                var moduleName = $"test_file_with_long_file_name_{i}";
+                var funcName = $"test_func_{i}";
+                var testFilePath = Path.Combine(testEnv.SourceFolderPath, $"{moduleName}.py");
+                var testContents = $"def {funcName}(): pass";
+                File.WriteAllText(testFilePath, testContents);
+
+                expectedTests.Add(new TestInfo(
+                    funcName,
+                    $"{moduleName}.py::{moduleName}::{funcName}",
+                    testFilePath,
+                    1
+                ));
+            }
+
+            var runSettings = new MockRunSettings(
+                new MockRunSettingsXmlBuilder(testEnv.TestFramework, testEnv.InterpreterPath, testEnv.ResultsFolderPath, testEnv.SourceFolderPath, isWorkspace: isWorkspace)
+                    .WithTestFilesFromFolder(testEnv.SourceFolderPath)
+                    .ToXml()
+            );
+
+            DiscoverTests(testEnv, expectedTests.Select(t => t.FilePath).ToArray(), runSettings, expectedTests.ToArray());
         }
 
         [TestMethod, Priority(0)]
@@ -314,6 +346,49 @@ namespace TestAdapterTests {
             );
 
             DiscoverTests(testEnv, new[] { testFilePath }, runSettings, expectedTests);
+        }
+
+        [TestMethod, Priority(0)]
+        [TestCategory("10s")]
+        public void DiscoverUnittestLargeProject() {
+            var testEnv = TestEnvironment.GetOrCreate(Version, FrameworkUnittest);
+
+            // Test that we don't try passing 1000 files via command line arguments
+            // since that would exceed the 32k limit and fail.
+            var isWorkspace = false;
+            var testContentsFormat = @"import unittest
+
+class {0}(unittest.TestCase):
+    def {1}(self): pass
+
+if __name__ == '__main__':
+    unittest.main()
+";
+            var expectedTests = new List<TestInfo>();
+
+            for (int i = 0; i < 1000; i++) {
+                var moduleName = $"test_file_with_long_file_name_{i}";
+                var className = $"MyTest{i}";
+                var funcName = $"test_func_{i}";
+                var testFilePath = Path.Combine(testEnv.SourceFolderPath, $"{moduleName}.py");
+                var testContents = string.Format(testContentsFormat, className, funcName);
+                File.WriteAllText(testFilePath, testContents);
+
+                expectedTests.Add(new TestInfo(
+                    funcName,
+                    $"{moduleName}.py::{className}::{funcName}",
+                    testFilePath,
+                    4
+                ));
+            }
+
+            var runSettings = new MockRunSettings(
+                new MockRunSettingsXmlBuilder(testEnv.TestFramework, testEnv.InterpreterPath, testEnv.ResultsFolderPath, testEnv.SourceFolderPath, isWorkspace: isWorkspace)
+                    .WithTestFilesFromFolder(testEnv.SourceFolderPath)
+                    .ToXml()
+            );
+
+            DiscoverTests(testEnv, expectedTests.Select(t => t.FilePath).ToArray(), runSettings, expectedTests.ToArray());
         }
 
         [TestMethod, Priority(0)]


### PR DESCRIPTION
Add tests for test file usage.

`open` builtin on Python 2.7 doesn't take a `encoding` parameter. `io.open` works on both 2.7 and 3.7. I've removed the `< 2.6` conditional import since we haven't supported 2.5 for unittests in a while.

Fix #5534 