### PR TITLE
Adding better validation around discovery results matching test c…

### DIFF
--- a/Common/Product/TestAdapter/TestContainer.cs
+++ b/Common/Product/TestAdapter/TestContainer.cs
@@ -28,7 +28,7 @@ namespace Microsoft.VisualStudioTools.TestAdapter {
 
         public TestContainer(ITestContainerDiscoverer discoverer, string source, string projectHome, string projectName, int version, Architecture architecture, bool isWorkspace) {
             Discoverer = discoverer;
-            Source = source.ToLower(); // Make sure source matches pytest discovery test file paths.
+            Source = source; // Make sure source matches discovery new TestCase source.
             Version = version;
             Project = projectHome;
             ProjectName = projectName;

--- a/Python/Product/Common/Strings.Designer.cs
+++ b/Python/Product/Common/Strings.Designer.cs
@@ -3087,6 +3087,15 @@ namespace Microsoft.PythonTools {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Go to https://aka.ms/VSTestExplorerPython for more details on test discovery configuration..
+        /// </summary>
+        public static string DiscoveryConfigurationMessage {
+            get {
+                return ResourceManager.GetString("DiscoveryConfigurationMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Python Documentation.
         /// </summary>
         public static string DocumentationClassificationType {

--- a/Python/Product/Common/Strings.Designer.cs
+++ b/Python/Product/Common/Strings.Designer.cs
@@ -3465,6 +3465,15 @@ namespace Microsoft.PythonTools {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Test container was not found for {0}..
+        /// </summary>
+        public static string ErrorTestContainerNotFound {
+            get {
+                return ResourceManager.GetString("ErrorTestContainerNotFound", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Execute File in P&amp;ython Interactive.
         /// </summary>
         public static string ExecuteInReplCommand_ExecuteFile {

--- a/Python/Product/Common/Strings.resx
+++ b/Python/Product/Common/Strings.resx
@@ -2938,4 +2938,8 @@ Please specify at least one package.</value>
   <data name="PythonDiscoveryResultsNotFound" xml:space="preserve">
     <value>Discovery results file '{0}' was not found.</value>
   </data>
+  <data name="ErrorTestContainerNotFound" xml:space="preserve">
+    <value>Test container was not found for {0}.</value>
+    <comment>{0} is the test info</comment>
+  </data>
 </root>

--- a/Python/Product/Common/Strings.resx
+++ b/Python/Product/Common/Strings.resx
@@ -2942,4 +2942,7 @@ Please specify at least one package.</value>
     <value>Test container was not found for {0}.</value>
     <comment>{0} is the test info</comment>
   </data>
+  <data name="DiscoveryConfigurationMessage" xml:space="preserve">
+    <value>Go to https://aka.ms/VSTestExplorerPython for more details on test discovery configuration.</value>
+  </data>
 </root>

--- a/Python/Product/TestAdapter.Executor/Pytest/PytestDiscoveryResults.cs
+++ b/Python/Product/TestAdapter.Executor/Pytest/PytestDiscoveryResults.cs
@@ -15,6 +15,7 @@
 // See the Apache Version 2.0 License for specific language governing
 // permissions and limitations under the License.
 
+using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
 
@@ -50,6 +51,10 @@ namespace Microsoft.PythonTools.TestAdapter.Pytest {
 
         [JsonProperty("parentid")]
         public string Parentid { get; set; }
+
+        public override string ToString() {
+            return String.Format("{0}: Id:{1} Source:{2}", this.GetType().Name, this.Id, this.Source);
+        }
     }
 
     sealed class PytestDiscoveryResults {

--- a/Python/Product/TestAdapter.Executor/Pytest/TestDiscovererPytest.cs
+++ b/Python/Product/TestAdapter.Executor/Pytest/TestDiscovererPytest.cs
@@ -38,8 +38,11 @@ namespace Microsoft.PythonTools.TestAdapter.Pytest {
             _settings = settings;
         }
 
-        public void DiscoverTests(IEnumerable<string> sources, IMessageLogger logger, ITestCaseDiscoverySink discoverySink) {
-            _logger = logger;
+        public void DiscoverTests(IEnumerable<string> sources,
+                                  IMessageLogger logger,
+                                  ITestCaseDiscoverySink discoverySink,
+                                  Dictionary<string, PythonProjectSettings> sourceToProjectSettings) {
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             var workspaceText = _settings.IsWorkspace ? Strings.WorkspaceText : Strings.ProjectText;
             LogInfo(Strings.PythonTestDiscovererStartedMessage.FormatUI(PythonConstants.PytestText, _settings.ProjectName, workspaceText, _settings.DiscoveryWaitTimeInSeconds));
 
@@ -81,7 +84,7 @@ namespace Microsoft.PythonTools.TestAdapter.Pytest {
             List<PytestDiscoveryResults> results = null;
             try {
                 results = JsonConvert.DeserializeObject<List<PytestDiscoveryResults>>(json);
-                CreateVsTests(results, discoverySink);
+                CreateVsTests(results, discoverySink, sourceToProjectSettings);
             } catch (InvalidOperationException ex) {
                 Error("Failed to parse: {0}".FormatInvariant(ex.Message));
                 Error(json);
@@ -91,12 +94,27 @@ namespace Microsoft.PythonTools.TestAdapter.Pytest {
             }
         }
 
-        private void CreateVsTests(IEnumerable<PytestDiscoveryResults> discoveryResults, ITestCaseDiscoverySink discoverySink) {
+        private void CreateVsTests(IEnumerable<PytestDiscoveryResults> discoveryResults,
+                                   ITestCaseDiscoverySink discoverySink,
+                                   Dictionary<string, PythonProjectSettings> sourceToProjectSettings) {
             foreach (var result in discoveryResults.MaybeEnumerate()) {
                 var parentMap = result.Parents.ToDictionary(p => p.Id, p => p);
                 foreach (PytestTest test in result.Tests) {
                     try {
-                        TestCase tc = test.ToVsTestCase(_settings.ProjectHome, parentMap);
+                        (string parsedSource, int line) = test.ParseSourceAndLine();
+                        var fullSourcePath = Path.IsPathRooted(parsedSource) ? parsedSource : Path.Combine(_settings.ProjectHome, parsedSource);
+                        if (!sourceToProjectSettings.ContainsKey(fullSourcePath)) {
+                            Warn(Strings.ErrorTestContainerNotFound.FormatUI(test.ToString()));
+                            continue;
+                        }
+
+                        // Discovery adapter will lowercase the source field but Test Explorer needs TestCase to match TestContainer Source
+                        var testContainerSourcePath = sourceToProjectSettings
+                            .Where(pair => String.Compare(pair.Key, fullSourcePath, StringComparison.OrdinalIgnoreCase) == 0)
+                            .Select(x => x.Key)
+                            .FirstOrDefault();
+
+                        TestCase tc = test.ToVsTestCase(testContainerSourcePath, line, parentMap);
                         discoverySink?.SendTestCase(tc);
                     } catch (Exception ex) {
                         Error(ex.Message);
@@ -110,7 +128,6 @@ namespace Microsoft.PythonTools.TestAdapter.Pytest {
             arguments.Add(DiscoveryAdapterPath);
             arguments.Add("discover");
             arguments.Add("pytest");
-
             arguments.Add("--output-file");
             arguments.Add(outputfilename);
 
@@ -178,6 +195,9 @@ namespace Microsoft.PythonTools.TestAdapter.Pytest {
 
         private void Error(string message) {
             _logger?.SendMessage(TestMessageLevel.Error, message ?? String.Empty);
+        }
+        private void Warn(string message) {
+            _logger?.SendMessage(TestMessageLevel.Warning, message ?? String.Empty);
         }
     }
 }

--- a/Python/Product/TestAdapter.Executor/Pytest/TestDiscovererPytest.cs
+++ b/Python/Product/TestAdapter.Executor/Pytest/TestDiscovererPytest.cs
@@ -101,6 +101,7 @@ namespace Microsoft.PythonTools.TestAdapter.Pytest {
             ITestCaseDiscoverySink discoverySink,
             Dictionary<string, PythonProjectSettings> sourceToProjectSettings
         ) {
+            bool showConfigurationHint = false;
             foreach (var result in discoveryResults.MaybeEnumerate()) {
                 var parentMap = result.Parents.ToDictionary(p => p.Id, p => p);
                 foreach (PytestTest test in result.Tests) {
@@ -109,6 +110,7 @@ namespace Microsoft.PythonTools.TestAdapter.Pytest {
                         var fullSourcePath = Path.IsPathRooted(parsedSource) ? parsedSource : Path.Combine(_settings.ProjectHome, parsedSource);
                         if (!sourceToProjectSettings.ContainsKey(fullSourcePath)) {
                             Warn(Strings.ErrorTestContainerNotFound.FormatUI(test.ToString()));
+                            showConfigurationHint = true;
                             continue;
                         }
 
@@ -124,6 +126,10 @@ namespace Microsoft.PythonTools.TestAdapter.Pytest {
                         Error(ex.Message);
                     }
                 }
+            }
+
+            if (showConfigurationHint) {
+                LogInfo(Strings.DiscoveryConfigurationMessage);
             }
         }
 

--- a/Python/Product/TestAdapter.Executor/Pytest/TestDiscovererPytest.cs
+++ b/Python/Product/TestAdapter.Executor/Pytest/TestDiscovererPytest.cs
@@ -38,10 +38,12 @@ namespace Microsoft.PythonTools.TestAdapter.Pytest {
             _settings = settings;
         }
 
-        public void DiscoverTests(IEnumerable<string> sources,
-                                  IMessageLogger logger,
-                                  ITestCaseDiscoverySink discoverySink,
-                                  Dictionary<string, PythonProjectSettings> sourceToProjectSettings) {
+        public void DiscoverTests(
+            IEnumerable<string> sources,
+            IMessageLogger logger,
+            ITestCaseDiscoverySink discoverySink,
+            Dictionary<string, PythonProjectSettings> sourceToProjectSettings
+        ) {
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             var workspaceText = _settings.IsWorkspace ? Strings.WorkspaceText : Strings.ProjectText;
             LogInfo(Strings.PythonTestDiscovererStartedMessage.FormatUI(PythonConstants.PytestText, _settings.ProjectName, workspaceText, _settings.DiscoveryWaitTimeInSeconds));
@@ -94,9 +96,11 @@ namespace Microsoft.PythonTools.TestAdapter.Pytest {
             }
         }
 
-        private void CreateVsTests(IEnumerable<PytestDiscoveryResults> discoveryResults,
-                                   ITestCaseDiscoverySink discoverySink,
-                                   Dictionary<string, PythonProjectSettings> sourceToProjectSettings) {
+        private void CreateVsTests(
+            IEnumerable<PytestDiscoveryResults> discoveryResults,
+            ITestCaseDiscoverySink discoverySink,
+            Dictionary<string, PythonProjectSettings> sourceToProjectSettings
+        ) {
             foreach (var result in discoveryResults.MaybeEnumerate()) {
                 var parentMap = result.Parents.ToDictionary(p => p.Id, p => p);
                 foreach (PytestTest test in result.Tests) {

--- a/Python/Product/TestAdapter.Executor/Pytest/TestExecutorPytest.cs
+++ b/Python/Product/TestAdapter.Executor/Pytest/TestExecutorPytest.cs
@@ -81,7 +81,7 @@ namespace Microsoft.PythonTools.TestAdapter {
 
                 try {
                     var discovery = DiscovererFactory.GetDiscoverer(settings);
-                    discovery.DiscoverTests(testGroup, frameworkHandle, testColletion);
+                    discovery.DiscoverTests(testGroup, frameworkHandle, testColletion, sourceToProjSettings);
                 } catch (Exception ex) {
                     frameworkHandle.SendMessage(TestMessageLevel.Error, ex.Message);
                 }

--- a/Python/Product/TestAdapter.Executor/Pytest/TestExecutorPytest.cs
+++ b/Python/Product/TestAdapter.Executor/Pytest/TestExecutorPytest.cs
@@ -55,17 +55,12 @@ namespace Microsoft.PythonTools.TestAdapter {
         }
 
         public void RunTests(IEnumerable<string> sources, IRunContext runContext, IFrameworkHandle frameworkHandle) {
-
-            //MessageBox.Show("Hello1: " + Process.GetCurrentProcess().Id);
-
             if (sources == null) {
                 throw new ArgumentNullException(nameof(sources));
             }
-
             if (runContext == null) {
                 throw new ArgumentNullException(nameof(runContext));
             }
-
             if (frameworkHandle == null) {
                 throw new ArgumentNullException(nameof(frameworkHandle));
             }
@@ -73,15 +68,13 @@ namespace Microsoft.PythonTools.TestAdapter {
             _cancelRequested.Reset();
 
             var sourceToProjSettings = RunSettingsUtil.GetSourceToProjSettings(runContext.RunSettings);
-
-            var testColletion = new TestCollection();
-
+            var testCollection = new TestCollection();
             foreach (var testGroup in sources.GroupBy(x => sourceToProjSettings[x])) {
                 var settings = testGroup.Key;
 
                 try {
                     var discovery = DiscovererFactory.GetDiscoverer(settings);
-                    discovery.DiscoverTests(testGroup, frameworkHandle, testColletion, sourceToProjSettings);
+                    discovery.DiscoverTests(testGroup, frameworkHandle, testCollection, sourceToProjSettings);
                 } catch (Exception ex) {
                     frameworkHandle.SendMessage(TestMessageLevel.Error, ex.Message);
                 }
@@ -90,13 +83,10 @@ namespace Microsoft.PythonTools.TestAdapter {
                     return;
                 }
             }
-
-            RunPytest(testColletion.Tests, runContext, frameworkHandle);
+            RunPytest(testCollection.Tests, runContext, frameworkHandle);
         }
 
         public void RunTests(IEnumerable<TestCase> tests, IRunContext runContext, IFrameworkHandle frameworkHandle) {
-
-            //MessageBox.Show("Hello1: " + Process.GetCurrentProcess().Id);
 
             if (tests == null) {
                 throw new ArgumentNullException(nameof(tests));
@@ -136,7 +126,11 @@ namespace Microsoft.PythonTools.TestAdapter {
             }
         }
 
-        private void RunTestGroup(IGrouping<PythonProjectSettings, TestCase> testGroup, IRunContext runContext, IFrameworkHandle frameworkHandle) {
+        private void RunTestGroup(
+            IGrouping<PythonProjectSettings, TestCase> testGroup,
+            IRunContext runContext,
+            IFrameworkHandle frameworkHandle
+        ) {
             PythonProjectSettings settings = testGroup.Key;
             if (settings.TestFramwork != TestFrameworkType.Pytest) {
                 return;

--- a/Python/Product/TestAdapter.Executor/PythonTestDiscoverer.cs
+++ b/Python/Product/TestAdapter.Executor/PythonTestDiscoverer.cs
@@ -33,9 +33,12 @@ namespace Microsoft.PythonTools.TestAdapter {
     [FileExtension(".py")]
     [DefaultExecutorUri(PythonConstants.PytestExecutorUriString)]
     public class PythonTestDiscoverer : ITestDiscoverer {
-        public void DiscoverTests(IEnumerable<string> sources, IDiscoveryContext discoveryContext, IMessageLogger logger, ITestCaseDiscoverySink discoverySink) {
-            //MessageBox.Show("Discover: " + Process.GetCurrentProcess().Id);
-
+        public void DiscoverTests(
+            IEnumerable<string> sources,
+            IDiscoveryContext discoveryContext,
+            IMessageLogger logger,
+            ITestCaseDiscoverySink discoverySink
+        ) {
             if (sources == null) {
                 throw new ArgumentNullException(nameof(sources));
             }
@@ -51,13 +54,14 @@ namespace Microsoft.PythonTools.TestAdapter {
             }
         }
 
-        private void DiscoverTestGroup(IGrouping<PythonProjectSettings, string> testGroup,
-                                       IDiscoveryContext discoveryContext,
-                                       IMessageLogger logger,
-                                       ITestCaseDiscoverySink discoverySink,
-                                       Dictionary<string, PythonProjectSettings> sourceToProjSettings) {
+        private void DiscoverTestGroup(
+            IGrouping<PythonProjectSettings, string> testGroup,
+            IDiscoveryContext discoveryContext,
+            IMessageLogger logger,
+            ITestCaseDiscoverySink discoverySink,
+            Dictionary<string, PythonProjectSettings> sourceToProjSettings
+        ) {
             PythonProjectSettings settings = testGroup.Key;
-
             try {
                 var discovery = DiscovererFactory.GetDiscoverer(settings);
                 discovery.DiscoverTests(testGroup, logger, discoverySink, sourceToProjSettings);

--- a/Python/Product/TestAdapter.Executor/PythonTestDiscoverer.cs
+++ b/Python/Product/TestAdapter.Executor/PythonTestDiscoverer.cs
@@ -47,16 +47,20 @@ namespace Microsoft.PythonTools.TestAdapter {
             var sourceToProjSettings = RunSettingsUtil.GetSourceToProjSettings(discoveryContext.RunSettings);
 
             foreach (var testGroup in sources.GroupBy(x => sourceToProjSettings[x])) {
-                DiscoverTestGroup(testGroup, discoveryContext, logger, discoverySink);
+                DiscoverTestGroup(testGroup, discoveryContext, logger, discoverySink, sourceToProjSettings);
             }
         }
 
-        private void DiscoverTestGroup(IGrouping<PythonProjectSettings, string> testGroup, IDiscoveryContext discoveryContext,  IMessageLogger logger, ITestCaseDiscoverySink discoverySink) {
+        private void DiscoverTestGroup(IGrouping<PythonProjectSettings, string> testGroup,
+                                       IDiscoveryContext discoveryContext,
+                                       IMessageLogger logger,
+                                       ITestCaseDiscoverySink discoverySink,
+                                       Dictionary<string, PythonProjectSettings> sourceToProjSettings) {
             PythonProjectSettings settings = testGroup.Key;
 
             try {
                 var discovery = DiscovererFactory.GetDiscoverer(settings);
-                discovery.DiscoverTests(testGroup, logger, discoverySink);
+                discovery.DiscoverTests(testGroup, logger, discoverySink, sourceToProjSettings);
             } catch (Exception ex) {
                 logger.SendMessage(TestMessageLevel.Error, ex.Message);
             }

--- a/Python/Product/TestAdapter.Executor/Services/IPythonTestDiscoverer.cs
+++ b/Python/Product/TestAdapter.Executor/Services/IPythonTestDiscoverer.cs
@@ -22,9 +22,11 @@ using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
 
 namespace Microsoft.PythonTools.TestAdapter.Services {
     interface IPythonTestDiscoverer {
-        void DiscoverTests(IEnumerable<string> sources,
-                           IMessageLogger logger,
-                           ITestCaseDiscoverySink discoverySink,
-                           Dictionary<string, PythonProjectSettings> sourceToProjectSettings);
+        void DiscoverTests(
+            IEnumerable<string> sources,
+            IMessageLogger logger,
+            ITestCaseDiscoverySink discoverySink,
+            Dictionary<string, PythonProjectSettings> sourceToProjectSettings
+        );
     }
 }

--- a/Python/Product/TestAdapter.Executor/Services/IPythonTestDiscoverer.cs
+++ b/Python/Product/TestAdapter.Executor/Services/IPythonTestDiscoverer.cs
@@ -15,12 +15,16 @@
 // permissions and limitations under the License.
 
 using System.Collections.Generic;
+using Microsoft.PythonTools.TestAdapter.Config;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
 
 
 namespace Microsoft.PythonTools.TestAdapter.Services {
     interface IPythonTestDiscoverer {
-        void DiscoverTests(IEnumerable<string> sources, IMessageLogger logger, ITestCaseDiscoverySink discoverySink);
+        void DiscoverTests(IEnumerable<string> sources,
+                           IMessageLogger logger,
+                           ITestCaseDiscoverySink discoverySink,
+                           Dictionary<string, PythonProjectSettings> sourceToProjectSettings);
     }
 }

--- a/Python/Product/TestAdapter.Executor/UnitTest/TestDiscovererUnitTest.cs
+++ b/Python/Product/TestAdapter.Executor/UnitTest/TestDiscovererUnitTest.cs
@@ -116,18 +116,24 @@ namespace Microsoft.PythonTools.TestAdapter.UnitTest {
             ITestCaseDiscoverySink discoverySink,
             Dictionary<string, PythonProjectSettings> sourceToProjectSettings
         ) {
+            bool showConfigurationHint = false;
             foreach (var test in unitTestResults?.SelectMany(result => result.Tests.Select(test => test)).MaybeEnumerate()) {
                 try {
                     if(!sourceToProjectSettings.ContainsKey(test.Source)) {
                         Warn(Strings.ErrorTestContainerNotFound.FormatUI(test.ToString()));
+                        showConfigurationHint = true;
                         continue;
                     }
 
-                    TestCase tc = test.ToVsTestCase(_settings.IsWorkspace, _settings.ProjectHome);
+                    TestCase tc = test.ToVsTestCase(_settings.ProjectHome);
                     discoverySink?.SendTestCase(tc);
                 } catch (Exception ex) {
                     Error(ex.Message);
                 }
+            }
+
+            if (showConfigurationHint) {
+                LogInfo(Strings.DiscoveryConfigurationMessage);
             }
         }
 

--- a/Python/Product/TestAdapter.Executor/UnitTest/TestDiscovererUnitTest.cs
+++ b/Python/Product/TestAdapter.Executor/UnitTest/TestDiscovererUnitTest.cs
@@ -52,10 +52,12 @@ namespace Microsoft.PythonTools.TestAdapter.UnitTest {
             _settings = settings;
         }
 
-        public void DiscoverTests(IEnumerable<string> sources,
-                                  IMessageLogger logger,
-                                  ITestCaseDiscoverySink discoverySink,
-                                  Dictionary<string, PythonProjectSettings> sourceToProjectSettings) {
+        public void DiscoverTests(
+            IEnumerable<string> sources,
+            IMessageLogger logger,
+            ITestCaseDiscoverySink discoverySink,
+            Dictionary<string, PythonProjectSettings> sourceToProjectSettings
+         ) {
             _logger = logger;
             var workspaceText = _settings.IsWorkspace ? Strings.WorkspaceText : Strings.ProjectText;
             LogInfo(Strings.PythonTestDiscovererStartedMessage.FormatUI(PythonConstants.UnitTestText, _settings.ProjectName, workspaceText, _settings.DiscoveryWaitTimeInSeconds));
@@ -108,10 +110,12 @@ namespace Microsoft.PythonTools.TestAdapter.UnitTest {
             }
         }
 
-        private void CreateVsTests(IEnumerable<UnitTestDiscoveryResults> unitTestResults,
-                                   IMessageLogger logger,
-                                   ITestCaseDiscoverySink discoverySink,
-                                   Dictionary<string, PythonProjectSettings> sourceToProjectSettings) {
+        private void CreateVsTests(
+            IEnumerable<UnitTestDiscoveryResults> unitTestResults,
+            IMessageLogger logger,
+            ITestCaseDiscoverySink discoverySink,
+            Dictionary<string, PythonProjectSettings> sourceToProjectSettings
+        ) {
             foreach (var test in unitTestResults?.SelectMany(result => result.Tests.Select(test => test)).MaybeEnumerate()) {
                 try {
                     if(!sourceToProjectSettings.ContainsKey(test.Source)) {

--- a/Python/Product/TestAdapter.Executor/UnitTest/TestExecutorUnitTest.cs
+++ b/Python/Product/TestAdapter.Executor/UnitTest/TestExecutorUnitTest.cs
@@ -94,7 +94,7 @@ namespace Microsoft.PythonTools.TestAdapter {
 
                 try {
                     var discovery = DiscovererFactory.GetDiscoverer(settings);
-                    discovery.DiscoverTests(testGroup, frameworkHandle, testColletion);
+                    discovery.DiscoverTests(testGroup, frameworkHandle, testColletion, sourceToProjSettings);
                 } catch (Exception ex) {
                     frameworkHandle.SendMessage(TestMessageLevel.Error, ex.Message);
                 }

--- a/Python/Product/TestAdapter.Executor/UnitTest/UnitTestDiscoveryResults.cs
+++ b/Python/Product/TestAdapter.Executor/UnitTest/UnitTestDiscoveryResults.cs
@@ -14,6 +14,7 @@
 // See the Apache Version 2.0 License for specific language governing
 // permissions and limitations under the License.
 
+using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
 
@@ -31,6 +32,9 @@ namespace Microsoft.PythonTools.TestAdapter.UnitTest {
 
         [JsonProperty("source")]
         public string Source { get; set; }
+        public override string ToString() {
+            return String.Format("{0}: Id:{1} Source:{2} Line:{3}", this.GetType().Name, this.Id, this.Source, this.Line);
+        }
     }
 
     sealed public class UnitTestDiscoveryResults {

--- a/Python/Product/TestAdapter.Executor/UnitTest/UnitTestExtensions.cs
+++ b/Python/Product/TestAdapter.Executor/UnitTest/UnitTestExtensions.cs
@@ -15,23 +15,26 @@
 // permissions and limitations under the License.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using Microsoft.PythonTools.Infrastructure;
+using Microsoft.PythonTools.TestAdapter.Config;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 
 namespace Microsoft.PythonTools.TestAdapter.UnitTest {
     public static class UnitTestExtensions {
 
-        public static TestCase ToVsTestCase(this UnitTestTestCase test, bool isWorkspace, string projectHome) {
-            var normalizedPath = test.Source.ToLowerInvariant();
-            var relativeModulePath = PathUtils.CreateFriendlyFilePath(projectHome, normalizedPath).ToLowerInvariant();
-
+        public static TestCase ToVsTestCase(this UnitTestTestCase test,
+                                            bool isWorkspace,
+                                            string projectHome) {
+            
+            var relativeModulePath = PathUtils.CreateFriendlyFilePath(projectHome, test.Source);
             var fullyQualifiedName = MakeFullyQualifiedTestName(relativeModulePath, test.Id);
-            var testCase = new TestCase(fullyQualifiedName, PythonConstants.UnitTestExecutorUri, normalizedPath) {
+            var testCase = new TestCase(fullyQualifiedName, PythonConstants.UnitTestExecutorUri, test.Source) {
                 DisplayName = test.Name,
                 LineNumber = test.Line,
-                CodeFilePath = normalizedPath
+                CodeFilePath = test.Source
             };
 
             return testCase;

--- a/Python/Product/TestAdapter.Executor/UnitTest/UnitTestExtensions.cs
+++ b/Python/Product/TestAdapter.Executor/UnitTest/UnitTestExtensions.cs
@@ -15,20 +15,15 @@
 // permissions and limitations under the License.
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using Microsoft.PythonTools.Infrastructure;
-using Microsoft.PythonTools.TestAdapter.Config;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 
 namespace Microsoft.PythonTools.TestAdapter.UnitTest {
     public static class UnitTestExtensions {
 
-        public static TestCase ToVsTestCase(this UnitTestTestCase test,
-                                            bool isWorkspace,
-                                            string projectHome) {
-            
+        public static TestCase ToVsTestCase(this UnitTestTestCase test, string projectHome) {
             var relativeModulePath = PathUtils.CreateFriendlyFilePath(projectHome, test.Source);
             var fullyQualifiedName = MakeFullyQualifiedTestName(relativeModulePath, test.Id);
             var testCase = new TestCase(fullyQualifiedName, PythonConstants.UnitTestExecutorUri, test.Source) {

--- a/Python/Tests/TestAdapterTests/TestDiscovererTests.cs
+++ b/Python/Tests/TestAdapterTests/TestDiscovererTests.cs
@@ -75,6 +75,27 @@ namespace TestAdapterTests {
 
         [TestMethod, Priority(0)]
         [TestCategory("10s")]
+        public void DiscoverPytestUppercaseFileName() {
+            var testEnv = TestEnvironment.GetOrCreate(Version, FrameworkPytest);
+
+            var testFilePath = Path.Combine(testEnv.SourceFolderPath, "test_Uppercase.py");
+            File.Copy(TestData.GetPath("TestData", "TestDiscoverer", "Uppercase", "test_Uppercase.py"), testFilePath);
+
+            var expectedTests = new[] {
+                new TestInfo("test_A", "test_uppercase.py::Test_UppercaseClass::test_A", testFilePath, 4),
+            };
+
+            var runSettings = new MockRunSettings(
+                new MockRunSettingsXmlBuilder(testEnv.TestFramework, testEnv.InterpreterPath, testEnv.ResultsFolderPath, testEnv.SourceFolderPath)
+                    .WithTestFilesFromFolder(testEnv.SourceFolderPath)
+                    .ToXml()
+            );
+
+            DiscoverTests(testEnv, new[] { testFilePath }, runSettings, expectedTests);
+        }
+
+        [TestMethod, Priority(0)]
+        [TestCategory("10s")]
         public void DiscoverPytestLargeProject() {
             var testEnv = TestEnvironment.GetOrCreate(Version, FrameworkPytest);
 
@@ -451,6 +472,28 @@ namespace TestAdapterTests {
             var expectedTests = new[] {
                 new TestInfo("test_ut_fail", "test_ut.py::TestClassUT::test_ut_fail", testFilePath, 4),
                 new TestInfo("test_ut_pass", "test_ut.py::TestClassUT::test_ut_pass", testFilePath, 7),
+            };
+
+            var runSettings = new MockRunSettings(
+                new MockRunSettingsXmlBuilder(testEnv.TestFramework, testEnv.InterpreterPath, testEnv.ResultsFolderPath, testEnv.SourceFolderPath)
+                    .WithTestFilesFromFolder(testEnv.SourceFolderPath)
+                    .ToXml()
+            );
+
+            DiscoverTests(testEnv, new[] { testFilePath }, runSettings, expectedTests);
+        }
+
+
+        [TestMethod, Priority(0)]
+        [TestCategory("10s")]
+        public void DiscoverUnittestUppercaseFileName() {
+            var testEnv = TestEnvironment.GetOrCreate(Version, FrameworkUnittest);
+
+            var testFilePath = Path.Combine(testEnv.SourceFolderPath, "test_Uppercase.py");
+            File.Copy(TestData.GetPath("TestData", "TestDiscoverer", "Uppercase", "test_Uppercase.py"), testFilePath);
+
+            var expectedTests = new[] {
+                new TestInfo("test_A", "test_Uppercase.py::Test_UppercaseClass::test_A", testFilePath, 4),
             };
 
             var runSettings = new MockRunSettings(

--- a/Python/Tests/TestAdapterTests/TestDiscovererTests.cs
+++ b/Python/Tests/TestAdapterTests/TestDiscovererTests.cs
@@ -249,7 +249,6 @@ namespace TestAdapterTests {
             );
         }
 
-        [Ignore] // discovers 0 tests, our pytest discovery cannot handle this?
         [TestMethod, Priority(0)]
         [TestCategory("10s")]
         public void DiscoverPytestImportError() {

--- a/Python/Tests/TestAdapterTests/TestExecutorTests.cs
+++ b/Python/Tests/TestAdapterTests/TestExecutorTests.cs
@@ -195,6 +195,36 @@ if __name__ == '__main__':
 
         [TestMethod, Priority(0)]
         [TestCategory("10s")]
+        public void RunPytestUppercaseFileName() {
+            Assert.Inconclusive("Need to fix pytestId filename portition being lowercased ie.test_Uppercase.py::Test_UppercaseClass::test_A");
+            var testEnv = TestEnvironment.GetOrCreate(Version, FrameworkPytest);
+
+            var testFilePath = Path.Combine(testEnv.SourceFolderPath, "test_Uppercase.py");
+            File.Copy(TestData.GetPath("TestData", "TestDiscoverer", "Uppercase", "test_Uppercase.py"), testFilePath);
+
+            var expectedTests = new[] {
+                new TestInfo(
+                   "test_A", 
+                   "test_uppercase.py::Test_UppercaseClass::test_A",
+                    testFilePath,
+                    4,
+                    outcome: TestOutcome.Passed,
+                    pytestXmlClassName: "Test_UppercaseClass"
+                ),
+            };
+
+            var runSettings = new MockRunSettings(
+                new MockRunSettingsXmlBuilder(testEnv.TestFramework, testEnv.InterpreterPath, testEnv.ResultsFolderPath, testEnv.SourceFolderPath)
+                    .WithTestFilesFromFolder(testEnv.SourceFolderPath)
+                    .ToXml()
+            );
+
+            ExecuteTests(testEnv, runSettings, expectedTests);
+        }
+
+
+        [TestMethod, Priority(0)]
+        [TestCategory("10s")]
         public void RunPytestLargeTestCount() {
             var testEnv = TestEnvironment.GetOrCreate(Version, FrameworkPytest);
 

--- a/Python/Tests/TestData/TestDiscoverer/Uppercase/test_Uppercase.py
+++ b/Python/Tests/TestData/TestDiscoverer/Uppercase/test_Uppercase.py
@@ -1,0 +1,8 @@
+import unittest
+
+class Test_UppercaseClass(unittest.TestCase):
+    def test_A(self):
+        pass
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Unittest execution fails for files with uppercase characters fix #5551
Pytest discovery fails for files with uppercase characters fix #5550
Unittest discovery KeyNotFoundException when excluding tests from project fix #5554

![image](https://user-images.githubusercontent.com/1946977/62806547-06a10a00-baa8-11e9-8744-1212af13e66b.png)
