### PR TITLE
Changed discovery test warning 

### DIFF
--- a/Python/Product/TestAdapter.Executor/Config/PythonProjectSettings.cs
+++ b/Python/Product/TestAdapter.Executor/Config/PythonProjectSettings.cs
@@ -48,6 +48,9 @@ namespace Microsoft.PythonTools.TestAdapter.Config {
             EnableNativeCodeDebugging = nativeDebugging;
             SearchPath = new List<string>();
             Environment = new Dictionary<string, string>();
+            // Mapping of full file path to full file path which was assigned to the TestContainer.  
+            // The pytest adapter discovery is returning lowercase paths and Test Explorer needs TestCase sources and TestContainer sources
+            // to match or else tests wont be removed when you unload a project.
             TestContainerSources = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
             IsWorkspace = isWorkspace;
             UseLegacyDebugger = useLegacyDebugger;

--- a/Python/Product/TestAdapter.Executor/Config/PythonProjectSettings.cs
+++ b/Python/Product/TestAdapter.Executor/Config/PythonProjectSettings.cs
@@ -23,7 +23,7 @@ namespace Microsoft.PythonTools.TestAdapter.Config {
         public readonly bool EnableNativeCodeDebugging;
         public readonly List<string> SearchPath;
         public readonly Dictionary<string, string> Environment;
-        public readonly List<string> Sources;
+        public readonly Dictionary<string, string> TestContainerSources;
         public readonly bool IsWorkspace;
         public readonly bool UseLegacyDebugger;
         public readonly TestFrameworkType TestFramwork;
@@ -48,7 +48,7 @@ namespace Microsoft.PythonTools.TestAdapter.Config {
             EnableNativeCodeDebugging = nativeDebugging;
             SearchPath = new List<string>();
             Environment = new Dictionary<string, string>();
-            Sources = new List<string>();
+            TestContainerSources = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
             IsWorkspace = isWorkspace;
             UseLegacyDebugger = useLegacyDebugger;
             TestFramwork = TestFrameworkType.None;
@@ -74,7 +74,8 @@ namespace Microsoft.PythonTools.TestAdapter.Config {
                 return false;
             }
 
-            if (ProjectHome == other.ProjectHome &&
+            if (ProjectName == other.ProjectName &&
+                ProjectHome == other.ProjectHome &&
                 WorkingDirectory == other.WorkingDirectory &&
                 InterpreterPath == other.InterpreterPath &&
                 PathEnv == other.PathEnv &&
@@ -83,31 +84,12 @@ namespace Microsoft.PythonTools.TestAdapter.Config {
                 UseLegacyDebugger == other.UseLegacyDebugger &&
                 TestFramwork == other.TestFramwork &&
                 UnitTestPattern == other.UnitTestPattern &&
-                UnitTestRootDir == other.UnitTestRootDir) {
-                if (SearchPath.Count == other.SearchPath.Count &&
-                    Environment.Count == other.Environment.Count) {
-                    for (int i = 0; i < SearchPath.Count; i++) {
-                        if (SearchPath[i] != other.SearchPath[i]) {
-                            return false;
-                        }
-                    }
-
-                    for (int i = 0; i < Sources.Count; i++) {
-                        if (Sources[i] != other.Sources[i]) {
-                            return false;
-                        }
-                    }
-
-                    foreach (var keyValue in Environment) {
-                        string value;
-                        if (!other.Environment.TryGetValue(keyValue.Key, out value) ||
-                            value != keyValue.Value) {
-                            return false;
-                        }
-                    }
-
-                    return true;
-                }
+                UnitTestRootDir == other.UnitTestRootDir &&
+                SearchPath.Count == other.SearchPath.Count &&
+                Environment.Count == other.Environment.Count &&
+                TestContainerSources.Count == other.TestContainerSources.Count &&
+                DiscoveryWaitTimeInSeconds == other.DiscoveryWaitTimeInSeconds) {
+                return true;
             }
 
             return false;

--- a/Python/Product/TestAdapter.Executor/Config/RunSettingsUtil.cs
+++ b/Python/Product/TestAdapter.Executor/Config/RunSettingsUtil.cs
@@ -44,6 +44,7 @@ namespace Microsoft.PythonTools.TestAdapter.Config {
 
                 foreach (XPathNavigator test in project.Select("Test")) {
                     string testFile = test.GetAttribute("file", "");
+                    projSettings.TestContainerSources.Add(testFile, testFile);
                     res[testFile] = projSettings;
                 }
             }

--- a/Python/Product/TestAdapter.Executor/Pytest/TestExecutorPytest.cs
+++ b/Python/Product/TestAdapter.Executor/Pytest/TestExecutorPytest.cs
@@ -74,7 +74,7 @@ namespace Microsoft.PythonTools.TestAdapter {
 
                 try {
                     var discovery = DiscovererFactory.GetDiscoverer(settings);
-                    discovery.DiscoverTests(testGroup, frameworkHandle, testCollection, sourceToProjSettings);
+                    discovery.DiscoverTests(testGroup, frameworkHandle, testCollection);
                 } catch (Exception ex) {
                     frameworkHandle.SendMessage(TestMessageLevel.Error, ex.Message);
                 }

--- a/Python/Product/TestAdapter.Executor/PythonTestDiscoverer.cs
+++ b/Python/Product/TestAdapter.Executor/PythonTestDiscoverer.cs
@@ -50,7 +50,7 @@ namespace Microsoft.PythonTools.TestAdapter {
             var sourceToProjSettings = RunSettingsUtil.GetSourceToProjSettings(discoveryContext.RunSettings);
 
             foreach (var testGroup in sources.GroupBy(x => sourceToProjSettings[x])) {
-                DiscoverTestGroup(testGroup, discoveryContext, logger, discoverySink, sourceToProjSettings);
+                DiscoverTestGroup(testGroup, discoveryContext, logger, discoverySink);
             }
         }
 
@@ -58,13 +58,12 @@ namespace Microsoft.PythonTools.TestAdapter {
             IGrouping<PythonProjectSettings, string> testGroup,
             IDiscoveryContext discoveryContext,
             IMessageLogger logger,
-            ITestCaseDiscoverySink discoverySink,
-            Dictionary<string, PythonProjectSettings> sourceToProjSettings
+            ITestCaseDiscoverySink discoverySink
         ) {
             PythonProjectSettings settings = testGroup.Key;
             try {
                 var discovery = DiscovererFactory.GetDiscoverer(settings);
-                discovery.DiscoverTests(testGroup, logger, discoverySink, sourceToProjSettings);
+                discovery.DiscoverTests(testGroup, logger, discoverySink);
             } catch (Exception ex) {
                 logger.SendMessage(TestMessageLevel.Error, ex.Message);
             }

--- a/Python/Product/TestAdapter.Executor/Services/IPythonTestDiscoverer.cs
+++ b/Python/Product/TestAdapter.Executor/Services/IPythonTestDiscoverer.cs
@@ -25,8 +25,7 @@ namespace Microsoft.PythonTools.TestAdapter.Services {
         void DiscoverTests(
             IEnumerable<string> sources,
             IMessageLogger logger,
-            ITestCaseDiscoverySink discoverySink,
-            Dictionary<string, PythonProjectSettings> sourceToProjectSettings
+            ITestCaseDiscoverySink discoverySink
         );
     }
 }

--- a/Python/Product/TestAdapter.Executor/UnitTest/TestDiscovererUnitTest.cs
+++ b/Python/Product/TestAdapter.Executor/UnitTest/TestDiscovererUnitTest.cs
@@ -117,7 +117,7 @@ namespace Microsoft.PythonTools.TestAdapter.UnitTest {
             foreach (var test in unitTestResults?.SelectMany(result => result.Tests.Select(test => test)).MaybeEnumerate()) {
                 try {
                     // Note: Test Explorer will show a key not found exception if we use a source path that doesn't match a test container's source.
-                    if (_settings.TestContainerSources.TryGetValue(test.Source, out string testContainerSourcePath)) {
+                    if (_settings.TestContainerSources.TryGetValue(test.Source, out _)) {
                         TestCase tc = test.ToVsTestCase(_settings.ProjectHome);
                         discoverySink?.SendTestCase(tc);
                     } else {

--- a/Python/Product/TestAdapter.Executor/UnitTest/TestExecutorUnitTest.cs
+++ b/Python/Product/TestAdapter.Executor/UnitTest/TestExecutorUnitTest.cs
@@ -86,7 +86,6 @@ namespace Microsoft.PythonTools.TestAdapter {
             _cancelRequested.Reset();
 
             var sourceToProjSettings = RunSettingsUtil.GetSourceToProjSettings(runContext.RunSettings);
-
             var testColletion = new TestCollection();
 
             foreach (var testGroup in sources.GroupBy(x => sourceToProjSettings[x])) {
@@ -94,7 +93,7 @@ namespace Microsoft.PythonTools.TestAdapter {
 
                 try {
                     var discovery = DiscovererFactory.GetDiscoverer(settings);
-                    discovery.DiscoverTests(testGroup, frameworkHandle, testColletion, sourceToProjSettings);
+                    discovery.DiscoverTests(testGroup, frameworkHandle, testColletion);
                 } catch (Exception ex) {
                     frameworkHandle.SendMessage(TestMessageLevel.Error, ex.Message);
                 }

--- a/Python/Product/TestAdapter/PythonRunSettings.cs
+++ b/Python/Product/TestAdapter/PythonRunSettings.cs
@@ -134,86 +134,22 @@ namespace Microsoft.PythonTools.TestAdapter {
                     writer.WriteStartElement("TestCases");
 
                     foreach (var project in pyContainers) {
+                        writer.WriteStartElement("Project");
+                        bool isFirstElement = true;
+                        bool didFindProjectInfo = false;
                         foreach (var container in project) {
-                            writer.WriteStartElement("Project");
-                            writer.WriteAttributeString("home", container.Project);
-
-                            string nativeCode = "", djangoSettings = "", projectName = "", testFramework = "", unitTestPattern = "", unitTestRootDir = "";
-                            bool isWorkspace = false;
-                            ProjectInfo projInfo = null;
-                            LaunchConfiguration config = null;
-
-                            ThreadHelper.JoinableTaskFactory.Run(async () => {
-                                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-
-                                if (container.Discoverer is TestContainerDiscovererProject) {
-                                    var discoverer = container.Discoverer as TestContainerDiscovererProject;
-                                    isWorkspace = discoverer.IsWorkspace;
-                                    projInfo = discoverer.GetProjectInfo(container.Project);
-                                } else if (container.Discoverer is TestContainerDiscovererWorkspace) {
-                                    var discoverer = container.Discoverer as TestContainerDiscovererWorkspace;
-                                    isWorkspace = discoverer.IsWorkspace;
-                                    projInfo = discoverer.GetProjectInfo(container.Project);
-                                }
-
-                                if (projInfo != null) {
-                                    try {
-                                        config = projInfo.GetLaunchConfigurationOrThrow();
-                                    } catch {
-                                    }
-                                    nativeCode = projInfo.GetProperty(PythonConstants.EnableNativeCodeDebugging);
-                                    djangoSettings = projInfo.GetProperty("DjangoSettingsModule");
-                                    testFramework = projInfo.GetProperty(PythonConstants.TestFrameworkSetting);
-                                    projectName = projInfo.ProjectName;
-                                    unitTestRootDir = projInfo.GetProperty(PythonConstants.UnitTestRootDirectorySetting);
-                                    unitTestPattern = projInfo.GetProperty(PythonConstants.UnitTestPatternSetting);
-                                }
-                            });
-
-                            if (config == null || projInfo == null) {
-                                log.Log(
-                                    MessageLevel.Warning,
-                                    Strings.TestDiscoveryFailedMissingLaunchConfiguration.FormatUI(container.Project)
-                                );
-                                continue;
+                            if (isFirstElement) {
+                                isFirstElement = false;
+                                didFindProjectInfo = WriteProjectInfoForContainer(writer, container, log);
                             }
-                            writer.WriteAttributeString("name", projectName);
-                            writer.WriteAttributeString("isWorkspace", isWorkspace.ToString());
-                            writer.WriteAttributeString("useLegacyDebugger", UseLegacyDebugger ? "1" : "0");
-                            writer.WriteAttributeString("nativeDebugging", nativeCode);
-                            writer.WriteAttributeString("djangoSettingsModule", djangoSettings);
-                            writer.WriteAttributeString("testFramework", testFramework);
-                            writer.WriteAttributeString("workingDir", config.WorkingDirectory);
-                            writer.WriteAttributeString("interpreter", config.GetInterpreterPath());
-                            writer.WriteAttributeString("pathEnv", config.Interpreter.PathEnvironmentVariable);
-                            writer.WriteAttributeString("unitTestRootDir", unitTestRootDir);
-                            writer.WriteAttributeString("unitTestPattern", unitTestPattern);
 
-                            writer.WriteStartElement("Environment");
-
-                            foreach (var keyValue in config.Environment) {
-                                writer.WriteStartElement("Variable");
-                                writer.WriteAttributeString("name", keyValue.Key);
-                                writer.WriteAttributeString("value", keyValue.Value);
-                                writer.WriteEndElement();
+                            if (didFindProjectInfo) {
+                                writer.WriteStartElement("Test");
+                                writer.WriteAttributeString("file", container.Source);
+                                writer.WriteEndElement(); // Test    
                             }
-                            writer.WriteEndElement(); // Environment
-
-                            writer.WriteStartElement("SearchPaths");
-                            foreach (var path in config.SearchPaths) {
-                                writer.WriteStartElement("Search");
-                                writer.WriteAttributeString("value", path);
-                                writer.WriteEndElement();
-                            }
-                            writer.WriteEndElement(); // SearchPaths
-
-                            writer.WriteStartElement("Test");
-                            writer.WriteAttributeString("file", container.Source);
-
-                            writer.WriteEndElement(); // Test
-
-                            writer.WriteEndElement();  // Project
                         }
+                        writer.WriteEndElement();  // Project
                     }
 
                     writer.WriteEndElement(); // TestCases
@@ -281,6 +217,81 @@ namespace Microsoft.PythonTools.TestAdapter {
             }
 
             return inputRunSettingDocument;
+        }
+
+
+        bool WriteProjectInfoForContainer(System.Xml.XmlWriter writer, TestContainer container, ILogger log) {
+            writer.WriteAttributeString("home", container.Project);
+            string nativeCode = "", djangoSettings = "", projectName = "", testFramework = "", unitTestPattern = "", unitTestRootDir = "";
+            bool isWorkspace = false;
+            ProjectInfo projInfo = null;
+            LaunchConfiguration config = null;
+
+            ThreadHelper.JoinableTaskFactory.Run(async () => {
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+                if (container.Discoverer is TestContainerDiscovererProject) {
+                    var discoverer = container.Discoverer as TestContainerDiscovererProject;
+                    isWorkspace = discoverer.IsWorkspace;
+                    projInfo = discoverer.GetProjectInfo(container.Project);
+                } else if (container.Discoverer is TestContainerDiscovererWorkspace) {
+                    var discoverer = container.Discoverer as TestContainerDiscovererWorkspace;
+                    isWorkspace = discoverer.IsWorkspace;
+                    projInfo = discoverer.GetProjectInfo(container.Project);
+                }
+
+                if (projInfo != null) {
+                    try {
+                        config = projInfo.GetLaunchConfigurationOrThrow();
+                    } catch {
+                    }
+                    nativeCode = projInfo.GetProperty(PythonConstants.EnableNativeCodeDebugging);
+                    djangoSettings = projInfo.GetProperty("DjangoSettingsModule");
+                    testFramework = projInfo.GetProperty(PythonConstants.TestFrameworkSetting);
+                    projectName = projInfo.ProjectName;
+                    unitTestRootDir = projInfo.GetProperty(PythonConstants.UnitTestRootDirectorySetting);
+                    unitTestPattern = projInfo.GetProperty(PythonConstants.UnitTestPatternSetting);
+                }
+            });
+
+            if (config == null || projInfo == null) {
+                log.Log(
+                    MessageLevel.Warning,
+                    Strings.TestDiscoveryFailedMissingLaunchConfiguration.FormatUI(container.Project)
+                );
+                return false;
+            }
+            writer.WriteAttributeString("name", projectName);
+            writer.WriteAttributeString("isWorkspace", isWorkspace.ToString());
+            writer.WriteAttributeString("useLegacyDebugger", UseLegacyDebugger ? "1" : "0");
+            writer.WriteAttributeString("nativeDebugging", nativeCode);
+            writer.WriteAttributeString("djangoSettingsModule", djangoSettings);
+            writer.WriteAttributeString("testFramework", testFramework);
+            writer.WriteAttributeString("workingDir", config.WorkingDirectory);
+            writer.WriteAttributeString("interpreter", config.GetInterpreterPath());
+            writer.WriteAttributeString("pathEnv", config.Interpreter.PathEnvironmentVariable);
+            writer.WriteAttributeString("unitTestRootDir", unitTestRootDir);
+            writer.WriteAttributeString("unitTestPattern", unitTestPattern);
+
+            writer.WriteStartElement("Environment");
+
+            foreach (var keyValue in config.Environment) {
+                writer.WriteStartElement("Variable");
+                writer.WriteAttributeString("name", keyValue.Key);
+                writer.WriteAttributeString("value", keyValue.Value);
+                writer.WriteEndElement();
+            }
+            writer.WriteEndElement(); // Environment
+
+            writer.WriteStartElement("SearchPaths");
+            foreach (var path in config.SearchPaths) {
+                writer.WriteStartElement("Search");
+                writer.WriteAttributeString("value", path);
+                writer.WriteEndElement();
+            }
+            writer.WriteEndElement(); // SearchPaths
+
+            return true;
         }
     }
 }


### PR DESCRIPTION
Changing runtime settings to write project/workspace info once for all sub testcontainers

-Now we also use a dictionary lookup, instead of linear search,  for verifying filepaths from discovery match a TestContainer.