### PR TITLE
Bschnurr/fix pytest uppercase exec

### DIFF
--- a/Python/Product/Common/Strings.Designer.cs
+++ b/Python/Product/Common/Strings.Designer.cs
@@ -5226,6 +5226,15 @@ namespace Microsoft.PythonTools {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Invalid source in test: {0}.
+        /// </summary>
+        public static string PytestInvalidTestSource {
+            get {
+                return ResourceManager.GetString("PytestInvalidTestSource", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Pytest is enabled in the {0} {1}, but it is not installed in the active environment..
         /// </summary>
         public static string PyTestNotInstalled {
@@ -5240,6 +5249,15 @@ namespace Microsoft.PythonTools {
         public static string PyTestNotInstalledConfigurationFileFound {
             get {
                 return ResourceManager.GetString("PyTestNotInstalledConfigurationFileFound", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Results for pytest not found {0}.
+        /// </summary>
+        public static string PytestResultsXmlNotFound {
+            get {
+                return ResourceManager.GetString("PytestResultsXmlNotFound", resourceCulture);
             }
         }
         

--- a/Python/Product/Common/Strings.Designer.cs
+++ b/Python/Product/Common/Strings.Designer.cs
@@ -3474,6 +3474,15 @@ namespace Microsoft.PythonTools {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Testcase not found for test result: {0}.
+        /// </summary>
+        public static string ErrorTestCaseNotFound {
+            get {
+                return ResourceManager.GetString("ErrorTestCaseNotFound", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Test container was not found for {0}..
         /// </summary>
         public static string ErrorTestContainerNotFound {

--- a/Python/Product/Common/Strings.resx
+++ b/Python/Product/Common/Strings.resx
@@ -2967,5 +2967,14 @@ Please specify at least one package.</value>
     <value>Testcase not found for test result: {0}</value>
     <comment>{0} is the result xml data found</comment>
   </data>
+  <data name="PytestInvalidTestSource" xml:space="preserve">
+    <value>Invalid source in test: {0}</value>
+    <comment>{0} is the test info</comment>
+  </data>
+  <data name="PytestResultsXmlNotFound" xml:space="preserve">
+    <value>Results for pytest not found {0}</value>
+    <comment>{0} is the expected file path</comment>
+  </data>
+
     
 </root>

--- a/Python/Product/Common/Strings.resx
+++ b/Python/Product/Common/Strings.resx
@@ -2963,4 +2963,9 @@ Please specify at least one package.</value>
   <data name="DiscoveryConfigurationMessage" xml:space="preserve">
     <value>Go to https://aka.ms/VSTestExplorerPython for more details on test discovery configuration.</value>
   </data>
+  <data name="ErrorTestCaseNotFound" xml:space="preserve">
+    <value>Testcase not found for test result: {0}</value>
+    <comment>{0} is the result xml data found</comment>
+  </data>
+    
 </root>

--- a/Python/Product/TestAdapter.Executor/Pytest/Constants.cs
+++ b/Python/Product/TestAdapter.Executor/Pytest/Constants.cs
@@ -19,8 +19,6 @@ using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 
 namespace Microsoft.PythonTools.TestAdapter.Pytest {
     internal static class Constants {
-        internal static readonly TestProperty PytestIdProperty = TestProperty.Register("PytestId", "PytestId", typeof(string), TestPropertyAttributes.Hidden, typeof(TestCase));
-        internal static readonly TestProperty PyTestXmlClassNameProperty = TestProperty.Register("PytestXmlClassName", "PytestXmlClassName", typeof(string), TestPropertyAttributes.Hidden, typeof(TestCase));
-        internal static readonly TestProperty PytestTestExecutionPathPropertery = TestProperty.Register("PytestTestExecPath", "PytestTestExecPath", typeof(string), TestPropertyAttributes.Hidden, typeof(TestCase));
+        internal static readonly TestProperty PytestIdProperty = TestProperty.Register("PytestId", "PytestId", typeof(string), TestPropertyAttributes.Hidden, typeof(TestCase)); 
     }
 }

--- a/Python/Product/TestAdapter.Executor/Pytest/PytestExtensions.cs
+++ b/Python/Product/TestAdapter.Executor/Pytest/PytestExtensions.cs
@@ -36,7 +36,7 @@ namespace Microsoft.PythonTools.TestAdapter.Pytest {
             var sourceParts = sourceAndLineNum.Split(':');
             if (sourceParts.Length != 2 ||
                 !Int32.TryParse(sourceParts[1], out line)) {
-                throw new FormatException(String.Format("Invalid source: {0}", test.ToString()));
+                throw new FormatException(Strings.PytestInvalidTestSource.FormatUI(test.ToString()));
             }
 
             return (sourceParts[0], line);

--- a/Python/Product/TestAdapter.Executor/Pytest/TestDiscovererPytest.cs
+++ b/Python/Product/TestAdapter.Executor/Pytest/TestDiscovererPytest.cs
@@ -110,7 +110,11 @@ namespace Microsoft.PythonTools.TestAdapter.Pytest {
                         //Note: Pytest adapter is currently returning lowercase source paths
                         //Test Explorer will show a key not found exception if we use a source path that doesn't match a test container's source.
                         if (_settings.TestContainerSources.TryGetValue(parsedFullSourcePath, out string testContainerSourcePath)) {
-                            TestCase tc = test.ToVsTestCase(testContainerSourcePath, line, parentMap);
+                            TestCase tc = test.ToVsTestCase(
+                                testContainerSourcePath, 
+                                line, 
+                                parentMap, 
+                                _settings.ProjectHome);
                             discoverySink?.SendTestCase(tc);
                         } else {
                             Warn(Strings.ErrorTestContainerNotFound.FormatUI(test.ToString()));

--- a/Python/Product/TestAdapter.Executor/Pytest/TestExecutorPytest.cs
+++ b/Python/Product/TestAdapter.Executor/Pytest/TestExecutorPytest.cs
@@ -145,16 +145,18 @@ namespace Microsoft.PythonTools.TestAdapter {
                             break;
                         }
                         try {
-                            string pytestId = TestResultParser.GetPytestId(pytestResultNode);
+                            var pytestId = TestResultParser.GetPytestId(pytestResultNode);
                             if (pytestId != null && idToResultsMap.TryGetValue(pytestId, out TestResult vsTestResult)) {
                                 TestResultParser.UpdateVsTestResult(vsTestResult, pytestResultNode);
                             } else {
-                                frameworkHandle.SendMessage(TestMessageLevel.Error, Strings.ErrorTestCaseNotFound.FormatInvariant(pytestResultNode.OuterXml));
+                                frameworkHandle.SendMessage(TestMessageLevel.Error, Strings.ErrorTestCaseNotFound.FormatUI(pytestResultNode.OuterXml));
                             }
                         } catch (Exception ex) {
                             frameworkHandle.SendMessage(TestMessageLevel.Error, ex.Message);
                         }
                     }
+                } else {
+                    frameworkHandle.SendMessage(TestMessageLevel.Error, Strings.PytestResultsXmlNotFound.FormatUI(resultsXML));
                 }
 
                 foreach (var result in idToResultsMap.Values) {

--- a/Python/Product/TestAdapter.Executor/Pytest/TestExecutorPytest.cs
+++ b/Python/Product/TestAdapter.Executor/Pytest/TestExecutorPytest.cs
@@ -134,7 +134,7 @@ namespace Microsoft.PythonTools.TestAdapter {
             }
 
             using (var executor = new ExecutorService(settings, frameworkHandle, runContext)) {
-                Dictionary<string, TestResult> idToResultsMap = CreatePytestIdToVsTestResultsMap(testGroup);
+                var idToResultsMap = CreatePytestIdToVsTestResultsMap(testGroup);
                 var resultsXML = executor.Run(testGroup);
 
                 //Read pytest results from xml

--- a/Python/Product/TestAdapter.Executor/Pytest/TestExecutorPytest.cs
+++ b/Python/Product/TestAdapter.Executor/Pytest/TestExecutorPytest.cs
@@ -18,8 +18,11 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.IO;
 using System.Linq;
 using System.Threading;
+using System.Xml.XPath;
+using Microsoft.PythonTools.Analysis;
 using Microsoft.PythonTools.Infrastructure;
 using Microsoft.PythonTools.TestAdapter.Config;
 using Microsoft.PythonTools.TestAdapter.Pytest;
@@ -38,12 +41,9 @@ namespace Microsoft.PythonTools.TestAdapter {
         private static readonly Guid PythonRemoteDebugPortSupplierUnsecuredId = new Guid("{FEB76325-D127-4E02-B59D-B16D93D46CF5}");
         private static readonly Guid PythonDebugEngineGuid = new Guid("EC1375B7-E2CE-43E8-BF75-DC638DE1F1F9");
         private static readonly Guid NativeDebugEngineGuid = new Guid("3B476D35-A401-11D2-AAD4-00C04F990171");
-
         private static readonly string TestLauncherPath = PythonToolsInstallPath.GetFile("visualstudio_py_testlauncher.py");
         internal static readonly Uri PythonCodeCoverageUri = new Uri("datacollector://Microsoft/PythonCodeCoverage/1.0");
-
         private readonly ManualResetEvent _cancelRequested = new ManualResetEvent(false);
-
         private readonly VisualStudioProxy _app;
 
         public TestExecutorPytest() {
@@ -87,15 +87,12 @@ namespace Microsoft.PythonTools.TestAdapter {
         }
 
         public void RunTests(IEnumerable<TestCase> tests, IRunContext runContext, IFrameworkHandle frameworkHandle) {
-
             if (tests == null) {
                 throw new ArgumentNullException(nameof(tests));
             }
-
             if (runContext == null) {
                 throw new ArgumentNullException(nameof(runContext));
             }
-
             if (frameworkHandle == null) {
                 throw new ArgumentNullException(nameof(frameworkHandle));
             }
@@ -132,22 +129,46 @@ namespace Microsoft.PythonTools.TestAdapter {
             IFrameworkHandle frameworkHandle
         ) {
             PythonProjectSettings settings = testGroup.Key;
-            if (settings.TestFramwork != TestFrameworkType.Pytest) {
+            if (settings == null || settings.TestFramwork != TestFrameworkType.Pytest) {
                 return;
             }
 
             using (var executor = new ExecutorService(settings, frameworkHandle, runContext)) {
+                Dictionary<string, TestResult> idToResultsMap = CreatePytestIdToVsTestResultsMap(testGroup);
                 var resultsXML = executor.Run(testGroup);
 
-                var testResults = TestResultParser.Parse(resultsXML, testGroup);
-                foreach (var result in testResults) {
+                if (File.Exists(resultsXML)) {
+                    var xmlTestResultNodes = TestResultParser.Read(resultsXML).CreateNavigator().Select("/testsuite/testcase");
+                    foreach (XPathNavigator pytestResultNode in xmlTestResultNodes) {
+                        if (_cancelRequested.WaitOne(0)) {
+                            break;
+                        }
+                        try {
+                            string pytestId = TestResultParser.GetPytestId(pytestResultNode);
 
+                            if (idToResultsMap.TryGetValue(pytestId, out TestResult vsTestResult)) {
+                                TestResultParser.UpdateVsTestResult(vsTestResult, pytestResultNode);
+                            } else {
+                                frameworkHandle.SendMessage(TestMessageLevel.Error, "Test not found for result: {0}".FormatInvariant(pytestResultNode.InnerXml));
+                            }
+                        } catch (Exception ex) {
+                            frameworkHandle.SendMessage(TestMessageLevel.Error, ex.Message);
+                        }
+                    }
+                }
+
+                foreach (var result in idToResultsMap.Values) {
                     if (_cancelRequested.WaitOne(0)) {
                         break;
                     }
                     frameworkHandle.RecordResult(result);
                 }
             }
+        }
+
+        private static Dictionary<string, TestResult> CreatePytestIdToVsTestResultsMap(IEnumerable<TestCase> vsTestCases) {
+            return vsTestCases.Select(tc => new TestResult(tc) { Outcome = TestOutcome.NotFound })
+                .ToDictionary(tr => tr.TestCase.GetPropertyValue<string>(Pytest.Constants.PytestIdProperty, String.Empty), tr => tr);
         }
     }
 }

--- a/Python/Product/TestAdapter.Executor/Pytest/TestExecutorPytest.cs
+++ b/Python/Product/TestAdapter.Executor/Pytest/TestExecutorPytest.cs
@@ -137,6 +137,7 @@ namespace Microsoft.PythonTools.TestAdapter {
                 Dictionary<string, TestResult> idToResultsMap = CreatePytestIdToVsTestResultsMap(testGroup);
                 var resultsXML = executor.Run(testGroup);
 
+                //Read pytest results from xml
                 if (File.Exists(resultsXML)) {
                     var xmlTestResultNodes = TestResultParser.Read(resultsXML).CreateNavigator().Select("/testsuite/testcase");
                     foreach (XPathNavigator pytestResultNode in xmlTestResultNodes) {
@@ -145,11 +146,10 @@ namespace Microsoft.PythonTools.TestAdapter {
                         }
                         try {
                             string pytestId = TestResultParser.GetPytestId(pytestResultNode);
-
-                            if (idToResultsMap.TryGetValue(pytestId, out TestResult vsTestResult)) {
+                            if (pytestId != null && idToResultsMap.TryGetValue(pytestId, out TestResult vsTestResult)) {
                                 TestResultParser.UpdateVsTestResult(vsTestResult, pytestResultNode);
                             } else {
-                                frameworkHandle.SendMessage(TestMessageLevel.Error, "Test not found for result: {0}".FormatInvariant(pytestResultNode.InnerXml));
+                                frameworkHandle.SendMessage(TestMessageLevel.Error, Strings.ErrorTestCaseNotFound.FormatInvariant(pytestResultNode.OuterXml));
                             }
                         } catch (Exception ex) {
                             frameworkHandle.SendMessage(TestMessageLevel.Error, ex.Message);

--- a/Python/Product/TestAdapter.Executor/Pytest/TestResultParser.cs
+++ b/Python/Product/TestAdapter.Executor/Pytest/TestResultParser.cs
@@ -48,11 +48,11 @@ namespace Microsoft.PythonTools.TestAdapter.Pytest {
 
         /// <summary>
         /// Handles two cases:
-        /// case A: Function instead a class
+        /// case A: Function inside a class - classname drops the filename portion 
         ///  <testcase classname="test2.Test_test2" file="test2.py" name="test_A" >
         ///  pytestId .\test2.py::Test_test2::test_A
         ///  
-        /// case B: Global function
+        /// case B: Global function - classname dropped entirely
         ///   <testcase classname="test_sample" file="test_sample.py" name="test_answer" >
         ///   pytestId .\test_sample.py::test_answer 
         /// </summary>
@@ -61,9 +61,9 @@ namespace Microsoft.PythonTools.TestAdapter.Pytest {
         /// <param name="funcname"></param>
         /// <returns></returns>
         internal static string CreatePytestId(string filename, string classname, string funcname) {
-            var classParts = classname.Split('.');
-            if (classParts.Length > 1) {
-                var classNameWithoutFilename = String.Join("", classParts.Skip(1));
+            var classIndex = classname.IndexOf(".");
+            if (classIndex >= 0 && classIndex < (classname.Length - 1)) {
+                var classNameWithoutFilename = classname.Substring(classIndex + 1);
                 return $".\\{filename}::{classNameWithoutFilename}::{funcname}";
             } else {
                 return $".\\{filename}::{funcname}";

--- a/Python/Tests/TestAdapterTests/TestDiscovererTests.cs
+++ b/Python/Tests/TestAdapterTests/TestDiscovererTests.cs
@@ -379,7 +379,6 @@ namespace TestAdapterTests {
         }
 
 
-        [Ignore] // TODO: discovers 3 tests instead of 2, it shouldn't be finding the one in example_pt.py
         [TestMethod, Priority(0)]
         [TestCategory("10s")]
         public void DiscoverPytestConfigPythonFiles() {

--- a/Python/Tests/TestAdapterTests/TestDiscovererTests.cs
+++ b/Python/Tests/TestAdapterTests/TestDiscovererTests.cs
@@ -82,7 +82,7 @@ namespace TestAdapterTests {
             File.Copy(TestData.GetPath("TestData", "TestDiscoverer", "Uppercase", "test_Uppercase.py"), testFilePath);
 
             var expectedTests = new[] {
-                new TestInfo("test_A", "test_uppercase.py::Test_UppercaseClass::test_A", testFilePath, 4),
+                new TestInfo("test_A", "test_Uppercase.py::Test_UppercaseClass::test_A", testFilePath, 4),
             };
 
             var runSettings = new MockRunSettings(
@@ -173,7 +173,7 @@ namespace TestAdapterTests {
             var searchPath = Path.Combine(testEnv.SourceFolderPath, "SearchPath");
 
             var expectedTests = new[] {
-                new TestInfo("test_imported_module", "testfolder\\test_search_path.py::SearchPathTests::test_imported_module", testFilePath, 5),
+                new TestInfo("test_imported_module", "TestFolder\\test_search_path.py::SearchPathTests::test_imported_module", testFilePath, 5),
             };
 
             var runSettings = new MockRunSettings(
@@ -781,8 +781,6 @@ if __name__ == '__main__':
                 Console.WriteLine($"CodeFilePath: {tst.CodeFilePath}");
                 Console.WriteLine($"LineNumber: {tst.LineNumber.ToString()}");
                 Console.WriteLine($"PytestId: {tst.GetPropertyValue<string>(Microsoft.PythonTools.TestAdapter.Pytest.Constants.PytestIdProperty, null)}");
-                Console.WriteLine($"PytestXmlClassName: {tst.GetPropertyValue<string>(Microsoft.PythonTools.TestAdapter.Pytest.Constants.PyTestXmlClassNameProperty, null)}");
-                Console.WriteLine($"PytestTestExecPath: {tst.GetPropertyValue<string>(Microsoft.PythonTools.TestAdapter.Pytest.Constants.PytestTestExecutionPathPropertery, null)}");
                 Console.WriteLine("");
             }
         }

--- a/Python/Tests/TestAdapterTests/TestExecutorTests.cs
+++ b/Python/Tests/TestAdapterTests/TestExecutorTests.cs
@@ -196,7 +196,6 @@ if __name__ == '__main__':
         [TestMethod, Priority(0)]
         [TestCategory("10s")]
         public void RunPytestUppercaseFileName() {
-            Assert.Inconclusive("Need to fix pytestId filename portition being lowercased ie.test_Uppercase.py::Test_UppercaseClass::test_A");
             var testEnv = TestEnvironment.GetOrCreate(Version, FrameworkPytest);
 
             var testFilePath = Path.Combine(testEnv.SourceFolderPath, "test_Uppercase.py");
@@ -205,11 +204,11 @@ if __name__ == '__main__':
             var expectedTests = new[] {
                 new TestInfo(
                    "test_A", 
-                   "test_uppercase.py::Test_UppercaseClass::test_A",
+                   "test_Uppercase.py::Test_UppercaseClass::test_A",
                     testFilePath,
                     4,
                     outcome: TestOutcome.Passed,
-                    pytestXmlClassName: "Test_UppercaseClass"
+                    pytestXmlClassName: "test_Uppercase.Test_UppercaseClass"
                 ),
             };
 
@@ -724,11 +723,9 @@ if __name__ == '__main__':
                 string id = ".\\" + ti.FullyQualifiedName;
                 if (testEnv.TestFramework == FrameworkPytest) {
                     var classParts = ti.PytestXmlClassName.Split('.');
-                    id = (classParts.Length > 1) ? ".\\" + ti.FullyQualifiedName : ".\\" + Path.GetFileName(ti.FilePath) + "::" + ti.DisplayName;
+                    id = (classParts.Length > 1) ? id : ".\\" + Path.GetFileName(ti.FilePath) + "::" + ti.DisplayName;
                 }
              
-                string xmlClassName = ti.PytestXmlClassName;
-
                 // FullyQualifiedName as exec path suffix only works for test class case,
                 // for standalone methods, specify the exec path suffix when creating TestInfo.
                 string execPath;
@@ -739,8 +736,6 @@ if __name__ == '__main__':
                 }
 
                 testCase.SetPropertyValue<string>((TestProperty)Microsoft.PythonTools.TestAdapter.Pytest.Constants.PytestIdProperty, id);
-                testCase.SetPropertyValue<string>((TestProperty)Microsoft.PythonTools.TestAdapter.Pytest.Constants.PyTestXmlClassNameProperty, xmlClassName);
-                testCase.SetPropertyValue<string>((TestProperty)Microsoft.PythonTools.TestAdapter.Pytest.Constants.PytestTestExecutionPathPropertery, execPath);
                 return (TestCase)testCase;
             }).ToList();
         }


### PR DESCRIPTION
Fixing  pytest execution when filenames contain uppercase characters. Fix #5566

- The pytest adapter was lowercasing the filepath portion of pytestId which was causing issues with pytest not being able to find the correct tests when we try to execute with the lowercase pytestid.

- Improved matching test results with testscases by building a map of pytestId to testcases.  Now when i parse a junitxml pytest result I rebuild the pytestId and look up the corresponding discovered test in the map, instead of linearing searching for classname and function.

- Updated all unit tests that were lowercasing the filename portion of pytestid or fullyqualifiedname, since for pytest fullyqualfiedname is bulit of pytestid.

- removed test properties that are no longer used