### PR TITLE
Fix 5544 Pytest with ini file with python_files returns tests in proj…

### DIFF
--- a/Python/Product/TestAdapter.Executor/Pytest/TestDiscovererPytest.cs
+++ b/Python/Product/TestAdapter.Executor/Pytest/TestDiscovererPytest.cs
@@ -139,27 +139,8 @@ namespace Microsoft.PythonTools.TestAdapter.Pytest {
             arguments.Add("pytest");
             arguments.Add("--output-file");
             arguments.Add(outputfilename);
-
-            // For a small set of tests, we'll pass them on the command
-            // line. Once we exceed a certain (arbitrary) number, create
-            // a test list on disk so that we do not overflow the 
-            // 32K argument limit.
-            bool useTestList = sources.Count() > 5;
-            if (!projSettings.IsWorkspace &&
-                useTestList) {
-                var testListFilePath = TestUtils.CreateTestListFile(sources);
-                arguments.Add("--test-list");
-                arguments.Add(testListFilePath);
-            }
             //Note pytest specific arguments go after this separator
             arguments.Add("--");
-            // Add source files to pytest as arguments
-            if (!projSettings.IsWorkspace &&
-                !useTestList) {
-                foreach (var s in sources) {
-                    arguments.Add(s);
-                }
-            }
             arguments.Add("--cache-clear");
             return arguments.ToArray();
         }

--- a/Python/Tests/TestAdapterTests/TestDiscovererTests.cs
+++ b/Python/Tests/TestAdapterTests/TestDiscovererTests.cs
@@ -470,49 +470,7 @@ namespace TestAdapterTests {
             DiscoverTests(testEnv, new[] { testFilePath }, runSettings, expectedTests);
         }
 
-        [TestMethod, Priority(0)]
-        [TestCategory("10s")]
-        public void DiscoverUnittestLargeProject() {
-            var testEnv = TestEnvironment.GetOrCreate(Version, FrameworkUnittest);
-
-            // Test that we don't try passing 1000 files via command line arguments
-            // since that would exceed the 32k limit and fail.
-            var isWorkspace = false;
-            var testContentsFormat = @"import unittest
-
-class {0}(unittest.TestCase):
-    def {1}(self): pass
-
-if __name__ == '__main__':
-    unittest.main()
-";
-            var expectedTests = new List<TestInfo>();
-
-            for (int i = 0; i < 1000; i++) {
-                var moduleName = $"test_file_with_long_file_name_{i}";
-                var className = $"MyTest{i}";
-                var funcName = $"test_func_{i}";
-                var testFilePath = Path.Combine(testEnv.SourceFolderPath, $"{moduleName}.py");
-                var testContents = string.Format(testContentsFormat, className, funcName);
-                File.WriteAllText(testFilePath, testContents);
-
-                expectedTests.Add(new TestInfo(
-                    funcName,
-                    $"{moduleName}.py::{className}::{funcName}",
-                    testFilePath,
-                    4
-                ));
-            }
-
-            var runSettings = new MockRunSettings(
-                new MockRunSettingsXmlBuilder(testEnv.TestFramework, testEnv.InterpreterPath, testEnv.ResultsFolderPath, testEnv.SourceFolderPath, isWorkspace: isWorkspace)
-                    .WithTestFilesFromFolder(testEnv.SourceFolderPath)
-                    .ToXml()
-            );
-
-            DiscoverTests(testEnv, expectedTests.Select(t => t.FilePath).ToArray(), runSettings, expectedTests.ToArray());
-        }
-
+     
         [TestMethod, Priority(0)]
         [TestCategory("10s")]
         public void DiscoverUnittestTimeoutError() {

--- a/Python/Tests/TestAdapterTests/TestDiscovererTests.cs
+++ b/Python/Tests/TestAdapterTests/TestDiscovererTests.cs
@@ -94,39 +94,6 @@ namespace TestAdapterTests {
             DiscoverTests(testEnv, new[] { testFilePath }, runSettings, expectedTests);
         }
 
-        [TestMethod, Priority(TestExtensions.P0_FAILING_UNIT_TEST)]
-        [TestCategory("10s")]
-        public void DiscoverPytestLargeProject() {
-            var testEnv = TestEnvironment.GetOrCreate(Version, FrameworkPytest);
-
-            // Test that we don't try passing 1000 files via command line arguments
-            // since that would exceed the 32k limit and fail.
-            var isWorkspace = false;
-            var expectedTests = new List<TestInfo>();
-            for (int i = 0; i < 1000; i++) {
-                var moduleName = $"test_file_with_long_file_name_{i}";
-                var funcName = $"test_func_{i}";
-                var testFilePath = Path.Combine(testEnv.SourceFolderPath, $"{moduleName}.py");
-                var testContents = $"def {funcName}(): pass";
-                File.WriteAllText(testFilePath, testContents);
-
-                expectedTests.Add(new TestInfo(
-                    funcName,
-                    $"{moduleName}.py::{moduleName}::{funcName}",
-                    testFilePath,
-                    1
-                ));
-            }
-
-            var runSettings = new MockRunSettings(
-                new MockRunSettingsXmlBuilder(testEnv.TestFramework, testEnv.InterpreterPath, testEnv.ResultsFolderPath, testEnv.SourceFolderPath, isWorkspace: isWorkspace)
-                    .WithTestFilesFromFolder(testEnv.SourceFolderPath)
-                    .ToXml()
-            );
-
-            DiscoverTests(testEnv, expectedTests.Select(t => t.FilePath).ToArray(), runSettings, expectedTests.ToArray());
-        }
-
         [TestMethod, Priority(0)]
         [TestCategory("10s")]
         public void DiscoverPytestTimeoutError() {


### PR DESCRIPTION
…ect that don't match the specified pattern

- we nolonger pass pytest discovery a list of source files and just use the project/workspace folder instead.
- we do filter the results of discovery to make sure they are in the workspace/project
- removing test around large project pytest discovery which was testing writing commandline source arguments to a file.