### PR TITLE
Test discoverer and executor tests

### DIFF
--- a/Python/Tests/TestAdapterTests/Mocks/MockRunSettingsXmlBuilder.cs
+++ b/Python/Tests/TestAdapterTests/Mocks/MockRunSettingsXmlBuilder.cs
@@ -15,6 +15,7 @@
 // permissions and limitations under the License.
 
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Text;
 using Microsoft.PythonTools;
 
@@ -36,10 +37,16 @@ namespace TestAdapterTests.Mocks {
         // {4} is one or more formatted _runSettingTest lines
         // {5} is one or more formatted _runSettingEnvironment lines
         // {6} is one or more formatted _runSettingSearch lines
+        // {7} is the discovery wait time
+        // {8} is the workspace true/false
+        // {9} is the unit test configuration formatted _unitTestConfig
 
-        private const string _runSettingProject = @"<Project name=""{0}"" home=""{1}"" nativeDebugging="""" djangoSettingsModule="""" workingDir=""{1}"" interpreter=""{2}"" pathEnv=""PYTHONPATH"" testFramework= ""{3}"" discoveryWaitTime= ""{7}"" isWorkspace=""{8}""><Environment>{5}</Environment><SearchPaths>{6}</SearchPaths>
+        private const string _runSettingProject = @"<Project name=""{0}"" home=""{1}"" nativeDebugging="""" djangoSettingsModule="""" workingDir=""{1}"" interpreter=""{2}"" pathEnv=""PYTHONPATH"" testFramework= ""{3}"" {9} discoveryWaitTime= ""{7}"" isWorkspace=""{8}""><Environment>{5}</Environment><SearchPaths>{6}</SearchPaths>
 {4}
 </Project>";
+
+        // {0} is the full path to the file
+        private const string _unitTestConfig = @" unitTestRootDir=""{0}"" unitTestPattern=""{1}""";
 
         // {0} is the variable name
         // {1} is the variable value
@@ -55,6 +62,7 @@ namespace TestAdapterTests.Mocks {
         private string _resultsDir;
         private string _testDir;
         private string _interpreterPath;
+        private string _unitTestConfigAttributes;
         private int _discoveryWaitTimeInSeconds;
         private bool _isWorkspace;
         private StringBuilder _environmentLines = new StringBuilder();
@@ -69,6 +77,7 @@ namespace TestAdapterTests.Mocks {
             _interpreterPath = interpreterPath;
             _resultsDir = resultsDir;
             _testDir = testDir;
+            _unitTestConfigAttributes = string.Empty;
             _discoveryWaitTimeInSeconds = discoveryWaitTimeInSeconds;
             _isWorkspace = isWorkspace;
         }
@@ -85,6 +94,11 @@ namespace TestAdapterTests.Mocks {
 
         public MockRunSettingsXmlBuilder WithTestFile(string filePath) {
             _testLines.Append(string.Format(_runSettingTest, filePath));
+            return this;
+        }
+
+        public MockRunSettingsXmlBuilder WithUnitTestConfiguration(string rootFolderPath, string pattern) {
+            _unitTestConfigAttributes = string.Format(_unitTestConfig, rootFolderPath, pattern);
             return this;
         }
 
@@ -109,7 +123,8 @@ namespace TestAdapterTests.Mocks {
                     _environmentLines.ToString(),
                     _searchLines.ToString(),
                     _discoveryWaitTimeInSeconds < 0 ? string.Empty : _discoveryWaitTimeInSeconds.ToString(),
-                    _isWorkspace
+                    _isWorkspace,
+                    _unitTestConfigAttributes
                 ),
                 "false",
                 "false"

--- a/Python/Tests/TestAdapterTests/TestDiscovererTests.cs
+++ b/Python/Tests/TestAdapterTests/TestDiscovererTests.cs
@@ -481,6 +481,33 @@ namespace TestAdapterTests {
             DiscoverTests(testEnv, new[] { testFilePath }, runSettings, expectedTests);
         }
 
+        [TestMethod, Priority(0)]
+        [TestCategory("10s")]
+        public void DiscoverUnittestConfiguration() {
+            var testEnv = TestEnvironment.GetOrCreate(Version, FrameworkUnittest);
+
+            FileUtils.CopyDirectory(TestData.GetPath("TestData", "TestDiscoverer", "ConfigUnittest"), testEnv.SourceFolderPath);
+
+            // We have 3 files
+            // product/prefix_not_included.py (should not be found, outside test folder)
+            // test/test_not_included.py (should not be found, incorrect filename pattern)
+            // test/prefix_included.py (should be found)
+            var testFilePath = Path.Combine(testEnv.SourceFolderPath, "test", "prefix_included.py");
+
+            var expectedTests = new[] {
+                new TestInfo("test_included", "test\\prefix_included.py::PrefixIncluded::test_included", testFilePath, 4),
+            };
+
+            var runSettings = new MockRunSettings(
+                new MockRunSettingsXmlBuilder(testEnv.TestFramework, testEnv.InterpreterPath, testEnv.ResultsFolderPath, testEnv.SourceFolderPath)
+                    .WithTestFilesFromFolder(Path.Combine(testEnv.SourceFolderPath, "product"))
+                    .WithTestFilesFromFolder(Path.Combine(testEnv.SourceFolderPath, "test"))
+                    .WithUnitTestConfiguration("test", "prefix_*.py")
+                    .ToXml()
+            );
+
+            DiscoverTests(testEnv, new[] { testFilePath }, runSettings, expectedTests);
+        }
 
         [TestMethod, Priority(0)]
         [TestCategory("10s")]

--- a/Python/Tests/TestAdapterTests/TestDiscovererTests.cs
+++ b/Python/Tests/TestAdapterTests/TestDiscovererTests.cs
@@ -464,12 +464,16 @@ namespace TestAdapterTests {
         public void DiscoverUnittest() {
             var testEnv = TestEnvironment.GetOrCreate(Version, FrameworkUnittest);
 
-            var testFilePath = Path.Combine(testEnv.SourceFolderPath, "test_ut.py");
-            File.Copy(TestData.GetPath("TestData", "TestDiscoverer", "BasicUnittest", "test_ut.py"), testFilePath);
+            var testFile1Path = Path.Combine(testEnv.SourceFolderPath, "test_ut.py");
+            File.Copy(TestData.GetPath("TestData", "TestDiscoverer", "BasicUnittest", "test_ut.py"), testFile1Path);
+
+            var testFile2Path = Path.Combine(testEnv.SourceFolderPath, "test_runtest.py");
+            File.Copy(TestData.GetPath("TestData", "TestDiscoverer", "BasicUnittest", "test_runtest.py"), testFile2Path);
 
             var expectedTests = new[] {
-                new TestInfo("test_ut_fail", "test_ut.py::TestClassUT::test_ut_fail", testFilePath, 4),
-                new TestInfo("test_ut_pass", "test_ut.py::TestClassUT::test_ut_pass", testFilePath, 7),
+                new TestInfo("test_ut_fail", "test_ut.py::TestClassUT::test_ut_fail", testFile1Path, 4),
+                new TestInfo("test_ut_pass", "test_ut.py::TestClassUT::test_ut_pass", testFile1Path, 7),
+                new TestInfo("runTest", "test_runtest.py::TestClassRunTest::runTest", testFile2Path, 4),
             };
 
             var runSettings = new MockRunSettings(
@@ -478,7 +482,7 @@ namespace TestAdapterTests {
                     .ToXml()
             );
 
-            DiscoverTests(testEnv, new[] { testFilePath }, runSettings, expectedTests);
+            DiscoverTests(testEnv, new[] { testFile1Path }, runSettings, expectedTests);
         }
 
         [TestMethod, Priority(0)]

--- a/Python/Tests/TestAdapterTests/TestExecutorTests.cs
+++ b/Python/Tests/TestAdapterTests/TestExecutorTests.cs
@@ -71,22 +71,32 @@ namespace TestAdapterTests {
         public void RunUnittest() {
             var testEnv = TestEnvironment.GetOrCreate(Version, FrameworkUnittest);
 
-            var testFilePath = Path.Combine(testEnv.SourceFolderPath, "test_ut.py");
-            File.Copy(TestData.GetPath("TestData", "TestDiscoverer", "BasicUnittest", "test_ut.py"), testFilePath);
+            var testFile1Path = Path.Combine(testEnv.SourceFolderPath, "test_ut.py");
+            File.Copy(TestData.GetPath("TestData", "TestDiscoverer", "BasicUnittest", "test_ut.py"), testFile1Path);
+
+            var testFile2Path = Path.Combine(testEnv.SourceFolderPath, "test_runtest.py");
+            File.Copy(TestData.GetPath("TestData", "TestDiscoverer", "BasicUnittest", "test_runtest.py"), testFile2Path);
 
             var expectedTests = new[] {
                 new TestInfo(
                     "test_ut_fail",
                     "test_ut.py::TestClassUT::test_ut_fail",
-                    testFilePath,
+                    testFile1Path,
                     4,
                     outcome: TestOutcome.Failed
                 ),
                 new TestInfo(
                     "test_ut_pass",
                     "test_ut.py::TestClassUT::test_ut_pass",
-                    testFilePath,
+                    testFile1Path,
                     7,
+                    outcome: TestOutcome.Passed
+                ),
+                new TestInfo(
+                    "runTest",
+                    "test_runtest.py::TestClassRunTest::runTest",
+                    testFile2Path,
+                    4,
                     outcome: TestOutcome.Passed
                 ),
             };
@@ -383,7 +393,6 @@ if __name__ == '__main__':
             Assert.IsTrue(recorder.Results.Count < expectedTests.Length);
         }
 
-        [Ignore] // TODO: is this a bug in product? See equivalent test for test discoverer
         [TestMethod, Priority(0)]
         [TestCategory("10s")]
         public void RunUnittestRelativeImport() {
@@ -396,7 +405,7 @@ if __name__ == '__main__':
             var expectedTests = new[] {
                 new TestInfo(
                     "test_relative_import",
-                    "test_relative_import.py::RelativeImportTests::test_relative_import",
+                    "relativeimportpackage\\test_relative_import.py::RelativeImportTests::test_relative_import",
                     testFilePath,
                     5,
                     outcome: TestOutcome.Passed

--- a/Python/Tests/TestData/TestDiscoverer/BasicUnittest/test_runtest.py
+++ b/Python/Tests/TestData/TestDiscoverer/BasicUnittest/test_runtest.py
@@ -1,0 +1,8 @@
+import unittest
+
+class TestClassRunTest(unittest.TestCase):
+    def runTest(self):
+        pass
+
+if __name__ == '__main__':
+    unittest.main()

--- a/Python/Tests/TestData/TestDiscoverer/ConfigUnittest/Product/prefix_not_included.py
+++ b/Python/Tests/TestData/TestDiscoverer/ConfigUnittest/Product/prefix_not_included.py
@@ -1,0 +1,8 @@
+import unittest
+
+class PrefixNotIncluded(unittest.TestCase):
+    def test_not_included(self):
+        pass
+
+if __name__ == '__main__':
+    unittest.main()

--- a/Python/Tests/TestData/TestDiscoverer/ConfigUnittest/Test/prefix_included.py
+++ b/Python/Tests/TestData/TestDiscoverer/ConfigUnittest/Test/prefix_included.py
@@ -1,0 +1,8 @@
+import unittest
+
+class PrefixIncluded(unittest.TestCase):
+    def test_included(self):
+        pass
+
+if __name__ == '__main__':
+    unittest.main()

--- a/Python/Tests/TestData/TestDiscoverer/ConfigUnittest/Test/test_not_included.py
+++ b/Python/Tests/TestData/TestDiscoverer/ConfigUnittest/Test/test_not_included.py
@@ -1,0 +1,8 @@
+import unittest
+
+class TestNotIncluded(unittest.TestCase):
+    def test_not_included(self):
+        pass
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Fix #5537 Add unittest discovery test for root dir and pattern
Fix #5494 Add discovery/execution test for unittest runTest()

Also fixes a test that was being ignored due to failing, it now passes