### PR TITLE
Updating python test adapter with the latest version from vscode.

### DIFF
--- a/Python/Product/TestAdapter.Executor/PythonFiles/testing_tools/adapter/info.py
+++ b/Python/Product/TestAdapter.Executor/PythonFiles/testing_tools/adapter/info.py
@@ -26,18 +26,19 @@ class TestPath(namedtuple('TestPath', 'root relfile func sub')):
         # self.sub may be None.
 
 
-class ParentInfo(namedtuple('ParentInfo', 'id kind name root parentid')):
+class ParentInfo(namedtuple('ParentInfo', 'id kind name root relpath parentid')):
 
     KINDS = ('folder', 'file', 'suite', 'function', 'subtest')
 
-    def __new__(cls, id, kind, name, root=None, parentid=None):
+    def __new__(cls, id, kind, name, root=None, relpath=None, parentid=None):
         self = super(ParentInfo, cls).__new__(
                 cls,
-                str(id) if id else None,
-                str(kind) if kind else None,
-                str(name) if name else None,
-                str(root) if root else None,
-                str(parentid) if parentid else None,
+                id=str(id) if id else None,
+                kind=str(kind) if kind else None,
+                name=str(name) if name else None,
+                root=str(root) if root else None,
+                relpath=str(relpath) if relpath else None,
+                parentid=str(parentid) if parentid else None,
                 )
         return self
 
@@ -53,8 +54,12 @@ class ParentInfo(namedtuple('ParentInfo', 'id kind name root parentid')):
         if self.root is None:
             if self.parentid is not None or self.kind != 'folder':
                 raise TypeError('missing root')
+            if self.relpath is not None:
+                raise TypeError('unexpected relpath {}'.format(self.relpath))
         elif self.parentid is None:
             raise TypeError('missing parentid')
+        elif self.relpath is None and self.kind in ('folder', 'file'):
+            raise TypeError('missing relpath')
 
 
 class TestInfo(namedtuple('TestInfo', 'id name path source markers parentid kind')):

--- a/Python/Product/TestAdapter.Executor/PythonFiles/testing_tools/adapter/pytest/_discovery.py
+++ b/Python/Product/TestAdapter.Executor/PythonFiles/testing_tools/adapter/pytest/_discovery.py
@@ -3,7 +3,6 @@
 
 from __future__ import absolute_import, print_function
 
-import os.path
 import sys
 
 import pytest
@@ -28,11 +27,15 @@ def discover(pytestargs=None, hidestdio=False,
         # No tests were discovered.
         pass
     elif ec != 0:
+        print(('equivalent command: {} -m pytest {}'
+               ).format(sys.executable, util.shlex_unsplit(pytestargs)))
         if hidestdio:
             print(stdio.getvalue(), file=sys.stderr)
             sys.stdout.flush()
         print('pytest discovery failed (exit code {})'.format(ec))
     if not _plugin._started:
+        print(('equivalent command: {} -m pytest {}'
+               ).format(sys.executable, util.shlex_unsplit(pytestargs)))
         if hidestdio:
             print(stdio.getvalue(), file=sys.stderr)
             sys.stdout.flush()
@@ -57,8 +60,9 @@ def _adjust_pytest_args(pytestargs):
 class TestCollector(object):
     """This is a pytest plugin that collects the discovered tests."""
 
-    NORMCASE = staticmethod(os.path.normcase)
-    PATHSEP = os.path.sep
+    @classmethod
+    def parse_item(cls, item):
+        return parse_item(item)
 
     def __init__(self, tests=None):
         if tests is None:
@@ -73,7 +77,7 @@ class TestCollector(object):
         self._started = True
         self._tests.reset()
         for item in items:
-            test, parents = parse_item(item, self.NORMCASE, self.PATHSEP)
+            test, parents = self.parse_item(item)
             self._tests.add_test(test, parents)
 
     # This hook is not specified in the docs, so we also provide
@@ -87,5 +91,5 @@ class TestCollector(object):
             return
         self._tests.reset()
         for item in items:
-            test, parents = parse_item(item, self.NORMCASE, self.PATHSEP)
+            test, parents = self.parse_item(item)
             self._tests.add_test(test, parents)

--- a/Python/Product/TestAdapter.Executor/PythonFiles/testing_tools/adapter/pytest/_pytest_item.py
+++ b/Python/Product/TestAdapter.Executor/PythonFiles/testing_tools/adapter/pytest/_pytest_item.py
@@ -13,7 +13,7 @@ as the collector that collected it.
 Collectors and items are collectively identified as "nodes".  The pytest
 API relies on collector and item objects providing specific methods and
 attributes.  In addition to corresponding base classes, pytest provides
-a number of concrete impementations.
+a number of concrete implementations.
 
 The following are the known pytest node types:
 
@@ -100,9 +100,10 @@ import _pytest.doctest
 import _pytest.unittest
 
 from ..info import TestInfo, TestPath
+from ..util import fix_fileid, PATH_SEP, NORMCASE
 
 
-def should_never_reach_here(node, *extra):
+def should_never_reach_here(item, **extra):
     """Indicates a code path we should never reach."""
     print('The Python extension has run into an unexpected situation')
     print('while processing a pytest node during test discovery.  Please')
@@ -110,19 +111,20 @@ def should_never_reach_here(node, *extra):
     print('  https://github.com/microsoft/vscode-python/issues')
     print('and paste the following output there.')
     print()
-    for field, info in _summarize_item(node):
+    for field, info in _summarize_item(item):
         print('{}: {}'.format(field, info))
     if extra:
         print()
         print('extra info:')
-        for info in extra:
-            if isinstance(line, str):
-                print(str)
+        for name, info in extra.items():
+            print('{:10}'.format(name + ':'), end='')
+            if isinstance(info, str):
+                print(info)
             else:
                 try:
-                    print(*line)
+                    print(*info)
                 except TypeError:
-                    print(line)
+                    print(info)
     print()
     print('traceback:')
     import traceback
@@ -130,11 +132,16 @@ def should_never_reach_here(node, *extra):
 
     msg = 'Unexpected pytest node (see printed output).'
     exc = NotImplementedError(msg)
-    exc.node = node
+    exc.item = item
     return exc
 
 
-def parse_item(item, _normcase, _pathsep):
+def parse_item(item, #*,
+               _get_item_kind=(lambda *a: _get_item_kind(*a)),
+               _parse_node_id=(lambda *a: _parse_node_id(*a)),
+               _split_fspath=(lambda *a: _split_fspath(*a)),
+               _get_location=(lambda *a: _get_location(*a)),
+               ):
     """Return (TestInfo, [suite ID]) for the given item.
 
     The suite IDs, if any, are in parent order with the item's direct
@@ -146,36 +153,28 @@ def parse_item(item, _normcase, _pathsep):
     #_debug_item(item, showsummary=True)
     kind, _ = _get_item_kind(item)
     (nodeid, parents, fileid, testfunc, parameterized
-     ) = _parse_node_id(item.nodeid, kind, _pathsep, _normcase)
+     ) = _parse_node_id(item.nodeid, kind)
     # Note: testfunc does not necessarily match item.function.__name__.
     # This can result from importing a test function from another module.
 
     # Figure out the file.
-    relfile = fileid
-    fspath = _normcase(str(item.fspath))
-    if not fspath.endswith(relfile[1:]):
-        raise should_never_reach_here(
-            item,
-            fspath,
-            relfile,
-            )
-    testroot = fspath[:-len(relfile) + 1]
-    location, fullname = _get_location(item, relfile, _normcase, _pathsep)
+    testroot, relfile = _split_fspath(str(item.fspath), fileid, item)
+    location, fullname = _get_location(item, testroot, relfile)
     if kind == 'function':
         if testfunc and fullname != testfunc + parameterized:
             raise should_never_reach_here(
                 item,
-                fullname,
-                testfunc,
-                parameterized,
+                fullname=fullname,
+                testfunc=testfunc,
+                parameterized=parameterized,
                 )
     elif kind == 'doctest':
         if (testfunc and fullname != testfunc and
                 fullname != '[doctest] ' + testfunc):
             raise should_never_reach_here(
                 item,
-                fullname,
-                testfunc,
+                fullname=fullname,
+                testfunc=testfunc,
                 )
         testfunc = None
 
@@ -188,7 +187,7 @@ def parse_item(item, _normcase, _pathsep):
     # Sort out markers.
     #  See: https://docs.pytest.org/en/latest/reference.html#marks
     markers = set()
-    for marker in item.own_markers:
+    for marker in getattr(item, 'own_markers', []):
         if marker.name == 'parameterize':
             # We've already covered these.
             continue
@@ -218,18 +217,66 @@ def parse_item(item, _normcase, _pathsep):
     return test, parents
 
 
-def _get_location(item, relfile, _normcase, _pathsep):
+def _split_fspath(fspath, fileid, item, #*,
+                  _normcase=NORMCASE,
+                  ):
+    """Return (testroot, relfile) for the given fspath.
+
+    "relfile" will match "fileid".
+    """
+    # "fileid" comes from nodeid and is always relative to the testroot
+    # (with a "./" prefix).  There are no guarantees about casing, so we
+    # normcase just be to sure.
+    relsuffix = fileid[1:]  # Drop (only) the "." prefix.
+    if not _normcase(fspath).endswith(_normcase(relsuffix)):
+        raise should_never_reach_here(
+            item,
+            fspath=fspath,
+            fileid=fileid,
+            )
+    testroot = fspath[:-len(fileid) + 1]  # Ignore the "./" prefix.
+    relfile = '.' + fspath[-len(fileid) + 1:]  # Keep the pathsep.
+    return testroot, relfile
+
+
+def _get_location(item, testroot, relfile, #*,
+                  _matches_relfile=(lambda *a: _matches_relfile(*a)),
+                  _is_legacy_wrapper=(lambda *a: _is_legacy_wrapper(*a)),
+                  _unwrap_decorator=(lambda *a: _unwrap_decorator(*a)),
+                  _pathsep=PATH_SEP,
+                  ):
     """Return (loc str, fullname) for the given item."""
+    # When it comes to normcase, we favor relfile (from item.fspath)
+    # over item.location in this function.
+
     srcfile, lineno, fullname = item.location
-    srcfile = _normcase(srcfile)
-    if srcfile in (relfile, relfile[len(_pathsep) + 1:]):
+    if _matches_relfile(srcfile, testroot, relfile):
         srcfile = relfile
     else:
         # pytest supports discovery of tests imported from other
         # modules.  This is reflected by a different filename
         # in item.location.
-        srcfile, lineno = _find_location(
-                srcfile, lineno, relfile, item.function, _pathsep)
+
+        if _is_legacy_wrapper(srcfile):
+            srcfile = relfile
+            unwrapped = _unwrap_decorator(item.function)
+            if unwrapped is None:
+                # It was an invalid legacy wrapper so we just say
+                # "somewhere in relfile".
+                lineno = None
+            else:
+                _srcfile, lineno = unwrapped
+                if not _matches_relfile(_srcfile, testroot, relfile):
+                    # For legacy wrappers we really expect the wrapped
+                    # function to be in relfile.  So here we ignore any
+                    # other file and just say "somewhere in relfile".
+                    lineno = None
+            if lineno is None:
+                lineno = -1  # i.e. "unknown"
+        elif _matches_relfile(srcfile, testroot, relfile):
+            srcfile = relfile
+        # Otherwise we just return the info from item.location as-is.
+
         if not srcfile.startswith('.' + _pathsep):
             srcfile = '.' + _pathsep + srcfile
     # from pytest, line numbers are 0-based
@@ -237,29 +284,72 @@ def _get_location(item, relfile, _normcase, _pathsep):
     return location, fullname
 
 
-def _find_location(srcfile, lineno, relfile, func, _pathsep):
-    """Return (filename, lno) for the given location info."""
-    if sys.version_info > (3,):
-        return srcfile, lineno
-    if (_pathsep + 'unittest' + _pathsep + 'case.py') not in srcfile:
-        return srcfile, lineno
+def _matches_relfile(srcfile, testroot, relfile, #*,
+                     _normcase=NORMCASE,
+                     _pathsep=PATH_SEP,
+                     ):
+    """Return True if "srcfile" matches the given relfile."""
+    testroot = _normcase(testroot)
+    srcfile = _normcase(srcfile)
+    relfile = _normcase(relfile)
+    if srcfile == relfile:
+        return True
+    elif srcfile == relfile[len(_pathsep) + 1:]:
+        return True
+    elif srcfile == testroot + relfile[1:]:
+        return True
+    else:
+        return False
 
-    # Unwrap the decorator (e.g. unittest.skip).
-    srcfile = relfile
-    lineno = -1
+
+def _is_legacy_wrapper(srcfile, #*,
+                       _pathsep=PATH_SEP,
+                       _pyversion=sys.version_info,
+                       ):
+    """Return True if the test might be wrapped.
+
+    In Python 2 unittest's decorators (e.g. unittest.skip) do not wrap
+    properly, so we must manually unwrap them.
+    """
+    if _pyversion > (3,):
+        return False
+    if (_pathsep + 'unittest' + _pathsep + 'case.py') not in srcfile:
+        return False
+    return True
+
+
+def _unwrap_decorator(func):
+    """Return (filename, lineno) for the func the given func wraps.
+
+    If the wrapped func cannot be identified then return None.  Likewise
+    for the wrapped filename.  "lineno" is None if it cannot be found
+    but the filename could.
+    """
     try:
         func = func.__closure__[0].cell_contents
     except (IndexError, AttributeError):
-        return srcfile, lineno
+        return None
     else:
-        if callable(func) and func.__code__.co_filename.endswith(relfile[1:]):
-            lineno = func.__code__.co_firstlineno - 1
-    return srcfile, lineno
+        if not callable(func):
+            return None
+        try:
+            filename = func.__code__.co_filename
+        except AttributeError:
+            return None
+        else:
+            try:
+                lineno = func.__code__.co_firstlineno - 1
+            except AttributeError:
+                return (filename, None)
+            else:
+                return filename, lineno
 
 
-def _parse_node_id(testid, kind, _pathsep, _normcase):
+def _parse_node_id(testid, kind, #*,
+                   _iter_nodes=(lambda *a: _iter_nodes(*a)),
+                   ):
     """Return the components of the given node ID, in heirarchical order."""
-    nodes = iter(_iter_nodes(testid, kind, _pathsep, _normcase))
+    nodes = iter(_iter_nodes(testid, kind))
 
     testid, name, kind = next(nodes)
     parents = []
@@ -281,7 +371,7 @@ def _parse_node_id(testid, kind, _pathsep, _normcase):
         else:
             raise should_never_reach_here(
                 testid,
-                kind,
+                kind=kind,
                 )
         fullname = funcname
 
@@ -299,7 +389,7 @@ def _parse_node_id(testid, kind, _pathsep, _normcase):
         else:
             raise should_never_reach_here(
                 testid,
-                node,
+                node=node,
                 )
     else:
         fileid = None
@@ -308,9 +398,15 @@ def _parse_node_id(testid, kind, _pathsep, _normcase):
     return testid, parents, fileid, fullname, parameterized or ''
 
 
-def _iter_nodes(nodeid, kind, _pathsep, _normcase):
+def _iter_nodes(testid, kind, #*,
+                _normalize_test_id=(lambda *a: _normalize_test_id(*a)),
+                _normcase=NORMCASE,
+                _pathsep=PATH_SEP,
+                ):
     """Yield (nodeid, name, kind) for the given node ID and its parents."""
-    nodeid = _normalize_node_id(nodeid, kind, _pathsep, _normcase)
+    nodeid, testid = _normalize_test_id(testid, kind)
+    if len(nodeid) > len(testid):
+        testid = '.' + _pathsep + testid
 
     if kind == 'function' and nodeid.endswith(']'):
         funcid, sep, parameterized = nodeid.partition('[')
@@ -342,37 +438,48 @@ def _iter_nodes(nodeid, kind, _pathsep, _normcase):
 
     # Extract the file and folders.
     fileid = parentid
-    parentid, _, filename = fileid.rpartition(_pathsep)
-    yield (fileid, filename, 'file')
+    raw = testid[:len(fileid)]
+    _parentid, _, filename = _normcase(fileid).rpartition(_pathsep)
+    parentid = fileid[:len(_parentid)]
+    raw, name = raw[:len(_parentid)], raw[-len(filename):]
+    yield (fileid, name, 'file')
     # We're guaranteed at least one (the test root).
-    while _pathsep in parentid:
+    while _pathsep in _normcase(parentid):
         folderid = parentid
-        parentid, _, foldername = folderid.rpartition(_pathsep)
-        yield (folderid, foldername, 'folder')
+        _parentid, _, foldername = _normcase(folderid).rpartition(_pathsep)
+        parentid = folderid[:len(_parentid)]
+        raw, name = raw[:len(parentid)], raw[-len(foldername):]
+        yield (folderid, name, 'folder')
     # We set the actual test root later at the bottom of parse_item().
     testroot = None
     yield (parentid, testroot, 'folder')
 
 
-def _normalize_node_id(nodeid, kind, _pathsep, _normcase):
+def _normalize_test_id(testid, kind, #*,
+                       _fix_fileid=fix_fileid,
+                       _pathsep=PATH_SEP,
+                       ):
     """Return the canonical form for the given node ID."""
-    while '::()::' in nodeid:
-        nodeid = nodeid.replace('::()::', '::')
+    while '::()::' in testid:
+        testid = testid.replace('::()::', '::')
     if kind is None:
-        return nodeid
+        return testid, testid
+    orig = testid
 
-    fileid, sep, remainder = nodeid.partition('::')
-    if sep:
-        # pytest works fine even if we normalize the filename.
-        nodeid = _normcase(fileid) + sep + remainder
-
-    if nodeid.startswith(_pathsep):
+    # We need to keep the testid as-is, or else pytest won't recognize
+    # it when we try to use it later (e.g. to run a test).  The only
+    # exception is that we add a "./" prefix for relative paths.
+    # Note that pytest always uses "/" as the path separator in IDs.
+    fileid, sep, remainder = testid.partition('::')
+    fileid = _fix_fileid(fileid)
+    if not fileid.startswith('./'):  # Absolute "paths" not expected.
         raise should_never_reach_here(
-            nodeid,
+            testid,
+            fileid=fileid,
             )
-    if not nodeid.startswith('.' + _pathsep):
-        nodeid = '.' + _pathsep + nodeid
-    return nodeid
+    testid = fileid + sep + remainder
+
+    return testid, orig
 
 
 def _get_item_kind(item):
@@ -424,7 +531,7 @@ def _summarize_item(item):
             else:
                 yield field, getattr(item, field, '<???>')
         except Exception as exc:
-            yield field, '<error>'
+            yield field, '<error {!r}>'.format(exc)
 
 
 def _debug_item(item, showsummary=False):

--- a/Python/Product/TestAdapter.Executor/PythonFiles/testing_tools/adapter/report.py
+++ b/Python/Product/TestAdapter.Executor/PythonFiles/testing_tools/adapter/report.py
@@ -36,15 +36,19 @@ def report_discovered(tests, parents, pretty=False, simple=False,
                 root['id'] = parent.id
                 continue
             root['parents'].append({
+                # "id" must match what the testing framework recognizes.
                 'id': parent.id,
                 'kind': parent.kind,
                 'name': parent.name,
                 'parentid': parent.parentid,
                 })
+            if parent.relpath is not None:
+                root['parents'][-1]['relpath'] = parent.relpath
         for test in tests:
             # We are guaranteed that the parent was added.
             root = byroot[test.path.root]
             testdata = {
+                # "id" must match what the testing framework recognizes.
                 'id': test.id,
                 'name': test.name,
                 # TODO: Add a "kind" field
@@ -72,10 +76,6 @@ def report_discovered(tests, parents, pretty=False, simple=False,
     serialized = json.dumps(data, **kwargs)
 
     _send(serialized)
-
-
-
-
 
 
 def report_unittest_discovered(suites, parents, pretty=False, simple=False,

--- a/Python/Product/TestAdapter.Executor/PythonFiles/testing_tools/adapter/util.py
+++ b/Python/Product/TestAdapter.Executor/PythonFiles/testing_tools/adapter/util.py
@@ -6,33 +6,13 @@ try:
     from io import StringIO
 except ImportError:
     from StringIO import StringIO  # 2.7
+import os.path
 import sys
 
 
 @contextlib.contextmanager
 def noop_cm():
     yield
-
-
-@contextlib.contextmanager
-def hide_stdio():
-    """Swallow stdout and stderr."""
-    ignored = StdioStream()
-    sys.stdout = ignored
-    sys.stderr = ignored
-    try:
-        yield ignored
-    finally:
-        sys.stdout = sys.__stdout__
-        sys.stderr = sys.__stderr__
-
-
-if sys.version_info < (3,):
-    class StdioStream(StringIO):
-        def write(self, msg):
-            StringIO.write(self, msg.decode())
-else:
-    StdioStream = StringIO
 
 
 def group_attr_names(attrnames):
@@ -59,3 +39,173 @@ def group_attr_names(attrnames):
             group = 'other'
         grouped[group].append(name)
     return grouped
+
+
+if sys.version_info < (3,):
+    def _str_to_lower(value):
+        return value.decode().lower()
+else:
+    _str_to_lower = str.lower
+
+
+#############################
+# file paths
+
+_os_path = os.path
+# Uncomment to test Windows behavior on non-windows OS:
+#import ntpath as _os_path
+PATH_SEP = _os_path.sep
+NORMCASE = _os_path.normcase
+DIRNAME = _os_path.dirname
+BASENAME = _os_path.basename
+IS_ABS_PATH = _os_path.isabs
+PATH_JOIN = _os_path.join
+
+
+def fix_path(path, #*,
+             _pathsep=PATH_SEP):
+    """Return a platform-appropriate path for the given path."""
+    if not path:
+        return '.'
+    return path.replace('/', _pathsep)
+
+
+def fix_relpath(path, #*,
+                _fix_path=fix_path,
+                _path_isabs=IS_ABS_PATH,
+                _pathsep=PATH_SEP
+                ):
+    """Return a ./-prefixed, platform-appropriate path for the given path."""
+    path = _fix_path(path)
+    if path in ('.', '..'):
+        return path
+    if not _path_isabs(path):
+        if not path.startswith('.' + _pathsep):
+            path = '.' + _pathsep + path
+    return path
+
+
+def _resolve_relpath(path, rootdir=None, #*,
+                     _path_isabs=IS_ABS_PATH,
+                     _normcase=NORMCASE,
+                     _pathsep=PATH_SEP,
+                     ):
+    # "path" is expected to use "/" for its path separator, regardless
+    # of the provided "_pathsep".
+
+    if path.startswith('./'):
+        return path[2:]
+    if not _path_isabs(path):
+        return path
+
+    # Deal with root-dir-as-fileid.
+    _, sep, relpath = path.partition('/')
+    if sep and not relpath.replace('/', ''):
+        return ''
+
+    if rootdir is None:
+        return None
+    rootdir = _normcase(rootdir)
+    if not rootdir.endswith(_pathsep):
+        rootdir += _pathsep
+
+    if not _normcase(path).startswith(rootdir):
+        return None
+    return path[len(rootdir):]
+
+
+def fix_fileid(fileid, rootdir=None, #*,
+               normalize=False,
+               strictpathsep=None,
+               _pathsep=PATH_SEP,
+               **kwargs
+               ):
+    """Return a pathsep-separated file ID ("./"-prefixed) for the given value.
+
+    The file ID may be absolute.  If so and "rootdir" is
+    provided then make the file ID relative.  If absolute but "rootdir"
+    is not provided then leave it absolute.
+    """
+    if not fileid or fileid == '.':
+        return fileid
+
+    # We default to "/" (forward slash) as the final path sep, since
+    # that gives us a consistent, cross-platform result.  (Windows does
+    # actually support "/" as a path separator.)  Most notably, node IDs
+    # from pytest use "/" as the path separator by default.
+    _fileid = fileid.replace(_pathsep, '/')
+
+    relpath = _resolve_relpath(_fileid, rootdir,
+                               _pathsep=_pathsep,
+                               **kwargs
+                               )
+    if relpath:  # Note that we treat "" here as an absolute path.
+        _fileid = './' + relpath
+
+    if normalize:
+        if strictpathsep:
+            raise ValueError(
+                    'cannot normalize *and* keep strict path separator')
+        _fileid = _str_to_lower(_fileid)
+    elif strictpathsep:
+        # We do not use _normcase since we want to preserve capitalization.
+        _fileid = _fileid.replace('/', _pathsep)
+    return _fileid
+
+
+#############################
+# stdio
+
+@contextlib.contextmanager
+def hide_stdio():
+    """Swallow stdout and stderr."""
+    ignored = StdioStream()
+    sys.stdout = ignored
+    sys.stderr = ignored
+    try:
+        yield ignored
+    finally:
+        sys.stdout = sys.__stdout__
+        sys.stderr = sys.__stderr__
+
+
+if sys.version_info < (3,):
+    class StdioStream(StringIO):
+        def write(self, msg):
+            StringIO.write(self, msg.decode())
+else:
+    StdioStream = StringIO
+
+
+#############################
+# shell
+
+def shlex_unsplit(argv):
+    """Return the shell-safe string for the given arguments.
+
+    This effectively the equivalent of reversing shlex.split().
+    """
+    argv = [_quote_arg(a) for a in argv]
+    return ' '.join(argv)
+
+
+try:
+    from shlex import quote as _quote_arg
+except ImportError:
+    def _quote_arg(arg):
+        parts = None
+        for i, c in enumerate(arg):
+            if c.isspace():
+                pass
+            elif c == '"':
+                pass
+            elif c == "'":
+                c = "'\"'\"'"
+            else:
+                continue
+            if parts is None:
+                parts = list(arg)
+            parts[i] = c
+        if parts is not None:
+            arg = "'" + ''.join(parts) + "'"
+        return arg

--- a/Python/Product/TestAdapter.Executor/PythonFiles/testing_tools/run_adapter.py
+++ b/Python/Product/TestAdapter.Executor/PythonFiles/testing_tools/run_adapter.py
@@ -4,9 +4,11 @@
 # Replace the "." entry.
 import os.path
 import sys
-sys.path[0] = os.path.dirname(
-    os.path.dirname(
-        os.path.abspath(__file__)))
+
+sys.path.insert(1,
+                os.path.dirname(
+                    os.path.dirname(
+                        os.path.abspath(__file__))))
 
 from testing_tools.adapter.__main__ import parse_args, main
 

--- a/Python/Product/TestAdapter/testlauncher.py
+++ b/Python/Product/TestAdapter/testlauncher.py
@@ -1,18 +1,6 @@
-# Python Tools for Visual Studio
-# Copyright(c) Microsoft Corporation
-# All rights reserved.
-# 
-# Licensed under the Apache License, Version 2.0 (the License); you may not use
-# this file except in compliance with the License. You may obtain a copy of the
-# License at http://www.apache.org/licenses/LICENSE-2.0
-# 
-# THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
-# OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
-# IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
-# MERCHANTABILITY OR NON-INFRINGEMENT.
-# 
-# See the Apache Version 2.0 License for specific language governing
-# permissions and limitations under the License.
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
 
 import io
 import os


### PR DESCRIPTION
Grabbed the latest from VsCode. 

Eric Snow  Send "relpath" back for all test files/folders. (#6877)
Eric Snow  Make sure filenames are not norm-cased on Windows. (#6856)
Eric Snow Return relfile and location as-is (do no normcase). (#6781)
Kim-Adeline Miguel Fix overwriting of cwd in test discovery path list (#6713)
Rainer Dreyer Fixes pytest discovery: Not all pytest items have `own_markers` (#6514)
Min ho Kim Fix typos (#6470)
Eric Snow Show equivalent pytest command (#6363)