### PR TITLE
Changing commandline logging for test discovery and execution 

### DIFF
--- a/Python/Product/TestAdapter.Executor/Pytest/TestDiscovererPytest.cs
+++ b/Python/Product/TestAdapter.Executor/Pytest/TestDiscovererPytest.cs
@@ -22,7 +22,6 @@ using System.Linq;
 using Microsoft.PythonTools.Infrastructure;
 using Microsoft.PythonTools.TestAdapter.Config;
 using Microsoft.PythonTools.TestAdapter.Services;
-using Microsoft.PythonTools.TestAdapter.Utils;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
@@ -51,9 +50,9 @@ namespace Microsoft.PythonTools.TestAdapter.Pytest {
             var outputFilePath = Path.GetTempFileName();
             var arguments = GetArguments(sources, _settings, outputFilePath);
 
-            DebugInfo("cd " + _settings.WorkingDirectory);
-            DebugInfo("set " + _settings.PathEnv + "=" + env[_settings.PathEnv]);
-            DebugInfo($"{_settings.InterpreterPath} {string.Join(" ", arguments)}");
+            LogInfo("cd " + _settings.WorkingDirectory);
+            LogInfo("set " + _settings.PathEnv + "=" + env[_settings.PathEnv]);
+            LogInfo($"{_settings.InterpreterPath} {string.Join(" ", arguments)}");
 
             try {
                 var stdout = ProcessExecute.RunWithTimeout(

--- a/Python/Product/TestAdapter.Executor/Services/ExecutorService.cs
+++ b/Python/Product/TestAdapter.Executor/Services/ExecutorService.cs
@@ -174,9 +174,9 @@ namespace Microsoft.PythonTools.TestAdapter.Services {
                     visible: true,
                     testRedirector
                 )) {
-                    DebugInfo("cd " + _projectSettings.WorkingDirectory);
-                    DebugInfo("set " + _projectSettings.PathEnv + "=" + env[_projectSettings.PathEnv]);
-                    DebugInfo(proc.Arguments);
+                    LogInfo("cd " + _projectSettings.WorkingDirectory);
+                    LogInfo("set " + _projectSettings.PathEnv + "=" + env[_projectSettings.PathEnv]);
+                    LogInfo(proc.Arguments);
 
                     if (!proc.ExitCode.HasValue) {
                         try {
@@ -224,6 +224,10 @@ namespace Microsoft.PythonTools.TestAdapter.Services {
         [Conditional("DEBUG")]
         private void DebugError(string message) {
             _frameworkHandle.SendMessage(TestMessageLevel.Error, message);
+        }
+
+        private void LogInfo(string message) {
+            _frameworkHandle?.SendMessage(TestMessageLevel.Informational, message ?? String.Empty);
         }
 
         private void Error(string message) {

--- a/Python/Product/TestAdapter.Executor/UnitTest/TestDiscovererUnitTest.cs
+++ b/Python/Product/TestAdapter.Executor/UnitTest/TestDiscovererUnitTest.cs
@@ -65,9 +65,9 @@ namespace Microsoft.PythonTools.TestAdapter.UnitTest {
             var outputFilePath = Path.GetTempFileName();
             var arguments = GetArguments(sources, outputFilePath);
 
-            DebugInfo("cd " + _settings.WorkingDirectory);
-            DebugInfo("set " + _settings.PathEnv + "=" + env[_settings.PathEnv]);
-            DebugInfo($"{_settings.InterpreterPath} {string.Join(" ", arguments)}");
+            LogInfo("cd " + _settings.WorkingDirectory);
+            LogInfo("set " + _settings.PathEnv + "=" + env[_settings.PathEnv]);
+            LogInfo($"{_settings.InterpreterPath} {string.Join(" ", arguments)}");
 
             try {
                 var stdout = ProcessExecute.RunWithTimeout(

--- a/Python/Product/TestAdapter.Executor/UnitTest/TestExecutorUnitTest.cs
+++ b/Python/Product/TestAdapter.Executor/UnitTest/TestExecutorUnitTest.cs
@@ -524,9 +524,9 @@ namespace Microsoft.PythonTools.TestAdapter {
                     )) {
                         bool killed = false;
 
-                        DebugInfo("cd " + _settings.WorkingDirectory);
-                        DebugInfo("set " + pythonPath.Key + "=" + pythonPath.Value);
-                        DebugInfo(proc.Arguments);
+                        Info("cd " + _settings.WorkingDirectory);
+                        Info("set " + pythonPath.Key + "=" + pythonPath.Value);
+                        Info(proc.Arguments);
 
                         // If there's an error in the launcher script,
                         // it will terminate without connecting back.


### PR DESCRIPTION
adding commandline print to be at informational level instead and to do it always for unittest/pytest discovery and execution