### PR TITLE
Change default file name for unit test item template.

### DIFF
--- a/Python/Templates/Core/ItemTemplates/Python/UnitTestFile/test.vstemplate
+++ b/Python/Templates/Core/ItemTemplates/Python/UnitTestFile/test.vstemplate
@@ -4,7 +4,7 @@
     <Description Package="{6dbd7c1e-1f1b-496d-ac7c-c55dae66c783}" ID="5009" />
     <Icon Package="{6dbd7c1e-1f1b-496d-ac7c-c55dae66c783}" ID="404" />
     <ProjectType>Python</ProjectType>
-    <DefaultName>test.py</DefaultName>
+    <DefaultName>test_.py</DefaultName>
     <SortOrder>40</SortOrder>
   </TemplateData>
   <TemplateContent>


### PR DESCRIPTION
Fix #5592 

Now the default name will match both unittest and pytest file patterns.

ex: `test_1.py`