### PR TITLE
fix missing pytest results due to pytest xml change 

### DIFF
--- a/Python/Product/TestAdapter.Executor/Pytest/TestExecutorPytest.cs
+++ b/Python/Product/TestAdapter.Executor/Pytest/TestExecutorPytest.cs
@@ -139,7 +139,7 @@ namespace Microsoft.PythonTools.TestAdapter {
 
                 //Read pytest results from xml
                 if (File.Exists(resultsXML)) {
-                    var xmlTestResultNodes = TestResultParser.Read(resultsXML).CreateNavigator().Select("/testsuite/testcase");
+                    var xmlTestResultNodes = TestResultParser.Read(resultsXML).CreateNavigator().SelectDescendants("testcase", "", false);
                     foreach (XPathNavigator pytestResultNode in xmlTestResultNodes) {
                         if (_cancelRequested.WaitOne(0)) {
                             break;


### PR DESCRIPTION
that added another node called testsuites

```
<?xml version="1.0" encoding="utf-8"?>
<testsuites>
    <testsuite errors="0" failures="1" hostname="MININT-K8R65DJ" name="pytest" skipped="0" tests="3" time="0.050" timestamp="2019-08-16T12:05:17.455766">
        <testcase classname="test_pt" file="test_pt.py" line="0" name="test_pt_pass" time="0.000"> 
       </testcase>
```