### PR TITLE
Partial fix for pytest test does not complete (bottle repo)

### DIFF
--- a/Python/Product/Common/Infrastructure/ProcessOutput.cs
+++ b/Python/Product/Common/Infrastructure/ProcessOutput.cs
@@ -363,20 +363,23 @@ namespace Microsoft.PythonTools.Infrastructure {
                 }
 
                 if (redirector != null) {
-                    var reader = new StreamReader(client.GetStream(), utf8, false, 4096, true);
                     Task.Run(() => {
-                        try {
-                            for (var line = reader.ReadLine(); line != null; line = reader.ReadLine()) {
-                                if (line.StartsWithOrdinal("OUT:")) {
-                                    redirector.WriteLine(line.Substring(4));
-                                } else if (line.StartsWithOrdinal("ERR:")) {
-                                    redirector.WriteErrorLine(line.Substring(4));
-                                } else {
-                                    redirector.WriteLine(line);
+                        using (var reader = new StreamReader(client.GetStream(), utf8, false, 4096, true)) {
+                            try {
+                                string line;
+                                while ((line = reader.ReadLine()) != null) { 
+                                
+                                    if (line.StartsWithOrdinal("OUT:")) {
+                                        redirector.WriteLine(line.Substring(4));
+                                    } else if (line.StartsWithOrdinal("ERR:")) {
+                                        redirector.WriteErrorLine(line.Substring(4));
+                                    } else {
+                                        redirector.WriteLine(line);
+                                    }
                                 }
+                            } catch (IOException) {
+                            } catch (ObjectDisposedException) {
                             }
-                        } catch (IOException) {
-                        } catch (ObjectDisposedException) {
                         }
                     });
                 }

--- a/Python/Product/TestAdapter.Executor/Services/ExecutorService.cs
+++ b/Python/Product/TestAdapter.Executor/Services/ExecutorService.cs
@@ -58,11 +58,17 @@ namespace Microsoft.PythonTools.TestAdapter.Services {
             }
 
             public override void WriteErrorLine(string line) {
-                _logger.SendMessage(TestMessageLevel.Error, line);
+                try {
+                    _logger.SendMessage(TestMessageLevel.Error, line);
+                } catch (ArgumentException) {
+                }
             }
 
             public override void WriteLine(string line) {
-                _logger.SendMessage(TestMessageLevel.Informational, line);
+                try {
+                    _logger.SendMessage(TestMessageLevel.Informational, line);
+                } catch (ArgumentException) {
+                }
             }
         }
 
@@ -171,8 +177,12 @@ namespace Microsoft.PythonTools.TestAdapter.Services {
                     arguments,
                     _projectSettings.WorkingDirectory,
                     env,
-                    visible: true,
-                    testRedirector
+                    visible: false,
+                    testRedirector,
+                    quoteArgs:true,
+                    elevate:false,
+                    System.Text.Encoding.UTF8,
+                    System.Text.Encoding.UTF8
                 )) {
                     LogInfo("cd " + _projectSettings.WorkingDirectory);
                     LogInfo("set " + _projectSettings.PathEnv + "=" + env[_projectSettings.PathEnv]);
@@ -227,7 +237,7 @@ namespace Microsoft.PythonTools.TestAdapter.Services {
         }
 
         private void LogInfo(string message) {
-            _frameworkHandle?.SendMessage(TestMessageLevel.Informational, message ?? String.Empty);
+            _frameworkHandle.SendMessage(TestMessageLevel.Informational, message);
         }
 
         private void Error(string message) {


### PR DESCRIPTION
![MicrosoftTeams-image (2)](https://user-images.githubusercontent.com/1946977/63197252-21d1c380-c02c-11e9-8323-74ac1a267d18.png)
-Fixes the hang but not the underlining issue of why newline is coming back as a special character
-Changed ProcessOutput to wrap StreamReader in a using incase exceptions are thrown inside.

the last new line is coming back as not null but IMessageLogger.SendMessage thinks it is null and throws arugmentException

In bottle.py line 189

    text = "Warning: Use of deprecated feature or API. (Deprecated in Bottle-%d.%d)\n"\
           "Cause: %s\n"\
           "Fix: %s\n" % (major, minor, cause, fix)

Fix #5531