### PR TITLE
fix for no pytest result for flake8

### DIFF
--- a/Python/Product/TestAdapter.Executor/Pytest/TestResultParser.cs
+++ b/Python/Product/TestAdapter.Executor/Pytest/TestResultParser.cs
@@ -67,7 +67,7 @@ namespace Microsoft.PythonTools.TestAdapter.Pytest {
         /// <returns></returns>
         internal static string CreatePytestId(string filename, string classname, string funcname) {
             var classNameWithoutFilename = String.Empty;
-            var filenamePortion = filename.Replace(".py", "").Replace("\\", ".");
+            var filenamePortion = Path.ChangeExtension(filename, null).Replace("\\", ".");
             if (filenamePortion.Length < classname.Length) {
                 classNameWithoutFilename = classname.Substring(filenamePortion.Length + 1);
             }

--- a/Python/Product/TestAdapter.Executor/Pytest/TestResultParser.cs
+++ b/Python/Product/TestAdapter.Executor/Pytest/TestResultParser.cs
@@ -66,9 +66,13 @@ namespace Microsoft.PythonTools.TestAdapter.Pytest {
         /// <param name="funcname"></param>
         /// <returns></returns>
         internal static string CreatePytestId(string filename, string classname, string funcname) {
-            var classIndex = classname.LastIndexOf(".");
-            if (classIndex >= 0 && classIndex < (classname.Length - 1)) {
-                var classNameWithoutFilename = classname.Substring(classIndex + 1);
+            var classNameWithoutFilename = String.Empty;
+            var filenamePortion = filename.Replace(".py", "").Replace("\\", ".");
+            if (filenamePortion.Length < classname.Length) {
+                classNameWithoutFilename = classname.Substring(filenamePortion.Length + 1);
+            }
+
+            if (!String.IsNullOrEmpty(classNameWithoutFilename)) {
                 return $".\\{filename}::{classNameWithoutFilename}::{funcname}";
             } else {
                 return $".\\{filename}::{funcname}";

--- a/Python/Tests/TestAdapterTests/TestResultParserTests.cs
+++ b/Python/Tests/TestAdapterTests/TestResultParserTests.cs
@@ -39,6 +39,14 @@ namespace TestAdapterTests {
         }
 
         [TestMethod]
+        public void CreatePytestId_GlobalFuncRelative() {
+            Assert.AreEqual(
+                ".\\tests\\unit\\test_statistics.py::test_key_creation",
+                TestResultParser.CreatePytestId("tests\\unit\\test_statistics.py", "tests.unit.test_statistics", "test_key_creation")
+            );
+        }
+
+        [TestMethod]
         public void CreatePytestId_ClassFuncWithRelativeFilename() {
             Assert.AreEqual(
                 ".\\package1\\packageA\\test1.py::Test_test1::test_A", 


### PR DESCRIPTION
- global functions from a relative path didn't have the right pytestId
Fix #5598 
Fix #5603
Fix #5604
Fix #5605