### PR TITLE
Add support for code coverage for pytest.

### DIFF
--- a/Python/Product/PythonTools/PythonConstants.cs
+++ b/Python/Product/PythonTools/PythonConstants.cs
@@ -193,12 +193,15 @@ namespace Microsoft.PythonTools {
         internal const string PytestExecutorUriString = "executor://PythonPyTestExecutor/v1";
         internal const string PythonProjectContainerDiscovererUriString = "executor://PythonProjectDiscoverer/v1";
         internal const string PythonWorkspaceContainerDiscovererUriString = "executor://PythonWorkspaceDiscoverer/v1";
+        internal const string PythonCodeCoverageUriString = "datacollector://Microsoft/PythonCodeCoverage/1.0";
 
         public static readonly Uri UnitTestExecutorUri = new Uri(UnitTestExecutorUriString);
         public static readonly Uri PytestExecutorUri = new Uri(PytestExecutorUriString);
 
         public static readonly Uri PythonProjectContainerDiscovererUri = new Uri(PythonProjectContainerDiscovererUriString);
         public static readonly Uri PythonWorkspaceContainerDiscovererUri = new Uri(PythonWorkspaceContainerDiscovererUriString);
+
+        public static readonly Uri PythonCodeCoverageUri = new Uri(PythonCodeCoverageUriString);
 
         //Discovery
         internal const string PytestText = "pytest";

--- a/Python/Product/TestAdapter.Executor/Services/PythonDebugMode.cs
+++ b/Python/Product/TestAdapter.Executor/Services/PythonDebugMode.cs
@@ -1,0 +1,23 @@
+﻿// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+namespace Microsoft.PythonTools.TestAdapter.Services {
+    internal enum PythonDebugMode {
+        None,
+        PythonOnly,
+        PythonAndNative
+    }
+}

--- a/Python/Product/TestAdapter.Executor/TestAdapter.Executor.csproj
+++ b/Python/Product/TestAdapter.Executor/TestAdapter.Executor.csproj
@@ -98,6 +98,7 @@
     <Compile Include="Pytest\TestResultParser.cs" />
     <Compile Include="Services\IPythonTestDiscoverer.cs" />
     <Compile Include="Services\ProcessExecute.cs" />
+    <Compile Include="Services\PythonDebugMode.cs" />
     <Compile Include="TestCollection.cs" />
     <Compile Include="PythonTestDiscoverer.cs" />
     <Compile Include="TestProtocol.cs" />

--- a/Python/Product/TestAdapter/PythonRunSettings.cs
+++ b/Python/Product/TestAdapter/PythonRunSettings.cs
@@ -41,7 +41,6 @@ namespace Microsoft.PythonTools.TestAdapter {
     class PythonRunSettings : IRunSettingsService {
         private readonly IComponentModel _compModel;
         private readonly IServiceProvider _serviceProvider;
-        internal static Uri PythonCodeCoverageUri = new Uri("datacollector://Microsoft/PythonCodeCoverage/1.0");
 
         private const string CodeCoverageImportName = "Microsoft.VisualStudio.TestWindow.CodeCoverage.ICodeCoverageSettingsService";
         internal const string CodeCoverageUriString = @"datacollector://Microsoft/CodeCoverage/2.0";
@@ -57,7 +56,7 @@ namespace Microsoft.PythonTools.TestAdapter {
 
         private void StateChange(object sender, OperationStateChangedEventArgs e) {
             if (e.State == TestOperationStates.TestExecutionFinished) {
-                var resultUris = e.Operation.GetRunSettingsDataCollectorResultUri(PythonCodeCoverageUri);
+                var resultUris = e.Operation.GetRunSettingsDataCollectorResultUri(PythonConstants.PythonCodeCoverageUri);
                 if (resultUris != null) {
                     foreach (var eachAttachment in resultUris) {
                         string filePath = eachAttachment.LocalPath;

--- a/Python/Tests/TestAdapterTests/ExecutorServiceTests.cs
+++ b/Python/Tests/TestAdapterTests/ExecutorServiceTests.cs
@@ -1,0 +1,38 @@
+// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+extern alias pt;
+using Microsoft.PythonTools.TestAdapter.Services;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace TestAdapterTests {
+    [TestClass]
+    public class ExecutorServiceTests {
+        [TestMethod, Priority(0)]
+        public void TestBestFile() {
+            var file1 = "C:\\Some\\Path\\file1.py";
+            var file2 = "C:\\Some\\Path\\file2.py";
+            var best = ExecutorService.UpdateBestFile(null, file1);
+            Assert.AreEqual(best, file1);
+
+            best = ExecutorService.UpdateBestFile(null, file1);
+            Assert.AreEqual(best, file1);
+
+            best = ExecutorService.UpdateBestFile(best, file2);
+            Assert.AreEqual("C:\\Some\\Path", best);
+        }
+    }
+}

--- a/Python/Tests/TestAdapterTests/TestAdapterTests.csproj
+++ b/Python/Tests/TestAdapterTests/TestAdapterTests.csproj
@@ -66,6 +66,7 @@
     <Compile Include="Mocks\MockRunSettingsXmlBuilder.cs" />
     <Compile Include="Mocks\MockTestCaseDiscoverySink.cs" />
     <Compile Include="Mocks\MockTestExecutionRecorder.cs" />
+    <Compile Include="ExecutorServiceTests.cs" />
     <Compile Include="TestInfo.cs" />
     <Compile Include="TestDiscovererTests.cs" />
     <Compile Include="TestEnvironment.cs" />

--- a/Python/Tests/TestAdapterTests/TestExecutorTests.cs
+++ b/Python/Tests/TestAdapterTests/TestExecutorTests.cs
@@ -543,7 +543,7 @@ if __name__ == '__main__':
             var expectedCoverages = new[] {
                 new CoverageInfo(
                     "test_coverage.py",
-                    new[] { 1, 3, 5, 6, 7, 8, 10, 11, 13 }
+                    new[] { 1, 3, 5, 6, 7, 8, 10, 11, 13, 16 }
                 ),
                 new CoverageInfo(
                     "package1\\__init__.py",
@@ -587,12 +587,21 @@ if __name__ == '__main__':
                     outcome: TestOutcome.Passed,
                     pytestXmlClassName: "test_coverage.TestCoverage"
                 ),
+                new TestInfo(
+                    "test_global",
+                    "test_coverage.py::test_coverage::test_global",
+                    testFilePath,
+                    13,
+                    outcome: TestOutcome.Passed,
+                    pytestXmlClassName: "test_coverage",
+                    pytestExecPathSuffix: "test_global"
+                ),
             };
 
             var expectedCoverages = new[] {
                 new CoverageInfo(
                     "test_coverage.py",
-                    new[] { 1, 3, 5, 6, 7, 8, 10, 11, 13 }
+                    new[] { 1, 3, 5, 6, 7, 8, 10, 11, 13, 14, 16 }
                 ),
                 new CoverageInfo(
                     "package1\\__init__.py",

--- a/Python/Tests/TestData/TestExecutor/Coverage/test_coverage.py
+++ b/Python/Tests/TestData/TestExecutor/Coverage/test_coverage.py
@@ -10,5 +10,8 @@ class TestCoverage(unittest.TestCase):
     def test_two(self):
         full_coverage()
 
+def test_global():
+    partial_coverage(1)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fix #5444 

In order to avoid duplicating a bunch of code, I moved several methods from `TestExecutorUnitTest` to `ExecutorService` (as static methods) so it can be reused between both unittest and pytest execution code.

![image](https://user-images.githubusercontent.com/1696845/63215866-ac282f00-c0e1-11e9-8764-db70862c1608.png)
