### PR TITLE
Fix Test explorer displays confusing error when Python environment is missing

### DIFF
--- a/Python/Product/TestAdapter.Executor/Pytest/TestExecutorPytest.cs
+++ b/Python/Product/TestAdapter.Executor/Pytest/TestExecutorPytest.cs
@@ -108,7 +108,7 @@ namespace Microsoft.PythonTools.TestAdapter {
         ) {
             var sourceToProjSettings = RunSettingsUtil.GetSourceToProjSettings(runContext.RunSettings);
 
-            foreach (var testGroup in tests.GroupBy(t => sourceToProjSettings.TryGetValue(t.CodeFilePath, out PythonProjectSettings proj) ? proj : null)) {
+            foreach (var testGroup in tests.GroupBy(t => sourceToProjSettings.TryGetValue(t.CodeFilePath ?? String.Empty, out PythonProjectSettings proj) ? proj : null)) {
                 if (testGroup.Key == null) {
                     Debug.WriteLine("Missing projectSettings for TestCases:");
                     Debug.WriteLine(String.Join(",\n", testGroup));

--- a/Python/Product/TestAdapter.Executor/PythonTestDiscoverer.cs
+++ b/Python/Product/TestAdapter.Executor/PythonTestDiscoverer.cs
@@ -48,8 +48,11 @@ namespace Microsoft.PythonTools.TestAdapter {
             }
 
             var sourceToProjSettings = RunSettingsUtil.GetSourceToProjSettings(discoveryContext.RunSettings);
+            if (!sourceToProjSettings.Any()) {
+                return;
+            }
 
-            foreach (var testGroup in sources.GroupBy(x => sourceToProjSettings[x])) {
+            foreach (var testGroup in sources.GroupBy(x => sourceToProjSettings.TryGetValue(x, out PythonProjectSettings project) ? project : null )) {
                 DiscoverTestGroup(testGroup, discoveryContext, logger, discoverySink);
             }
         }
@@ -61,6 +64,10 @@ namespace Microsoft.PythonTools.TestAdapter {
             ITestCaseDiscoverySink discoverySink
         ) {
             PythonProjectSettings settings = testGroup.Key;
+            if (settings == null) {
+                return;
+            }
+
             try {
                 var discovery = DiscovererFactory.GetDiscoverer(settings);
                 discovery.DiscoverTests(testGroup, logger, discoverySink);

--- a/Python/Tests/TestAdapterTests/TestExecutorTests.cs
+++ b/Python/Tests/TestAdapterTests/TestExecutorTests.cs
@@ -822,6 +822,44 @@ if __name__ == '__main__':
             ExecuteTests(testEnv, runSettings, expectedTests);
         }
 
+        [TestMethod, Priority(0)]
+        [TestCategory("10s")]
+        public void RunPytestCodeFilePathNotFound() {
+            var runSettings = new MockRunSettings(
+                new MockRunSettingsXmlBuilder("pytest", "", "", "")
+                    .WithTestFile("DummyFilePath")
+                    .ToXml()
+            );
+
+            var differentDummyFilePath = "DifferentDummyFilePath";
+            var testCases = new List<TestCase>() { new TestCase("fakeTest", pt.Microsoft.PythonTools.PythonConstants.PytestExecutorUri, differentDummyFilePath) { CodeFilePath = differentDummyFilePath } };
+            var runContext = new MockRunContext(runSettings, testCases, "");
+            var recorder = new MockTestExecutionRecorder();
+            var executor = new TestExecutorPytest();
+            
+            //should not throw
+            executor.RunTests(testCases, runContext, recorder);
+        }
+
+        [TestMethod, Priority(0)]
+        [TestCategory("10s")]
+        public void RunPytestNullCodeFilePath() {
+            var runSettings = new MockRunSettings(
+                new MockRunSettingsXmlBuilder("pytest", "", "", "")
+                    .WithTestFile("DummyFilePath")
+                    .ToXml()
+            );
+
+            var differentDummyFilePath = "DifferentDummyFilePath";
+            var testCases = new List<TestCase>() { new TestCase("fakeTest", pt.Microsoft.PythonTools.PythonConstants.PytestExecutorUri, differentDummyFilePath) { CodeFilePath = null } };
+            var runContext = new MockRunContext(runSettings, testCases, "");
+            var recorder = new MockTestExecutionRecorder();
+            var executor = new TestExecutorPytest();
+
+            //should not throw
+            executor.RunTests(testCases, runContext, recorder);
+        }
+
         private static void ExecuteTests(TestEnvironment testEnv, MockRunSettings runSettings, TestInfo[] expectedTests, CoverageInfo[] expectedCoverages = null) {
             var testCases = CreateTestCasesFromTestInfo(testEnv, expectedTests);
             var runContext = new MockRunContext(runSettings, testCases, testEnv.ResultsFolderPath);


### PR DESCRIPTION
- Fix runsettings so that we dont write out the "Project" field until we know we can get a valid launch config.
- Added better null checking on the discoverer around missing or empty projectsettings.

Related:
Test explorer displays confusing error when Python environment is missing Fix #5614