### PR TITLE
Implement exclude file regex for projects and workspace

### DIFF
--- a/Python/Product/Common/Strings.Designer.cs
+++ b/Python/Product/Common/Strings.Designer.cs
@@ -5532,7 +5532,7 @@ namespace Microsoft.PythonTools {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to A file containing Python tests was detected in the {0} {1}, but the test framework is disabled..
+        ///   Looks up a localized string similar to A file which may contain Python tests was detected in the {0} {1}, but the test framework is disabled..
         /// </summary>
         public static string PythonTestFileDetected {
             get {

--- a/Python/Product/Common/Strings.resx
+++ b/Python/Product/Common/Strings.resx
@@ -2950,7 +2950,7 @@ Please specify at least one package.</value>
     <value>Enable unittest</value>
   </data>
   <data name="PythonTestFileDetected" xml:space="preserve">
-    <value>A file containing Python tests was detected in the {0} {1}, but the test framework is disabled.</value>
+    <value>A file which may contain Python tests was detected in the {0} {1}, but the test framework is disabled.</value>
     <comment>{0} is project or workspace name. {1} is "project" or "workspace"</comment>
   </data>
   <data name="PythonDiscoveryResultsNotFound" xml:space="preserve">

--- a/Python/Product/PythonTools/PythonConstants.cs
+++ b/Python/Product/PythonTools/PythonConstants.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Text.RegularExpressions;
 
 namespace Microsoft.PythonTools {
     public enum TestFrameworkType {
@@ -134,7 +135,8 @@ namespace Microsoft.PythonTools {
         public const string DefaultUnitTestRootDirectory = ".";
         public const string UnitTestPatternSetting = "UnitTestPattern";
         public const string DefaultUnitTestPattern = "test*.py";
-        public const string TestPatternFileNameRegex = @"((^test.*)|(^.*_test))\.(py|txt)";
+        public static readonly Regex DefaultTestFileNameRegex = 
+            new Regex(@"((^test.*)|(^.*_test))\.(py|txt)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         public static readonly HashSet<string> PyTestFrameworkConfigFiles =
             new HashSet<string>(StringComparer.OrdinalIgnoreCase) {"pytest.ini", "setup.cfg", "tox.ini"};

--- a/Python/Product/PythonTools/PythonConstants.cs
+++ b/Python/Product/PythonTools/PythonConstants.cs
@@ -134,6 +134,7 @@ namespace Microsoft.PythonTools {
         public const string DefaultUnitTestRootDirectory = ".";
         public const string UnitTestPatternSetting = "UnitTestPattern";
         public const string DefaultUnitTestPattern = "test*.py";
+        public const string TestPatternFileNameRegex = @"((^test.*)|(^.*_test))\.(py|txt)";
 
         public static readonly HashSet<string> PyTestFrameworkConfigFiles =
             new HashSet<string>(StringComparer.OrdinalIgnoreCase) {"pytest.ini", "setup.cfg", "tox.ini"};

--- a/Python/Product/PythonTools/PythonTools/Project/ConfigureTestFrameworkInfoBar.cs
+++ b/Python/Product/PythonTools/PythonTools/Project/ConfigureTestFrameworkInfoBar.cs
@@ -80,7 +80,7 @@ namespace Microsoft.PythonTools.Project {
                     acceptActionItems.Add(new InfoBarHyperlink(Strings.PyTestInstallAndEnableInfoBarAction, (Action)InstallAndEnablePytestAction));
                 }
 
-            } else if (PythonTestFileFound((x) => Regex.IsMatch(PathUtils.GetFileOrDirectoryName(x), PythonConstants.TestPatternFileNameRegex))) {
+            } else if (PythonTestFileFound((x) => PythonConstants.DefaultTestFileNameRegex.IsMatch(PathUtils.GetFileOrDirectoryName(x)))) {
                 infoBarMessage = Strings.PythonTestFileDetected.FormatUI(_infoBarData.Caption, _infoBarData.ContextLocalized);
 
                 if (await IsPyTestInstalledAsync()) {

--- a/Python/Product/TestAdapter/TestContainerDiscovererWorkspace.cs
+++ b/Python/Product/TestAdapter/TestContainerDiscovererWorkspace.cs
@@ -177,7 +177,8 @@ namespace Microsoft.PythonTools.TestAdapter {
                 _testFilesUpdateWatcher.AddDirectoryWatch(workspace.Location);
                 oldWatcher?.Dispose();
 
-                Predicate<string> testFileFilter = (x) => Regex.IsMatch(PythonConstants.TestPatternFileNameRegex, x);
+                Regex testFileFilterRegex = new Regex(@".*\.(py|txt)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+                Predicate<string> testFileFilter = (x) => testFileFilterRegex.IsMatch(x);
                 foreach (var file in _workspaceContextProvider.Workspace.EnumerateUserFiles(testFileFilter)) {
                     projInfo.AddTestContainer(this, file);
                 }
@@ -292,7 +293,6 @@ namespace Microsoft.PythonTools.TestAdapter {
             }
             NotifyContainerChanged();
         }
-
 
         private bool IsFileExcluded(ProjectInfo projectInfo, string filePath) {
             bool isFileInVirtualEnv = _interpreterRegistryService.Configurations

--- a/Python/Product/TestAdapter/TestContainerDiscovererWorkspace.cs
+++ b/Python/Product/TestAdapter/TestContainerDiscovererWorkspace.cs
@@ -21,6 +21,7 @@ using System.ComponentModel.Composition;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Threading;
 using Microsoft.PythonTools.Infrastructure;
 using Microsoft.PythonTools.Interpreter;
@@ -176,7 +177,8 @@ namespace Microsoft.PythonTools.TestAdapter {
                 _testFilesUpdateWatcher.AddDirectoryWatch(workspace.Location);
                 oldWatcher?.Dispose();
 
-                foreach (var file in GetTestContainerFiles(projInfo)) {
+                Predicate<string> testFileFilter = (x) => Regex.IsMatch(PythonConstants.TestPatternFileNameRegex, x);
+                foreach (var file in _workspaceContextProvider.Workspace.EnumerateUserFiles(testFileFilter)) {
                     projInfo.AddTestContainer(this, file);
                 }
 
@@ -291,23 +293,6 @@ namespace Microsoft.PythonTools.TestAdapter {
             NotifyContainerChanged();
         }
 
-        private IEnumerable<string> GetTestContainerFiles(ProjectInfo projectInfo) {
-            var validFiles = Directory.EnumerateFiles(projectInfo.ProjectHome, "*.py", SearchOption.TopDirectoryOnly);
-            var workspaceInterpreterConfigs = _interpreterRegistryService.Configurations
-                .Where(x => PathUtils.IsSubpathOf(projectInfo.ProjectHome, x.InterpreterPath))
-                .ToList();
-            var workspaceCacheDirPath = Path.Combine(projectInfo.ProjectHome, ".vs");
-
-            foreach (var directory in Directory.EnumerateDirectories(projectInfo.ProjectHome)) {
-                if (!workspaceInterpreterConfigs.Any(x => PathUtils.IsSameDirectory(x.GetPrefixPath(), directory)) &&
-                    !PathUtils.IsSameDirectory(directory, workspaceCacheDirPath)
-                ) {
-                    validFiles = validFiles.Concat(Directory.EnumerateFiles(directory, "*.py", SearchOption.AllDirectories));
-                }
-            }
-
-            return validFiles;
-        }
 
         private bool IsFileExcluded(ProjectInfo projectInfo, string filePath) {
             bool isFileInVirtualEnv = _interpreterRegistryService.Configurations

--- a/Python/Product/VSInterpreters/Interpreter/IPythonWorkspaceContext.cs
+++ b/Python/Product/VSInterpreters/Interpreter/IPythonWorkspaceContext.cs
@@ -108,6 +108,12 @@ namespace Microsoft.PythonTools.Interpreter {
         IEnumerable<string> GetAbsoluteSearchPaths();
 
         /// <summary>
+        /// Filters and returns a list of workspace user files based on predicate
+        /// </summary>
+        /// <param name="predicate">Predicate for file filtering</param>
+        /// <returns>An IEnumerable for all the files in workspace which do not belong to virtual environment or VS cache</returns>
+        IEnumerable<string> EnumerateUserFiles(Predicate<string> predicate);
+
         /// Get the absolute path to the workspace's requirements.txt file.
         /// </summary>
         /// <returns>

--- a/Python/Product/VSInterpreters/Interpreter/PythonWorkspaceContext.cs
+++ b/Python/Product/VSInterpreters/Interpreter/PythonWorkspaceContext.cs
@@ -175,6 +175,7 @@ namespace Microsoft.PythonTools.Interpreter {
                 }
             }
         }
+
         public string GetRequirementsTxtPath() {
             return _workspace.GetRequirementsTxtPath();
         }

--- a/Python/Tests/Core/WorkspaceTestHelper.cs
+++ b/Python/Tests/Core/WorkspaceTestHelper.cs
@@ -403,6 +403,8 @@ namespace PythonToolsTests {
             public Task SetPropertyAsync(string propertyName, bool? propertyVal) {
                 throw new NotImplementedException();
             }
+
+            public IEnumerable<string> EnumerateUserFiles(Predicate<string> predicate) => throw new NotImplementedException();
         }
     }
 }


### PR DESCRIPTION
Fix #5508 

Regex will handle most cases correctly, but it might encounter some edge cases it cannot correctly parse. For example, "test.test.py" or "test.txtfpp" result in false positives.

These cases will be correctly parsed: 
![image](https://user-images.githubusercontent.com/3315992/63383221-3f1ad080-c351-11e9-8fda-9262a3c5ae84.png)
 