### PR TITLE
pytest not found in azure-cli Fix #5626

### DIFF
--- a/Python/Product/TestAdapter.Executor/Pytest/TestDiscovererPytest.cs
+++ b/Python/Product/TestAdapter.Executor/Pytest/TestDiscovererPytest.cs
@@ -141,6 +141,7 @@ namespace Microsoft.PythonTools.TestAdapter.Pytest {
             //Note pytest specific arguments go after this separator
             arguments.Add("--");
             arguments.Add("--cache-clear");
+            arguments.Add(String.Format("--rootdir={0}", projSettings.ProjectHome));
             return arguments.ToArray();
         }
 

--- a/Python/Product/TestAdapter.Executor/Services/ExecutorService.cs
+++ b/Python/Product/TestAdapter.Executor/Services/ExecutorService.cs
@@ -84,7 +84,7 @@ namespace Microsoft.PythonTools.TestAdapter.Services {
 
         }
 
-        public string[] GetArguments(IEnumerable<TestCase> tests, string outputfile, string coveragePath) {
+        public string[] GetArguments(IEnumerable<TestCase> tests, string outputfile, string coveragePath, PythonProjectSettings settings) {
             var arguments = new List<string> {
                 TestLauncherPath,
                 _projectSettings.WorkingDirectory,
@@ -113,6 +113,7 @@ namespace Microsoft.PythonTools.TestAdapter.Services {
 
             // output results to xml file
             arguments.Add(String.Format("--junitxml={0}", outputfile));
+            arguments.Add(String.Format("--rootdir={0}", settings.ProjectHome));
 
             return arguments.ToArray();
         }
@@ -321,7 +322,7 @@ namespace Microsoft.PythonTools.TestAdapter.Services {
 
                 var env = InitializeEnvironment(tests);
                 ouputFile = GetJunitXmlFile();
-                var arguments = GetArguments(tests, ouputFile, coveragePath);
+                var arguments = GetArguments(tests, ouputFile, coveragePath, _projectSettings);
 
                 var testRedirector = new TestRedirector(_frameworkHandle);
 


### PR DESCRIPTION
Issues: Pytest execute will search up the parent folders for a config .ini file which will change the rootdir from the project to the subfolder.  This will cause a mismatch between discovered test filepaths and results.

now force both disocvery  and execution to set the rootdir so that .ini location wont override it.

also note it appears the user can't set the rootdir from inside the .ini file
ie
 addopt = --rootdir=XXX
 or
 rootdir = XXX

both appear to have no effect so it should be safe to force it to be the project/workspace location.

Users can still set "testpaths = testing" to optimize the search but the paths will be relative to the project/workspace dir from now on.

https://docs.pytest.org/en/2.8.7/customize.html