### PR TITLE
pytest with parameterize values that include '::' breaking RunAll due…

### DIFF
--- a/Python/Product/TestAdapter.Executor/PythonFiles/testing_tools/adapter/pytest/_discovery.py
+++ b/Python/Product/TestAdapter.Executor/PythonFiles/testing_tools/adapter/pytest/_discovery.py
@@ -4,12 +4,31 @@
 from __future__ import absolute_import, print_function
 
 import sys
-
 import pytest
 
 from .. import util, discovery
 from ._pytest_item import parse_item
 
+#note: this must match testlauncher.py
+def patch_translate_non_printable():
+    import _pytest.compat
+    translate_non_printable =  getattr(_pytest.compat, "_translate_non_printable")
+
+    if translate_non_printable:
+        def _translate_non_printable_patched(s):
+            s = translate_non_printable(s)
+            s = s.replace(':', '/:')  # pytest testcase not found error and VS TestExplorer FQN parsing
+            s = s.replace('.', '_')   # VS TestExplorer FQN parsing
+            s = s.replace('\n', '/n') # pytest testcase not found error 
+            s = s.replace('\\', '/')  # pytest testcase not found error, fixes cases (actual backslash followed by n)
+            s = s.replace('\r', '/r') # pytest testcase not found error
+            return s
+
+        _pytest.compat._translate_non_printable = _translate_non_printable_patched
+    else:
+        print("ERROR: failed to patch pytest, _pytest.compat._translate_non_printable")
+
+patch_translate_non_printable()
 
 def discover(pytestargs=None, hidestdio=False,
              _pytest_main=pytest.main, _plugin=None, **_ignored):

--- a/Python/Product/TestAdapter/testlauncher.py
+++ b/Python/Product/TestAdapter/testlauncher.py
@@ -40,7 +40,8 @@ def load_debugger(secret, port, debugger_search_path, mixed_mode):
             import ptvsd
             from ptvsd.debugger import DONT_DEBUG, DEBUG_ENTRYPOINTS, get_code
             from ptvsd import enable_attach, wait_for_attach
-
+            
+            DONT_DEBUG.append(os.path.normcase(__file__))
             DEBUG_ENTRYPOINTS.add(get_code(main))
             enable_attach(secret, ('127.0.0.1', port), redirect_output = True)
             wait_for_attach()

--- a/Python/Product/TestAdapter/testlauncher.py
+++ b/Python/Product/TestAdapter/testlauncher.py
@@ -159,7 +159,9 @@ class TestCollector(object):
         # Wrap the actual collect() call and clear any _notfound errors to prevent exceptions which skips remaining tests to run
         # We still print the same errors to the user
         def collectwapper():
-            yield from originalCollect()
+            for item in originalCollect():
+                yield item
+           
             notfound = getattr(collector, '_notfound', [])
             if notfound:
                   for arg, exc in notfound: 

--- a/Python/Tests/TestAdapterTests/TestExecutorTests.cs
+++ b/Python/Tests/TestAdapterTests/TestExecutorTests.cs
@@ -216,7 +216,7 @@ if __name__ == '__main__':
             }
 
             Assert.IsTrue(discoverySink.Tests.Any());
-            Assert.AreEqual(discoverySink.Tests.Count(), 20);
+            Assert.AreEqual(discoverySink.Tests.Count(), 21);
 
             var testCases = discoverySink.Tests;
             var runContext = new MockRunContext(runSettings, testCases, testEnv.ResultsFolderPath);
@@ -283,8 +283,8 @@ if __name__ == '__main__':
 
             //Check for Partial Results
             Assert.IsTrue(recorder.Results.Any());
-            Assert.IsFalse(recorder.Results[0].Outcome != TestOutcome.Passed);
-            Assert.IsFalse(recorder.Results[1].Outcome != TestOutcome.NotFound);
+            Assert.IsFalse(recorder.Results.Single( r => r.TestCase.DisplayName == discoverySink.Tests[0].DisplayName).Outcome != TestOutcome.Passed);
+            Assert.IsFalse(recorder.Results.Single(r => r.TestCase.DisplayName == discoverySink.Tests[1].DisplayName).Outcome != TestOutcome.NotFound);
         }
 
         [TestMethod, Priority(0)]

--- a/Python/Tests/TestData/TestDiscoverer/Parameterized/test_Parameters.py
+++ b/Python/Tests/TestData/TestDiscoverer/Parameterized/test_Parameters.py
@@ -1,0 +1,94 @@
+
+#http://doc.pytest.org/en/latest/example/parametrize.html
+
+import pytest
+
+from datetime import datetime, timedelta
+
+testdata = [
+    (datetime(2001, 12, 12), datetime(2001, 12, 11), timedelta(1)),
+    (datetime(2001, 12, 11), datetime(2001, 12, 12), timedelta(-1)),
+]
+
+
+@pytest.mark.parametrize(",expected", testdata)
+def test_timedistance_v0(a, expected):
+    
+    assert a == expected
+
+@pytest.mark.parametrize("a,b,expected", testdata)
+def test_timedistance_v0(a, b, expected):
+    diff = a - b
+    assert diff == expected
+
+
+@pytest.mark.parametrize("a,b,expected", testdata, ids=["forward", "backward"])
+def test_timedistance_v1(a, b, expected):
+    diff = a - b
+    assert diff == expected
+
+
+def idfn(val):
+    if isinstance(val, (datetime,)):
+        # note this wouldn't show any hours/minutes/seconds
+        return val.strftime("%Y%m%d")
+
+
+@pytest.mark.parametrize("a,b,expected", testdata, ids=idfn)
+def test_timedistance_v2(a, b, expected):
+    diff = a - b
+    assert diff == expected
+
+
+@pytest.mark.parametrize(
+    "a,b,expected",
+    [
+        pytest.param(
+            datetime(2001, 12, 12), datetime(2001, 12, 11), timedelta(1), id="forward"
+        ),
+        pytest.param(
+            datetime(2001, 12, 11), datetime(2001, 12, 12), timedelta(-1), id="backward"
+        ),
+    ],
+)
+def test_timedistance_v3(a, b, expected):
+    diff = a - b
+    assert diff == expected
+
+
+@pytest.mark.parametrize(
+    "test_input,expected",
+    [
+        ("3+5", 8),
+        pytest.param("1+7", 8, marks=pytest.mark.basic),
+        pytest.param("2+4", 6, marks=pytest.mark.basic, id="basic_2+4"),
+    ],
+)
+def test_eval(test_input, expected):
+    assert eval(test_input) == expected
+
+
+@pytest.mark.parametrize(
+    "test_input,expected",
+    [
+        ("::", "::"),
+        ("\\n", "\\n"),
+        ("\r", "\r"),
+        ("\n","\n"),
+        ("\\", "\\"),
+        ("\n \n", "\n \n"),
+        (":", ":"),
+    ],
+)
+def test_pytest_finds_tests_with_special_strings(test_input, expected):
+    assert test_input == expected
+
+
+@pytest.mark.parametrize(
+    "test_input,expected",
+    [
+      pytest.param("::", "::", id="colon")
+    ],
+)
+def test_ids_found(test_input, expected):
+    assert test_input == expected

--- a/Python/Tests/TestData/TestDiscoverer/Parameterized/test_Parameters.py
+++ b/Python/Tests/TestData/TestDiscoverer/Parameterized/test_Parameters.py
@@ -78,6 +78,19 @@ def test_eval(test_input, expected):
         ("\\", "\\"),
         ("\n \n", "\n \n"),
         (":", ":"),
+        (  """
+           .. figure:: foo.jpg
+
+ 
+
+              this is title
+           """, """
+           .. figure:: foo.jpg
+
+ 
+
+              this is title
+           """)
     ],
 )
 def test_pytest_finds_tests_with_special_strings(test_input, expected):

--- a/Python/Tests/TestData/TestDiscoverer/Parameterized/test_indirect_list.py
+++ b/Python/Tests/TestData/TestDiscoverer/Parameterized/test_indirect_list.py
@@ -1,0 +1,20 @@
+
+# content of test_indirect_list.py
+
+import pytest
+
+
+@pytest.fixture(scope="function")
+def x(request):
+    return request.param * 3
+
+
+@pytest.fixture(scope="function")
+def y(request):
+    return request.param * 2
+
+
+@pytest.mark.parametrize("x, y", [("a", "b")], indirect=["x"])
+def test_indirect(x, y):
+    assert x == "aaa"
+    assert y == "b"


### PR DESCRIPTION
… to pytestId not found Fix #5635
Fix #5621

- fixes certain parameterised tests Id's that contain characters like "::" and "\n", This was causing RunAll to fail when a single pytestId wasn't found by pytest itself
- fixes Test Explorer displaying of parameteried tests by replacing "." and "::" wich TE uses to delimit on.
- Catch all fix for RunAll case to change the Pytest erorr handling of testcase not found to still continue with running the remaing tests, while still printing the same error