### PR TITLE
fix testdiscoverysession telemetry 

### DIFF
--- a/Python/Product/TestAdapter.Executor/Config/PythonProjectSettings.cs
+++ b/Python/Product/TestAdapter.Executor/Config/PythonProjectSettings.cs
@@ -26,7 +26,7 @@ namespace Microsoft.PythonTools.TestAdapter.Config {
         public readonly Dictionary<string, string> TestContainerSources;
         public readonly bool IsWorkspace;
         public readonly bool UseLegacyDebugger;
-        public readonly TestFrameworkType TestFramwork;
+        public readonly TestFrameworkType TestFramework;
         public readonly int DiscoveryWaitTimeInSeconds;
         public PythonProjectSettings(string projectName,
             string projectHome,
@@ -54,8 +54,8 @@ namespace Microsoft.PythonTools.TestAdapter.Config {
             TestContainerSources = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
             IsWorkspace = isWorkspace;
             UseLegacyDebugger = useLegacyDebugger;
-            TestFramwork = TestFrameworkType.None;
-            Enum.TryParse<TestFrameworkType>(testFramework, ignoreCase: true, out TestFramwork);
+            TestFramework = TestFrameworkType.None;
+            Enum.TryParse<TestFrameworkType>(testFramework, ignoreCase: true, out TestFramework);
             UnitTestPattern = string.IsNullOrEmpty(unitTestPattern) ? PythonConstants.DefaultUnitTestPattern : unitTestPattern;
             UnitTestRootDir = string.IsNullOrEmpty(unitTestRootDir) ? PythonConstants.DefaultUnitTestRootDirectory : unitTestRootDir;
             DiscoveryWaitTimeInSeconds = Int32.TryParse(discoveryWaitTimeInSeconds, out int parsedWaitTime) ? parsedWaitTime : PythonConstants.DiscoveryTimeoutInSeconds;
@@ -85,7 +85,7 @@ namespace Microsoft.PythonTools.TestAdapter.Config {
                 EnableNativeCodeDebugging == other.EnableNativeCodeDebugging &&
                 IsWorkspace == other.IsWorkspace &&
                 UseLegacyDebugger == other.UseLegacyDebugger &&
-                TestFramwork == other.TestFramwork &&
+                TestFramework == other.TestFramework &&
                 UnitTestPattern == other.UnitTestPattern &&
                 UnitTestRootDir == other.UnitTestRootDir &&
                 SearchPath.Count == other.SearchPath.Count &&

--- a/Python/Product/TestAdapter.Executor/Config/RunSettingsUtil.cs
+++ b/Python/Product/TestAdapter.Executor/Config/RunSettingsUtil.cs
@@ -8,12 +8,13 @@ using System.Xml.XPath;
 
 namespace Microsoft.PythonTools.TestAdapter.Config {
     public class RunSettingsUtil {
-        public static Dictionary<string, PythonProjectSettings> GetSourceToProjSettings(IRunSettings settings) {
+        public static Dictionary<string, PythonProjectSettings> GetSourceToProjSettings(IRunSettings settings, TestFrameworkType filterType) {
             var doc = Read(settings.SettingsXml);
             XPathNodeIterator nodes = doc.CreateNavigator().Select("/RunSettings/Python/TestCases/Project");
             var res = new Dictionary<string, PythonProjectSettings>(StringComparer.OrdinalIgnoreCase);
 
             foreach (XPathNavigator project in nodes) {
+                
                 PythonProjectSettings projSettings = new PythonProjectSettings(
                     project.GetAttribute("name", ""),
                     project.GetAttribute("home", ""),
@@ -28,6 +29,10 @@ namespace Microsoft.PythonTools.TestAdapter.Config {
                     project.GetAttribute("unitTestRootDir", ""),
                     project.GetAttribute("discoveryWaitTime", "")
                 ); 
+
+                if (projSettings.TestFramework != filterType) {
+                    continue;
+                }
 
                 foreach (XPathNavigator environment in project.Select("Environment/Variable")) {
                     projSettings.Environment[environment.GetAttribute("name", "")] = environment.GetAttribute("value", "");

--- a/Python/Product/TestAdapter.Executor/Pytest/TestExecutorPytest.cs
+++ b/Python/Product/TestAdapter.Executor/Pytest/TestExecutorPytest.cs
@@ -66,7 +66,7 @@ namespace Microsoft.PythonTools.TestAdapter {
 
             _cancelRequested.Reset();
 
-            var sourceToProjSettings = RunSettingsUtil.GetSourceToProjSettings(runContext.RunSettings);
+            var sourceToProjSettings = RunSettingsUtil.GetSourceToProjSettings(runContext.RunSettings, filterType:TestFrameworkType.Pytest);
             var testCollection = new TestCollection();
             foreach (var testGroup in sources.GroupBy(x => sourceToProjSettings[x])) {
                 var settings = testGroup.Key;
@@ -106,7 +106,7 @@ namespace Microsoft.PythonTools.TestAdapter {
             IRunContext runContext,
             IFrameworkHandle frameworkHandle
         ) {
-            var sourceToProjSettings = RunSettingsUtil.GetSourceToProjSettings(runContext.RunSettings);
+            var sourceToProjSettings = RunSettingsUtil.GetSourceToProjSettings(runContext.RunSettings, filterType:TestFrameworkType.Pytest);
 
             foreach (var testGroup in tests.GroupBy(t => sourceToProjSettings.TryGetValue(t.CodeFilePath ?? String.Empty, out PythonProjectSettings proj) ? proj : null)) {
                 if (testGroup.Key == null) {
@@ -128,7 +128,7 @@ namespace Microsoft.PythonTools.TestAdapter {
             IFrameworkHandle frameworkHandle
         ) {
             PythonProjectSettings settings = testGroup.Key;
-            if (settings == null || settings.TestFramwork != TestFrameworkType.Pytest) {
+            if (settings == null || settings.TestFramework != TestFrameworkType.Pytest) {
                 return;
             }
 

--- a/Python/Product/TestAdapter.Executor/PythonTestDiscoverer.cs
+++ b/Python/Product/TestAdapter.Executor/PythonTestDiscoverer.cs
@@ -25,14 +25,39 @@ using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
 
 namespace Microsoft.PythonTools.TestAdapter {
 
+    /// <summary>
+    /// Note even though we we specify  [DefaultExecutorUri(PythonConstants.UnitTestExecutorUriString)] we still get all .py source files
+    /// from all testcontainers.  
+    /// </summary>
+    [FileExtension(".py")]
+    [DefaultExecutorUri(PythonConstants.UnitTestExecutorUriString)]
+    public class UnitTestDiscoverer : PythonTestDiscoverer {
+        public UnitTestDiscoverer() : base(TestFrameworkType.UnitTest) {
+        }
+    }
 
     /// <summary>
-    /// Note even though we we specify  [DefaultExecutorUri(PythonConstants.PytestExecutorUri)] we still get all .py source files
+    /// Note even though we we specify  [DefaultExecutorUri(PythonConstants.PytestExecutorUriString)] we still get all .py source files
     /// from all testcontainers.  
     /// </summary>
     [FileExtension(".py")]
     [DefaultExecutorUri(PythonConstants.PytestExecutorUriString)]
+    public class PytestTestDiscoverer : PythonTestDiscoverer {
+        public PytestTestDiscoverer() : base(TestFrameworkType.Pytest) { 
+        }
+    }
+    
     public class PythonTestDiscoverer : ITestDiscoverer {
+        private TestFrameworkType _frameworkType;
+
+        /// <summary>
+        /// Create a test framework specific Test Discoverer
+        /// </summary>
+        /// <param name="frameworkType"></param>
+        public PythonTestDiscoverer(TestFrameworkType frameworkType) {
+            _frameworkType = frameworkType;
+        }
+
         public void DiscoverTests(
             IEnumerable<string> sources,
             IDiscoveryContext discoveryContext,
@@ -47,12 +72,12 @@ namespace Microsoft.PythonTools.TestAdapter {
                 throw new ArgumentNullException(nameof(discoverySink));
             }
 
-            var sourceToProjSettings = RunSettingsUtil.GetSourceToProjSettings(discoveryContext.RunSettings);
+            var sourceToProjSettings = RunSettingsUtil.GetSourceToProjSettings(discoveryContext.RunSettings, filterType: _frameworkType);
             if (!sourceToProjSettings.Any()) {
                 return;
             }
 
-            foreach (var testGroup in sources.GroupBy(x => sourceToProjSettings.TryGetValue(x, out PythonProjectSettings project) ? project : null )) {
+            foreach (var testGroup in sources.GroupBy(x => sourceToProjSettings.TryGetValue(x, out PythonProjectSettings project) ? project : null)) {
                 DiscoverTestGroup(testGroup, discoveryContext, logger, discoverySink);
             }
         }
@@ -64,7 +89,7 @@ namespace Microsoft.PythonTools.TestAdapter {
             ITestCaseDiscoverySink discoverySink
         ) {
             PythonProjectSettings settings = testGroup.Key;
-            if (settings == null) {
+            if (settings == null || settings.TestFramework != _frameworkType) {
                 return;
             }
 

--- a/Python/Product/TestAdapter.Executor/PythonTestDiscoverer.cs
+++ b/Python/Product/TestAdapter.Executor/PythonTestDiscoverer.cs
@@ -26,7 +26,7 @@ using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
 namespace Microsoft.PythonTools.TestAdapter {
 
     /// <summary>
-    /// Note even though we we specify  [DefaultExecutorUri(PythonConstants.UnitTestExecutorUriString)] we still get all .py source files
+    /// Note even though we specify  [DefaultExecutorUri(PythonConstants.UnitTestExecutorUriString)] we still get all .py source files
     /// from all testcontainers.  
     /// </summary>
     [FileExtension(".py")]
@@ -37,7 +37,7 @@ namespace Microsoft.PythonTools.TestAdapter {
     }
 
     /// <summary>
-    /// Note even though we we specify  [DefaultExecutorUri(PythonConstants.PytestExecutorUriString)] we still get all .py source files
+    /// Note even though we specify  [DefaultExecutorUri(PythonConstants.PytestExecutorUriString)] we still get all .py source files
     /// from all testcontainers.  
     /// </summary>
     [FileExtension(".py")]
@@ -47,14 +47,14 @@ namespace Microsoft.PythonTools.TestAdapter {
         }
     }
     
-    public class PythonTestDiscoverer : ITestDiscoverer {
+    public abstract class PythonTestDiscoverer : ITestDiscoverer {
         private TestFrameworkType _frameworkType;
 
         /// <summary>
         /// Create a test framework specific Test Discoverer
         /// </summary>
         /// <param name="frameworkType"></param>
-        public PythonTestDiscoverer(TestFrameworkType frameworkType) {
+        protected PythonTestDiscoverer(TestFrameworkType frameworkType) {
             _frameworkType = frameworkType;
         }
 

--- a/Python/Product/TestAdapter.Executor/Services/DiscovererFactory.cs
+++ b/Python/Product/TestAdapter.Executor/Services/DiscovererFactory.cs
@@ -24,14 +24,14 @@ namespace Microsoft.PythonTools.TestAdapter.Services {
     internal class DiscovererFactory {
 
         public static IPythonTestDiscoverer GetDiscoverer(PythonProjectSettings settings) {
-            switch (settings.TestFramwork) {
+            switch (settings.TestFramework) {
                 case TestFrameworkType.Pytest:
                     return new TestDiscovererPytest(settings);
                 case TestFrameworkType.UnitTest:
                     return new TestDiscovererUnitTest(settings);
                 case TestFrameworkType.None:
                 default:
-                    throw new NotImplementedException($"CreateDiscoveryService TestFrameworkType:{settings.TestFramwork.ToString()} not supported");
+                    throw new NotImplementedException($"CreateDiscoveryService TestFrameworkType:{settings.TestFramework.ToString()} not supported");
             }
         }
     }

--- a/Python/Product/TestAdapter.Executor/UnitTest/TestExecutorUnitTest.cs
+++ b/Python/Product/TestAdapter.Executor/UnitTest/TestExecutorUnitTest.cs
@@ -72,7 +72,7 @@ namespace Microsoft.PythonTools.TestAdapter {
 
             _cancelRequested.Reset();
 
-            var sourceToProjSettings = RunSettingsUtil.GetSourceToProjSettings(runContext.RunSettings);
+            var sourceToProjSettings = RunSettingsUtil.GetSourceToProjSettings(runContext.RunSettings, filterType:TestFrameworkType.UnitTest);
             var testColletion = new TestCollection();
 
             foreach (var testGroup in sources.GroupBy(x => sourceToProjSettings[x])) {
@@ -125,14 +125,14 @@ namespace Microsoft.PythonTools.TestAdapter {
                 covPath = ExecutorService.GetCoveragePath(tests);
             }
             // .py file path -> project settings
-            var sourceToSettings = RunSettingsUtil.GetSourceToProjSettings(runContext.RunSettings);
+            var sourceToSettings = RunSettingsUtil.GetSourceToProjSettings(runContext.RunSettings, filterType:TestFrameworkType.UnitTest);
 
             foreach (var testGroup in tests.GroupBy(x => sourceToSettings[x.CodeFilePath])) {
                 if (_cancelRequested.WaitOne(0)) {
                     break;
                 }
                 
-                if (testGroup.Key.TestFramwork != TestFrameworkType.UnitTest) {
+                if (testGroup.Key.TestFramework != TestFrameworkType.UnitTest) {
                     continue;
                 }
 

--- a/Python/Tests/TestAdapterTests/TestDiscovererTests.cs
+++ b/Python/Tests/TestAdapterTests/TestDiscovererTests.cs
@@ -22,6 +22,7 @@ using System.Linq;
 using Microsoft.PythonTools;
 using Microsoft.PythonTools.TestAdapter;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using TestAdapterTests.Mocks;
 using TestUtilities;
@@ -112,7 +113,7 @@ namespace TestAdapterTests {
             var discoveryContext = new MockDiscoveryContext(runSettings);
             var discoverySink = new MockTestCaseDiscoverySink();
             var logger = new MockMessageLogger();
-            var discoverer = new PythonTestDiscoverer();
+            var discoverer = new PytestTestDiscoverer();
 
             discoverer.DiscoverTests(new[] { testFilePath }, discoveryContext, logger, discoverySink);
             Assert.AreEqual(0, discoverySink.Tests.Count);
@@ -205,7 +206,7 @@ namespace TestAdapterTests {
             var discoveryContext = new MockDiscoveryContext(runSettings);
             var discoverySink = new MockTestCaseDiscoverySink();
             var logger = new MockMessageLogger();
-            var discoverer = new PythonTestDiscoverer();
+            var discoverer = new PytestTestDiscoverer();
 
             discoverer.DiscoverTests(new[] { testFilePath1, testFilePath2 }, discoveryContext, logger, discoverySink);
 
@@ -295,7 +296,7 @@ namespace TestAdapterTests {
             var discoveryContext = new MockDiscoveryContext(runSettings);
             var discoverySink = new MockTestCaseDiscoverySink();
             var logger = new MockMessageLogger();
-            var discoverer = new PythonTestDiscoverer();
+            var discoverer = new UnitTestDiscoverer();
 
             discoverer.DiscoverTests(new[] { testFilePath1, testFilePath2 }, discoveryContext, logger, discoverySink);
 
@@ -330,7 +331,7 @@ namespace TestAdapterTests {
             var discoveryContext = new MockDiscoveryContext(runSettings);
             var discoverySink = new MockTestCaseDiscoverySink();
             var logger = new MockMessageLogger();
-            var discoverer = new PythonTestDiscoverer();
+            var discoverer = new UnitTestDiscoverer();
 
             discoverer.DiscoverTests(new[] { testFilePath1, testFilePath2 }, discoveryContext, logger, discoverySink);
            
@@ -417,7 +418,7 @@ namespace TestAdapterTests {
             var discoveryContext = new MockDiscoveryContext(runSettings);
             var discoverySink = new MockTestCaseDiscoverySink();
             var logger = new MockMessageLogger();
-            var discoverer = new PythonTestDiscoverer();
+            var discoverer = new PytestTestDiscoverer();
 
             discoverer.DiscoverTests(new[] { testFilePath }, discoveryContext, logger, discoverySink);
             Assert.AreEqual(0, discoverySink.Tests.Count);
@@ -520,7 +521,7 @@ namespace TestAdapterTests {
             var discoveryContext = new MockDiscoveryContext(runSettings);
             var discoverySink = new MockTestCaseDiscoverySink();
             var logger = new MockMessageLogger();
-            var discoverer = new PythonTestDiscoverer();
+            var discoverer = new UnitTestDiscoverer();
 
             discoverer.DiscoverTests(new[] { testFilePath }, discoveryContext, logger, discoverySink);
             Assert.AreEqual(0, discoverySink.Tests.Count);
@@ -688,7 +689,20 @@ namespace TestAdapterTests {
             var discoveryContext = new MockDiscoveryContext(runSettings);
             var discoverySink = new MockTestCaseDiscoverySink();
             var logger = new MockMessageLogger();
-            var discoverer = new PythonTestDiscoverer();
+
+            ITestDiscoverer discoverer = null;
+            switch (testEnv.TestFramework) {
+                case FrameworkPytest:
+                    discoverer = new PytestTestDiscoverer();
+                    break;
+
+                case FrameworkUnittest:
+                    discoverer = new UnitTestDiscoverer();
+                    break;
+                default:
+                    Assert.Fail();
+                    break;
+            }
 
             discoverer.DiscoverTests(sources, discoveryContext, logger, discoverySink);
 

--- a/Python/Tests/TestAdapterTests/TestDiscovererTests.cs
+++ b/Python/Tests/TestAdapterTests/TestDiscovererTests.cs
@@ -700,7 +700,7 @@ namespace TestAdapterTests {
                     discoverer = new UnitTestDiscoverer();
                     break;
                 default:
-                    Assert.Fail();
+                    Assert.Fail($"unknown testframework: {testEnv.TestFramework.ToString()}");
                     break;
             }
 

--- a/Python/Tests/TestAdapterTests/TestExecutorTests.cs
+++ b/Python/Tests/TestAdapterTests/TestExecutorTests.cs
@@ -207,7 +207,7 @@ if __name__ == '__main__':
             var discoveryContext = new MockDiscoveryContext(runSettings);
             var discoverySink = new MockTestCaseDiscoverySink();
             var logger = new MockMessageLogger();
-            var discoverer = new PythonTestDiscoverer();
+            var discoverer = new PytestTestDiscoverer();
             discoverer.DiscoverTests(new[] { testFilePath1, testFilePath2 }, discoveryContext, logger, discoverySink);
 
             Console.WriteLine($"Discovered Tests");
@@ -246,7 +246,7 @@ if __name__ == '__main__':
             var discoveryContext = new MockDiscoveryContext(runSettings);
             var discoverySink = new MockTestCaseDiscoverySink();
             var logger = new MockMessageLogger();
-            var discoverer = new PythonTestDiscoverer();
+            var discoverer = new PytestTestDiscoverer();
             discoverer.DiscoverTests(new[] { testFilePath1 }, discoveryContext, logger, discoverySink);
 
             Console.WriteLine($"Discovered Tests");


### PR DESCRIPTION
testdiscovery session telemetry data relies on DefaultExecutorUri so we need 2 separate classes to get separate telemetry for unittest and pytest

Fix #5688