### PR TITLE
Revert update of Newtonsoft.Json

### DIFF
--- a/Build/16.0/packages.config
+++ b/Build/16.0/packages.config
@@ -4,7 +4,7 @@
     <package id="CommandLineParser" version="2.2.1" />
     <package id="Python2" version="2.7.15" />
     <package id="Python" version="3.6.6" />
-    <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net45" /> 
+    <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" /> 
     <!--These 2 packages are obtained from private sources. See nuget.config for more info -->
     <package id="Microsoft.VisualStudio.Python.LanguageServer" version="0.1.29" />
     <package id="Microsoft.Internal.VisualStudio.Shell.Embeddable" version="16.3.28923.271" />


### PR DESCRIPTION
Fix #5700 as well as analyzer failing to start

Need to stay with the version that is used by the analyzer executable.