### PR TITLE
Add support for profiling on Python 3.8.

### DIFF
--- a/Python/Product/VSInterpreters/PackageManager/CondaUtils.cs
+++ b/Python/Product/VSInterpreters/PackageManager/CondaUtils.cs
@@ -60,6 +60,10 @@ namespace Microsoft.PythonTools.Interpreter {
         /// <param name="prefixPath">Path to the environment.</param>
         /// <returns><c>true</c> if it is a conda environment.</returns>
         internal static bool IsCondaEnvironment(string prefixPath) {
+            if (string.IsNullOrEmpty(prefixPath)) {
+                return false;
+            }
+
             return File.Exists(Path.Combine(prefixPath, "python.exe")) &&
                 Directory.Exists(Path.Combine(prefixPath, "conda-meta"));
         }

--- a/Python/Product/VsPyProf/PythonApi.cpp
+++ b/Python/Product/VsPyProf/PythonApi.cpp
@@ -90,7 +90,7 @@ VsPyProf* VsPyProf::Create(HMODULE pythonModule) {
                 }
 
                 if ((major == 2 && (minor >= 4 && minor <= 7)) ||
-                    (major == 3 && (minor >= 0 && minor <= 7))) {
+                    (major == 3 && (minor >= 0 && minor <= 8))) {
                         return new VsPyProf(pythonModule,
                             major,
                             minor,
@@ -140,6 +140,8 @@ bool VsPyProf::GetUserToken(PyFrameObject* frameObj, DWORD_PTR& func, DWORD_PTR&
             filename = ((PyCodeObject36*)codeObj)->co_filename;
         } else if (PyCodeObject37::IsFor(MajorVersion, MinorVersion)) {
             filename = ((PyCodeObject37*)codeObj)->co_filename;
+        } else if (PyCodeObject38::IsFor(MajorVersion, MinorVersion)) {
+            filename = ((PyCodeObject38*)codeObj)->co_filename;
         }
         module = (DWORD_PTR)filename;
 
@@ -222,6 +224,9 @@ bool VsPyProf::GetUserToken(PyFrameObject* frameObj, DWORD_PTR& func, DWORD_PTR&
             } else if (PyCodeObject37::IsFor(MajorVersion, MinorVersion)) {
                 RegisterName(func, ((PyCodeObject37*)codeObj)->co_name, &moduleName);
                 lineno = ((PyCodeObject37*)codeObj)->co_firstlineno;
+            } else if (PyCodeObject38::IsFor(MajorVersion, MinorVersion)) {
+                RegisterName(func, ((PyCodeObject38*)codeObj)->co_name, &moduleName);
+                lineno = ((PyCodeObject38*)codeObj)->co_firstlineno;
             }
 
             // give the profiler the line number of this function
@@ -260,6 +265,9 @@ wstring VsPyProf::GetClassNameFromFrame(PyFrameObject* frameObj, PyObject *codeO
         } else if (PyCodeObject37::IsFor(MajorVersion, MinorVersion)) {
             argCount = ((PyCodeObject37*)codeObj)->co_argcount;
             argNames = (PyTupleObject*)((PyCodeObject37*)codeObj)->co_varnames;
+        } else if (PyCodeObject38::IsFor(MajorVersion, MinorVersion)) {
+            argCount = ((PyCodeObject38*)codeObj)->co_argcount;
+            argNames = (PyTupleObject*)((PyCodeObject38*)codeObj)->co_varnames;
         }
 
         if (argCount != 0 && argNames && argNames->ob_type == PyTuple_Type) {
@@ -305,6 +313,8 @@ wstring VsPyProf::GetClassNameFromSelf(PyObject* self, PyObject *codeObj) {
             nameObj = ((PyCodeObject36*)codeObj)->co_name;
         } else if (PyCodeObject37::IsFor(MajorVersion, MinorVersion)) {
             nameObj = ((PyCodeObject37*)codeObj)->co_name;
+        } else if (PyCodeObject38::IsFor(MajorVersion, MinorVersion)) {
+            nameObj = ((PyCodeObject38*)codeObj)->co_name;
         }
         GetNameAscii(nameObj, codeName);
 

--- a/Python/Product/VsPyProf/python.h
+++ b/Python/Product/VsPyProf/python.h
@@ -30,7 +30,8 @@ enum PythonVersion {
     PythonVersion_34 = 0x0304,
     PythonVersion_35 = 0x0305,
     PythonVersion_36 = 0x0306,
-    PythonVersion_37 = 0x0307
+    PythonVersion_37 = 0x0307,
+    PythonVersion_38 = 0x0308
 };
 
 typedef const char* (GetVersionFunc)();
@@ -57,6 +58,7 @@ static PythonVersion GetPythonVersion(HMODULE hMod) {
                 case '5': return PythonVersion_35;
                 case '6': return PythonVersion_36;
                 case '7': return PythonVersion_37;
+                case '8': return PythonVersion_38;
                 }
             }
         }
@@ -231,15 +233,47 @@ public:
     void *co_zombieframe;       /* for optimization only (see frameobject.c) */
 
     static bool IsFor(int majorVersion, int minorVersion) {
-        return majorVersion == 3 && minorVersion >= 7;
+        return majorVersion == 3 && minorVersion == 7;
     }
 
     static bool IsFor(PythonVersion version) {
-        return version >= PythonVersion_37;
+        return version == PythonVersion_37;
     }
 };
 
-// 2.5 - 3.7
+// 3.8
+class PyCodeObject38 : public PyObject {
+public:
+    int co_argcount;            /* #arguments, except *args */
+    int co_posonlyargcount;     /* #positional only arguments */
+    int co_kwonlyargcount;      /* #keyword only arguments */
+    int co_nlocals;             /* #local variables */
+    int co_stacksize;           /* #entries needed for evaluation stack */
+    int co_flags;               /* CO_..., see below */
+    int co_firstlineno;         /* first source line number */
+    PyObject* co_code;          /* instruction opcodes */
+    PyObject* co_consts;        /* list (constants used) */
+    PyObject* co_names;         /* list of strings (names used) */
+    PyObject* co_varnames;      /* tuple of strings (local variable names) */
+    PyObject* co_freevars;      /* tuple of strings (free variable names) */
+    PyObject* co_cellvars;      /* tuple of strings (cell variable names) */
+                                /* The rest doesn't count for hash or comparisons */
+    SSIZE_T* co_cell2arg;       /* Maps cell vars which are arguments. */
+    PyObject* co_filename;      /* unicode (where it was loaded from) */
+    PyObject* co_name;          /* unicode (name, for reference) */
+    PyObject* co_lnotab;        /* string (encoding addr<->lineno mapping) */
+    void* co_zombieframe;       /* for optimization only (see frameobject.c) */
+
+    static bool IsFor(int majorVersion, int minorVersion) {
+        return majorVersion == 3 && minorVersion >= 8;
+    }
+
+    static bool IsFor(PythonVersion version) {
+        return version >= PythonVersion_38;
+    }
+};
+
+// 2.5 - 3.8
 class PyFunctionObject : public PyObject {
 public:
     PyObject *func_code;    /* A code object */
@@ -262,7 +296,7 @@ public:
      */
 };
 
-// 2.4 - 3.7 compatible
+// 2.4 - 3.8 compatible
 typedef struct {
     PyObject_HEAD
     size_t length;      /* Length of raw Unicode data in buffer */
@@ -270,7 +304,7 @@ typedef struct {
     long hash;          /* Hash value; -1 if not set */
 } PyUnicodeObject;
 
-// 2.4 - 3.7 compatible
+// 2.4 - 3.8 compatible
 class PyFrameObject : public PyVarObject {
 public:
     PyFrameObject *f_back;  /* previous frame, or NULL */
@@ -355,7 +389,7 @@ public:
 
 typedef void (*destructor)(PyObject *);
 
-// 2.4 - 3.7
+// 2.4 - 3.8
 class PyMethodDef {
 public:
     char    *ml_name;    /* The name of the built-in function/method */
@@ -363,7 +397,7 @@ public:
 
 
 // 
-// 2.5 - 3.7
+// 2.5 - 3.8
 // While these are compatible there are fields only available on later versions.
 class PyTypeObject : public PyVarObject {
 public:
@@ -373,7 +407,7 @@ public:
     /* Methods to implement standard operations */
 
     destructor tp_dealloc;
-    void *tp_print;
+    void *tp_print; // 3.8: Py_ssize_t tp_vectorcall_offset; (same size as void*)
     void *tp_getattr;
     void *tp_setattr;
     union {
@@ -448,7 +482,7 @@ public:
     unsigned int tp_version_tag;
 };
 
-// 2.4 - 3.7
+// 2.4 - 3.8
 class PyTupleObject : public PyVarObject {
 public:
     PyObject *ob_item[1];
@@ -459,7 +493,7 @@ public:
      */
 };
 
-// 2.4 - 3.7
+// 2.4 - 3.8
 class PyCFunctionObject : public PyObject {
 public:
     PyMethodDef *m_ml;      /* Description of the C function to call */

--- a/Python/Tests/ProfilingUITests/ProfilingUITests.cs
+++ b/Python/Tests/ProfilingUITests/ProfilingUITests.cs
@@ -232,13 +232,39 @@ namespace ProfilingUITests {
             }
         }
 
-        public void LaunchProject(PythonVisualStudioApp app, ProfileCleanup cleanup, DotNotWaitOnExit optionSetter) {
-            LaunchProjectAndVerifyReport(
-                app,
-                @"TestData\ProfileTest.sln",
-                "HelloWorld",
-                new[] { "Program.f", "time.sleep" }
-            );
+        public void LaunchProjectPython27(PythonVisualStudioApp app, ProfileCleanup cleanup, DotNotWaitOnExit optionSetter) {
+            var version = PythonPaths.Python27_x64 ?? PythonPaths.Python27;
+            version.AssertInstalled();
+
+            LaunchProject(app, version);
+        }
+
+        public void LaunchProjectPython35(PythonVisualStudioApp app, ProfileCleanup cleanup, DotNotWaitOnExit optionSetter) {
+            var version = PythonPaths.Python35_x64 ?? PythonPaths.Python35;
+            version.AssertInstalled();
+
+            LaunchProject(app, version);
+        }
+
+        public void LaunchProjectPython36(PythonVisualStudioApp app, ProfileCleanup cleanup, DotNotWaitOnExit optionSetter) {
+            var version = PythonPaths.Python36_x64 ?? PythonPaths.Python36;
+            version.AssertInstalled();
+
+            LaunchProject(app, version);
+        }
+
+        public void LaunchProjectPython37(PythonVisualStudioApp app, ProfileCleanup cleanup, DotNotWaitOnExit optionSetter) {
+            var version = PythonPaths.Python37_x64 ?? PythonPaths.Python37;
+            version.AssertInstalled();
+
+            LaunchProject(app, version);
+        }
+
+        public void LaunchProjectPython38(PythonVisualStudioApp app, ProfileCleanup cleanup, DotNotWaitOnExit optionSetter) {
+            var version = PythonPaths.Python38_x64 ?? PythonPaths.Python38;
+            version.AssertInstalled();
+
+            LaunchProject(app, version);
         }
 
         public void LaunchProjectWithSpaceInFilename(PythonVisualStudioApp app, ProfileCleanup cleanup, DotNotWaitOnExit optionSetter) {
@@ -1106,6 +1132,24 @@ namespace ProfilingUITests {
             );
         }
 
+        public void BuiltinsProfilePython38(PythonVisualStudioApp app, ProfileCleanup cleanup, DotNotWaitOnExit optionSetter) {
+            BuiltinsProfile(
+                app,
+                PythonPaths.Python38,
+                new[] { "BuiltinsProfile.f", "str.startswith", "isinstance", "marshal.dumps", "array.array.tostring" },
+                new[] { "compile", "exec", "execfile", "_io.TextIOWrapper.read" }
+            );
+        }
+
+        public void BuiltinsProfilePython38x64(PythonVisualStudioApp app, ProfileCleanup cleanup, DotNotWaitOnExit optionSetter) {
+            BuiltinsProfile(
+                app,
+                PythonPaths.Python38_x64,
+                new[] { "BuiltinsProfile.f", "str.startswith", "isinstance", "marshal.dumps", "array.array.tostring" },
+                new[] { "compile", "exec", "execfile", "_io.TextIOWrapper.read" }
+            );
+        }
+
         public void LaunchExecutableUsingInterpreterGuid(PythonVisualStudioApp app, ProfileCleanup cleanup, DotNotWaitOnExit optionSetter) {
             PythonPaths.Python27.AssertInstalled();
 
@@ -1463,6 +1507,17 @@ namespace ProfilingUITests {
                 }
             } finally {
                 app.InvokeOnMainThread(() => profiling.RemoveSession(session, false));
+            }
+        }
+
+        private void LaunchProject(PythonVisualStudioApp app, PythonVersion version) {
+            using (app.SelectDefaultInterpreter(version)) {
+                LaunchProjectAndVerifyReport(
+                    app,
+                    @"TestData\ProfileTest.sln",
+                    "HelloWorld",
+                    new[] { "Program.f", "time.sleep" }
+                );
             }
         }
 

--- a/Python/Tests/ProfilingUITestsRunner/ProfilingUITests.cs
+++ b/Python/Tests/ProfilingUITestsRunner/ProfilingUITests.cs
@@ -78,8 +78,32 @@ namespace ProfilingUITestsRunner {
 
         [TestMethod, Priority(2)]
         [TestCategory("Installed")]
-        public void LaunchProject() {
-            _vs.RunTest(nameof(PUIT.LaunchProject));
+        public void LaunchProjectPython27() {
+            _vs.RunTest(nameof(PUIT.LaunchProjectPython27));
+        }
+
+        [TestMethod, Priority(2)]
+        [TestCategory("Installed")]
+        public void LaunchProjectPython35() {
+            _vs.RunTest(nameof(PUIT.LaunchProjectPython35));
+        }
+
+        [TestMethod, Priority(2)]
+        [TestCategory("Installed")]
+        public void LaunchProjectPython36() {
+            _vs.RunTest(nameof(PUIT.LaunchProjectPython36));
+        }
+
+        [TestMethod, Priority(2)]
+        [TestCategory("Installed")]
+        public void LaunchProjectPython37() {
+            _vs.RunTest(nameof(PUIT.LaunchProjectPython37));
+        }
+
+        [TestMethod, Priority(2)]
+        [TestCategory("Installed")]
+        public void LaunchProjectPython38() {
+            _vs.RunTest(nameof(PUIT.LaunchProjectPython38));
         }
 
         [TestMethod, Priority(2)]
@@ -273,6 +297,18 @@ namespace ProfilingUITestsRunner {
         [TestMethod, Priority(2)]
         [TestCategory("Installed")]
         public void BuiltinsProfilePython37x64() {
+            _vs.RunTest(nameof(PUIT.BuiltinsProfilePython37x64));
+        }
+
+        [TestMethod, Priority(2)]
+        [TestCategory("Installed")]
+        public void BuiltinsProfilePython38() {
+            _vs.RunTest(nameof(PUIT.BuiltinsProfilePython37));
+        }
+
+        [TestMethod, Priority(2)]
+        [TestCategory("Installed")]
+        public void BuiltinsProfilePython38x64() {
             _vs.RunTest(nameof(PUIT.BuiltinsProfilePython37x64));
         }
 

--- a/Python/Tests/Utilities.Python.Analysis/PythonPaths.cs
+++ b/Python/Tests/Utilities.Python.Analysis/PythonPaths.cs
@@ -36,11 +36,13 @@ namespace TestUtilities {
         public static readonly PythonVersion Python35 = GetCPythonVersion(PythonLanguageVersion.V35, InterpreterArchitecture.x86);
         public static readonly PythonVersion Python36 = GetCPythonVersion(PythonLanguageVersion.V36, InterpreterArchitecture.x86);
         public static readonly PythonVersion Python37 = GetCPythonVersion(PythonLanguageVersion.V37, InterpreterArchitecture.x86);
+        public static readonly PythonVersion Python38 = GetCPythonVersion(PythonLanguageVersion.V38, InterpreterArchitecture.x86);
         public static readonly PythonVersion IronPython27 = GetIronPythonVersion(false);
         public static readonly PythonVersion Python27_x64 = GetCPythonVersion(PythonLanguageVersion.V27, InterpreterArchitecture.x64);
         public static readonly PythonVersion Python35_x64 = GetCPythonVersion(PythonLanguageVersion.V35, InterpreterArchitecture.x64);
         public static readonly PythonVersion Python36_x64 = GetCPythonVersion(PythonLanguageVersion.V36, InterpreterArchitecture.x64);
         public static readonly PythonVersion Python37_x64 = GetCPythonVersion(PythonLanguageVersion.V37, InterpreterArchitecture.x64);
+        public static readonly PythonVersion Python38_x64 = GetCPythonVersion(PythonLanguageVersion.V38, InterpreterArchitecture.x64);
         public static readonly PythonVersion Anaconda27 = GetAnacondaVersion(PythonLanguageVersion.V27, InterpreterArchitecture.x86);
         public static readonly PythonVersion Anaconda27_x64 = GetAnacondaVersion(PythonLanguageVersion.V27, InterpreterArchitecture.x64);
         public static readonly PythonVersion Anaconda36 = GetAnacondaVersion(PythonLanguageVersion.V36, InterpreterArchitecture.x86);


### PR DESCRIPTION
Fix #5683 
Fix #5341

I added version specific project profiling tests, to ensure that Python 2.7...3.8 are covered (and the 3.8 test fails without my changes)

![image](https://user-images.githubusercontent.com/1696845/64461888-6db7db80-d0b3-11e9-9bfd-5e6dca9ee980.png)
