### PR TITLE
Fix for FieSystemWatcher not sending an event when saving edits in Vi…

### DIFF
--- a/Python/Product/TestAdapter/TestFileAddRemoveListener.cs
+++ b/Python/Product/TestAdapter/TestFileAddRemoveListener.cs
@@ -118,8 +118,7 @@ namespace Microsoft.VisualStudioTools.TestAdapter {
         }
 
         int IVsTrackProjectDocumentsEvents2.OnAfterRenameFiles(int cProjects, int cFiles, IVsProject[] rgpProjects, int[] rgFirstIndices, string[] rgszMkOldNames, string[] rgszMkNewNames, VSRENAMEFILEFLAGS[] rgFlags) {
-            NotifyTestFileAddRemove(cProjects, rgpProjects, rgszMkOldNames, rgFirstIndices, TestFileChangedReason.Removed);
-            return NotifyTestFileAddRemove(cProjects, rgpProjects, rgszMkNewNames, rgFirstIndices, TestFileChangedReason.Added);
+            return VSConstants.S_OK;
         }
 
         int IVsTrackProjectDocumentsEvents2.OnAfterSccStatusChanged(int cProjects, int cFiles, IVsProject[] rgpProjects, int[] rgFirstIndices, string[] rgpszMkDocuments, uint[] rgdwSccStatus) {

--- a/Python/Product/TestAdapter/TestFilesUpdateWatcher.cs
+++ b/Python/Product/TestAdapter/TestFilesUpdateWatcher.cs
@@ -42,11 +42,12 @@ namespace Microsoft.VisualStudioTools.TestAdapter {
                         var watcher = new FileSystemWatcher(directoryName, filter);
                         _fileWatchers[path] = watcher;
 
-                        watcher.NotifyFilter = NotifyFilters.LastWrite 
-                                            | NotifyFilters.FileName 
-                                            | NotifyFilters.DirectoryName 
+                        watcher.NotifyFilter = NotifyFilters.LastWrite
+                                            | NotifyFilters.FileName
+                                            | NotifyFilters.DirectoryName
                                             | NotifyFilters.CreationTime;
                         watcher.Changed += OnChanged;  //only handle on change  in project mode
+                        watcher.Renamed += OnRenamed;
                         watcher.EnableRaisingEvents = true;
                         return true;
                     } catch (Exception ex) when (!ex.IsCriticalException()) {
@@ -90,6 +91,9 @@ namespace Microsoft.VisualStudioTools.TestAdapter {
                 && _fileWatchers.TryRemove(path, out FileSystemWatcher watcher)) {
                 watcher.EnableRaisingEvents = false;
                 watcher.Changed -= OnChanged;
+                watcher.Renamed -= OnRenamed;
+                watcher.Created -= OnCreated;
+                watcher.Deleted -= OnDeleted;
                 watcher.Dispose();
             }
         }
@@ -134,6 +138,9 @@ namespace Microsoft.VisualStudioTools.TestAdapter {
                 foreach (var watcher in _fileWatchers.Values) {
                     if (watcher != null) {
                         watcher.Changed -= OnChanged;
+                        watcher.Renamed -= OnRenamed;
+                        watcher.Created -= OnCreated;
+                        watcher.Deleted -= OnDeleted;
                         watcher.Dispose();
                     }
                 }


### PR DESCRIPTION
…sual studio.

I was only able to repro this by using temp Test Results folders for a new project.
Visual studio uses rename to save a temp file as the original and previously adding the NotifyFilters.CreatedTime filter would then trigger "Changed" on file save.  However now I need to add "OnRenamed" to handle these additonal temp folder cases.  Also I'm now no longer listening for VS rename events because I dont want to have to handle multiple rename events.


Fix #5705