### PR TITLE
Fixing broken UI tests for Text ExplorerTests

### DIFF
--- a/Python/Tests/Core.UI/TestExplorerTests.cs
+++ b/Python/Tests/Core.UI/TestExplorerTests.cs
@@ -30,13 +30,13 @@ namespace PythonToolsUITests {
 
         private static TestInfo[] AllPytests = new TestInfo[] {
             // test_pt.py
-            new TestInfo("test_pt_fail", "test_pt", "test_pt", "test_pt.py", 4, "Failed", "assert False"),
-            new TestInfo("test_pt_pass", "test_pt", "test_pt", "test_pt.py", 1, "Passed"),
+            new TestInfo("test__pt_fail", "test_pt", "test_pt", "test_pt.py", 4, "Failed", "assert False"),
+            new TestInfo("test__pt_pass", "test_pt", "test_pt", "test_pt.py", 1, "Passed"),
             new TestInfo("test_method_pass", "test_pt", "TestClassPT", "test_pt.py", 8, "Passed"),
 
             // test_ut.py
-            new TestInfo("test_ut_fail", "test_ut", "TestClassUT", "test_ut.py", 4, "Failed", "AssertionError: Not implemented"),
-            new TestInfo("test_ut_pass", "test_ut", "TestClassUT", "test_ut.py", 7, "Passed"),
+            new TestInfo("test__ut_fail", "test_ut", "TestClassUT", "test_ut.py", 4, "Failed", "AssertionError: Not implemented"),
+            new TestInfo("test__ut_pass", "test_ut", "TestClassUT", "test_ut.py", 7, "Passed"),
 
             // test_mark.py
             new TestInfo("test_webtest", "test_mark", "test_mark", "test_mark.py", 5, "Passed"),

--- a/Python/Tests/TestData/TestExplorerPytest/test_pt.py
+++ b/Python/Tests/TestData/TestExplorerPytest/test_pt.py
@@ -1,7 +1,7 @@
-def test_pt_pass():
+def test__pt_pass():
     assert True
 
-def test_pt_fail():
+def test__pt_fail():
     assert False
 
 class TestClassPT(object):

--- a/Python/Tests/TestData/TestExplorerPytest/test_ut.py
+++ b/Python/Tests/TestData/TestExplorerPytest/test_ut.py
@@ -1,10 +1,10 @@
 import unittest
 
 class TestClassUT(unittest.TestCase):
-    def test_ut_fail(self):
+    def test__ut_fail(self):
         self.fail("Not implemented")
 
-    def test_ut_pass(self):
+    def test__ut_pass(self):
         pass
 
 if __name__ == '__main__':

--- a/Python/Tests/Utilities.Python/PythonTestExplorerGridView.cs
+++ b/Python/Tests/Utilities.Python/PythonTestExplorerGridView.cs
@@ -16,8 +16,10 @@
 
 using System;
 using System.Diagnostics;
+using System.Drawing;
 using System.Threading;
 using System.Windows.Automation;
+using System.Windows.Input;
 
 namespace TestUtilities.UI {
     public class PythonTestExplorerGridView : ListView {
@@ -64,6 +66,14 @@ namespace TestUtilities.UI {
             }
         }
 
+        public void ExpandAll() {
+            foreach (AutomationElement child in Element.FindAll(TreeScope.Descendants, Condition.TrueCondition)) {
+                if (child.TryGetCurrentPattern(ExpandCollapsePattern.Pattern, out var pattern)) {
+                    ((ExpandCollapsePattern)pattern).Expand();
+                }
+            }
+        }
+
         /// <summary>
         /// Finds the specified item in the tree and returns it.
         /// </summary>
@@ -78,7 +88,7 @@ namespace TestUtilities.UI {
                 var node = nodes[i];
                 var name = node.GetCurrentPropertyValue(AutomationElement.NameProperty) as string;
 
-                if (name.Equals(splitPath[depth], StringComparison.CurrentCulture)) {
+                if (name.Contains(splitPath[depth])) {
                     if (depth == splitPath.Length - 1) {
                         return node;
                     }
@@ -91,7 +101,7 @@ namespace TestUtilities.UI {
                         Console.WriteLine("Failed to expand {0}", splitPath[depth]);
                     }
                     return FindNode(node.FindAll(TreeScope.Children, Condition.TrueCondition), splitPath, depth + 1);
-                }
+               }
             }
             return null;
         }

--- a/Python/Tests/Utilities.Python/PythonVisualStudioApp.cs
+++ b/Python/Tests/Utilities.Python/PythonVisualStudioApp.cs
@@ -211,7 +211,7 @@ namespace TestUtilities.UI.Python {
             get {
                 if (_testExplorer == null) {
                     AutomationElement element = null;
-                    for (int i = 0; i < 10 && element == null; i++) {
+                    for (int i = 0; i < 40 && element == null; i++) {
                         element = Element.FindFirst(TreeScope.Descendants,
                             new AndCondition(
                                 new PropertyCondition(
@@ -224,11 +224,50 @@ namespace TestUtilities.UI.Python {
                                 )
                             )
                         );
-                        if (element == null) {
+                        if (element != null) {
+                            break;
+                        }
+                        System.Threading.Thread.Sleep(500);
+                    }
+                    Assert.IsTrue(element != null, "Missing Text Explorer window");
+                    
+                    AutomationElement searchControl = null;
+                    AutomationElement searchElement = null;
+                    if (element != null) {
+                        for (int i = 0; i < 30 && searchControl == null; i++) {
+                            searchControl = Element.FindFirst(
+                                TreeScope.Descendants,
+                                new PropertyCondition(
+                                    AutomationElement.AutomationIdProperty,
+                                    "SearchControl"
+                                )
+                            );
+                            if (searchControl != null) {
+                                break;
+                            }
                             System.Threading.Thread.Sleep(500);
                         }
+
+                        if (searchControl != null) {
+                            for (int i = 0; i < 30 && searchElement == null; i++) {
+                                searchElement = searchControl.FindFirst(
+                                    TreeScope.Children,
+                                    new PropertyCondition(
+                                        AutomationElement.ClassNameProperty,
+                                        "TextBox"
+                                    )
+                                );
+                                if (searchElement != null) {
+                                    break;
+                                }
+                                System.Threading.Thread.Sleep(500);
+                            }
+                        }
+
                     }
-                    _testExplorer = new PythonTestExplorer(this, element);
+                    Assert.IsTrue(searchElement != null, "Missing Search Bar Textbox");
+
+                    _testExplorer = new PythonTestExplorer(this, element, searchElement);
                 }
                 return _testExplorer;
             }


### PR DESCRIPTION
- Added test functions to searchbar to help fix offscreen elements not being found by automationId
- After filtering we then expand all descendants, multiple times to for child dataItems to load
- Renamed some test functions to work around test explorer bug where they shorten the function name if it contains the classname.
- Change the test function name compare to use "Contains" instead of equals because now test explorer is appending strings like "Not Run" to the test name.

Fix #5693