### PR TITLE
Unable to cancel a running pytest Fix #5542

### DIFF
--- a/Python/Product/TestAdapter.Executor/Pytest/TestExecutorPytest.cs
+++ b/Python/Product/TestAdapter.Executor/Pytest/TestExecutorPytest.cs
@@ -139,7 +139,7 @@ namespace Microsoft.PythonTools.TestAdapter {
                     covPath = ExecutorService.GetCoveragePath(testGroup);
                 }
 
-                var resultsXML = executor.Run(testGroup, covPath);
+                var resultsXML = executor.Run(testGroup, covPath, _cancelRequested);
 
                 // Default TestResults
                 var pytestIdToResultsMap = testGroup.Select(tc => new TestResult(tc) { Outcome = TestOutcome.Skipped })

--- a/Python/Tests/TestAdapterTests/TestExecutorTests.cs
+++ b/Python/Tests/TestAdapterTests/TestExecutorTests.cs
@@ -395,7 +395,20 @@ if __name__ == '__main__':
         [TestCategory("10s")]
         public void RunUnittestCancel() {
             var testEnv = TestEnvironment.GetOrCreate(Version, FrameworkUnittest);
+            var executor = new TestExecutorUnitTest();
+            TestCancel(testEnv, executor);
+        }
 
+        [TestMethod, Priority(0)]
+        [TestCategory("10s")]
+        public void RunPytestCancel() {
+            var testEnv = TestEnvironment.GetOrCreate(Version, FrameworkPytest);
+            var executor = new TestExecutorPytest();
+            TestCancel(testEnv, executor);
+        }
+
+
+        private void TestCancel(TestEnvironment testEnv, ITestExecutor executor) {
             var testFilePath = Path.Combine(testEnv.SourceFolderPath, "test_cancel.py");
             File.Copy(TestData.GetPath("TestData", "TestExecutor", "test_cancel.py"), testFilePath);
 
@@ -447,7 +460,6 @@ if __name__ == '__main__':
             var testCases = CreateTestCasesFromTestInfo(testEnv, expectedTests);
             var runContext = new MockRunContext(runSettings, testCases, testEnv.ResultsFolderPath);
             var recorder = new MockTestExecutionRecorder();
-            var executor = new TestExecutorUnitTest();
 
             var thread = new System.Threading.Thread(o => {
                 executor.RunTests(testCases, runContext, recorder);
@@ -477,6 +489,7 @@ if __name__ == '__main__':
             // Canceled test cases do not get recorded
             Assert.IsTrue(recorder.Results.Count < expectedTests.Length);
         }
+
 
         [TestMethod, Priority(0)]
         [TestCategory("10s")]


### PR DESCRIPTION
- This is just a force process kill for now
- Added the same cancel test that unittest has