### PR TITLE
Fix issue with executing the activate_this script

### DIFF
--- a/Python/Product/BuildTasks/ptvs_virtualenv_proxy.py
+++ b/Python/Product/BuildTasks/ptvs_virtualenv_proxy.py
@@ -98,7 +98,9 @@ def get_wsgi_handler(handler_name):
 activate_this = os.getenv('WSGI_ALT_VIRTUALENV_ACTIVATE_THIS')
 if not activate_this:
     raise Exception('WSGI_ALT_VIRTUALENV_ACTIVATE_THIS is not set')
-
+if not isinstance(activate_this, str):
+    activate_this = to_str(activate_this)
+        
 def get_virtualenv_handler():
     log('Activating virtualenv with %s\n' % activate_this)
     execfile(activate_this, dict(__file__=activate_this))


### PR DESCRIPTION
The activate_this.py file that is being executed by get_virtualenv_handler() might set the __file__ attribute to a unicode value. If I'm not mistaken then the value of __file__ should be of type 'str' in Python 2.7.

I discovered this when I ran into an issue where a core Python2.7 script (FixTk.py) raised an AssertionError because sys.prefix was of type unicode. It turned out that the activate_this.py script was replacing sys.prefix with a value based on its __file__ attribute.

I added 2 LOC to call the already defined to_str() function on the value of 'activate_this'.