### PR TITLE
Cleanup Services\ExecutorService.cs of pytest specific code

### DIFF
--- a/Python/Product/TestAdapter.Executor/Config/ITestConfiguration.cs
+++ b/Python/Product/TestAdapter.Executor/Config/ITestConfiguration.cs
@@ -18,8 +18,7 @@ using System.Collections.Generic;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 
 namespace Microsoft.PythonTools.TestAdapter.Config {
-    public interface ITestConfiguration {
-        
+    internal interface ITestConfiguration {
         string Command { get; }
 
         IList<string> GetExecutionArguments(IEnumerable<TestCase> testCases, PythonProjectSettings settings);

--- a/Python/Product/TestAdapter.Executor/Config/ITestConfiguration.cs
+++ b/Python/Product/TestAdapter.Executor/Config/ITestConfiguration.cs
@@ -1,0 +1,27 @@
+﻿// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System.Collections.Generic;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+
+namespace Microsoft.PythonTools.TestAdapter.Config {
+    public interface ITestConfiguration {
+        
+        string Command { get; }
+
+        IList<string> GetExecutionArguments(IEnumerable<TestCase> testCases, PythonProjectSettings settings);
+    }
+}

--- a/Python/Product/TestAdapter.Executor/Pytest/PytestConfiguration.cs
+++ b/Python/Product/TestAdapter.Executor/Pytest/PytestConfiguration.cs
@@ -1,0 +1,71 @@
+﻿
+// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Microsoft.PythonTools.TestAdapter.Config;
+using Microsoft.PythonTools.TestAdapter.Utils;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
+
+namespace Microsoft.PythonTools.TestAdapter.Pytest {
+    public class PytestConfiguration : ITestConfiguration {
+        private readonly IRunContext _runContext;
+
+        public PytestConfiguration(IRunContext runContext) {
+            _runContext = runContext;
+            ResultsXmlPath = GetJunitXmlFilePath();
+        }
+
+        public string Command => "pytest";
+
+        public string ResultsXmlPath { get; private set; }
+
+        public IList<string> GetExecutionArguments(IEnumerable<TestCase> tests, PythonProjectSettings settings) {
+            var args = new List<string>();
+
+            // For a small set of tests, we'll pass them on the command
+            // line. Once we exceed a certain (arbitrary) number, create
+            // a test list on disk so that we do not overflow the 
+            // 32K argument limit.
+            var testIds = tests.Select(t => t.GetPropertyValue<string>(Pytest.Constants.PytestIdProperty, default));
+            if (testIds.Count() > 5) {
+                var testListFilePath = TestUtils.CreateTestListFile(testIds);
+                args.Add(testListFilePath);
+            } else {
+                args.Add("dummyfilename"); //expected not to exist, but script excepts something
+                foreach (var testId in testIds) {
+                    args.Add(testId);
+                }
+            }
+
+            // output results to xml file
+            args.Add(String.Format("--junitxml={0}", ResultsXmlPath));
+            args.Add(String.Format("--rootdir={0}", settings.ProjectHome));
+
+            return args;
+        }
+
+        private string GetJunitXmlFilePath() {
+            string baseName = "junitresults_";
+            string path = Path.Combine(_runContext.TestRunDirectory, baseName + Guid.NewGuid().ToString() + ".xml");
+            return path;
+        }
+    }
+}

--- a/Python/Product/TestAdapter.Executor/Pytest/PytestConfiguration.cs
+++ b/Python/Product/TestAdapter.Executor/Pytest/PytestConfiguration.cs
@@ -1,5 +1,4 @@
-﻿
-// Python Tools for Visual Studio
+﻿// Python Tools for Visual Studio
 // Copyright(c) Microsoft Corporation
 // All rights reserved.
 //
@@ -25,19 +24,28 @@ using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
 
 namespace Microsoft.PythonTools.TestAdapter.Pytest {
-    public class PytestConfiguration : ITestConfiguration {
+    internal class PytestConfiguration : ITestConfiguration {
         private readonly IRunContext _runContext;
 
         public PytestConfiguration(IRunContext runContext) {
-            _runContext = runContext;
+            _runContext = runContext ?? throw new ArgumentNullException(nameof(runContext));
             ResultsXmlPath = GetJunitXmlFilePath();
         }
 
         public string Command => "pytest";
 
-        public string ResultsXmlPath { get; private set; }
+        public string ResultsXmlPath { get; }
 
         public IList<string> GetExecutionArguments(IEnumerable<TestCase> tests, PythonProjectSettings settings) {
+            
+            if (tests is null) {
+                throw new ArgumentNullException(nameof(tests));
+            }
+
+            if (settings is null) {
+                throw new ArgumentNullException(nameof(settings));
+            }
+
             var args = new List<string>();
 
             // For a small set of tests, we'll pass them on the command

--- a/Python/Product/TestAdapter.Executor/Pytest/TestExecutorPytest.cs
+++ b/Python/Product/TestAdapter.Executor/Pytest/TestExecutorPytest.cs
@@ -131,12 +131,6 @@ namespace Microsoft.PythonTools.TestAdapter {
                 return;
             }
 
-            bool codeCoverage = ExecutorService.EnableCodeCoverage(runContext);
-            string covPath = null;
-            if (codeCoverage) {
-                covPath = ExecutorService.GetCoveragePath(testGroup);
-            }
-
             var testConfig = new PytestConfiguration(runContext);
             using (var executor = new ExecutorService(
                 testConfig,
@@ -144,7 +138,7 @@ namespace Microsoft.PythonTools.TestAdapter {
                 frameworkHandle,
                 runContext)
             ) {
-                executor.Run(testGroup, covPath, _cancelRequested);
+                executor.Run(testGroup, _cancelRequested);
             }
             
             var testResults = ParseResults(testConfig.ResultsXmlPath, testGroup, frameworkHandle);
@@ -154,10 +148,6 @@ namespace Microsoft.PythonTools.TestAdapter {
                     break;
                 }
                 frameworkHandle.RecordResult(result);
-            }
-
-            if (codeCoverage) {
-                ExecutorService.AttachCoverageResults(frameworkHandle, covPath);
             }
         }
 

--- a/Python/Product/TestAdapter.Executor/Pytest/TestExecutorPytest.cs
+++ b/Python/Product/TestAdapter.Executor/Pytest/TestExecutorPytest.cs
@@ -22,7 +22,6 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Xml.XPath;
-using Microsoft.PythonTools.Analysis;
 using Microsoft.PythonTools.Infrastructure;
 using Microsoft.PythonTools.TestAdapter.Config;
 using Microsoft.PythonTools.TestAdapter.Pytest;
@@ -132,41 +131,53 @@ namespace Microsoft.PythonTools.TestAdapter {
                 return;
             }
 
-            using (var executor = new ExecutorService(settings, frameworkHandle, runContext)) {
-                bool codeCoverage = ExecutorService.EnableCodeCoverage(runContext);
-                string covPath = null;
-                if (codeCoverage) {
-                    covPath = ExecutorService.GetCoveragePath(testGroup);
-                }
-
-                var resultsXML = executor.Run(testGroup, covPath, _cancelRequested);
-
-                // Default TestResults
-                var pytestIdToResultsMap = testGroup.Select(tc => new TestResult(tc) { Outcome = TestOutcome.Skipped })
-                .ToDictionary(tr => tr.TestCase.GetPropertyValue<string>(Pytest.Constants.PytestIdProperty, String.Empty), tr => tr);
-
-                if (File.Exists(resultsXML)) {
-                    try {
-                        var doc = JunitXmlTestResultParser.Read(resultsXML);
-                        Parse(doc, pytestIdToResultsMap, frameworkHandle);
-                    } catch (Exception ex) {
-                        frameworkHandle.SendMessage(TestMessageLevel.Error, ex.Message);
-                    }
-                } else {
-                    frameworkHandle.SendMessage(TestMessageLevel.Error, Strings.PytestResultsXmlNotFound.FormatUI(resultsXML));
-                }
-
-                foreach (var result in pytestIdToResultsMap.Values) {
-                    if (_cancelRequested.WaitOne(0)) {
-                        break;
-                    }
-                    frameworkHandle.RecordResult(result);
-                }
-
-                if (codeCoverage) {
-                    ExecutorService.AttachCoverageResults(frameworkHandle, covPath);
-                }
+            bool codeCoverage = ExecutorService.EnableCodeCoverage(runContext);
+            string covPath = null;
+            if (codeCoverage) {
+                covPath = ExecutorService.GetCoveragePath(testGroup);
             }
+
+            var testConfig = new PytestConfiguration(runContext);
+            using (var executor = new ExecutorService(
+                testConfig,
+                settings,
+                frameworkHandle,
+                runContext)
+            ) {
+                executor.Run(testGroup, covPath, _cancelRequested);
+            }
+            
+            var testResults = ParseResults(testConfig.ResultsXmlPath, testGroup, frameworkHandle);
+
+            foreach (var result in testResults) {
+                if (_cancelRequested.WaitOne(0)) {
+                    break;
+                }
+                frameworkHandle.RecordResult(result);
+            }
+
+            if (codeCoverage) {
+                ExecutorService.AttachCoverageResults(frameworkHandle, covPath);
+            }
+        }
+
+        private IEnumerable<TestResult> ParseResults(string resultsXMLPath, IEnumerable<TestCase> testCases, IFrameworkHandle frameworkHandle) {
+            // Default TestResults
+            var pytestIdToResultsMap = testCases.Select(tc => new TestResult(tc) { Outcome = TestOutcome.Skipped })
+            .ToDictionary(tr => tr.TestCase.GetPropertyValue<string>(Pytest.Constants.PytestIdProperty, String.Empty), tr => tr);
+
+            if (File.Exists(resultsXMLPath)) {
+                try {
+                    var doc = JunitXmlTestResultParser.Read(resultsXMLPath);
+                    Parse(doc, pytestIdToResultsMap, frameworkHandle);
+                } catch (Exception ex) {
+                    frameworkHandle.SendMessage(TestMessageLevel.Error, ex.Message);
+                }
+            } else {
+                frameworkHandle.SendMessage(TestMessageLevel.Error, Strings.PytestResultsXmlNotFound.FormatUI(resultsXMLPath));
+            }
+
+            return pytestIdToResultsMap.Values;
         }
 
         private void Parse(XPathDocument doc, Dictionary<string, TestResult> pytestIdToResultsMap, IFrameworkHandle frameworkHandle) {

--- a/Python/Product/TestAdapter.Executor/Services/ExecutorService.cs
+++ b/Python/Product/TestAdapter.Executor/Services/ExecutorService.cs
@@ -33,7 +33,7 @@ using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
 
 namespace Microsoft.PythonTools.TestAdapter.Services {
-    public class ExecutorService : IDisposable {
+    internal class ExecutorService : IDisposable {
         private readonly IFrameworkHandle _frameworkHandle;
         private static readonly string TestLauncherPath = PythonToolsInstallPath.GetFile("testlauncher.py");
         private static readonly Guid PythonRemoteDebugPortSupplierUnsecuredId = new Guid("{FEB76325-D127-4E02-B59D-B16D93D46CF5}");
@@ -71,16 +71,16 @@ namespace Microsoft.PythonTools.TestAdapter.Services {
             }
         }
 
-        public ExecutorService(
+        internal ExecutorService(
             ITestConfiguration config, 
             PythonProjectSettings projectSettings, 
             IFrameworkHandle frameworkHandle, 
             IRunContext runContext
         ) {
-            _testConfig = config;
-            _projectSettings = projectSettings;
-            _frameworkHandle = frameworkHandle;
-            _runContext = runContext;
+            _testConfig = config ?? throw new ArgumentNullException(nameof(config));
+            _projectSettings = projectSettings ?? throw new ArgumentNullException(nameof(projectSettings));
+            _frameworkHandle = frameworkHandle ?? throw new ArgumentNullException(nameof(frameworkHandle));
+            _runContext = runContext ?? throw new ArgumentNullException(nameof(runContext)); ;
             _app = VisualStudioProxy.FromEnvironmentVariable(PythonConstants.PythonToolsProcessIdEnvironmentVariable);
 
             GetDebugSettings(_app, _runContext, _projectSettings, out _debugMode, out _debugSecret, out _debugPort);
@@ -90,7 +90,7 @@ namespace Microsoft.PythonTools.TestAdapter.Services {
 
         }
 
-        public string[] GetArguments(IEnumerable<TestCase> tests, string coveragePath) {
+        private string[] GetArguments(IEnumerable<TestCase> tests, string coveragePath) {
             var arguments = new List<string> {
                 TestLauncherPath,
                 _projectSettings.WorkingDirectory,

--- a/Python/Product/TestAdapter.Executor/Services/ExecutorService.cs
+++ b/Python/Product/TestAdapter.Executor/Services/ExecutorService.cs
@@ -28,7 +28,6 @@ using System.Xml.XPath;
 using Microsoft.PythonTools.Analysis;
 using Microsoft.PythonTools.Infrastructure;
 using Microsoft.PythonTools.TestAdapter.Config;
-using Microsoft.PythonTools.TestAdapter.Utils;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
@@ -46,7 +45,7 @@ namespace Microsoft.PythonTools.TestAdapter.Services {
         private readonly string _debugSecret;
         private readonly int _debugPort;
         private readonly IRunContext _runContext;
-
+        private readonly ITestConfiguration _testConfig;
         /// <summary>
         /// Used to send messages to TestExplorer's Test output pane
         /// </summary>
@@ -72,7 +71,13 @@ namespace Microsoft.PythonTools.TestAdapter.Services {
             }
         }
 
-        public ExecutorService(PythonProjectSettings projectSettings, IFrameworkHandle frameworkHandle, IRunContext runContext) {
+        public ExecutorService(
+            ITestConfiguration config, 
+            PythonProjectSettings projectSettings, 
+            IFrameworkHandle frameworkHandle, 
+            IRunContext runContext
+        ) {
+            _testConfig = config;
             _projectSettings = projectSettings;
             _frameworkHandle = frameworkHandle;
             _runContext = runContext;
@@ -85,11 +90,11 @@ namespace Microsoft.PythonTools.TestAdapter.Services {
 
         }
 
-        public string[] GetArguments(IEnumerable<TestCase> tests, string outputfile, string coveragePath, PythonProjectSettings settings) {
+        public string[] GetArguments(IEnumerable<TestCase> tests, string coveragePath) {
             var arguments = new List<string> {
                 TestLauncherPath,
                 _projectSettings.WorkingDirectory,
-                "pytest",
+                _testConfig.Command,
                 _debugSecret,
                 _debugPort.ToString(),
                 GetDebuggerSearchPath(_projectSettings.UseLegacyDebugger),
@@ -97,25 +102,8 @@ namespace Microsoft.PythonTools.TestAdapter.Services {
                 coveragePath ?? string.Empty
             };
 
-            // For a small set of tests, we'll pass them on the command
-            // line. Once we exceed a certain (arbitrary) number, create
-            // a test list on disk so that we do not overflow the 
-            // 32K argument limit.
-            var testIds = tests.Select(t => t.GetPropertyValue<string>(Pytest.Constants.PytestIdProperty, default));
-            if (testIds.Count() > 5) {
-                var testListFilePath = TestUtils.CreateTestListFile(testIds);
-                arguments.Add(testListFilePath);
-            } else {
-                arguments.Add("dummyfilename"); //expected not to exist, but script excepts something
-                foreach (var testId in testIds) {
-                    arguments.Add(testId);
-                }
-            }
-
-            // output results to xml file
-            arguments.Add(String.Format("--junitxml={0}", outputfile));
-            arguments.Add(String.Format("--rootdir={0}", settings.ProjectHome));
-
+            var testAruguments = _testConfig.GetExecutionArguments(tests, _projectSettings);
+            arguments.AddRange(testAruguments);
             return arguments.ToArray();
         }
 
@@ -316,15 +304,12 @@ namespace Microsoft.PythonTools.TestAdapter.Services {
             return searchPaths;
         }
 
-        public string Run(IEnumerable<TestCase> tests, string coveragePath, ManualResetEvent cancelRequested) {
-            string ouputFile = "";
+        public void Run(IEnumerable<TestCase> tests, string coveragePath, ManualResetEvent cancelRequested) {
             try {
                 DetachFromSillyManagedProcess(_app, _debugMode);
 
                 var env = InitializeEnvironment(tests);
-                ouputFile = GetJunitXmlFile();
-                var arguments = GetArguments(tests, ouputFile, coveragePath, _projectSettings);
-
+                var arguments = GetArguments(tests, coveragePath);
                 var testRedirector = new TestRedirector(_frameworkHandle);
 
                 using (var proc = ProcessOutput.Run(
@@ -379,8 +364,6 @@ namespace Microsoft.PythonTools.TestAdapter.Services {
             } catch (Exception e) {
                 Error(e.ToString());
             }
-
-            return ouputFile;
         }
 
         internal static void AttachDebugger(VisualStudioProxy app, ProcessOutput proc, PythonDebugMode debugMode, string debugSecret, int debugPort) {
@@ -400,13 +383,6 @@ namespace Microsoft.PythonTools.TestAdapter.Services {
                 }
             }
         }
-
-        private string GetJunitXmlFile() {
-            string baseName = "junitresults_";
-            string outPath = Path.Combine(_runContext.TestRunDirectory, baseName + Guid.NewGuid().ToString() + ".xml");
-            return outPath;
-        }
-
 
         [Conditional("DEBUG")]
         private void DebugInfo(string message) {

--- a/Python/Product/TestAdapter.Executor/Services/ExecutorService.cs
+++ b/Python/Product/TestAdapter.Executor/Services/ExecutorService.cs
@@ -304,7 +304,21 @@ namespace Microsoft.PythonTools.TestAdapter.Services {
             return searchPaths;
         }
 
-        public void Run(IEnumerable<TestCase> tests, string coveragePath, ManualResetEvent cancelRequested) {
+        public void Run(IEnumerable<TestCase> tests, ManualResetEvent cancelRequested) {
+            bool codeCoverage = ExecutorService.EnableCodeCoverage(_runContext);
+            string coveragePath = null;
+            if (codeCoverage) {
+                coveragePath = ExecutorService.GetCoveragePath(tests);
+            }
+
+            RunInternal(tests, coveragePath, cancelRequested);
+
+            if (codeCoverage) {
+                ExecutorService.AttachCoverageResults(_frameworkHandle, coveragePath);
+            }
+        }
+
+        private void RunInternal(IEnumerable<TestCase> tests, string coveragePath, ManualResetEvent cancelRequested) {
             try {
                 DetachFromSillyManagedProcess(_app, _debugMode);
 
@@ -319,8 +333,8 @@ namespace Microsoft.PythonTools.TestAdapter.Services {
                     env,
                     visible: false,
                     testRedirector,
-                    quoteArgs:true,
-                    elevate:false,
+                    quoteArgs: true,
+                    elevate: false,
                     System.Text.Encoding.UTF8,
                     System.Text.Encoding.UTF8
                 )) {

--- a/Python/Product/TestAdapter.Executor/TestAdapter.Executor.csproj
+++ b/Python/Product/TestAdapter.Executor/TestAdapter.Executor.csproj
@@ -85,7 +85,9 @@
     <Compile Include="..\VSCommon\Infrastructure\VisualStudioApp.cs">
       <Link>VisualStudioApp.cs</Link>
     </Compile>
+    <Compile Include="Config\ITestConfiguration.cs" />
     <Compile Include="Pytest\Constants.cs" />
+    <Compile Include="Pytest\PytestConfiguration.cs" />
     <Compile Include="Pytest\PytestDiscoveryResults.cs" />
     <Compile Include="Config\PythonProjectSettings.cs" />
     <Compile Include="Config\RunSettingsUtil.cs" />


### PR DESCRIPTION
- Moved pytest specific  execution arguments to its own config class

Fix #5609