### PR TITLE
replacing testcontainer version number with cached timeStamp 

### DIFF
--- a/Common/Product/TestAdapter/TestContainer.cs
+++ b/Common/Product/TestAdapter/TestContainer.cs
@@ -60,9 +60,7 @@ namespace Microsoft.VisualStudioTools.TestAdapter {
             _lastWriteTime = copy._lastWriteTime;
             _cachedTime = copy._cachedTime;
         }
-
-        public int Version { get; private set; }
-
+      
         /// <summary>
         /// Project path
         /// </summary>

--- a/Common/Product/TestAdapter/TestContainer.cs
+++ b/Common/Product/TestAdapter/TestContainer.cs
@@ -23,27 +23,42 @@ using Microsoft.VisualStudio.TestWindow.Extensibility.Model;
 
 namespace Microsoft.VisualStudioTools.TestAdapter {
     internal class TestContainer : ITestContainer {
-        private readonly DateTime _timeStamp;
+        private readonly DateTime _lastWriteTime;
+        private readonly DateTime _cachedTime;
         private readonly bool _isWorkspace;
 
-        public TestContainer(ITestContainerDiscoverer discoverer, string source, string projectHome, string projectName, int version, Architecture architecture, bool isWorkspace) {
+        public TestContainer(
+            ITestContainerDiscoverer discoverer,
+            string source,
+            string projectHome,
+            string projectName,
+            Architecture architecture,
+            bool isWorkspace
+        ) {
             Discoverer = discoverer;
             Source = source; // Make sure source matches discovery new TestCase source.
-            Version = version;
             Project = projectHome;
             ProjectName = projectName;
             TargetPlatform = architecture;
-            _timeStamp = GetTimeStamp();
+            _lastWriteTime = GetLastWriteTimeStamp();
+            _cachedTime = DateTime.Now;
             _isWorkspace = isWorkspace;
         }
-        
+
         /// <summary>
         /// Copy constructor
         /// </summary>
         /// <param name="copy"></param>
-        private TestContainer(TestContainer copy)
-            : this(copy.Discoverer, copy.Source, copy.Project, copy.ProjectName, copy.Version, copy.TargetPlatform, copy._isWorkspace) {
-            _timeStamp = copy._timeStamp;
+        private TestContainer(TestContainer copy): this(
+                   copy.Discoverer,
+                   copy.Source,
+                   copy.Project,
+                   copy.ProjectName,
+                   copy.TargetPlatform,
+                   copy._isWorkspace
+        ) {
+            _lastWriteTime = copy._lastWriteTime;
+            _cachedTime = copy._cachedTime;
         }
 
         public int Version { get; private set; }
@@ -54,7 +69,7 @@ namespace Microsoft.VisualStudioTools.TestAdapter {
         public string Project { get; private set; }
 
         public string ProjectName { get; private set; }
-             
+
         public int CompareTo(ITestContainer other) {
             var container = other as TestContainer;
             if (container == null) {
@@ -69,10 +84,6 @@ namespace Microsoft.VisualStudioTools.TestAdapter {
             if (result != 0) {
                 return result;
             }
-            
-            if (Version.CompareTo(container.Version) != 0) {
-                return -1;
-            }
 
             result = String.Compare(this.Project, container.Project, StringComparison.Ordinal);
             if (result != 0) {
@@ -84,7 +95,13 @@ namespace Microsoft.VisualStudioTools.TestAdapter {
                 return result;
             }
 
-            return _timeStamp.CompareTo(container._timeStamp);
+            result = _cachedTime.CompareTo(container._cachedTime);
+            if (result != 0) {
+                return result;
+            }
+
+            result = _lastWriteTime.CompareTo(container._lastWriteTime);
+            return result;
         }
 
         public IEnumerable<Guid> DebugEngines {
@@ -123,7 +140,7 @@ namespace Microsoft.VisualStudioTools.TestAdapter {
             return Source + ":" + Discoverer.ExecutorUri.ToString();
         }
 
-        private DateTime GetTimeStamp() {
+        private DateTime GetLastWriteTimeStamp() {
             if (!String.IsNullOrEmpty(this.Source) && File.Exists(this.Source)) {
                 return File.GetLastWriteTime(this.Source);
             } else {

--- a/Python/Product/TestAdapter/Model/ProjectInfo.cs
+++ b/Python/Product/TestAdapter/Model/ProjectInfo.cs
@@ -99,32 +99,14 @@ namespace Microsoft.PythonTools.TestAdapter.Model {
             if (!Path.GetExtension(path).Equals(PythonConstants.FileExtension, StringComparison.OrdinalIgnoreCase))
                 return;
 
-            TestContainer existing;
-            if (!TryGetContainer(path, out existing)) {
-            
-                _containers[path] = new TestContainer(
-                    discoverer,
-                    path,
-                    _projectHome,
-                    ProjectName,
-                    version:0,
-                    Architecture,
-                    IsWorkspace
-                );
-            } 
-            else {
-                RemoveTestContainer(path);
-
-                _containers[path] = new TestContainer(
-                   discoverer,
-                   path,
-                   _projectHome,
-                   ProjectName,
-                   version: existing.Version + 1,
-                   Architecture,
-                   IsWorkspace
-               );
-            }
+            _containers[path] = new TestContainer(
+                discoverer,
+                path,
+                _projectHome,
+                ProjectName,
+                Architecture,
+                IsWorkspace
+            );
         }
 
         public bool RemoveTestContainer(string path) {


### PR DESCRIPTION
replacing testcontainer version number with cached timeStamp because on settings change, when we refresh, we are clearing all testContainers, so version was always being reset to 0 incorrectly.

Alternatively I could of changed refresh logic to not clear all testcontainers but I think this is simplier logic.

In the bug below what was happening on setting the pattern to test_1.py, both test_1 and test_2 were deleted and version numbers were both then rebuilt as 0 and their compare functions were returning 0 for no change, so Test Explorer thought it should keep test_2.py tests around.  But then discovery would only return tests matching test_1.py,

cannot discover the tests immediately after update the configuration in "Test" tab for unittest Fix #5734