### PR TITLE
Removing "Test container source not found" warning

### DIFF
--- a/Python/Product/Common/Strings.Designer.cs
+++ b/Python/Product/Common/Strings.Designer.cs
@@ -3087,15 +3087,6 @@ namespace Microsoft.PythonTools {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Go to https://aka.ms/VSTestExplorerPython for more details on test discovery configuration..
-        /// </summary>
-        public static string DiscoveryConfigurationMessage {
-            get {
-                return ResourceManager.GetString("DiscoveryConfigurationMessage", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Python Documentation.
         /// </summary>
         public static string DocumentationClassificationType {
@@ -3479,15 +3470,6 @@ namespace Microsoft.PythonTools {
         public static string ErrorTestCaseNotFound {
             get {
                 return ResourceManager.GetString("ErrorTestCaseNotFound", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Matching test container source was not found under folder {0} for test {1}..
-        /// </summary>
-        public static string ErrorTestContainerNotFound {
-            get {
-                return ResourceManager.GetString("ErrorTestContainerNotFound", resourceCulture);
             }
         }
         

--- a/Python/Product/Common/Strings.resx
+++ b/Python/Product/Common/Strings.resx
@@ -2956,14 +2956,6 @@ Please specify at least one package.</value>
   <data name="PythonDiscoveryResultsNotFound" xml:space="preserve">
     <value>Discovery results file '{0}' was not found.</value>
   </data>
-  <data name="ErrorTestContainerNotFound" xml:space="preserve">
-    <value>Matching test container source was not found under folder {0} for test {1}.</value>
-    <comment>{0} is the root directory
-{1} is the test info</comment>
-  </data>
-  <data name="DiscoveryConfigurationMessage" xml:space="preserve">
-    <value>Go to https://aka.ms/VSTestExplorerPython for more details on test discovery configuration.</value>
-  </data>
   <data name="ErrorTestCaseNotFound" xml:space="preserve">
     <value>Testcase not found for test result: {0}</value>
     <comment>{0} is the result xml data found</comment>

--- a/Python/Product/TestAdapter.Executor/Pytest/TestDiscovererPytest.cs
+++ b/Python/Product/TestAdapter.Executor/Pytest/TestDiscovererPytest.cs
@@ -110,7 +110,11 @@ namespace Microsoft.PythonTools.TestAdapter.Pytest {
         }
 
         internal IEnumerable<TestCase> ParseDiscoveryResults(IList<PytestDiscoveryResults> results) {
-            var testcases = results?
+            if (results is null) {
+                throw new ArgumentNullException(nameof(results));
+            }
+
+            var testcases = results
                 .Where(r => r.Tests != null)
                 .SelectMany(r => r.Tests.Select(test => TryCreateVsTestCase(test)))
                 .Where(tc => tc != null);

--- a/Python/Product/TestAdapter.Executor/Pytest/TestDiscovererPytest.cs
+++ b/Python/Product/TestAdapter.Executor/Pytest/TestDiscovererPytest.cs
@@ -98,7 +98,6 @@ namespace Microsoft.PythonTools.TestAdapter.Pytest {
             IEnumerable<PytestDiscoveryResults> discoveryResults,
             ITestCaseDiscoverySink discoverySink
         ) {
-            bool showConfigurationHint = false;
             foreach (var result in discoveryResults.MaybeEnumerate()) {
                 var parentMap = result.Parents.ToDictionary(p => p.Id, p => p);
                 foreach (PytestTest test in result.Tests) {
@@ -116,18 +115,12 @@ namespace Microsoft.PythonTools.TestAdapter.Pytest {
                                 parentMap, 
                                 _settings.ProjectHome);
                             discoverySink?.SendTestCase(tc);
-                        } else {
-                            Warn(Strings.ErrorTestContainerNotFound.FormatUI(_settings.ProjectHome, test.ToString()));
-                            showConfigurationHint = true;
                         }
+                        // Else ingore tests found in other testContainrs that haven't changed.
                     } catch (Exception ex) {
                         Error(ex.Message);
                     }
                 }
-            }
-
-            if (showConfigurationHint) {
-                LogInfo(Strings.DiscoveryConfigurationMessage);
             }
         }
 

--- a/Python/Product/TestAdapter.Executor/Pytest/TestDiscovererPytest.cs
+++ b/Python/Product/TestAdapter.Executor/Pytest/TestDiscovererPytest.cs
@@ -92,10 +92,7 @@ namespace Microsoft.PythonTools.TestAdapter.Pytest {
 
             try {
                 var results = JsonConvert.DeserializeObject<List<PytestDiscoveryResults>>(json);
-
-                var testcases = results?
-                    .SelectMany(result => result.Tests?.Select(test => TryCreateVsTestCase(test)))
-                    .Where(tc => tc != null);
+                var testcases = ParseDiscoveryResults(results);
 
                 foreach (var tc in testcases) {
                     // Note: Test Explorer will show a key not found exception if we use a source path that doesn't match a test container's source.
@@ -110,6 +107,15 @@ namespace Microsoft.PythonTools.TestAdapter.Pytest {
                 Error("Failed to parse: {0}".FormatInvariant(ex.Message));
                 Error(json);
             }
+        }
+
+        internal IEnumerable<TestCase> ParseDiscoveryResults(IList<PytestDiscoveryResults> results) {
+            var testcases = results?
+                .Where(r => r.Tests != null)
+                .SelectMany(r => r.Tests.Select(test => TryCreateVsTestCase(test)))
+                .Where(tc => tc != null);
+
+            return testcases;
         }
 
         private TestCase TryCreateVsTestCase(PytestTest test) {

--- a/Python/Product/TestAdapter.Executor/Pytest/TestDiscovererPytest.cs
+++ b/Python/Product/TestAdapter.Executor/Pytest/TestDiscovererPytest.cs
@@ -42,7 +42,16 @@ namespace Microsoft.PythonTools.TestAdapter.Pytest {
             IMessageLogger logger,
             ITestCaseDiscoverySink discoverySink
         ) {
+            if (sources is null) {
+                throw new ArgumentNullException(nameof(sources));
+            }
+
+            if (discoverySink is null) {
+                throw new ArgumentNullException(nameof(discoverySink));
+            }
+
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+
             var workspaceText = _settings.IsWorkspace ? Strings.WorkspaceText : Strings.ProjectText;
             LogInfo(Strings.PythonTestDiscovererStartedMessage.FormatUI(PythonConstants.PytestText, _settings.ProjectName, workspaceText, _settings.DiscoveryWaitTimeInSeconds));
 
@@ -83,12 +92,17 @@ namespace Microsoft.PythonTools.TestAdapter.Pytest {
 
             try {
                 var results = JsonConvert.DeserializeObject<List<PytestDiscoveryResults>>(json);
-                results?
-                    .SelectMany(result => result?.Tests?.Select(test => TryCreateVsTestCase(test)))
-                    .Where(tc => tc != null && discoverySink != null)
-                    .ToList()
-                    .ForEach(tc => discoverySink.SendTestCase(tc));
 
+                var testcases = results?
+                    .SelectMany(result => result.Tests?.Select(test => TryCreateVsTestCase(test)))
+                    .Where(tc => tc != null);
+
+                foreach (var tc in testcases) {
+                    // Note: Test Explorer will show a key not found exception if we use a source path that doesn't match a test container's source.
+                    if (_settings.TestContainerSources.TryGetValue(tc.CodeFilePath, out _)) {
+                        discoverySink.SendTestCase(tc);
+                    }
+                }
             } catch (InvalidOperationException ex) {
                 Error("Failed to parse: {0}".FormatInvariant(ex.Message));
                 Error(json);

--- a/Python/Product/TestAdapter.Executor/UnitTest/TestDiscovererUnitTest.cs
+++ b/Python/Product/TestAdapter.Executor/UnitTest/TestDiscovererUnitTest.cs
@@ -125,7 +125,11 @@ namespace Microsoft.PythonTools.TestAdapter.UnitTest {
         }
 
         internal IEnumerable<TestCase> ParseDiscoveryResults(IList<UnitTestDiscoveryResults> results) {
-            return results?
+            if (results is null) {
+                throw new ArgumentNullException(nameof(results));
+            }
+
+            return results
                 .Where(r => r.Tests != null)
                 .SelectMany(r => r.Tests.Select(test => TryCreateVsTestCase(test)))
                 .Where(tc => tc != null);

--- a/Python/Product/TestAdapter.Executor/UnitTest/TestDiscovererUnitTest.cs
+++ b/Python/Product/TestAdapter.Executor/UnitTest/TestDiscovererUnitTest.cs
@@ -107,11 +107,8 @@ namespace Microsoft.PythonTools.TestAdapter.UnitTest {
 
             try {
                 var results = JsonConvert.DeserializeObject<List<UnitTestDiscoveryResults>>(json);
+                var testcases = ParseDiscoveryResults(results);
 
-                var testcases = results?
-                    .SelectMany(result => result.Tests?.Select(test => TryCreateVsTestCase(test)))
-                    .Where(tc => tc != null);
-              
                 foreach (var tc in testcases) {
                     // Note: Test Explorer will show a key not found exception if we use a source path that doesn't match a test container's source.
                     if (_settings.TestContainerSources.TryGetValue(tc.CodeFilePath, out _)) {
@@ -125,6 +122,13 @@ namespace Microsoft.PythonTools.TestAdapter.UnitTest {
                 Error("Failed to parse: {0}".FormatInvariant(ex.Message));
                 Error(json);
             }
+        }
+
+        internal IEnumerable<TestCase> ParseDiscoveryResults(IList<UnitTestDiscoveryResults> results) {
+            return results?
+                .Where(r => r.Tests != null)
+                .SelectMany(r => r.Tests.Select(test => TryCreateVsTestCase(test)))
+                .Where(tc => tc != null);
         }
 
         private TestCase TryCreateVsTestCase(UnitTestTestCase test) {

--- a/Python/Product/TestAdapter.Executor/UnitTest/TestDiscovererUnitTest.cs
+++ b/Python/Product/TestAdapter.Executor/UnitTest/TestDiscovererUnitTest.cs
@@ -113,24 +113,17 @@ namespace Microsoft.PythonTools.TestAdapter.UnitTest {
             IEnumerable<UnitTestDiscoveryResults> unitTestResults,
             ITestCaseDiscoverySink discoverySink
         ) {
-            bool showConfigurationHint = false;
             foreach (var test in unitTestResults?.SelectMany(result => result.Tests.Select(test => test)).MaybeEnumerate()) {
                 try {
                     // Note: Test Explorer will show a key not found exception if we use a source path that doesn't match a test container's source.
                     if (_settings.TestContainerSources.TryGetValue(test.Source, out _)) {
                         TestCase tc = test.ToVsTestCase(_settings.ProjectHome);
                         discoverySink?.SendTestCase(tc);
-                    } else {
-                        Warn(Strings.ErrorTestContainerNotFound.FormatUI(_settings.ProjectHome, test.ToString()));
-                        showConfigurationHint = true;
-                    }
+                    } 
+                    // Else ignore tests from testContainers not in our list
                 } catch (Exception ex) {
                     Error(ex.Message);
                 }
-            }
-
-            if (showConfigurationHint) {
-                LogInfo(Strings.DiscoveryConfigurationMessage);
             }
         }
 

--- a/Python/Tests/TestAdapterTests/TestAdapterTests.csproj
+++ b/Python/Tests/TestAdapterTests/TestAdapterTests.csproj
@@ -67,6 +67,7 @@
     <Compile Include="Mocks\MockTestCaseDiscoverySink.cs" />
     <Compile Include="Mocks\MockTestExecutionRecorder.cs" />
     <Compile Include="ExecutorServiceTests.cs" />
+    <Compile Include="TestDiscovererParseTests.cs" />
     <Compile Include="TestInfo.cs" />
     <Compile Include="TestDiscovererTests.cs" />
     <Compile Include="TestEnvironment.cs" />

--- a/Python/Tests/TestAdapterTests/TestDiscovererParseTests.cs
+++ b/Python/Tests/TestAdapterTests/TestDiscovererParseTests.cs
@@ -1,0 +1,89 @@
+﻿// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.PythonTools.TestAdapter.Config;
+using Microsoft.PythonTools.TestAdapter.Pytest;
+using Microsoft.PythonTools.TestAdapter.UnitTest;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace TestAdapterTests {
+    [TestClass]
+    public class TestDiscovererParseTests {
+
+        static PythonProjectSettings CreateMockSettings(string projectDir) {
+            return new PythonProjectSettings(
+                projectName: string.Empty,
+                projectHome: projectDir,
+                workingDir: string.Empty,
+            interpreter: string.Empty,
+            pathEnv: string.Empty,
+            nativeDebugging: false,
+            isWorkspace: false,
+            useLegacyDebugger: false,
+            testFramework: string.Empty,
+            unitTestPattern: string.Empty,
+            unitTestRootDir: string.Empty,
+            discoveryWaitTimeInSeconds: string.Empty);
+        }
+
+        [TestMethod]
+        public void PytestShouldHandleEmptyListResults() {
+            var settings = CreateMockSettings(projectDir:"dummypath");
+            var discoverer = new TestDiscovererPytest(settings);
+
+            var results = new List<PytestDiscoveryResults>();
+            var testcases = discoverer.ParseDiscoveryResults(results);
+
+            Assert.IsFalse(testcases.Any());
+        }
+
+        [TestMethod]
+        public void PytestShouldHandleEmptyResults() {
+            var settings = CreateMockSettings(projectDir: "dummypath");
+            var discoverer = new TestDiscovererPytest(settings);
+
+            var results = new List<PytestDiscoveryResults>() { new PytestDiscoveryResults() };
+            var testcases = discoverer.ParseDiscoveryResults(results);
+
+            Assert.IsFalse(testcases.Any());
+        }
+
+
+        [TestMethod]
+        public void UnittestShouldHandleEmptyListResults() {
+            var settings = CreateMockSettings(projectDir: "dummypath");
+            var discoverer = new TestDiscovererUnitTest(settings);
+
+            var results = new List<UnitTestDiscoveryResults>();
+            var testcases = discoverer.ParseDiscoveryResults(results);
+
+            Assert.IsFalse(testcases.Any());
+        }
+
+        [TestMethod]
+        public void UnittestShouldHandleEmptyResults() {
+            var settings = CreateMockSettings(projectDir: "dummypath");
+            var discoverer = new TestDiscovererUnitTest(settings);
+
+            var results = new List<UnitTestDiscoveryResults>() { new UnitTestDiscoveryResults() };
+            var testcases = discoverer.ParseDiscoveryResults(results);
+
+            Assert.IsFalse(testcases.Any());
+        }
+    }
+}

--- a/Python/Tests/TestAdapterTests/TestDiscovererParseTests.cs
+++ b/Python/Tests/TestAdapterTests/TestDiscovererParseTests.cs
@@ -14,6 +14,7 @@
 // See the Apache Version 2.0 License for specific language governing
 // permissions and limitations under the License.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.PythonTools.TestAdapter.Config;
@@ -30,15 +31,27 @@ namespace TestAdapterTests {
                 projectName: string.Empty,
                 projectHome: projectDir,
                 workingDir: string.Empty,
-            interpreter: string.Empty,
-            pathEnv: string.Empty,
-            nativeDebugging: false,
-            isWorkspace: false,
-            useLegacyDebugger: false,
-            testFramework: string.Empty,
-            unitTestPattern: string.Empty,
-            unitTestRootDir: string.Empty,
-            discoveryWaitTimeInSeconds: string.Empty);
+                interpreter: string.Empty,
+                pathEnv: string.Empty,
+                nativeDebugging: false,
+                isWorkspace: false,
+                useLegacyDebugger: false,
+                testFramework: string.Empty,
+                unitTestPattern: string.Empty,
+                unitTestRootDir: string.Empty,
+                discoveryWaitTimeInSeconds: string.Empty
+            );
+        }
+
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void PytestShouldThrowNullResults() {
+            var settings = CreateMockSettings(projectDir: "dummypath");
+            var discoverer = new TestDiscovererPytest(settings);
+            
+            var testcases = discoverer.ParseDiscoveryResults(null);
+            testcases.Any();
         }
 
         [TestMethod]
@@ -63,6 +76,16 @@ namespace TestAdapterTests {
             Assert.IsFalse(testcases.Any());
         }
 
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void UnnitShouldThrowNullResults() {
+            var settings = CreateMockSettings(projectDir: "dummypath");
+            var discoverer = new TestDiscovererUnitTest(settings);
+
+            var testcases = discoverer.ParseDiscoveryResults(null);
+            testcases.Any();
+        }
 
         [TestMethod]
         public void UnittestShouldHandleEmptyListResults() {


### PR DESCRIPTION
- Now that Test Explorer is no longer sending our discovery task a list of all sources, our logic around warning the user when tests are found in files not in the project is not valid.

- I spoke with Eric about incremental pytest, limiting discovery to just the source files that changed, but I still dont think its a good idea, because users can specify filename patterns in their pytest.ini and then when we pass files in to pytest as arguments they bypass those settings.

Fix #5743