### PR TITLE
fix TestExplorer displays wrong duration with pytest

### DIFF
--- a/Python/Product/TestAdapter.Executor/Pytest/JunitXmlTestResultParser.cs
+++ b/Python/Product/TestAdapter.Executor/Pytest/JunitXmlTestResultParser.cs
@@ -16,6 +16,7 @@
 using System;
 using System.IO;
 using System.Text;
+using System.Threading;
 using System.Xml;
 using System.Xml.XPath;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
@@ -88,9 +89,11 @@ namespace Microsoft.PythonTools.TestAdapter.Pytest {
 
             result.Outcome = TestOutcome.Passed;
 
-            var timeStr = navNode.GetAttribute("time", "");
-            if (Double.TryParse(timeStr, out Double time)) {
+            try {
+                var timeStr = navNode.GetAttribute("time", "");
+                var time = Double.Parse(timeStr, Thread.CurrentThread.CurrentCulture.NumberFormat);
                 result.Duration = TimeSpan.FromSeconds(time);
+            } catch (FormatException) {
             }
 
             if (navNode.HasChildren) {

--- a/Python/Product/TestAdapter.Executor/Pytest/JunitXmlTestResultParser.cs
+++ b/Python/Product/TestAdapter.Executor/Pytest/JunitXmlTestResultParser.cs
@@ -14,9 +14,9 @@
 // See the Apache Version 2.0 License for specific language governing
 // permissions and limitations under the License.
 using System;
+using System.Globalization;
 using System.IO;
 using System.Text;
-using System.Threading;
 using System.Xml;
 using System.Xml.XPath;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
@@ -91,7 +91,7 @@ namespace Microsoft.PythonTools.TestAdapter.Pytest {
 
             try {
                 var timeStr = navNode.GetAttribute("time", "");
-                var time = Double.Parse(timeStr, Thread.CurrentThread.CurrentCulture.NumberFormat);
+                var time = Double.Parse(timeStr, CultureInfo.InvariantCulture);
                 result.Duration = TimeSpan.FromSeconds(time);
             } catch (FormatException) {
             }

--- a/Python/Tests/TestAdapterTests/JunitXmlTestResultParserTests.cs
+++ b/Python/Tests/TestAdapterTests/JunitXmlTestResultParserTests.cs
@@ -209,7 +209,7 @@ namespace TestAdapterTests {
         }
 
         [TestMethod]
-        public void PytestHandlesDurationWithPeriod() {
+        public void PytestHandlesCultureDurationWithPeriod() {
             var test = @"<testcase classname=""test_failures"" file=""test_failures.py"" line=""8"" name=""test_ok"" time=""1.000""></testcase>";
             var xmlResults = string.Format(_junitXmlResultsFormat, test);
             
@@ -217,21 +217,21 @@ namespace TestAdapterTests {
             Thread.CurrentThread.CurrentCulture = new CultureInfo("de-DE");
             TestResult result = ParseXmlTestUtil(xmlResults);
             
-            Assert.AreEqual(TimeSpan.FromSeconds(1000), result.Duration);
+            Assert.AreEqual(TimeSpan.FromSeconds(1), result.Duration);
 
             Thread.CurrentThread.CurrentCulture = currentCulture;
         }
 
         [TestMethod]
-        public void PytestHandlesDurationWithComma() {
-            var test = @"<testcase classname=""test_failures"" file=""test_failures.py"" line=""8"" name=""test_ok"" time=""1,00""></testcase>";
+        public void PytestHandlesCultureDurationThousand() {
+            var test = @"<testcase classname=""test_failures"" file=""test_failures.py"" line=""8"" name=""test_ok"" time=""1000""></testcase>";
             var xmlResults = string.Format(_junitXmlResultsFormat, test);
 
             var currentCulture = Thread.CurrentThread.CurrentCulture;
             Thread.CurrentThread.CurrentCulture = new CultureInfo("de-DE");
             TestResult result = ParseXmlTestUtil(xmlResults);
 
-            Assert.AreEqual(TimeSpan.FromSeconds(1), result.Duration);
+            Assert.AreEqual(TimeSpan.FromSeconds(1000), result.Duration);
 
             Thread.CurrentThread.CurrentCulture = currentCulture;
         }


### PR DESCRIPTION
- German locales use commas for decimal points and period for thousand makers
- added testing around german locale

fix #5753