### PR TITLE
TestExplorer displays extra child nodes for pytest parameter sets con…

### DIFF
--- a/Python/Product/TestAdapter.Executor/Pytest/PytestExtensions.cs
+++ b/Python/Product/TestAdapter.Executor/Pytest/PytestExtensions.cs
@@ -64,13 +64,13 @@ namespace Microsoft.PythonTools.TestAdapter.Pytest {
             var pytestId = CreateProperCasedPytestId(sourceFullPath, projectHome, test.Id);
             var fullyQualifiedName = CreateFullyQualifiedTestNameFromId(sourceFullPath, pytestId);
             var tc = new TestCase(fullyQualifiedName, PythonConstants.PytestExecutorUri, sourceFullPath) {
-                DisplayName = test.Name,
+                DisplayName = FixupParameterSets(test.Name),
                 LineNumber = line,
                 CodeFilePath = sourceFullPath
             };
 
             tc.SetPropertyValue(Constants.PytestIdProperty, pytestId);
-          
+
             foreach (var marker in test.Markers.MaybeEnumerate()) {
                 tc.Traits.Add(new Trait(marker.ToString(), String.Empty));
             }
@@ -91,7 +91,6 @@ namespace Microsoft.PythonTools.TestAdapter.Pytest {
             idParts[0] = ".\\" + PathUtils.CreateFriendlyFilePath(projectHome, source);
             return String.Join("::", idParts);
         }
-
 
         /// <summary>
         /// Creates a classname that matches the junit testresult generated one so that we can match testresults with testcases
@@ -126,7 +125,26 @@ namespace Microsoft.PythonTools.TestAdapter.Pytest {
                 var className = Path.GetFileNameWithoutExtension(parts[0]);
                 return $"{parts[0]}::{className}::{parts[1]}";
             }
-            return fullyQualifiedName;
+            return FixupParameterSets(fullyQualifiedName);
+        }
+
+        /// <summary>
+        /// Replaces any period  after '[' with '_'
+        /// We override pytest's id generator to replace any string containing "." to replace it with "_"
+        /// but non string values like floats can still contain "." in the parameter list.
+        /// Test Explorer's parsing code will create extra child nodes if it finds a ".", which we dont want
+        /// </summary>
+        /// <param name="funcName"></param>
+        /// <returns></returns>
+        internal static string FixupParameterSets(string funcName) {
+            if (!String.IsNullOrEmpty(funcName)) {
+                int paramStart = funcName.IndexOf('[');
+                if (paramStart != -1) {
+                    var paramStr = funcName.Substring(paramStart);
+                    return funcName.Replace(paramStr, paramStr.Replace(".", "_"));
+                }
+            }
+            return funcName;
         }
 
         /// <summary>

--- a/Python/Product/TestAdapter.Executor/Pytest/PytestExtensions.cs
+++ b/Python/Product/TestAdapter.Executor/Pytest/PytestExtensions.cs
@@ -123,7 +123,7 @@ namespace Microsoft.PythonTools.TestAdapter.Pytest {
             // so test explorer doesn't use .py as the classname
             if (parts.Length == 2) {
                 var className = Path.GetFileNameWithoutExtension(parts[0]);
-                return $"{parts[0]}::{className}::{parts[1]}";
+                fullyQualifiedName = $"{parts[0]}::{className}::{parts[1]}";
             }
             return FixupParameterSets(fullyQualifiedName);
         }

--- a/Python/Tests/TestAdapterTests/TestExecutorTests.cs
+++ b/Python/Tests/TestAdapterTests/TestExecutorTests.cs
@@ -218,7 +218,7 @@ if __name__ == '__main__':
             }
 
             Assert.IsTrue(discoverySink.Tests.Any());
-            Assert.AreEqual(discoverySink.Tests.Count(), 21);
+            Assert.AreEqual(23, discoverySink.Tests.Count());
 
             var testCases = discoverySink.Tests;
             var runContext = new MockRunContext(runSettings, testCases, testEnv.ResultsFolderPath);
@@ -227,7 +227,8 @@ if __name__ == '__main__':
             executor.RunTests(testCases, runContext, recorder);
 
             PrintTestResults(recorder);
-
+            
+            Assert.IsFalse(recorder.Results.Any(tr => tr.TestCase.DisplayName.Contains(".")));
             Assert.IsFalse(recorder.Results.Any(tr => tr.Outcome != TestOutcome.Passed));
         }
 

--- a/Python/Tests/TestAdapterTests/TestExecutorTests.cs
+++ b/Python/Tests/TestAdapterTests/TestExecutorTests.cs
@@ -227,7 +227,12 @@ if __name__ == '__main__':
             executor.RunTests(testCases, runContext, recorder);
 
             PrintTestResults(recorder);
-            
+
+            // Check FQN parameter set doesn't contain "."
+            Assert.IsFalse(recorder.Results
+                .Select(tr => tr.TestCase.FullyQualifiedName)
+                .Where(fqn => fqn.IndexOf('[') != -1)
+                .Any(fqn => fqn.Substring(fqn.IndexOf('[')).Contains(".")));
             Assert.IsFalse(recorder.Results.Any(tr => tr.TestCase.DisplayName.Contains(".")));
             Assert.IsFalse(recorder.Results.Any(tr => tr.Outcome != TestOutcome.Passed));
         }

--- a/Python/Tests/TestData/TestDiscoverer/Parameterized/test_Parameters.py
+++ b/Python/Tests/TestData/TestDiscoverer/Parameterized/test_Parameters.py
@@ -78,6 +78,8 @@ def test_eval(test_input, expected):
         ("\\", "\\"),
         ("\n \n", "\n \n"),
         (":", ":"),
+        ("3.0", "3.0"),
+        (3.0, 3.0),
         (  """
            .. figure:: foo.jpg
 


### PR DESCRIPTION
…taining floats Fix #5658

Previously we added an override to pytest's id generation to fix strings with "." and replace it with "_" in parameter set defintions.

This fix is for floats/doubles in parameter sets, but now we fix the displaystring and FullyQualifiedName we give test explorer, because they split on "."