### PR TITLE
Python Projects losing Search Paths on reload

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Project/PythonProjectNode.cs
+++ b/Python/Product/PythonTools/PythonTools/Project/PythonProjectNode.cs
@@ -961,11 +961,11 @@ namespace Microsoft.PythonTools.Project {
                 _searchPaths.GetAbsolutePersistedSearchPaths();
         }
 
-        internal void OnInvalidateSearchPath(string absolutePath, object moniker) {
+        internal void OnUpdateSearchPath(string absolutePath, object moniker) {
             if (string.IsNullOrEmpty(absolutePath)) {
                 // Clear all paths associated with this moniker
                 _searchPaths.RemoveByMoniker(moniker);
-            } else if (!_searchPaths.AddOrReplace(moniker, absolutePath, false)) {
+            } else if (!_searchPaths.AddOrReplace(moniker, absolutePath, true)) {
                 // Didn't change a search path, so we need to trigger reanalysis
                 // manually.
                 UpdateAnalyzerSearchPaths();

--- a/Python/Product/PythonTools/PythonTools/Project/PythonProjectReferenceNode.cs
+++ b/Python/Product/PythonTools/PythonTools/Project/PythonProjectReferenceNode.cs
@@ -72,7 +72,7 @@ namespace Microsoft.PythonTools.Project {
                 searchPath = await GetOutputPathAsync();
             }
 
-            (ProjectMgr as PythonProjectNode)?.OnInvalidateSearchPath(searchPath, this);
+            (ProjectMgr as PythonProjectNode)?.OnUpdateSearchPath(searchPath, this);
         }
 
         private async Task<string> GetOutputPathAsync(int retries = 10) {
@@ -120,7 +120,7 @@ namespace Microsoft.PythonTools.Project {
 
         public override bool Remove(bool removeFromStorage) {
             if (base.Remove(removeFromStorage)) {
-                (ProjectMgr as PythonProjectNode)?.OnInvalidateSearchPath(null, this);
+                (ProjectMgr as PythonProjectNode)?.OnUpdateSearchPath(null, this);
                 return true;
             }
             return false;


### PR DESCRIPTION
 fix #5768 
- Adding a project reference was calling SearchPathManger.AddorReplace with isPeristed set to false
- normal right click add a serach path flow uses SearchPathManger.Add with persited set to true.

Setting  isPeristed to true will cause SearchPathManger.SavePathsToString to add the path to the list of saved setting values.

Note: removing a project reference still removes the search path.