### PR TITLE
Revert "Python Projects losing Search Paths on reload fix #5768 (#5781)"

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Project/PythonProjectNode.cs
+++ b/Python/Product/PythonTools/PythonTools/Project/PythonProjectNode.cs
@@ -961,11 +961,11 @@ namespace Microsoft.PythonTools.Project {
                 _searchPaths.GetAbsolutePersistedSearchPaths();
         }
 
-        internal void OnUpdateSearchPath(string absolutePath, object moniker) {
+        internal void OnInvalidateSearchPath(string absolutePath, object moniker) {
             if (string.IsNullOrEmpty(absolutePath)) {
                 // Clear all paths associated with this moniker
                 _searchPaths.RemoveByMoniker(moniker);
-            } else if (!_searchPaths.AddOrReplace(moniker, absolutePath, true)) {
+            } else if (!_searchPaths.AddOrReplace(moniker, absolutePath, false)) {
                 // Didn't change a search path, so we need to trigger reanalysis
                 // manually.
                 UpdateAnalyzerSearchPaths();

--- a/Python/Product/PythonTools/PythonTools/Project/PythonProjectReferenceNode.cs
+++ b/Python/Product/PythonTools/PythonTools/Project/PythonProjectReferenceNode.cs
@@ -72,7 +72,7 @@ namespace Microsoft.PythonTools.Project {
                 searchPath = await GetOutputPathAsync();
             }
 
-            (ProjectMgr as PythonProjectNode)?.OnUpdateSearchPath(searchPath, this);
+            (ProjectMgr as PythonProjectNode)?.OnInvalidateSearchPath(searchPath, this);
         }
 
         private async Task<string> GetOutputPathAsync(int retries = 10) {
@@ -120,7 +120,7 @@ namespace Microsoft.PythonTools.Project {
 
         public override bool Remove(bool removeFromStorage) {
             if (base.Remove(removeFromStorage)) {
-                (ProjectMgr as PythonProjectNode)?.OnUpdateSearchPath(null, this);
+                (ProjectMgr as PythonProjectNode)?.OnInvalidateSearchPath(null, this);
                 return true;
             }
             return false;


### PR DESCRIPTION
This reverts commit f4243e09b47884bede88aada587dfc158eafe330.


there would be issues with c++ references being saved because they contain debug/release folders in the path.