### PR TITLE
Fix for an exception related to the collection changing while we are …

### DIFF
--- a/Python/Product/TestAdapter/TestContainerDiscovererProject.cs
+++ b/Python/Product/TestAdapter/TestContainerDiscovererProject.cs
@@ -153,11 +153,14 @@ namespace Microsoft.PythonTools.TestAdapter {
             _testFilesUpdateWatcher.FileChangedEvent += OnProjectItemChanged;
             oldTestFilesUpdateWatcher?.Dispose();
 
-            var solution = (IVsSolution)_serviceProvider.GetService(typeof(SVsSolution));
-
-            // add all source files
-            foreach (var project in VsProjectExtensions.EnumerateLoadedProjects(solution)) {
-                LoadProject(project);
+            try {
+                // add all source files
+                var solution = (IVsSolution)_serviceProvider.GetService(typeof(SVsSolution));
+                foreach (var project in VsProjectExtensions.EnumerateLoadedProjects(solution)) {
+                    LoadProject(project);
+                }
+            } catch (Exception ex) when (!ex.IsCriticalException()) {
+                Trace.WriteLine("Exception : " + ex.Message);
             }
 
             _setupComplete = true;
@@ -238,9 +241,9 @@ namespace Microsoft.PythonTools.TestAdapter {
             _packageManagerEventSink.WatchPackageManagers(pyProj.GetInterpreterFactory());
 
             var projInfo = new ProjectInfo(pyProj);
-            _projectMap[projInfo.ProjectHome] = projInfo;
             var files = FilteredTestOrSettingsFiles(vsProject);
             UpdateContainersAndListeners(files, projInfo, isAdd: true);
+            _projectMap[projInfo.ProjectHome] = projInfo;
             return files.Any();
         }
 

--- a/Python/Tests/TestAdapterTests/Mocks/MockPythonProject.cs
+++ b/Python/Tests/TestAdapterTests/Mocks/MockPythonProject.cs
@@ -1,0 +1,67 @@
+﻿
+// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.PythonTools.Interpreter;
+using Microsoft.PythonTools.Projects;
+
+namespace TestAdapterTests.Mocks {
+    public class MockPythonProject : PythonProject {
+        public MockPythonProject(string projectHome, string projectName) {
+            ProjectHome = projectHome;
+            ProjectName = projectName;
+        }
+
+        [Obsolete]
+        public override ProjectAnalyzer Analyzer => throw new NotImplementedException();
+
+        public override string ProjectHome { get; }
+
+        public override string ProjectName { get; }
+
+#pragma warning disable 67
+        public override event EventHandler ProjectAnalyzerChanged;
+        public override event EventHandler<PythonProjectPropertyChangedArgs> ProjectPropertyChanged;
+        public override event EventHandler ActiveInterpreterChanged;
+#pragma warning restore  67
+
+        public override Task<ProjectAnalyzer> GetAnalyzerAsync() {
+            throw new NotImplementedException();
+        }
+
+        public override IPythonInterpreterFactory GetInterpreterFactory() {
+            throw new NotImplementedException();
+        }
+
+        public override LaunchConfiguration GetLaunchConfigurationOrThrow() {
+            throw new NotImplementedException();
+        }
+
+        public override string GetProperty(string name) {
+            throw new NotImplementedException();
+        }
+
+        public override string GetUnevaluatedProperty(string name) {
+            throw new NotImplementedException();
+        }
+
+        public override void SetProperty(string name, string value) {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/Python/Tests/TestAdapterTests/ProjectInfoTests.cs
+++ b/Python/Tests/TestAdapterTests/ProjectInfoTests.cs
@@ -31,7 +31,7 @@ namespace TestAdapterTests {
     public class ProjectInfoTests {
         /// <summary>
         /// Recreate collection was modified while iterating exception
-        ///  System.InvalidOperationException: Collection was modified; enumeration operation may not execute.
+        /// System.InvalidOperationException: Collection was modified; enumeration operation may not execute.
         /// Test shouldn't throw
         /// </summary>
         /// <returns></returns>
@@ -45,22 +45,22 @@ namespace TestAdapterTests {
             //Simualte rebuid workspace
             projectMap[projectName] = new ProjectInfo(dumpyProject);
 
-            var rebuildTasks = Enumerable.Range(1, 100)
+            var rebuildTasks = Enumerable.Range(1, 10)
                 .Select(i => Task.Run(async
                     () => {
                         projectMap.Clear();
-                        var project = new ProjectInfo(dumpyProject);
-                        foreach (int j in Enumerable.Range(1, 10000)) {
-                            project.AddTestContainer(dummyDiscoverer, j.ToString() + ".py");
+                        projectMap[projectName] = new ProjectInfo(dumpyProject);
+                        foreach (int j in Enumerable.Range(1, 1000)) {
+                            projectMap[projectName].AddTestContainer(dummyDiscoverer, j.ToString() + ".py");
                         }
-                        projectMap[projectName] = project;
+                        
                         await Task.Delay(100);
                     }
                 )
             );
 
             //Simulate Get TestContainers
-            var iterateTasks = Enumerable.Range(1, 1000)
+            var iterateTasks = Enumerable.Range(1, 100)
                 .Select(i => Task.Run(async
                     () => {
                         var items = projectMap.Values.SelectMany(p => p.GetAllContainers()).ToList();
@@ -70,6 +70,8 @@ namespace TestAdapterTests {
             );
 
             await Task.WhenAll(rebuildTasks.Concat(iterateTasks));
+
+            Assert.AreEqual(1000, projectMap[projectName].GetAllContainers().Count());
         }
     }
 }

--- a/Python/Tests/TestAdapterTests/ProjectInfoTests.cs
+++ b/Python/Tests/TestAdapterTests/ProjectInfoTests.cs
@@ -40,16 +40,16 @@ namespace TestAdapterTests {
             ITestContainerDiscoverer dummyDiscoverer = null;
             var projectMap = new ConcurrentDictionary<string, ProjectInfo>();
             var projectName = "dummyName";
-            PythonProject dumpyProject = new MockPythonProject("dummyHome", projectName);
+            PythonProject dummyProject = new MockPythonProject("dummyHome", projectName);
 
-            //Simualte rebuid workspace
-            projectMap[projectName] = new ProjectInfo(dumpyProject);
+            //Simulate rebuid workspace
+            projectMap[projectName] = new ProjectInfo(dummyProject);
 
             var rebuildTasks = Enumerable.Range(1, 10)
                 .Select(i => Task.Run(async
                     () => {
                         projectMap.Clear();
-                        projectMap[projectName] = new ProjectInfo(dumpyProject);
+                        projectMap[projectName] = new ProjectInfo(dummyProject);
                         foreach (int j in Enumerable.Range(1, 1000)) {
                             projectMap[projectName].AddTestContainer(dummyDiscoverer, j.ToString() + ".py");
                         }

--- a/Python/Tests/TestAdapterTests/ProjectInfoTests.cs
+++ b/Python/Tests/TestAdapterTests/ProjectInfoTests.cs
@@ -1,0 +1,72 @@
+﻿// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.PythonTools.Projects;
+using Microsoft.PythonTools.TestAdapter;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.VisualStudio.TestWindow.Extensibility;
+using TestAdapterTests.Mocks;
+
+namespace TestAdapterTests {
+    [TestClass]
+    public class ProjectInfoTests {
+        /// <summary>
+        /// Recreate collection was modified while iterating exception
+        /// Test shouldn't throw
+        /// </summary>
+        /// <returns></returns>
+        [TestMethod, Priority(0)]
+        public async Task TestBuildingAndClearingProjectMapConcurrently() {
+            ITestContainerDiscoverer dummyDiscoverer = null;
+            var projectMap = new ConcurrentDictionary<string, ProjectInfo>();
+            var projectName = "dummyName";
+            PythonProject dumpyProject = new MockPythonProject("dummyHome", projectName);
+
+            projectMap[projectName] = new ProjectInfo(dumpyProject);
+
+            var rebuildTasks = Enumerable.Range(1, 100)
+                .Select(i => Task.Run(async
+                    () => {
+                        projectMap.Clear();
+                        var project = new ProjectInfo(dumpyProject);
+                        foreach (int j in Enumerable.Range(1, 10000)) {
+                            project.AddTestContainer(dummyDiscoverer, j.ToString() + ".py");
+                        }
+                        projectMap[projectName] = project;
+                        await Task.Delay(100);
+                    }
+                )
+            );
+
+            var iterateTasks = Enumerable.Range(1, 1000)
+                .Select(i => Task.Run(async
+                    () => {
+                        var items = projectMap.Values.SelectMany(p => p.GetAllContainers()).ToList();
+                        await Task.Delay(10);
+                    }
+                )
+            );
+
+            await Task.WhenAll(rebuildTasks.Concat(iterateTasks));
+        }
+    }
+}

--- a/Python/Tests/TestAdapterTests/ProjectInfoTests.cs
+++ b/Python/Tests/TestAdapterTests/ProjectInfoTests.cs
@@ -31,6 +31,7 @@ namespace TestAdapterTests {
     public class ProjectInfoTests {
         /// <summary>
         /// Recreate collection was modified while iterating exception
+        ///  System.InvalidOperationException: Collection was modified; enumeration operation may not execute.
         /// Test shouldn't throw
         /// </summary>
         /// <returns></returns>
@@ -41,6 +42,7 @@ namespace TestAdapterTests {
             var projectName = "dummyName";
             PythonProject dumpyProject = new MockPythonProject("dummyHome", projectName);
 
+            //Simualte rebuid workspace
             projectMap[projectName] = new ProjectInfo(dumpyProject);
 
             var rebuildTasks = Enumerable.Range(1, 100)
@@ -57,6 +59,7 @@ namespace TestAdapterTests {
                 )
             );
 
+            //Simulate Get TestContainers
             var iterateTasks = Enumerable.Range(1, 1000)
                 .Select(i => Task.Run(async
                     () => {

--- a/Python/Tests/TestAdapterTests/TestAdapterTests.csproj
+++ b/Python/Tests/TestAdapterTests/TestAdapterTests.csproj
@@ -59,6 +59,7 @@
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Mocks\MockPythonProject.cs" />
     <Compile Include="Mocks\MockRunContext.cs" />
     <Compile Include="Mocks\MockMessageLogger.cs" />
     <Compile Include="Mocks\MockDiscoveryContext.cs" />
@@ -67,6 +68,7 @@
     <Compile Include="Mocks\MockTestCaseDiscoverySink.cs" />
     <Compile Include="Mocks\MockTestExecutionRecorder.cs" />
     <Compile Include="CodeCoverageTests.cs" />
+    <Compile Include="ProjectInfoTests.cs" />
     <Compile Include="TestDiscovererParseTests.cs" />
     <Compile Include="TestInfo.cs" />
     <Compile Include="TestDiscovererTests.cs" />
@@ -97,6 +99,10 @@
     <ProjectReference Include="..\..\..\Common\Tests\Utilities\TestUtilities.csproj">
       <Project>{d092d54e-ff29-4d32-9aee-4ef704c92f67}</Project>
       <Name>TestUtilities</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\Product\VSInterpreters\VSInterpreters.csproj">
+      <Project>{815db0cd-c0dd-4997-b43c-abee4dbeffe7}</Project>
+      <Name>VSInterpreters</Name>
     </ProjectReference>
     <ProjectReference Include="..\Utilities.Python.Analysis\TestUtilities.Python.Analysis.csproj">
       <Project>{A731C4C3-3741-4080-A946-C47574C1F3BF}</Project>


### PR DESCRIPTION
…iterating over testcontainers

System.InvalidOperationException: Collection was modified; enumeration operation may not execute.


Steps to repro.
1. Opening ptvsd in openfolder mode
2.  install/uninstall pytest multiple times
3. Test discovery eventually fails to trigger on pacakge update, due to exception in
_projectMap.Values.SelectMany(x => x.GetAllContainers());

This is fixed by updating the dictionary of testcontianers in ProjectInfo to be a concurrent dictionary.
- delay adding the new project's testcontainers into the projectMap until we are finished building it.
- new test that creates the exception when projectInfo used a regular dictionary

Installing/uninstalling a package should trigger test discovery Fix #5520