### PR TITLE
Info bar fix for cross thread call warning

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Project/CondaEnvCreateInfoBar.cs
+++ b/Python/Product/PythonTools/PythonTools/Project/CondaEnvCreateInfoBar.cs
@@ -18,7 +18,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Threading.Tasks;
 using Microsoft.PythonTools.Environments;
 using Microsoft.PythonTools.Infrastructure;
 using Microsoft.PythonTools.Interpreter;
@@ -119,6 +118,8 @@ namespace Microsoft.PythonTools.Project {
         private PythonProjectNode Project { get; }
 
         public override async Task CheckAsync() {
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
             if (IsCreated || IsGloballySuppressed) {
                 return;
             }
@@ -179,6 +180,8 @@ namespace Microsoft.PythonTools.Project {
         private IPythonWorkspaceContext Workspace { get; }
 
         public override async Task CheckAsync() {
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
             if (IsCreated || IsGloballySuppressed) {
                 return;
             }

--- a/Python/Product/PythonTools/PythonTools/Project/ConfigureTestFrameworkInfoBar.cs
+++ b/Python/Product/PythonTools/PythonTools/Project/ConfigureTestFrameworkInfoBar.cs
@@ -18,7 +18,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.PythonTools.Infrastructure;
@@ -256,6 +255,8 @@ namespace Microsoft.PythonTools.Project {
         }
 
         public override async Task CheckAsync() {
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
             var infoBarData = new TestFrameworkInfoBarData {
                 InterpreterOptionsService = Site.GetPythonToolsService().InterpreterOptionsService,
                 InterpreterFactory = Project.ActiveInterpreter,
@@ -297,6 +298,8 @@ namespace Microsoft.PythonTools.Project {
         }
 
         public override async Task CheckAsync() {
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
             var infoBarData = new TestFrameworkInfoBarData {
                 InterpreterOptionsService = Site.GetPythonToolsService().InterpreterOptionsService,
                 InterpreterFactory = WorkspaceContext.CurrentFactory,

--- a/Python/Product/PythonTools/PythonTools/Project/PackageInstallInfoBar.cs
+++ b/Python/Product/PythonTools/PythonTools/Project/PackageInstallInfoBar.cs
@@ -42,7 +42,7 @@ namespace Microsoft.PythonTools.Project {
         protected IPackageManager PackageManager { get; set; }
 
         protected bool IsGloballySuppressed =>
-            !Site.GetPythonToolsService().GeneralOptions.PromptForPackageInstallation;
+          !Site.GetPythonToolsService().GeneralOptions.PromptForPackageInstallation;
 
         protected abstract void Suppress();
 
@@ -119,6 +119,8 @@ namespace Microsoft.PythonTools.Project {
         private PythonProjectNode Project { get; }
 
         public override async Task CheckAsync() {
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
             if (IsCreated || IsGloballySuppressed) {
                 return;
             }

--- a/Python/Product/PythonTools/PythonTools/Project/PythonInfoBar.cs
+++ b/Python/Product/PythonTools/PythonTools/Project/PythonInfoBar.cs
@@ -16,8 +16,6 @@
 
 using System;
 using System.Diagnostics;
-using Microsoft.PythonTools.Infrastructure;
-using Microsoft.PythonTools.Interpreter;
 using Microsoft.PythonTools.Logging;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Shell;

--- a/Python/Product/PythonTools/PythonTools/Project/VirtualEnvCreateInfoBar.cs
+++ b/Python/Product/PythonTools/PythonTools/Project/VirtualEnvCreateInfoBar.cs
@@ -39,7 +39,7 @@ namespace Microsoft.PythonTools.Project {
         protected string Context { get; set; }
 
         protected bool IsGloballySuppressed =>
-            !Site.GetPythonToolsService().GeneralOptions.PromptForEnvCreate;
+          !Site.GetPythonToolsService().GeneralOptions.PromptForEnvCreate;
 
         protected abstract void ShowAddEnvironmentDialog();
 
@@ -102,10 +102,12 @@ namespace Microsoft.PythonTools.Project {
         private PythonProjectNode Project { get; }
 
         public override async Task CheckAsync() {
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
             if (IsCreated || IsGloballySuppressed) {
                 return;
             }
-
+        
             RequirementsTxtPath = Project.GetRequirementsTxtPath();
             Caption = Project.Caption;
             Context = InfoBarContexts.Project;
@@ -150,6 +152,8 @@ namespace Microsoft.PythonTools.Project {
         private IPythonWorkspaceContext Workspace { get; }
 
         public override async Task CheckAsync() {
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
             if (IsCreated || IsGloballySuppressed) {
                 return;
             }


### PR DESCRIPTION
- Moved the call to get the pythontoolssevice into the constructor of the base class so that is occurs on the mainthread

Invalid cross-thread call when opening workspace Fx #5617