### PR TITLE
Package manager stops working after closing project Fix #5795

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Project/InterpretersNode.cs
+++ b/Python/Product/PythonTools/PythonTools/Project/InterpretersNode.cs
@@ -108,8 +108,6 @@ namespace Microsoft.PythonTools.Project {
             if (!_disposed) {
                 if (_packageManager != null) {
                     _packageManager.InstalledPackagesChanged -= InstalledPackagesChanged;
-                    _packageManager.DisableNotifications();
-                    (_packageManager as IDisposable)?.Dispose();
                 }
             }
             _disposed = true;

--- a/Python/Product/PythonTools/PythonTools/Project/PythonProjectNode.cs
+++ b/Python/Product/PythonTools/PythonTools/Project/PythonProjectNode.cs
@@ -241,7 +241,6 @@ namespace Microsoft.PythonTools.Project {
                 _activePackageManagers = null;
 
                 foreach (var pm in oldPms.MaybeEnumerate()) {
-                    pm.DisableNotifications();
                     pm.InstalledFilesChanged -= PackageManager_InstalledFilesChanged;
                 }
 
@@ -1098,7 +1097,6 @@ namespace Microsoft.PythonTools.Project {
                 _reanalyzeProjectNotification.Dispose();
 
                 foreach (var pm in _activePackageManagers.MaybeEnumerate()) {
-                    pm.DisableNotifications();
                     pm.InstalledFilesChanged -= PackageManager_InstalledFilesChanged;
                 }
 


### PR DESCRIPTION
- Now that we share packageManagers we can't call disablenotifications or dispose on it from the project scrope because we dont know if others are relying on it.