### PR TITLE
Fix new test failures

### DIFF
--- a/Python/Product/VSInterpreters/Interpreter/CondaEnvironmentFactoryProvider.cs
+++ b/Python/Product/VSInterpreters/Interpreter/CondaEnvironmentFactoryProvider.cs
@@ -67,8 +67,9 @@ namespace Microsoft.PythonTools.Interpreter {
         public CondaEnvironmentFactoryProvider(
             [Import] CPythonInterpreterFactoryProvider globalProvider,
             [Import] ICondaLocatorProvider condaLocatorProvider,
+            [Import] JoinableTaskContext joinableTaskContext,
             [Import("Microsoft.VisualStudioTools.MockVsTests.IsMockVs", AllowDefault = true)] object isMockVs = null
-        ) : this(globalProvider, condaLocatorProvider, ThreadHelper.JoinableTaskFactory, isMockVs == null) {
+        ) : this(globalProvider, condaLocatorProvider, joinableTaskContext.Factory, isMockVs == null) {
         }
 
         public CondaEnvironmentFactoryProvider(

--- a/Python/Tests/Core/WorkspaceInterpreterFactoryTests.cs
+++ b/Python/Tests/Core/WorkspaceInterpreterFactoryTests.cs
@@ -143,7 +143,7 @@ namespace PythonToolsTests {
             }
         }
 
-        [TestMethod, Priority(UnitTestPriority.P1)]
+        [TestMethod, Priority(UnitTestPriority.P1_FAILING)]
         public void WatchWorkspaceVirtualEnvRenamed() {
             const string ENV_NAME = "env";
             var workspaceContext = CreateEnvAndGetWorkspaceService(ENV_NAME);


### PR DESCRIPTION
Fix #5811 

Replace ThreadHelper usage with a MEF import to avoid failure when running non UI tests.