### PR TITLE
Accessibility fix: Hide unused textblocks in Environments Window

### DIFF
--- a/Python/Product/EnvironmentsList/FileNameLabel.xaml
+++ b/Python/Product/EnvironmentsList/FileNameLabel.xaml
@@ -38,7 +38,7 @@
                             <ColumnDefinition Width="auto" />
                         </Grid.ColumnDefinitions>
 
-                        <TextBlock Grid.Column="0" 
+                        <TextBlock Grid.Column="0"
                                    Text="{Binding Mode=OneWay,Converter={StaticResource FileNameEllipsisHead}}" />
                         <TextBlock Grid.Column="1"
                                    Text="{Binding Mode=OneWay,Converter={StaticResource FileNameEllipsisBody}}"

--- a/Python/Product/EnvironmentsList/FileNameLabel.xaml
+++ b/Python/Product/EnvironmentsList/FileNameLabel.xaml
@@ -12,6 +12,13 @@
                             <local:FileNameEllipsisConverter IncludeHead="True" x:Key="FileNameEllipsisHead" />
                             <local:FileNameEllipsisConverter IncludeBody="True" x:Key="FileNameEllipsisBody" />
                             <local:FileNameEllipsisConverter IncludeTail="True" x:Key="FileNameEllipsisTail" />
+                            <Style TargetType="TextBlock">
+                                <Style.Triggers>
+                                    <Trigger Property="Text" Value="">
+                                        <Setter Property="Visibility" Value="Collapsed" />
+                                    </Trigger>
+                                </Style.Triggers>
+                            </Style>
                         </Grid.Resources>
 
                         <Grid.ColumnDefinitions>
@@ -31,7 +38,7 @@
                             <ColumnDefinition Width="auto" />
                         </Grid.ColumnDefinitions>
 
-                        <TextBlock Grid.Column="0"
+                        <TextBlock Grid.Column="0" 
                                    Text="{Binding Mode=OneWay,Converter={StaticResource FileNameEllipsisHead}}" />
                         <TextBlock Grid.Column="1"
                                    Text="{Binding Mode=OneWay,Converter={StaticResource FileNameEllipsisBody}}"


### PR DESCRIPTION

Text like "Visit the distributor's website" used 3 textblocks with 2 of them having width 0 but still being rendered. Now the style trigger will set empty textblocks to visibility collapsed

Fix #5864