### PR TITLE
Change accelerator key from 'p' to 'u' for launch profiling menu item

### DIFF
--- a/Python/Product/Profiling/PythonProfiling.vsct
+++ b/Python/Product/Profiling/PythonProfiling.vsct
@@ -92,7 +92,7 @@
       <Button guid="guidPythonProfilingCmdSet" id="cmdidStartPythonProfiling" priority="0x0100" type="Button">
         <Parent guid="guidPythonToolsCmdSet" id="PythonMenu"/>
         <Strings>
-          <ButtonText>Launch &amp;Python Profiling...</ButtonText>
+          <ButtonText>La&amp;unch Python Profiling...</ButtonText>
           <CanonicalName>Launch Profiling</CanonicalName>
           <LocCanonicalName>Launch Profiling</LocCanonicalName>
         </Strings>


### PR DESCRIPTION
…to avoid conflict with attach to process menu item. The conflict was introduced when we moved the command from the analyze menu to the debug menu.

I checked that no other debug menu item used 'u' as its accelerator.

fix #5806 
