### PR TITLE
Fix crash on unrecognized/unsupported python versions

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Debugger/DebugLaunchHelper.cs
+++ b/Python/Product/PythonTools/PythonTools/Debugger/DebugLaunchHelper.cs
@@ -153,7 +153,7 @@ namespace Microsoft.PythonTools.Debugger {
         }
 
         public static unsafe DebugTargetInfo CreateDebugTargetInfo(IServiceProvider provider, LaunchConfiguration config) {
-            if (config.Interpreter.Version < new Version(2, 6)) {
+            if (config.Interpreter.Version < new Version(2, 6) && config.Interpreter.Version > new Version(0, 0)) {
                 // We don't support Python 2.5 now that our debugger needs the json module
                 throw new NotSupportedException(Strings.DebuggerPythonVersionNotSupported);
             }

--- a/Python/Product/VSInterpreters/Interpreter/WorkspaceInterpreterFactoryProvider.cs
+++ b/Python/Product/VSInterpreters/Interpreter/WorkspaceInterpreterFactoryProvider.cs
@@ -21,6 +21,7 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using Microsoft.PythonTools.Infrastructure;
+using Microsoft.PythonTools.Parsing;
 
 namespace Microsoft.PythonTools.Interpreter {
     /// <summary>
@@ -302,6 +303,12 @@ namespace Microsoft.PythonTools.Interpreter {
 
             var arch = CPythonInterpreterFactoryProvider.ArchitectureFromExe(interpreterPath);
             var version = CPythonInterpreterFactoryProvider.VersionFromSysVersionInfo(interpreterPath);
+
+            try {
+                version.ToLanguageVersion();
+            } catch (InvalidOperationException) {
+                version = new Version(0, 0);
+            }
 
             var name = Path.GetFileName(prefixPath);
             var description = name;


### PR DESCRIPTION
Fix #5809 Unhandled exception in WorkspaceInterpreterFactoryProvider

Mark unrecognized versions of Python as 0.0 in workspace factory provider, like it is done by the registry factory provider (PythonRegistrySearch.cs). This avoids crashes later, for code that tries to convert interpreter version to Python language version.

Also allow debugging on unrecognized version ie 0.0.