### PR TITLE
Handle reset repl + changing repl environment

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Editor/PythonTextBufferInfo.cs
+++ b/Python/Product/PythonTools/PythonTools/Editor/PythonTextBufferInfo.cs
@@ -18,30 +18,17 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO;
 using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.Python.Parsing;
 using Microsoft.PythonTools.Infrastructure;
-using Microsoft.PythonTools.Intellisense;
 using Microsoft.PythonTools.LanguageServerClient;
-using Microsoft.PythonTools.Projects;
-using Microsoft.PythonTools.Repl;
-using Microsoft.VisualStudio.InteractiveWindow;
-using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Text;
-using Microsoft.VisualStudio.Text.Differencing;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Utilities;
-using Microsoft.VisualStudioTools;
 
 namespace Microsoft.PythonTools.Editor {
     internal sealed class PythonTextBufferInfo {
         private static readonly object PythonTextBufferInfoKey = new { Id = "PythonTextBufferInfo" };
-
-        private static readonly object _testFilename = new { Name = "TestFilename" };
-        private static readonly object _testDocumentUri = new { Name = "DocumentUri" };
 
         public static PythonTextBufferInfo ForBuffer(IServiceProvider site, ITextBuffer buffer) {
             var bi = (buffer ?? throw new ArgumentNullException(nameof(buffer))).Properties.GetOrCreateSingletonProperty(
@@ -76,7 +63,6 @@ namespace Microsoft.PythonTools.Editor {
             var bi = TryGetForBuffer(buffer);
             if (bi != null) {
                 bi._replace = true;
-                bi.TraceWithStack("MarkForReplacement");
             }
         }
 
@@ -88,32 +74,19 @@ namespace Microsoft.PythonTools.Editor {
 
         private readonly object _lock = new object();
 
-        // LSC
-        //private AnalysisEntry _analysisEntry;
-        //private TaskCompletionSource<AnalysisEntry> _waitingForEntry;
-
         private readonly ConcurrentDictionary<object, IPythonTextBufferInfoEventSink> _eventSinks;
 
-        private readonly Lazy<string> _filename;
-        private readonly Lazy<Uri> _documentUri;
         private readonly TokenCache _tokenCache;
-        // LSC
-        //private readonly LocationTracker _locationTracker;
 
         private readonly bool _hasChangedOnBackground;
         private bool _replace;
 
         internal PythonLanguageVersion _defaultLanguageVersion;
 
-        // LSC
-        //private readonly AnalysisLogWriter _traceLog;
-
         private PythonTextBufferInfo(IServiceProvider site, ITextBuffer buffer) {
             Site = site;
             Buffer = buffer;
             _eventSinks = new ConcurrentDictionary<object, IPythonTextBufferInfoEventSink>();
-            _filename = new Lazy<string>(GetOrCreateFilename);
-            _documentUri = new Lazy<Uri>(GetOrCreateDocumentUri);
             _tokenCache = new TokenCache();
             _defaultLanguageVersion = PythonLanguageVersion.None;
 
@@ -130,16 +103,9 @@ namespace Microsoft.PythonTools.Editor {
                 _hasChangedOnBackground = true;
                 buffer2.ChangedOnBackground += Buffer_TextContentChangedOnBackground;
             }
-
-            // LSC
-            //_locationTracker = new LocationTracker(Buffer.CurrentSnapshot);
-
-            //_traceLog = OpenTraceLog();
         }
 
         private PythonTextBufferInfo ReplaceBufferInfo() {
-            TraceWithStack("ReplaceBufferInfo");
-
             var newInfo = new PythonTextBufferInfo(Site, Buffer);
             foreach (var sink in _eventSinks) {
                 newInfo._eventSinks[sink.Key] = sink.Value;
@@ -155,73 +121,15 @@ namespace Microsoft.PythonTools.Editor {
                 buffer2.ChangedOnBackground -= Buffer_TextContentChangedOnBackground;
             }
 
-            // LSC
-            //Interlocked.Exchange(ref _waitingForEntry, null)?.TrySetResult(null);
-
             InvokeSinks(new PythonNewTextBufferInfoEventArgs(PythonTextBufferInfoEvents.NewTextBufferInfo, newInfo));
-
-            //_traceLog?.Dispose();
 
             return newInfo;
         }
-
-        private string GetOrCreateFilename() {
-            string path;
-            if (Buffer.Properties.TryGetProperty(_testFilename, out path)) {
-                return path;
-            }
-
-            var replEval = Buffer.GetInteractiveWindow()?.Evaluator as IPythonInteractiveIntellisense;
-            var docUri = replEval?.DocumentUri;
-            if (docUri != null && docUri.IsFile) {
-                return docUri.LocalPath;
-            }
-
-            if (Buffer.GetInteractiveWindow() != null) {
-                return null;
-            }
-
-            if (Buffer.Properties.TryGetProperty(typeof(ITextDocument), out ITextDocument doc) &&
-                !string.IsNullOrEmpty(path = doc.FilePath)) {
-                return PathUtils.NormalizePath(path);
-            }
-
-            return null;
-        }
-
-        private Uri GetOrCreateDocumentUri() {
-            if (Buffer.Properties.TryGetProperty(_testDocumentUri, out Uri uri)) {
-                return uri;
-            }
-
-            var path = Filename;
-            if (!string.IsNullOrEmpty(path)) {
-                try {
-                    if (Path.IsPathRooted(path)) {
-                        return new Uri(path);
-                    }
-                    // Make an opaque identifier for this file
-                    var ub = new UriBuilder("python://", Guid.NewGuid().ToString("N")) { Path = path };
-                    return ub.Uri;
-                } catch (ArgumentException ex) {
-                    Debug.Fail("{0} is not a valid path.{1}{2}".FormatInvariant(path, Environment.NewLine, ex.ToUnhandledExceptionMessage(GetType())));
-                } catch (UriFormatException ex) {
-                    Debug.Fail("{0} is not a valid URI.{1}{2}".FormatInvariant(path, Environment.NewLine, ex.ToUnhandledExceptionMessage(GetType())));
-                }
-                return null;
-            }
-
-            var replEval = Buffer.GetInteractiveWindow()?.Evaluator as IPythonInteractiveIntellisense;
-            return replEval?.NextDocumentUri();
-        }
-
 
         public ITextBuffer Buffer { get; }
         public ITextDocument Document { get; }
         public ITextSnapshot CurrentSnapshot => Buffer.CurrentSnapshot;
         public IContentType ContentType => Buffer.ContentType;
-        public string Filename => _filename.Value;
-        public Uri DocumentUri => _documentUri.Value;
 
         public IServiceProvider Site { get; }
 
@@ -234,25 +142,7 @@ namespace Microsoft.PythonTools.Editor {
 
         #region Events
 
-        // LSC
-        //private void OnNewAnalysisEntry(AnalysisEntry entry) {
-        //    Trace("OnNewAnalysisEntry", entry?.Analyzer);
-        //    ClearTokenCache();
-        //    InvokeSinks(new PythonTextBufferInfoEventArgs(PythonTextBufferInfoEvents.NewAnalysisEntry, entry));
-        //}
-
-        //private void AnalysisEntry_ParseComplete(object sender, EventArgs e) {
-        //    Trace("ParseComplete");
-        //    InvokeSinks(new PythonTextBufferInfoEventArgs(PythonTextBufferInfoEvents.NewParseTree, (AnalysisEntry)sender));
-        //}
-
-        //private void AnalysisEntry_AnalysisComplete(object sender, EventArgs e) {
-        //    Trace("AnalysisComplete");
-        //    InvokeSinks(new PythonTextBufferInfoEventArgs(PythonTextBufferInfoEvents.NewAnalysis, (AnalysisEntry)sender));
-        //}
-
         private void Buffer_TextContentChanged(object sender, TextContentChangedEventArgs e) {
-            Trace("TextContentChanged");
             if (!_hasChangedOnBackground) {
                 UpdateTokenCache(e);
             }
@@ -263,12 +153,10 @@ namespace Microsoft.PythonTools.Editor {
         }
 
         private void Buffer_TextContentChangedLowPriority(object sender, TextContentChangedEventArgs e) {
-            Trace("TextContentChangedLowPriority");
             InvokeSinks(new PythonTextBufferInfoNestedEventArgs(PythonTextBufferInfoEvents.TextContentChangedLowPriority, e));
         }
 
         private void Buffer_ContentTypeChanged(object sender, ContentTypeChangedEventArgs e) {
-            Trace("ContentTypeChanged", e.BeforeContentType, e.AfterContentType);
             ClearTokenCache();
             InvokeSinks(new PythonTextBufferInfoNestedEventArgs(PythonTextBufferInfoEvents.ContentTypeChanged, e));
         }
@@ -283,7 +171,6 @@ namespace Microsoft.PythonTools.Editor {
         }
 
         private void Document_EncodingChanged(object sender, EncodingChangedEventArgs e) {
-            Trace("EncodingChanged", e.OldEncoding, e.NewEncoding);
             InvokeSinks(new PythonTextBufferInfoNestedEventArgs(PythonTextBufferInfoEvents.DocumentEncodingChanged, e));
         }
 
@@ -297,20 +184,16 @@ namespace Microsoft.PythonTools.Editor {
                     throw new InvalidOperationException("cannot replace existing sink");
                 }
             }
-            TraceWithStack("AddSink", key, sink.GetType().FullName);
         }
 
         public T GetOrCreateSink<T>(object key, Func<PythonTextBufferInfo, T> creator) where T : class, IPythonTextBufferInfoEventSink {
             IPythonTextBufferInfoEventSink sink;
             if (_eventSinks.TryGetValue(key, out sink)) {
-                Trace("GetOrCreateSink", typeof(T).FullName, "get", sink.GetType().FullName);
                 return sink as T;
             }
             sink = creator(this);
-            TraceWithStack("GetOrCreateSink", typeof(T).FullName, "create", sink.GetType().FullName);
             if (!_eventSinks.TryAdd(key, sink)) {
                 sink = _eventSinks[key];
-                Trace("GetOrCreateSink", typeof(T).FullName, "lost create race", sink.GetType().FullName);
             }
             return sink as T;
         }
@@ -321,7 +204,6 @@ namespace Microsoft.PythonTools.Editor {
         }
 
         public bool RemoveSink(object key) {
-            Trace("RemoveSink", key, _eventSinks.ContainsKey(key));
             return _eventSinks.TryRemove(key, out _);
         }
 
@@ -334,171 +216,6 @@ namespace Microsoft.PythonTools.Editor {
         }
 
         #endregion
-
-        #region Analysis Info
-
-        // LSC
-        //public AnalysisEntry AnalysisEntry {
-        //    get {
-        //        var entry = Volatile.Read(ref _analysisEntry);
-        //        if (entry != null && (entry.Analyzer == null || !entry.Analyzer.IsActive)) {
-        //            // Analyzer has closed, so clear it out from our info.
-        //            TraceWithStack("AnalyzerExpired", entry.Analyzer);
-        //            var previous = TrySetAnalysisEntry(null, entry);
-        //            if (previous != entry) {
-        //                // The entry has already been updated, so return the new one
-        //                return previous;
-        //            }
-        //            InvokeSinks(new PythonTextBufferInfoEventArgs(PythonTextBufferInfoEvents.AnalyzerExpired));
-        //            return null;
-        //        }
-        //        return entry;
-        //    }
-        //}
-
-        ///// <summary>
-        ///// Returns the current analysis entry if it is not null. Otherwise
-        ///// waits for a non-null entry to be set and returns it. If cancelled,
-        ///// return null.
-        ///// </summary>
-        //public Task<AnalysisEntry> GetAnalysisEntryAsync(CancellationToken cancellationToken) {
-        //    var entry = AnalysisEntry;
-        //    if (entry != null) {
-        //        Trace("GetAnalysisEntryAsync", "completed synchronously");
-        //        return Task.FromResult(entry);
-        //    }
-        //    TraceWithStack("GetAnalysisEntryAsync", "waiting");
-        //    var tcs = Volatile.Read(ref _waitingForEntry);
-        //    if (tcs != null) {
-        //        return tcs.Task;
-        //    }
-        //    tcs = new TaskCompletionSource<AnalysisEntry>();
-        //    tcs = Interlocked.CompareExchange(ref _waitingForEntry, tcs, null) ?? tcs;
-        //    entry = AnalysisEntry;
-        //    if (entry != null) {
-        //        tcs.TrySetResult(entry);
-        //    } else if (cancellationToken.CanBeCanceled) {
-        //        cancellationToken.Register(() => tcs.TrySetResult(null));
-        //    }
-        //    return tcs.Task;
-        //}
-
-        ///// <summary>
-        ///// Changes the analysis entry to <paramref name="entry"/> if the current
-        ///// entry matches <paramref name="ifCurrent"/>. Returns the current analysis
-        ///// entry, regardless of whether it changed or not.
-        ///// </summary>
-        //public AnalysisEntry TrySetAnalysisEntry(AnalysisEntry entry, AnalysisEntry ifCurrent) {
-        //    var previous = Interlocked.CompareExchange(ref _analysisEntry, entry, ifCurrent);
-
-        //    if (previous != ifCurrent) {
-        //        TraceWithStack("FailedToSetAnalysisEntry", previous?.Analyzer, entry?.Analyzer, ifCurrent?.Analyzer);
-        //        return previous;
-        //    }
-
-        //    if (previous != null) {
-        //        previous.AnalysisComplete -= AnalysisEntry_AnalysisComplete;
-        //        previous.ParseComplete -= AnalysisEntry_ParseComplete;
-        //        previous.Analyzer.BufferDetached(previous, Buffer);
-        //    }
-        //    if (entry != null) {
-        //        entry.AnalysisComplete += AnalysisEntry_AnalysisComplete;
-        //        entry.ParseComplete += AnalysisEntry_ParseComplete;
-
-        //        Interlocked.Exchange(ref _waitingForEntry, null)?.TrySetResult(entry);
-        //    }
-
-        //    TraceWithStack("TrySetAnalysisEntry", entry?.Analyzer, ifCurrent?.Analyzer);
-        //    OnNewAnalysisEntry(entry);
-
-        //    return entry;
-        //}
-
-        //public void ClearAnalysisEntry() {
-        //    var previous = Interlocked.Exchange(ref _analysisEntry, null);
-        //    TraceWithStack("ClearAnalysisEntry", previous?.Analyzer);
-
-        //    if (previous != null) {
-        //        previous.AnalysisComplete -= AnalysisEntry_AnalysisComplete;
-        //        previous.ParseComplete -= AnalysisEntry_ParseComplete;
-        //        previous.Analyzer.BufferDetached(previous, Buffer);
-
-        //        OnNewAnalysisEntry(null);
-        //    }
-        //}
-
-        //private readonly SortedDictionary<int, ITextSnapshot> _expectParse = new SortedDictionary<int, ITextSnapshot>();
-        //private readonly SortedDictionary<int, ITextSnapshot> _expectAnalysis = new SortedDictionary<int, ITextSnapshot>();
-        //private ITextSnapshot _lastSentSnapshot;
-
-        //public ITextSnapshot LastAnalysisSnapshot { get; private set; }
-
-        //public ITextSnapshot LastSentSnapshot {
-        //    get {
-        //        lock (_lock) {
-        //            return _lastSentSnapshot;
-        //        }
-        //    }
-        //}
-
-        //public void ClearSentSnapshot() {
-        //    lock (_lock) {
-        //        _lastSentSnapshot = null;
-        //        _expectAnalysis.Clear();
-        //        _expectParse.Clear();
-        //    }
-        //}
-
-        //public ITextSnapshot AddSentSnapshot(ITextSnapshot sent) {
-        //    lock (_lock) {
-        //        var prevSent = _lastSentSnapshot;
-        //        Trace("AddSentSnapshot", prevSent?.Version?.VersionNumber, sent?.Version?.VersionNumber);
-        //        if (prevSent != null && prevSent.Version.VersionNumber > sent.Version.VersionNumber) {
-        //            return prevSent;
-        //        }
-        //        _lastSentSnapshot = sent;
-        //        _expectAnalysis[sent.Version.VersionNumber] = sent;
-        //        _expectParse[sent.Version.VersionNumber] = sent;
-        //        return prevSent;
-        //    }
-        //}
-
-        //public bool UpdateLastReceivedParse(int version) {
-        //    lock (_lock) {
-        //        Trace("UpdateLastReceivedParse", version, _expectParse.ContainsKey(version) ? "expected" : "unexpected");
-        //        var toRemove = _expectParse.Keys.TakeWhile(k => k < version).ToArray();
-        //        foreach (var i in toRemove) {
-        //            Debug.WriteLine($"Skipped parse for version {i}");
-        //            Trace("SkipParse", i);
-        //            _expectParse.Remove(i);
-        //        }
-        //        return _expectParse.Remove(version);
-        //    }
-        //}
-
-        //public bool UpdateLastReceivedAnalysis(int version) {
-        //    lock (_lock) {
-        //        Trace("UpdateLastReceivedAnalysis", version, _expectAnalysis.ContainsKey(version) ? "expected" : "unexpected");
-
-        //        var toRemove = _expectAnalysis.Keys.TakeWhile(k => k < version).ToArray();
-        //        foreach (var i in toRemove) {
-        //            Debug.WriteLine($"Skipped analysis for version {i}");
-        //            Trace("SkipAnalysis", i);
-        //            _expectAnalysis.Remove(i);
-        //        }
-        //        if (_expectAnalysis.TryGetValue(version, out var snapshot)) {
-        //            _expectAnalysis.Remove(version);
-        //            if (snapshot.Version.VersionNumber > (LastAnalysisSnapshot?.Version.VersionNumber ?? -1)) {
-        //                LastAnalysisSnapshot = snapshot;
-        //                _locationTracker.UpdateBaseSnapshot(snapshot);
-        //                return true;
-        //            }
-        //        }
-        //        return false;
-        //    }
-        //}
-
-        //public LocationTracker LocationTracker => _locationTracker;
 
         /// <summary>
         /// Returns the first token containing or adjacent to the specified point.
@@ -595,32 +312,8 @@ namespace Microsoft.PythonTools.Editor {
             }
         }
 
-        // LSC
-        //public bool DoNotParse {
-        //    get => Buffer.Properties.ContainsProperty(BufferParser.DoNotParse);
-        //    set {
-        //        if (value) {
-        //            Buffer.Properties[BufferParser.DoNotParse] = BufferParser.DoNotParse;
-        //        } else {
-        //            Buffer.Properties.RemoveProperty(BufferParser.DoNotParse);
-        //        }
-        //    }
-        //}
-
-        //public bool ParseImmediately {
-        //    get => Buffer.Properties.ContainsProperty(BufferParser.ParseImmediately);
-        //    set {
-        //        if (value) {
-        //            Buffer.Properties[BufferParser.ParseImmediately] = BufferParser.ParseImmediately;
-        //        } else {
-        //            Buffer.Properties.RemoveProperty(BufferParser.ParseImmediately);
-        //        }
-        //    }
-        //}
-
-        #endregion
-
         #region Token Cache Management
+
         private Lazy<Tokenizer> GetTokenizerLazy()
             => new Lazy<Tokenizer>(() => new Tokenizer(LanguageVersion, options: TokenizerOptions.Verbatim | TokenizerOptions.VerbatimCommentsAndLineJoins));
 
@@ -642,219 +335,7 @@ namespace Microsoft.PythonTools.Editor {
             // Prevent later updates overwriting our tokenization
             _tokenCache.Update(e, GetTokenizerLazy());
         }
-        #endregion
-
-        #region Diagnostic Tracing
-
-        // LSC
-        //private static readonly Lazy<bool> _shouldUseTraceLog = new Lazy<bool>(GetShouldUseTraceLog);
-        //private static bool GetShouldUseTraceLog() {
-        //    using (var root = Win32.Registry.CurrentUser.OpenSubKey(PythonCoreConstants.LoggingRegistrySubkey, false)) {
-        //        var value = root?.GetValue("BufferInfo", null);
-        //        int? asInt = value as int?;
-        //        if (asInt.HasValue) {
-        //            if (asInt.GetValueOrDefault() == 0) {
-        //                // REG_DWORD but 0 means no logging
-        //                return false;
-        //            }
-        //        } else if (string.IsNullOrEmpty(value as string)) {
-        //            // Empty string or no value means no logging
-        //            return false;
-        //        }
-        //    }
-        //    return true;
-        //}
-
-        //private AnalysisLogWriter OpenTraceLog() {
-        //    if (!_shouldUseTraceLog.Value) {
-        //        return null;
-        //    }
-        //    return new AnalysisLogWriter(
-        //        PathUtils.GetAvailableFilename(Path.GetTempPath(), "PythonTools_Buffer_{0}_{1:yyyyMMddHHmmss}".FormatInvariant(PathUtils.GetFileOrDirectoryName(_filename.Value), DateTime.Now), ".log"),
-        //        false,
-        //        false,
-        //        cacheSize: 1
-        //    );
-        //}
-
-        private void Trace(string eventName, params object[] args) {
-            //_traceLog?.Log(eventName, args);
-        }
-
-        private void TraceWithStack(string eventName, params object[] args) {
-            //if (_traceLog != null) {
-            //    var stack = new StackTrace(1, true).ToString().Replace("\r\n", "").Replace("\n", "");
-            //    _traceLog.Log(eventName, args.Concat(Enumerable.Repeat(stack, 1)).ToArray());
-            //    _traceLog.Flush();
-            //}
-        }
 
         #endregion
-    }
-
-    static class PythonTextBufferInfoExtensions {
-        public static PythonTextBufferInfo TryGetInfo(this ITextBuffer buffer) => PythonTextBufferInfo.TryGetForBuffer(buffer);
-
-        // LSC
-        //public static AnalysisEntry TryGetAnalysisEntry(this ITextBuffer buffer) => PythonTextBufferInfo.TryGetForBuffer(buffer)?.AnalysisEntry;
-
-        //public static Task<AnalysisEntry> GetAnalysisEntryAsync(this ITextBuffer buffer, PythonEditorServices services = null, CancellationToken cancellationToken = default(CancellationToken)) {
-        //    var bi = services == null ? PythonTextBufferInfo.TryGetForBuffer(buffer) : services.GetBufferInfo(buffer);
-        //    if (bi != null) {
-        //        return bi.GetAnalysisEntryAsync(cancellationToken);
-        //    }
-        //    return Task.FromResult<AnalysisEntry>(null);
-        //}
-
-        //public static AnalysisEntry TryGetAnalysisEntry(this ITextView view, IServiceProvider site) {
-        //    var entry = view.TextBuffer.TryGetAnalysisEntry();
-        //    if (entry != null) {
-        //        return entry;
-        //    }
-
-        //    var diffViewer = site.GetComponentModel().GetService<IWpfDifferenceViewerFactoryService>();
-        //    var viewer = diffViewer?.TryGetViewerForTextView(view);
-        //    if (viewer != null) {
-        //        entry = viewer.DifferenceBuffer.RightBuffer.TryGetAnalysisEntry() ??
-        //            viewer.DifferenceBuffer.LeftBuffer.TryGetAnalysisEntry();
-        //        if (entry != null) {
-        //            return entry;
-        //        }
-        //    }
-
-        //    return null;
-        //}
-
-        //public static async Task<ProjectAnalyzer> FindAnalyzerAsync(this IServiceProvider site, ITextView view) {
-        //    ProjectAnalyzer analyzer;
-
-        //    var bi = view.TextBuffer.TryGetInfo();
-        //    if (bi != null && (analyzer = await FindAnalyzerAsync(site, bi)) != null) {
-        //        return analyzer;
-        //    }
-
-        //    site.MustBeCalledFromUIThread();
-        //    var diffViewer = site.GetComponentModel().GetService<IWpfDifferenceViewerFactoryService>();
-        //    var viewer = diffViewer?.TryGetViewerForTextView(view);
-        //    if (viewer != null) {
-        //        bi = viewer.DifferenceBuffer.RightBuffer.TryGetInfo();
-        //        if (bi != null && (analyzer = await FindAnalyzerAsync(site, bi)) != null) {
-        //            return analyzer;
-        //        }
-        //        bi = viewer.DifferenceBuffer.LeftBuffer.TryGetInfo();
-        //        if (bi != null && (analyzer = await FindAnalyzerAsync(site, bi)) != null) {
-        //            return analyzer;
-        //        }
-        //    }
-
-        //    return null;
-        //}
-
-        //public static async Task<ProjectAnalyzer> FindAnalyzerAsync(this IServiceProvider site, PythonTextBufferInfo buffer) {
-        //    ProjectAnalyzer analyzer;
-
-        //    // If we have an analyzer in Properties, we will use that
-        //    // NOTE: This should only be used for tests.
-        //    if (buffer.Buffer.Properties.TryGetProperty(VsProjectAnalyzer._testAnalyzer, out analyzer)) {
-        //        return analyzer;
-        //    }
-
-        //    // If we have a REPL evaluator we'll use its analyzer
-        //    if (buffer.Buffer.GetInteractiveWindow()?.Evaluator is IPythonInteractiveIntellisense evaluator) {
-        //        return await evaluator.GetAnalyzerAsync();
-        //    }
-
-        //    // If the file is associated with a project, use its analyzer
-        //    analyzer = await site.GetUIThread().InvokeTask(() => {
-        //        var p = site.GetProjectFromFile(buffer.Filename);
-        //        if (p != null) {
-        //            return p.GetAnalyzerAsync();
-        //        }
-        //        return Task.FromResult<VsProjectAnalyzer>(null);
-        //    });
-        //    if (analyzer != null) {
-        //        return analyzer;
-        //    }
-
-        //    var workspaceAnalysis = site.GetComponentModel().GetService<WorkspaceAnalysis>();
-        //    analyzer = await workspaceAnalysis.GetAnalyzerAsync();
-        //    if (analyzer != null) {
-        //        return analyzer;
-        //    }
-
-        //    return null;
-        //}
-
-        //public static async Task<ProjectAnalyzer> FindAnalyzerAsync(this IServiceProvider site, string filename) {
-        //    return (await FindAllAnalyzersForFile(site, filename, true)).FirstOrDefault() ??
-        //        (await site.GetPythonToolsService().GetSharedAnalyzerAsync());
-        //}
-
-        //public static Task<IReadOnlyList<ProjectAnalyzer>> FindAllAnalyzersForFile(this IServiceProvider site, string filename) {
-        //    return FindAllAnalyzersForFile(site, filename, false);
-        //}
-
-        //private static async Task<IReadOnlyList<ProjectAnalyzer>> FindAllAnalyzersForFile(this IServiceProvider site, string filename, bool firstOnly) {
-        //    if (string.IsNullOrEmpty(filename)) {
-        //        throw new ArgumentNullException(nameof(filename));
-        //    }
-
-        //    var found = new HashSet<ProjectAnalyzer>();
-
-        //    // If we have an open document, return that
-        //    var buffer = site.GetTextBufferFromOpenFile(filename)?.TryGetInfo();
-        //    if (buffer != null) {
-        //        var analyzer = await site.FindAnalyzerAsync(buffer);
-        //        if (analyzer != null) {
-        //            found.Add(analyzer);
-        //            if (firstOnly) {
-        //                return found.ToArray();
-        //            }
-        //        }
-        //    }
-
-        //    var workspaceAnalysis = site.GetComponentModel().GetService<WorkspaceAnalysis>();
-        //    var workspaceAnalyzer = workspaceAnalysis.TryGetWorkspaceAnalyzer();
-        //    if (workspaceAnalyzer != null) {
-        //        found.Add(workspaceAnalyzer);
-        //        if (firstOnly) {
-        //            return found.ToArray();
-        //        }
-        //    }
-
-        //    // Yield all loaded projects containing the file
-        //    var sln = (IVsSolution)site.GetService(typeof(SVsSolution));
-        //    if (sln != null) {
-        //        if (Path.IsPathRooted(filename)) {
-        //            foreach (var project in sln.EnumerateLoadedPythonProjects()) {
-        //                if (project.FindNodeByFullPath(filename) != null) {
-        //                    var analyzer = project.TryGetAnalyzer();
-        //                    if (analyzer != null) {
-        //                        found.Add(analyzer);
-        //                        if (firstOnly) {
-        //                            return found.ToArray();
-        //                        }
-        //                    }
-        //                }
-        //            }
-        //        } else {
-        //            var withSlash = "\\" + filename;
-        //            foreach (var project in sln.EnumerateLoadedPythonProjects()) {
-        //                if (project.AllVisibleDescendants.Any(n => n.Url.Equals(filename, StringComparison.OrdinalIgnoreCase) ||
-        //                    n.Url.EndsWithOrdinal(withSlash, ignoreCase: true))) {
-        //                    var analyzer = project.TryGetAnalyzer();
-        //                    if (analyzer != null) {
-        //                        found.Add(analyzer);
-        //                        if (firstOnly) {
-        //                            return found.ToArray();
-        //                        }
-        //                    }
-        //                }
-        //            }
-        //        }
-        //    }
-
-        //    return found.ToArray();
-        //}
     }
 }

--- a/Python/Product/PythonTools/PythonTools/LanguageServerClient/PythonLanguageClient.cs
+++ b/Python/Product/PythonTools/PythonTools/LanguageServerClient/PythonLanguageClient.cs
@@ -81,12 +81,6 @@ namespace Microsoft.PythonTools.LanguageServerClient {
             _replWindow = replWindow;
             _disposables = new DisposableBag(GetType().Name);
 
-            if (replWindow != null) {
-                // TODO: need to hook into Reset REPL to restart language server, environment settings may have changed
-                ReplDocument = new ReplDocument(site, replWindow, this);
-                _disposables.Add(ReplDocument);
-            }
-
             var pythonWorkspaceProvider = site.GetComponentModel().GetService<IPythonWorkspaceContextProvider>();
             var pythonWorkspace = pythonWorkspaceProvider?.Workspace;
             if (pythonWorkspace != null) {
@@ -271,8 +265,6 @@ namespace Microsoft.PythonTools.LanguageServerClient {
             }
         }
 
-        public ReplDocument ReplDocument { get; }
-
         public string ContentTypeName { get; }
 
         public IPythonInterpreterFactory Factory { get; private set; }
@@ -394,10 +386,6 @@ namespace Microsoft.PythonTools.LanguageServerClient {
         }
 
         public async Task OnServerInitializedAsync() {
-            if (ReplDocument != null) {
-                await ReplDocument.InitializeAsync();
-            }
-
             IsInitialized = true;
         }
 

--- a/Python/Product/PythonTools/PythonTools/LanguageServerClient/PythonLanguageClient.cs
+++ b/Python/Product/PythonTools/PythonTools/LanguageServerClient/PythonLanguageClient.cs
@@ -332,9 +332,6 @@ namespace Microsoft.PythonTools.LanguageServerClient {
             string rootPath = null;
 
             if (_replWindow != null) {
-                // TODO: someone needs to unsubscribe
-                //_replWindow.SubmissionBufferAdded += OnReplInputBufferCreated;
-
                 var evaluator = _replWindow.Evaluator as PythonCommonInteractiveEvaluator;
                 if (_replWindow.Evaluator is SelectableReplEvaluator selEvaluator) {
                     evaluator = selEvaluator.Evaluator as PythonCommonInteractiveEvaluator;
@@ -447,12 +444,15 @@ namespace Microsoft.PythonTools.LanguageServerClient {
             var site = _site;
             var project = _project;
             var contentTypeName = ContentTypeName;
+            var replWindow = _replWindow;
 
             DisposeLanguageClient(ContentTypeName);
-            await EnsureLanguageClientAsync(site, project, contentTypeName);
 
-            //await StopAsync?.Invoke(this, EventArgs.Empty);
-            //await _broker.LoadAsync(new PythonLanguageClientMetadata(null, ContentTypeName), this);
+            if (replWindow != null) {
+                await EnsureLanguageClientAsync(site, replWindow, contentTypeName);
+            } else {
+                await EnsureLanguageClientAsync(site, project, contentTypeName);
+            }
         }
 
         private void OnProjectChanged(object sender, EventArgs e) {

--- a/Python/Product/PythonTools/PythonTools/Repl/IPythonInteractiveIntellisense.cs
+++ b/Python/Product/PythonTools/PythonTools/Repl/IPythonInteractiveIntellisense.cs
@@ -20,6 +20,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Python.Parsing;
 using Microsoft.PythonTools.Intellisense;
+using Microsoft.VisualStudio.Text;
+using LSP = Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.PythonTools.Repl {
     interface IPythonInteractiveIntellisense {
@@ -27,8 +29,7 @@ namespace Microsoft.PythonTools.Repl {
         IEnumerable<KeyValuePair<string, string>> GetAvailableScopesAndPaths();
         Task<CompletionResult[]> GetMemberNamesAsync(string text, CancellationToken ct);
         Task<OverloadDoc[]> GetSignatureDocumentationAsync(string text, CancellationToken ct);
-        Uri DocumentUri { get; }
-        Uri NextDocumentUri();
+        Task<LSP.CompletionItem[]> GetAnalysisCompletions(SnapshotPoint triggerPoint, LSP.CompletionContext context, CancellationToken token);
         PythonLanguageVersion LanguageVersion { get; }
     }
 }

--- a/Python/Product/PythonTools/PythonTools/Repl/InteractiveWindowProvider.cs
+++ b/Python/Product/PythonTools/PythonTools/Repl/InteractiveWindowProvider.cs
@@ -187,11 +187,6 @@ namespace Microsoft.PythonTools.Repl {
                 }
             };
 
-            _serviceProvider.GetUIThread().InvokeTaskSync(
-                () => evaluator.InitializeLanguageServerAsync(curId),
-                CancellationToken.None
-            );
-
             return window;
         }
 

--- a/Python/Product/PythonTools/PythonTools/Repl/PythonDebugProcessReplEvaluator.cs
+++ b/Python/Product/PythonTools/PythonTools/Repl/PythonDebugProcessReplEvaluator.cs
@@ -120,6 +120,10 @@ namespace Microsoft.PythonTools.Repl {
             return result;
         }
 
+        internal override Task InitializeLanguageServerAsync() {
+            // Don't run a language server for debug repl, at least for now
+            return Task.CompletedTask;
+        }
 
         private async void OnModulesChanged(object sender, EventArgs e) {
             await RefreshAvailableScopes();
@@ -200,7 +204,6 @@ namespace Microsoft.PythonTools.Repl {
 
         public PythonProcess Process {
             get { return _process; }
-
         }
 
         public int ProcessId {

--- a/Python/Product/PythonTools/PythonTools/Repl/PythonDebugReplEvaluator.cs
+++ b/Python/Product/PythonTools/PythonTools/Repl/PythonDebugReplEvaluator.cs
@@ -32,6 +32,7 @@ using Microsoft.VisualStudio.InteractiveWindow.Commands;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Utilities;
 using Microsoft.VisualStudioTools;
+using LSP = Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.PythonTools.Repl {
     [InteractiveWindowRole("Debug")]
@@ -621,6 +622,11 @@ namespace Microsoft.PythonTools.Repl {
 
         public string GetPrompt() {
             return _activeEvaluator?.GetPrompt();
+        }
+
+        public Task<LSP.CompletionItem[]> GetAnalysisCompletions(SnapshotPoint triggerPoint, LSP.CompletionContext context, CancellationToken token) {
+            // No analysis completions for debug repl
+            return Task.FromResult(Array.Empty<LSP.CompletionItem>());
         }
     }
 

--- a/Python/Product/PythonTools/PythonTools/Repl/SelectableReplEvaluator.cs
+++ b/Python/Product/PythonTools/PythonTools/Repl/SelectableReplEvaluator.cs
@@ -374,12 +374,5 @@ namespace Microsoft.PythonTools.Repl {
             return (await (_evaluator as IPythonInteractiveIntellisense)?.GetSignatureDocumentationAsync(text, ct))
                 ?? new OverloadDoc[0];
         }
-
-        public async Task InitializeLanguageServerAsync(int curId) {
-            var evaluator = _evaluator as PythonCommonInteractiveEvaluator;
-            if (evaluator != null) {
-                await evaluator.InitializeLanguageServerAsync(curId);
-            }
-        }
     }
 }

--- a/Python/Product/PythonTools/PythonTools/Repl/SelectableReplEvaluator.cs
+++ b/Python/Product/PythonTools/PythonTools/Repl/SelectableReplEvaluator.cs
@@ -24,12 +24,13 @@ using Microsoft.Python.Parsing;
 using Microsoft.PythonTools.Infrastructure;
 using Microsoft.PythonTools.Intellisense;
 using Microsoft.PythonTools.Interpreter;
-using Microsoft.PythonTools.LanguageServerClient;
 using Microsoft.VisualStudio.InteractiveWindow;
 using Microsoft.VisualStudio.InteractiveWindow.Commands;
 using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Utilities;
 using Task = System.Threading.Tasks.Task;
+using LSP = Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.PythonTools.Repl {
     [InteractiveWindowRole("Execution")]
@@ -145,9 +146,6 @@ namespace Microsoft.PythonTools.Repl {
         public string DisplayName => (_evaluator as IPythonInteractiveEvaluator)?.DisplayName;
 
         public bool LiveCompletionsOnly => (_evaluator as IPythonInteractiveIntellisense)?.LiveCompletionsOnly ?? false;
-
-        public Uri DocumentUri => (_evaluator as IPythonInteractiveIntellisense)?.DocumentUri;
-        public Uri NextDocumentUri() => (_evaluator as IPythonInteractiveIntellisense)?.NextDocumentUri();
 
         // Test methods
         internal string PrimaryPrompt => ((dynamic)_evaluator)?.PrimaryPrompt ?? ">>> ";
@@ -373,6 +371,11 @@ namespace Microsoft.PythonTools.Repl {
         public async Task<OverloadDoc[]> GetSignatureDocumentationAsync(string text, CancellationToken ct) {
             return (await (_evaluator as IPythonInteractiveIntellisense)?.GetSignatureDocumentationAsync(text, ct))
                 ?? new OverloadDoc[0];
+        }
+
+        public async Task<LSP.CompletionItem[]> GetAnalysisCompletions(SnapshotPoint triggerPoint, LSP.CompletionContext context, CancellationToken token) {
+            return (await (_evaluator as IPythonInteractiveIntellisense)?.GetAnalysisCompletions(triggerPoint, context, token))
+                ?? Array.Empty<LSP.CompletionItem>();
         }
     }
 }


### PR DESCRIPTION
Fix #5873 

REPL evaluator now takes care of initializing and shutting down language server, and that makes it easy to handle reset directly from the REPL evaluator implementation.

Also moved the initialization and ownership of that "stitched repl document" to the evaluator.

Pushed down the code that does the LS call for completion, from the broker to the "repl document", which simplified that REPL intellisense interface.

I've disabled language server and analysis completions for debug REPL. Well, before it was probably crashing, now it doesn't.

Ownership and responsabilities for debug REPL LSC stuff was quite bad before, hopefully it makes more sense now.