### PR TITLE
Set the msbuild global platform variable to the active configuration platform

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Project/PythonProjectNode.cs
+++ b/Python/Product/PythonTools/PythonTools/Project/PythonProjectNode.cs
@@ -508,11 +508,9 @@ namespace Microsoft.PythonTools.Project {
             if (!IsProjectOpened)
                 return;
 
-            if (this.IsAppxPackageableProject()) {
-                EnvDTE.Project automationObject = (EnvDTE.Project)GetAutomationObject();
+            var automationObject = (EnvDTE.Project)GetAutomationObject();
 
-                this.BuildProject.SetGlobalProperty(ProjectFileConstants.Platform, automationObject.ConfigurationManager.ActiveConfiguration.PlatformName);
-            }
+            this.BuildProject.SetGlobalProperty(ProjectFileConstants.Platform, automationObject.ConfigurationManager.ActiveConfiguration.PlatformName);
         }
 
         protected override bool SupportsIconMonikers {


### PR DESCRIPTION
Fix #5944 

Promote the code that used to execute for UWP projects only.