### PR TITLE
Fix the VS16 file association for .py .pyw .pyi

### DIFF
--- a/Build/Common.Build.Core.settings
+++ b/Build/Common.Build.Core.settings
@@ -110,5 +110,11 @@
     <!-- Allows assemblies to specify their own version -->
     <SuppressCommonAssemblyVersion Condition="'$(SuppressCommonAssemblyVersion)' == ''">false</SuppressCommonAssemblyVersion>
   </PropertyGroup>
+  <PropertyGroup>
+    <PackagePreprocessorDefinitions>
+      <!-- VsDdeApplication is defined incorrectly in Microsoft.Wix4.Swix.Tools.targets so we hard code it until they fix it -->
+      VsDdeApplication16=VisualStudio.16.0
+    </PackagePreprocessorDefinitions>
+  </PropertyGroup>
 
 </Project>

--- a/Python/Setup/swix/Packages/file_associations.swr
+++ b/Python/Setup/swix/Packages/file_associations.swr
@@ -28,7 +28,7 @@ vs.progIds
         DefaultIconPath="[InstallDir]\Common7\Extensions\Microsoft\Python\Core\PythonFile.ico"
         DefaultIconPosition=0
         Dde=true
-        DdeApplication=$(VsDdeApplication)
+        DdeApplication=$(VsDdeApplication16)
         DdeTopic=system
     
     vs.progId


### PR DESCRIPTION
Adding a temporary build property to update the registery file assocation value to point to VS16

typescrip had a similar issue
WorkItem
https://dev.azure.com/devdiv/DevDiv/_workitems/edit/987704

PR
https://dev.azure.com/devdiv/DevDiv/_git/TypeScript-VS/pullrequest/204555?_a=files&path=%2FVS%2FSetup%2FVSIX%2FFileAssociations%2Fext.typescript.swr

Fix # 5411
Python file association - VS does not open the file when double click / Open With from Windows File Explorer