### PR TITLE
Fix workspace interpreter on first load

### DIFF
--- a/Python/Product/VSInterpreters/Interpreter/PythonWorkspaceContextProvider.cs
+++ b/Python/Product/VSInterpreters/Interpreter/PythonWorkspaceContextProvider.cs
@@ -109,13 +109,15 @@ namespace Microsoft.PythonTools.Interpreter {
                 // workspace folder for factories.
                 WorkspaceOpening?.Invoke(this, new PythonWorkspaceContextEventArgs(context));
 
-                // Workspace sets its interpreter factory instance,
-                // now that they've been discovered by the factory provider.
-                context.Initialize();
-
                 lock (_currentContextLock) {
                     _currentContext = context;
                 }
+
+                // Workspace sets its interpreter factory instance
+                // This can trigger WorkspaceInterpreterFactoryProvider discovery
+                // which needs to look at this object's _currentContext, which is why we
+                // set that before calling initialize.
+                context.Initialize();
 
                 // Let users know this workspace context is all initialized
                 WorkspaceInitialized?.Invoke(this, new PythonWorkspaceContextEventArgs(context));


### PR DESCRIPTION
Fix intialization order of Python workspace object in relation to workspace interpreter factory provider. This fixes the workspace interpreter being incorrect for the first workspace that is loaded after VS has started. #5931 