### PR TITLE
Fix async get children in native debugger

### DIFF
--- a/Python/Product/Debugger.Concord/ExpressionEvaluator.cs
+++ b/Python/Product/Debugger.Concord/ExpressionEvaluator.cs
@@ -499,7 +499,7 @@ namespace Microsoft.PythonTools.Debugger.Concord {
                 var childResults = pyEvalResult.GetChildren(this, result, inspectionContext);
                 completionRoutine(
                     new DkmGetChildrenAsyncResult(
-                        new DkmEvaluationResult[0],
+                        childResults.Take(initialRequestSize).ToArray(),
                         DkmEvaluationResultEnumContext.Create(
                             childResults.Count,
                             result.StackFrame,


### PR DESCRIPTION
Fix #5973 