### PR TITLE
Prevent exception when closing file

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Navigation/CodeWindowManager.cs
+++ b/Python/Product/PythonTools/PythonTools/Navigation/CodeWindowManager.cs
@@ -123,11 +123,12 @@ namespace Microsoft.PythonTools.Navigation {
 
         private int RemoveDropDownBar() {
             var cpc = (IConnectionPointContainer)_window;
-            if (cpc != null) {
+            if (cpc != null && _cookieVsCodeWindowEvents != 0) {
                 IConnectionPoint cp;
                 cpc.FindConnectionPoint(typeof(IVsCodeWindowEvents).GUID, out cp);
                 if (cp != null) {
                     cp.Unadvise(_cookieVsCodeWindowEvents);
+                    _cookieVsCodeWindowEvents = 0;
                 }
             }
 


### PR DESCRIPTION
Fix #6061

If navigation bar option is off, it was trying to `Unadvise()` on a cookie that wasn't initialized aka `Advise()`.