### PR TITLE
New updates to pytest 5.4 removed output logging to junit files by de…

### DIFF
--- a/Python/Product/TestAdapter.Executor/Pytest/PytestConfiguration.cs
+++ b/Python/Product/TestAdapter.Executor/Pytest/PytestConfiguration.cs
@@ -66,6 +66,10 @@ namespace Microsoft.PythonTools.TestAdapter.Pytest {
             // output results to xml file
             args.Add(String.Format("--junitxml={0}", ResultsXmlPath));
             args.Add(String.Format("--rootdir={0}", settings.ProjectHome));
+            args.Add("-o");
+            args.Add("junit_logging=all");
+            args.Add("-o");
+            args.Add("junit_family=xunit1");
 
             return args;
         }


### PR DESCRIPTION
…fault, turning it back on.

Removed warnings, new junit 2.0 format is coming so specify we want orginal format.

https://docs.pytest.org/en/latest/reference.html#confval-junit_logging

#6058