### PR TITLE
Fix profiling tool window tree node expansion

### DIFF
--- a/Python/Product/Profiling/Profiling/SessionNode.cs
+++ b/Python/Product/Profiling/Profiling/SessionNode.cs
@@ -159,7 +159,7 @@ namespace Microsoft.PythonTools.Profiling {
                     if (itemid == VSConstants.VSITEMID_ROOT) {
                         pvar = ReportsItemId;
                     } else if (itemid == ReportsItemId && Reports.Count > 0) {
-                        pvar = Reports.First().Key;
+                        pvar = (int)Reports.First().Key;
                     } else {
                         pvar = VSConstants.VSITEMID_NIL;
                     }
@@ -171,12 +171,13 @@ namespace Microsoft.PythonTools.Profiling {
                         var items = Reports.Keys.ToArray();
                         for (int i = 0; i < items.Length; i++) {
                             if (items[i] > (int)itemid) {
-                                pvar = itemid + 1;
+                                pvar = (int)(itemid + 1);
                                 break;
                             }
                         }
                     }
                     break;
+
 
                 case __VSHPROPID.VSHPROPID_ItemDocCookie:
                     if (itemid == VSConstants.VSITEMID_ROOT) {


### PR DESCRIPTION
Fix #6042 

Change itemid type to int instead of uint for VSHPROPID_FirstChild and VSHPROPID_NextSibling in profile explorer to fix a regression in expansion of tree nodes.

VS got more strict for the type of those properties.

They should accept both int and uint, and will likely get back to doing that, but until then, int is apparently the more correct type to return, so it's best to change it.