### PR TITLE
Fix pylint command 

### DIFF
--- a/Python/Product/BuildTasks/Microsoft.PythonTools.targets
+++ b/Python/Product/BuildTasks/Microsoft.PythonTools.targets
@@ -165,7 +165,7 @@ permissions and limitations under the License.
   <Target Name="PythonRunPyLintCommand"
           Label="resource:Microsoft.PythonTools.Common;Microsoft.PythonTools.Common.Strings;RunPyLintLabel"
           Returns="@(Commands)">
-    <CreatePythonCommandItem Target="pylint.lint"
+    <CreatePythonCommandItem Target="pylint"
                              TargetType="module"
                              Arguments="&quot;--msg-template={abspath}({line},{column}): {category} {msg_id}: {msg} [{C}:{symbol}]&quot; -r n @(Compile, ' ')"
                              WorkingDirectory="$(MSBuildProjectDirectory)"


### PR DESCRIPTION
Fix #6113 

Fix verified on the latest available version of pylint on both Python 2.7 and 3.x.