### PR TITLE
Prevent localization related static analysis check in the Xaml build utility

### DIFF
--- a/Common/Tools/BuildTasks/ExtractLambdasFromXaml.cs
+++ b/Common/Tools/BuildTasks/ExtractLambdasFromXaml.cs
@@ -29,6 +29,8 @@ using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using Microsoft.VisualStudioTools.Wpf;
 
+#pragma warning disable CA1303 // Do not pass literals as localized parameters (this is a build utility that does not need localization)
+
 namespace Microsoft.VisualStudioTools.BuildTasks {
     public class ExtractLambdasFromXaml : Task {
         private struct LambdaInfo {
@@ -426,3 +428,5 @@ namespace Microsoft.VisualStudioTools.BuildTasks {
 #endif
     }
 }
+
+#pragma warning restore CA1303


### PR DESCRIPTION
After fixing up our policy build, it started reporting this static analysis error. It is safe to disable since that's just an internal utility that we use for the building of PTVS source code.