### PR TITLE
Add policheck exclusion file.

### DIFF
--- a/Build/PoliCheckExclusions.xml
+++ b/Build/PoliCheckExclusions.xml
@@ -1,0 +1,3 @@
+<PoliCheckExclusions>
+  <Exclusion Type="FolderPathFull">MINICONDA3-X64</Exclusion>
+</PoliCheckExclusions>


### PR DESCRIPTION
I've already run the policy pipeline and verified that this excludes all the miniconda related warnings.

This exclusion file is specified as a parameter to the policheck azure devops pipeline task.