### PR TITLE
Add .lcl files to PoliCheck exclusions.

### DIFF
--- a/Build/PoliCheckExclusions.xml
+++ b/Build/PoliCheckExclusions.xml
@@ -1,3 +1,4 @@
 <PoliCheckExclusions>
   <Exclusion Type="FolderPathFull">MINICONDA3-X64</Exclusion>
+  <Exclusion Type="FileType">.LCL</Exclusion>
 </PoliCheckExclusions>


### PR DESCRIPTION
The localization team is in charge of doing PoliCheck on their translations, and they have told us we should exclude them from our PoliCheck task (which uses the English term table).