### PR TITLE
Fix deadlock when loading a workspace.

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Environments/UserSpecifiedCondaLocator.cs
+++ b/Python/Product/PythonTools/PythonTools/Environments/UserSpecifiedCondaLocator.cs
@@ -30,19 +30,17 @@ namespace Microsoft.PythonTools.Environments {
     [ExportMetadata("Priority", 100)]
     sealed class UserSpecifiedCondaLocator : ICondaLocator {
         private readonly IServiceProvider _site;
-        private readonly PythonToolsService _pythonToolsService;
 
         [ImportingConstructor]
         public UserSpecifiedCondaLocator(
             [Import(typeof(SVsServiceProvider), AllowDefault = true)] IServiceProvider site = null
         ) {
             _site = site;
-            _pythonToolsService = site?.GetPythonToolsService();
         }
 
         public string CondaExecutablePath {
             get {
-                return _pythonToolsService?.CondaOptions.CustomCondaExecutablePath;
+                return _site?.GetPythonToolsService()?.CondaOptions.CustomCondaExecutablePath;
             }
         }
     }

--- a/Python/Tests/Core/PythonWorkspaceContextProviderTests.cs
+++ b/Python/Tests/Core/PythonWorkspaceContextProviderTests.cs
@@ -18,6 +18,7 @@ using System;
 using System.Threading;
 using Microsoft.PythonTools.Interpreter;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.VisualStudio.Threading;
 using TestUtilities;
 
 namespace PythonToolsTests {
@@ -38,7 +39,8 @@ namespace PythonToolsTests {
             var provider = new PythonWorkspaceContextProvider(
                 workspaceService,
                 new Lazy<IInterpreterOptionsService>(() => optionsService),
-                new Lazy<IInterpreterRegistryService>(() => registryService)
+                new Lazy<IInterpreterRegistryService>(() => registryService),
+                new JoinableTaskContext()
             );
 
             Assert.AreEqual(workspaceFolder, provider.Workspace.Location);
@@ -55,7 +57,8 @@ namespace PythonToolsTests {
             var provider = new PythonWorkspaceContextProvider(
                 workspaceService,
                 new Lazy<IInterpreterOptionsService>(() => optionsService),
-                new Lazy<IInterpreterRegistryService>(() => registryService)
+                new Lazy<IInterpreterRegistryService>(() => registryService),
+                new JoinableTaskContext()
             );
 
             Assert.AreEqual(null, provider.Workspace);
@@ -91,7 +94,8 @@ namespace PythonToolsTests {
             var provider = new PythonWorkspaceContextProvider(
                 workspaceService,
                 new Lazy<IInterpreterOptionsService>(() => optionsService),
-                new Lazy<IInterpreterRegistryService>(() => registryService)
+                new Lazy<IInterpreterRegistryService>(() => registryService),
+                new JoinableTaskContext()
             );
 
             Assert.AreEqual(workspaceFolder, provider.Workspace.Location);
@@ -129,7 +133,8 @@ namespace PythonToolsTests {
             var provider = new PythonWorkspaceContextProvider(
                 workspaceService,
                 new Lazy<IInterpreterOptionsService>(() => optionsService),
-                new Lazy<IInterpreterRegistryService>(() => registryService)
+                new Lazy<IInterpreterRegistryService>(() => registryService),
+                new JoinableTaskContext()
             );
 
             Assert.AreEqual(workspaceFolder1, provider.Workspace.Location);


### PR DESCRIPTION
Remove UI thread dependency from the MEF constructor, which was a violation of threading guidelines.
Ensure we are on UI thread in `OnActiveWorkspaceChanged`.

Fixes internal bug 1168894