### PR TITLE
Update to newer Microsoft.VisualStudio.Python.LanguageServer version.

### DIFF
--- a/Build/16.0/packages.config
+++ b/Build/16.0/packages.config
@@ -5,7 +5,7 @@
     <package id="Python" version="3.8.5" />
     <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" /> 
     <!--These 2 packages are obtained from private sources. See nuget.config for more info -->
-    <package id="Microsoft.VisualStudio.Python.LanguageServer" version="0.1.29" />
+    <package id="Microsoft.VisualStudio.Python.LanguageServer" version="0.1.31" />
     <package id="Microsoft.Internal.VisualStudio.Shell.Embeddable" version="16.3.28923.271" />
     <!-- Microsoft's packages -->
     <package id="EnvDTE" version="8.0.2" />


### PR DESCRIPTION
NuGet package now has enum members for versions 3.9, 3.10, 3.11.

That means we can now properly detect Python 3.9 as version 3.9 (instead of 0.0).
- Banner warning now appears for 3.9
- Package manager works correctly for 3.9

Fix #6049

![image](https://user-images.githubusercontent.com/1696845/90297057-2fd64200-de42-11ea-9e5b-9313fe1c39f2.png)
