### PR TITLE
Add the missing event handlers for the textbox and button in language server option page.

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Options/LanguageServerOptionsControl.Designer.cs
+++ b/Python/Product/PythonTools/PythonTools/Options/LanguageServerOptionsControl.Designer.cs
@@ -74,11 +74,13 @@ namespace Microsoft.PythonTools.Options {
             resources.ApplyResources(this.browseTypeShedPathButton, "browseTypeShedPathButton");
             this.browseTypeShedPathButton.Name = "browseTypeShedPathButton";
             this.browseTypeShedPathButton.UseVisualStyleBackColor = true;
+            this.browseTypeShedPathButton.Click += new System.EventHandler(this.browseTypeShedPathButton_Click);
             // 
             // typeShedPathTextBox
             // 
             resources.ApplyResources(this.typeShedPathTextBox, "typeShedPathTextBox");
             this.typeShedPathTextBox.Name = "typeShedPathTextBox";
+            this.typeShedPathTextBox.TextChanged += new System.EventHandler(this.TypeShedPath_TextChanged);
             // 
             // typeShedPathLabel
             // 


### PR DESCRIPTION
They were lost when I added the new checkbox for Disable IntelliSense, probably when I got rid / moved controls out of the groupbox.

Fix #6206