### PR TITLE
Fix deadlock when adding python file to empty workspace

### DIFF
--- a/Python/Product/VSInterpreters/Interpreter/WorkspaceInterpreterFactoryProvider.cs
+++ b/Python/Product/VSInterpreters/Interpreter/WorkspaceInterpreterFactoryProvider.cs
@@ -22,6 +22,7 @@ using System.Linq;
 using System.Threading;
 using Microsoft.PythonTools.Infrastructure;
 using Microsoft.PythonTools.Parsing;
+using Microsoft.VisualStudioTools;
 
 namespace Microsoft.PythonTools.Interpreter {
     /// <summary>
@@ -37,7 +38,7 @@ namespace Microsoft.PythonTools.Interpreter {
         private IPythonWorkspaceContext _workspace;
         private readonly Dictionary<string, PythonInterpreterInformation> _factories = new Dictionary<string, PythonInterpreterInformation>();
         internal const string FactoryProviderName = WorkspaceInterpreterFactoryConstants.FactoryProviderName;
-        private FileSystemWatcher _folderWatcher;
+        private FileWatcher _folderWatcher;
         private Timer _folderWatcherTimer;
         private bool _refreshPythonInterpreters;
         private int _ignoreNotifications;
@@ -128,7 +129,7 @@ namespace Microsoft.PythonTools.Interpreter {
                 if (_workspace != null) {
                     _workspace.InterpreterSettingChanged += OnInterpreterSettingChanged;
                     try {
-                        _folderWatcher = new FileSystemWatcher(_workspace.Location, "*.*");
+                        _folderWatcher = new FileWatcher(_workspace.Location, "*.*");
                         _folderWatcher.Created += OnFileCreatedDeletedRenamed;
                         _folderWatcher.Deleted += OnFileCreatedDeletedRenamed;
                         _folderWatcher.Renamed += OnFileCreatedDeletedRenamed;

--- a/Python/Product/VSInterpreters/VSInterpreters.csproj
+++ b/Python/Product/VSInterpreters/VSInterpreters.csproj
@@ -82,6 +82,9 @@
     <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\..\..\Common\Product\SharedProject\FileWatcher.cs">
+      <Link>Interpreter\FileWatcher.cs</Link>
+    </Compile>
     <Compile Include="Interpreter\InterpreterUIMode.cs" />
     <Compile Include="Interpreter\LaunchConfiguration.cs" />
     <Compile Include="Interpreter\LaunchConfigurationUtils.cs" />


### PR DESCRIPTION
Use our own FileWatcher class instead of FileSystemWatcher, to avoid deadlock on dispose.

See https://github.com/microsoft/PTVS/blob/master/Common/Product/SharedProject/FileWatcher.cs#L112

Fix #6203 