### PR TITLE
Remove legacy debugger option

### DIFF
--- a/Python/Product/Common/Strings.Designer.cs
+++ b/Python/Product/Common/Strings.Designer.cs
@@ -2563,11 +2563,11 @@ namespace Microsoft.PythonTools {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to This debug REPL feature is only supported with the legacy debugger..
+        ///   Looks up a localized string similar to Debugging REPL feature is not yet supported..
         /// </summary>
-        public static string DebugReplFeatureNotSupportedWithExperimentalDebugger {
+        public static string DebugReplFeatureNotSupported {
             get {
-                return ResourceManager.GetString("DebugReplFeatureNotSupportedWithExperimentalDebugger", resourceCulture);
+                return ResourceManager.GetString("DebugReplFeatureNotSupported", resourceCulture);
             }
         }
         
@@ -4030,24 +4030,6 @@ namespace Microsoft.PythonTools {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to There was an error loading ptvsd from the current environment. Please upgrade or uninstall ptvsd..
-        /// </summary>
-        public static string ImportPtvsdModuleNotFoundMessage {
-            get {
-                return ResourceManager.GetString("ImportPtvsdModuleNotFoundMessage", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Debugger package could not be loaded.
-        /// </summary>
-        public static string ImportPtvsdModuleNotFoundTitle {
-            get {
-                return ResourceManager.GetString("ImportPtvsdModuleNotFoundTitle", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to _Back.
         /// </summary>
         public static string ImportWizard_BackButton {
@@ -5083,60 +5065,6 @@ namespace Microsoft.PythonTools {
         public static string ProjectText {
             get {
                 return ResourceManager.GetString("ProjectText", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Use the legacy debugger.
-        /// </summary>
-        public static string PtvsdDisableCaption {
-            get {
-                return ResourceManager.GetString("PtvsdDisableCaption", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Future debugging sessions will use the legacy debugger. You can also change this setting in Tools, Options, Python, Debugging page by changing the &apos;Use legacy debugger&apos; option..
-        /// </summary>
-        public static string PtvsdDisableSubtext {
-            get {
-                return ResourceManager.GetString("PtvsdDisableSubtext", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to To debug this Python environment, please use the legacy debugger. Older versions of Python are not supported. See our &lt;a href=&quot;https://aka.ms/upgradeptvsd&quot;&gt;documentation&lt;/a&gt; for a list of supported Python versions and environment types..
-        /// </summary>
-        public static string PtvsdIncompatibleEnvMessage {
-            get {
-                return ResourceManager.GetString("PtvsdIncompatibleEnvMessage", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Debugger does not support this Python environment.
-        /// </summary>
-        public static string PtvsdIncompatibleEnvTitle {
-            get {
-                return ResourceManager.GetString("PtvsdIncompatibleEnvTitle", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Learn more.
-        /// </summary>
-        public static string PtvsdLearnMoreCaption {
-            get {
-                return ResourceManager.GetString("PtvsdLearnMoreCaption", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to View documentation on supported Python environments and how to upgrade or uninstall the ptvsd debugger package..
-        /// </summary>
-        public static string PtvsdLearnMoreSubtext {
-            get {
-                return ResourceManager.GetString("PtvsdLearnMoreSubtext", resourceCulture);
             }
         }
         

--- a/Python/Product/Common/Strings.resx
+++ b/Python/Product/Common/Strings.resx
@@ -2679,32 +2679,8 @@ Please specify at least one package.</value>
   <data name="WarningEncodingDifferentFromDefault" xml:space="preserve">
     <value>File is saved in encoding '{0}' which does not match default UTF-8 encoding</value>
   </data>
-  <data name="ImportPtvsdModuleNotFoundMessage" xml:space="preserve">
-    <value>There was an error loading ptvsd from the current environment. Please upgrade or uninstall ptvsd.</value>
-  </data>
-  <data name="ImportPtvsdModuleNotFoundTitle" xml:space="preserve">
-    <value>Debugger package could not be loaded</value>
-  </data>
-  <data name="PtvsdDisableCaption" xml:space="preserve">
-    <value>Use the legacy debugger</value>
-  </data>
-  <data name="PtvsdDisableSubtext" xml:space="preserve">
-    <value>Future debugging sessions will use the legacy debugger. You can also change this setting in Tools, Options, Python, Debugging page by changing the 'Use legacy debugger' option.</value>
-  </data>
-  <data name="PtvsdLearnMoreCaption" xml:space="preserve">
-    <value>Learn more</value>
-  </data>
-  <data name="PtvsdLearnMoreSubtext" xml:space="preserve">
-    <value>View documentation on supported Python environments and how to upgrade or uninstall the ptvsd debugger package.</value>
-  </data>
-  <data name="PtvsdIncompatibleEnvTitle" xml:space="preserve">
-    <value>Debugger does not support this Python environment</value>
-  </data>
-  <data name="PtvsdIncompatibleEnvMessage" xml:space="preserve">
-    <value>To debug this Python environment, please use the legacy debugger. Older versions of Python are not supported. See our &lt;a href="https://aka.ms/upgradeptvsd"&gt;documentation&lt;/a&gt; for a list of supported Python versions and environment types.</value>
-  </data>
-  <data name="DebugReplFeatureNotSupportedWithExperimentalDebugger" xml:space="preserve">
-    <value>This debug REPL feature is only supported with the legacy debugger.</value>
+  <data name="DebugReplFeatureNotSupported" xml:space="preserve">
+    <value>Debugging REPL feature is not yet supported.</value>
   </data>
   <data name="RunMypyLabel" xml:space="preserve">
     <value>Run Mypy</value>

--- a/Python/Product/Debugger/Debugger/DebugEngine/Remote/PythonRemoteDebugPort.cs
+++ b/Python/Product/Debugger/Debugger/DebugEngine/Remote/PythonRemoteDebugPort.cs
@@ -44,20 +44,9 @@ namespace Microsoft.PythonTools.Debugger.Remote {
         }
 
         public int EnumProcesses(out IEnumDebugProcesses2 ppEnum) {
-            if (!PythonDebugOptionsServiceHelper.Options.UseLegacyDebugger) {
-                var process = new PythonRemoteDebugProcess(this, 54321, "Python", "*", "*");
-                ppEnum = new PythonRemoteEnumDebugProcesses(process);
-                return VSConstants.S_OK;
-            } else {
-                var process = TaskHelpers.RunSynchronouslyOnUIThread(ct => PythonRemoteDebugProcess.ConnectAsync(this, _debugLog, ct));
-                if (process == null) {
-                    ppEnum = null;
-                    return VSConstants.E_FAIL;
-                } else {
-                    ppEnum = new PythonRemoteEnumDebugProcesses(process);
-                    return VSConstants.S_OK;
-                }
-            }
+            var process = new PythonRemoteDebugProcess(this, 54321, "Python", "*", "*");
+            ppEnum = new PythonRemoteEnumDebugProcesses(process);
+            return VSConstants.S_OK;
         }
 
         public int GetPortId(out Guid pguidPort) {

--- a/Python/Product/Debugger/Debugger/DebugEngine/Remote/PythonRemoteDebugPortSupplier.cs
+++ b/Python/Product/Debugger/Debugger/DebugEngine/Remote/PythonRemoteDebugPortSupplier.cs
@@ -74,17 +74,6 @@ namespace Microsoft.PythonTools.Debugger.Remote {
             }
 
             var port = new PythonRemoteDebugPort(this, pRequest, uri, DebugLog);
-
-            if (PythonDebugOptionsServiceHelper.Options.UseLegacyDebugger) {
-                // Validate connection early. Debugger automation (DTE) objects are not consistent in error checking from this
-                // point on, so errors reported from EnumProcesses and further calls may be ignored and treated as successes
-                // (with empty result). Reporting an error here works around that.
-                int hr = port.EnumProcesses(out IEnumDebugProcesses2 processes);
-                if (hr < 0) {
-                    return hr;
-                }
-            }
-
             ppPort = port;
             _ports.Add(port);
 
@@ -119,9 +108,7 @@ namespace Microsoft.PythonTools.Debugger.Remote {
         }
 
         public int GetPortSupplierName(out string pbstrName) {
-            pbstrName = PythonDebugOptionsServiceHelper.Options.UseLegacyDebugger
-                ? Strings.RemoteDebugPortSupplierNamePtvsd
-                : Strings.RemoteDebugPortSupplierNameDebugPy;
+            pbstrName = Strings.RemoteDebugPortSupplierNameDebugPy;
             return VSConstants.S_OK;
         }
 
@@ -132,9 +119,7 @@ namespace Microsoft.PythonTools.Debugger.Remote {
         }
 
         public int GetDescription(enum_PORT_SUPPLIER_DESCRIPTION_FLAGS[] pdwFlags, out string pbstrText) {
-            pbstrText = PythonDebugOptionsServiceHelper.Options.UseLegacyDebugger
-                ? Strings.RemoteDebugPortSupplierDescriptionPtvsd
-                : Strings.RemoteDebugPortSupplierDescriptionDebugPy;
+            pbstrText = Strings.RemoteDebugPortSupplierDescriptionDebugPy;
             return VSConstants.S_OK;
         }
     }

--- a/Python/Product/Debugger/Debugger/DebugEngine/Remote/PythonRemoteDebugProgram.cs
+++ b/Python/Product/Debugger/Debugger/DebugEngine/Remote/PythonRemoteDebugProgram.cs
@@ -88,11 +88,8 @@ namespace Microsoft.PythonTools.Debugger.Remote {
         }
 
         public int GetEngineInfo(out string pbstrEngine, out Guid pguidEngine) {
-            pguidEngine = PythonDebugOptionsServiceHelper.Options.UseLegacyDebugger ?
-                AD7Engine.DebugEngineGuid :
-                VSCodeDebugEngine;
+            pguidEngine = VSCodeDebugEngine;
             pbstrEngine = null;
-
             return 0;
         }
 

--- a/Python/Product/Debugger/Debugger/IPythonDebugOptionsService.cs
+++ b/Python/Product/Debugger/Debugger/IPythonDebugOptionsService.cs
@@ -60,10 +60,6 @@ namespace Microsoft.PythonTools.Debugger {
         /// Default is true.
         /// </summary>
         bool ShowFunctionReturnValue { get; }
-        
-        /// <summary>
-        /// True to use the legacy debugger. Default is false.
-        /// </summary>
-        bool UseLegacyDebugger { get; }
+       
     }
 }

--- a/Python/Product/PythonTools/PythonTools/Debugger/DebugAdapter/DebugAdapterRemoteProcess.cs
+++ b/Python/Product/PythonTools/PythonTools/Debugger/DebugAdapter/DebugAdapterRemoteProcess.cs
@@ -59,7 +59,6 @@ namespace Microsoft.PythonTools.Debugger {
                     _stream = new DebugRemoteAdapterProcessStream(new NetworkStream(socket, ownsSocket: true));
                     _stream.Disconnected += OnDisconnected;
                     _stream.Initialized += OnInitialized;
-                    _stream.LegacyDebugger += OnLegacyDebugger;
                 } else {
                     Debug.WriteLine("Timed out waiting for debugger to connect.", nameof(DebugAdapterRemoteProcess));
                     logger?.LogEvent(PythonLogEvent.DebugAdapterConnectionTimeout, "Attach");
@@ -73,6 +72,8 @@ namespace Microsoft.PythonTools.Debugger {
 
         private void OnDisconnected(object sender, EventArgs e) {
             if (_stream != null) {
+                _stream.Disconnected -= OnDisconnected;
+                _stream.Initialized -= OnInitialized;
                 _stream.Dispose();
             }
             Exited?.Invoke(this, null);
@@ -84,8 +85,6 @@ namespace Microsoft.PythonTools.Debugger {
                 DebugPyVersionHelper.VerifyDebugPyVersion,
                 DebugPyVersionHelper.ShowDebugPyVersionError);
         }
-
-        private void OnLegacyDebugger(object sender, EventArgs e) => DebugPyVersionHelper.ShowLegacyPtvsdVersionError();
 
         public IntPtr Handle => IntPtr.Zero;
 

--- a/Python/Product/PythonTools/PythonTools/Debugger/DebugLaunchHelper.cs
+++ b/Python/Product/PythonTools/PythonTools/Debugger/DebugLaunchHelper.cs
@@ -206,12 +206,9 @@ namespace Microsoft.PythonTools.Debugger {
                 } else {
                     var pyService = provider.GetPythonToolsService();
                     // Set the Python debugger
-                    dti.Info.clsidCustom = pyService.DebuggerOptions.UseLegacyDebugger ? AD7Engine.DebugEngineGuid : DebugAdapterLauncher.VSCodeDebugEngine;
+                    dti.Info.clsidCustom = DebugAdapterLauncher.VSCodeDebugEngine;
                     dti.Info.grfLaunch = (uint)__VSDBGLAUNCHFLAGS.DBGLAUNCH_StopDebuggingOnEnd;
-
-                    if (!pyService.DebuggerOptions.UseLegacyDebugger) {
-                        dti.Info.bstrOptions = GetLaunchJsonForVsCodeDebugAdapter(provider, config, fullEnvironment);
-                    }
+                    dti.Info.bstrOptions = GetLaunchJsonForVsCodeDebugAdapter(provider, config, fullEnvironment);
                 }
                 
                 // Null out dti so that it is not disposed before we return.

--- a/Python/Product/PythonTools/PythonTools/Debugger/DebugPyVersionHelper.cs
+++ b/Python/Product/PythonTools/PythonTools/Debugger/DebugPyVersionHelper.cs
@@ -56,7 +56,6 @@ namespace Microsoft.PythonTools.Debugger {
                     ShowDebuggingErrorMessage(
                         Strings.InstalledDebugPyOutdatedTitle,
                         Strings.InstalledDebugPyOutdatedMessage.FormatUI(response.Debugger.Version, DebugPyVersion.Version),
-                        allowDisable: false,
                         isError: false
                     );
                 }
@@ -67,39 +66,11 @@ namespace Microsoft.PythonTools.Debugger {
             ShowDebuggingErrorMessage(
                 Strings.InstalledDebugPyOutdatedTitle,
                 Strings.InstalledDebugPyOutdatedMessage.FormatUI("unknown", DebugPyVersion.Version),
-                allowDisable: false,
                 isError: false
             );
         }
 
-        public static void ShowLegacyPtvsdVersionError() {
-            ShowDebuggingErrorMessage(
-                Strings.InstalledDebugPyOutdatedTitle,
-                Strings.InstalledDebugPyOutdatedMessage.FormatUI("3.*", DebugPyVersion.Version),
-                allowDisable: false,
-                isError: false
-            );
-        }
-
-        public static void ShowDebugPyIncompatibleEnvError() {
-            ShowDebuggingErrorMessage(
-                Strings.PtvsdIncompatibleEnvTitle,
-                Strings.PtvsdIncompatibleEnvMessage,
-                allowDisable: true,
-                isError: true
-            );
-        }
-
-        public static void ShowDebugPyModuleNotFoundError() {
-            ShowDebuggingErrorMessage(
-                Strings.ImportPtvsdModuleNotFoundTitle,
-                Strings.ImportPtvsdModuleNotFoundMessage,
-                allowDisable: false,
-                isError: true
-            );
-        }
-
-        private static void ShowDebuggingErrorMessage(string main, string content, bool allowDisable, bool isError) {
+        private static void ShowDebuggingErrorMessage(string main, string content, bool isError) {
             var serviceProvider = VisualStudio.Shell.ServiceProvider.GlobalProvider;
             try {
                 serviceProvider.GetUIThread().Invoke(() => {
@@ -112,23 +83,8 @@ namespace Microsoft.PythonTools.Debugger {
                         EnableHyperlinks = true,
                     };
 
-                    var disable = new TaskDialogButton(Strings.PtvsdDisableCaption, Strings.PtvsdDisableSubtext);
-                    var learnMore = new TaskDialogButton(Strings.PtvsdLearnMoreCaption, Strings.PtvsdLearnMoreSubtext);
-
                     dlg.Buttons.Add(TaskDialogButton.OK);
-                    dlg.Buttons.Insert(0, learnMore);
-                    if (allowDisable) {
-                        dlg.Buttons.Insert(0, disable);
-                    }
-
-                    var selection = dlg.ShowModal();
-                    if (selection == learnMore) {
-                        Process.Start("https://aka.ms/upgradeptvsd")?.Dispose();
-                    } else if (selection == disable) {
-                        var debuggerOptions = ((PythonToolsService)Package.GetGlobalService(typeof(PythonToolsService))).DebuggerOptions;
-                        debuggerOptions.UseLegacyDebugger = true;
-                        debuggerOptions.Save();
-                    }
+                    dlg.ShowModal();
                 });
             } catch (Exception ex) when (!ex.IsCriticalException()) {
                 ex.ReportUnhandledException(serviceProvider, typeof(DebugPyVersionHelper));

--- a/Python/Product/PythonTools/PythonTools/DiagnosticsProvider.cs
+++ b/Python/Product/PythonTools/PythonTools/DiagnosticsProvider.cs
@@ -200,7 +200,6 @@ namespace Microsoft.PythonTools {
             writer.WriteLine("    PromptBeforeRunningWithBuildError: {0}", pyService.DebuggerOptions.PromptBeforeRunningWithBuildError);
             writer.WriteLine("    ShowFunctionReturnValue: {0}", pyService.DebuggerOptions.ShowFunctionReturnValue);
             writer.WriteLine("    TeeStandardOutput: {0}", pyService.DebuggerOptions.TeeStandardOutput);
-            writer.WriteLine("    UseLegacyDebugger: {0}", pyService.DebuggerOptions.UseLegacyDebugger);
             writer.WriteLine("    WaitOnAbnormalExit: {0}", pyService.DebuggerOptions.WaitOnAbnormalExit);
             writer.WriteLine("    WaitOnNormalExit: {0}", pyService.DebuggerOptions.WaitOnNormalExit);
             writer.WriteLine();

--- a/Python/Product/PythonTools/PythonTools/Options/PythonDebugOptionsService.cs
+++ b/Python/Product/PythonTools/PythonTools/Options/PythonDebugOptionsService.cs
@@ -33,6 +33,5 @@ namespace Microsoft.PythonTools.Options {
         public bool BreakOnSystemExitZero => debugOptions.BreakOnSystemExitZero;
         public bool DebugStdLib => debugOptions.DebugStdLib;
         public bool ShowFunctionReturnValue => debugOptions.ShowFunctionReturnValue;
-        public bool UseLegacyDebugger => debugOptions.UseLegacyDebugger;
     }
 }

--- a/Python/Product/PythonTools/PythonTools/Options/PythonDebuggingOptions.cs
+++ b/Python/Product/PythonTools/PythonTools/Options/PythonDebuggingOptions.cs
@@ -46,7 +46,6 @@ namespace Microsoft.PythonTools.Options {
             BreakOnSystemExitZero = _service.LoadBool(BreakOnSystemExitZeroSetting, Category) ?? false;
             DebugStdLib = _service.LoadBool(DebugStdLibSetting, Category) ?? false;
             ShowFunctionReturnValue = _service.LoadBool(ShowFunctionReturnValueSetting, Category) ?? true;
-            UseLegacyDebugger = _service.LoadBool(UseLegacyDebuggerSetting, Category) ?? false;
             Changed?.Invoke(this, EventArgs.Empty);
         }
 
@@ -58,7 +57,6 @@ namespace Microsoft.PythonTools.Options {
             _service.SaveBool(BreakOnSystemExitZeroSetting, Category, BreakOnSystemExitZero);
             _service.SaveBool(DebugStdLibSetting, Category, DebugStdLib);
             _service.SaveBool(ShowFunctionReturnValueSetting, Category, ShowFunctionReturnValue);
-            _service.SaveBool(UseLegacyDebuggerSetting, Category, UseLegacyDebugger);
             Changed?.Invoke(this, EventArgs.Empty);
         }
 
@@ -70,7 +68,6 @@ namespace Microsoft.PythonTools.Options {
             BreakOnSystemExitZero = false;
             DebugStdLib = false;
             ShowFunctionReturnValue = true;
-            UseLegacyDebugger = false;
             Changed?.Invoke(this, EventArgs.Empty);
         }
 
@@ -136,14 +133,6 @@ namespace Microsoft.PythonTools.Options {
         /// Default is true
         /// </summary>
         public bool ShowFunctionReturnValue {
-            get;
-            set;
-        }
-
-        /// <summary>
-        /// True to use the legacy debugger. Default is false.
-        /// </summary>
-        public bool UseLegacyDebugger {
             get;
             set;
         }

--- a/Python/Product/PythonTools/PythonTools/Options/PythonDebuggingOptionsControl.Designer.cs
+++ b/Python/Product/PythonTools/PythonTools/Options/PythonDebuggingOptionsControl.Designer.cs
@@ -31,7 +31,6 @@ namespace Microsoft.PythonTools.Options {
             this._breakOnSystemExitZero = new System.Windows.Forms.CheckBox();
             this._debugStdLib = new System.Windows.Forms.CheckBox();
             this._showFunctionReturnValue = new System.Windows.Forms.CheckBox();
-            this._useLegacyDebugger = new System.Windows.Forms.CheckBox();
             this.tableLayoutPanel2 = new System.Windows.Forms.TableLayoutPanel();
             this.tableLayoutPanel2.SuspendLayout();
             this.SuspendLayout();
@@ -84,13 +83,6 @@ namespace Microsoft.PythonTools.Options {
             this._showFunctionReturnValue.Name = "_showFunctionReturnValue";
             this._showFunctionReturnValue.UseVisualStyleBackColor = true;
             // 
-            // _useLegacyDebugger
-            // 
-            resources.ApplyResources(this._useLegacyDebugger, "_useLegacyDebugger");
-            this._useLegacyDebugger.AutoEllipsis = true;
-            this._useLegacyDebugger.Name = "_useLegacyDebugger";
-            this._useLegacyDebugger.UseVisualStyleBackColor = true;
-            // 
             // tableLayoutPanel2
             // 
             resources.ApplyResources(this.tableLayoutPanel2, "tableLayoutPanel2");
@@ -101,7 +93,6 @@ namespace Microsoft.PythonTools.Options {
             this.tableLayoutPanel2.Controls.Add(this._breakOnSystemExitZero, 0, 4);
             this.tableLayoutPanel2.Controls.Add(this._debugStdLib, 0, 5);
             this.tableLayoutPanel2.Controls.Add(this._showFunctionReturnValue, 0, 6);
-            this.tableLayoutPanel2.Controls.Add(this._useLegacyDebugger, 0, 7);
             this.tableLayoutPanel2.Name = "tableLayoutPanel2";
             // 
             // PythonDebuggingOptionsControl
@@ -126,7 +117,6 @@ namespace Microsoft.PythonTools.Options {
         private System.Windows.Forms.CheckBox _breakOnSystemExitZero;
         private System.Windows.Forms.CheckBox _debugStdLib;
         private System.Windows.Forms.CheckBox _showFunctionReturnValue;
-        private System.Windows.Forms.CheckBox _useLegacyDebugger;
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel2;
     }
 }

--- a/Python/Product/PythonTools/PythonTools/Options/PythonDebuggingOptionsControl.cs
+++ b/Python/Product/PythonTools/PythonTools/Options/PythonDebuggingOptionsControl.cs
@@ -30,7 +30,6 @@ namespace Microsoft.PythonTools.Options {
             _breakOnSystemExitZero.Checked = pyService.DebuggerOptions.BreakOnSystemExitZero;
             _debugStdLib.Checked = pyService.DebuggerOptions.DebugStdLib;
             _showFunctionReturnValue.Checked = pyService.DebuggerOptions.ShowFunctionReturnValue;
-            _useLegacyDebugger.Checked = pyService.DebuggerOptions.UseLegacyDebugger;
         }
 
         internal void SyncPageWithControlSettings(PythonToolsService pyService) {
@@ -41,7 +40,6 @@ namespace Microsoft.PythonTools.Options {
             pyService.DebuggerOptions.BreakOnSystemExitZero = _breakOnSystemExitZero.Checked;
             pyService.DebuggerOptions.DebugStdLib = _debugStdLib.Checked;
             pyService.DebuggerOptions.ShowFunctionReturnValue = _showFunctionReturnValue.Checked;
-            pyService.DebuggerOptions.UseLegacyDebugger = _useLegacyDebugger.Checked;
         }
     }
 }

--- a/Python/Product/PythonTools/PythonTools/Options/PythonDebuggingOptionsControl.resx
+++ b/Python/Product/PythonTools/PythonTools/Options/PythonDebuggingOptionsControl.resx
@@ -127,13 +127,13 @@
   </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="_promptOnBuildError.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 3</value>
+    <value>11, 6</value>
   </data>
   <data name="_promptOnBuildError.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 3, 6, 3</value>
+    <value>11, 6, 11, 6</value>
   </data>
   <data name="_promptOnBuildError.Size" type="System.Drawing.Size, System.Drawing">
-    <value>244, 17</value>
+    <value>440, 29</value>
   </data>
   <data name="_promptOnBuildError.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -160,13 +160,13 @@
     <value>True</value>
   </data>
   <data name="_waitOnAbnormalExit.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 26</value>
+    <value>11, 47</value>
   </data>
   <data name="_waitOnAbnormalExit.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 3, 6, 3</value>
+    <value>11, 6, 11, 6</value>
   </data>
   <data name="_waitOnAbnormalExit.Size" type="System.Drawing.Size, System.Drawing">
-    <value>235, 17</value>
+    <value>423, 29</value>
   </data>
   <data name="_waitOnAbnormalExit.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -193,13 +193,13 @@
     <value>True</value>
   </data>
   <data name="_waitOnNormalExit.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 49</value>
+    <value>11, 88</value>
   </data>
   <data name="_waitOnNormalExit.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 3, 6, 3</value>
+    <value>11, 6, 11, 6</value>
   </data>
   <data name="_waitOnNormalExit.Size" type="System.Drawing.Size, System.Drawing">
-    <value>223, 17</value>
+    <value>401, 29</value>
   </data>
   <data name="_waitOnNormalExit.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -226,13 +226,13 @@
     <value>True</value>
   </data>
   <data name="_teeStdOut.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 72</value>
+    <value>11, 129</value>
   </data>
   <data name="_teeStdOut.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 3, 6, 3</value>
+    <value>11, 6, 11, 6</value>
   </data>
   <data name="_teeStdOut.Size" type="System.Drawing.Size, System.Drawing">
-    <value>240, 17</value>
+    <value>427, 29</value>
   </data>
   <data name="_teeStdOut.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -259,13 +259,13 @@
     <value>True</value>
   </data>
   <data name="_breakOnSystemExitZero.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 95</value>
+    <value>11, 170</value>
   </data>
   <data name="_breakOnSystemExitZero.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 3, 6, 3</value>
+    <value>11, 6, 11, 6</value>
   </data>
   <data name="_breakOnSystemExitZero.Size" type="System.Drawing.Size, System.Drawing">
-    <value>275, 17</value>
+    <value>494, 29</value>
   </data>
   <data name="_breakOnSystemExitZero.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -292,13 +292,13 @@
     <value>True</value>
   </data>
   <data name="_debugStdLib.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 118</value>
+    <value>11, 211</value>
   </data>
   <data name="_debugStdLib.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 3, 6, 3</value>
+    <value>11, 6, 11, 6</value>
   </data>
   <data name="_debugStdLib.Size" type="System.Drawing.Size, System.Drawing">
-    <value>252, 17</value>
+    <value>453, 29</value>
   </data>
   <data name="_debugStdLib.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -325,13 +325,13 @@
     <value>True</value>
   </data>
   <data name="_showFunctionReturnValue.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 141</value>
+    <value>11, 252</value>
   </data>
   <data name="_showFunctionReturnValue.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 3, 6, 3</value>
+    <value>11, 6, 11, 6</value>
   </data>
   <data name="_showFunctionReturnValue.Size" type="System.Drawing.Size, System.Drawing">
-    <value>153, 17</value>
+    <value>268, 29</value>
   </data>
   <data name="_showFunctionReturnValue.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
@@ -351,42 +351,6 @@
   <data name="&gt;&gt;_showFunctionReturnValue.ZOrder" xml:space="preserve">
     <value>6</value>
   </data>
-  <data name="_useLegacyDebugger.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Left</value>
-  </data>
-  <data name="_useLegacyDebugger.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="_useLegacyDebugger.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="_useLegacyDebugger.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 164</value>
-  </data>
-  <data name="_useLegacyDebugger.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 3, 6, 3</value>
-  </data>
-  <data name="_useLegacyDebugger.Size" type="System.Drawing.Size, System.Drawing">
-    <value>127, 17</value>
-  </data>
-  <data name="_useLegacyDebugger.TabIndex" type="System.Int32, mscorlib">
-    <value>7</value>
-  </data>
-  <data name="_useLegacyDebugger.Text" xml:space="preserve">
-    <value>U&amp;se legacy debugger</value>
-  </data>
-  <data name="&gt;&gt;_useLegacyDebugger.Name" xml:space="preserve">
-    <value>_useLegacyDebugger</value>
-  </data>
-  <data name="&gt;&gt;_useLegacyDebugger.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;_useLegacyDebugger.Parent" xml:space="preserve">
-    <value>tableLayoutPanel2</value>
-  </data>
-  <data name="&gt;&gt;_useLegacyDebugger.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
   <data name="tableLayoutPanel2.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -402,11 +366,14 @@
   <data name="tableLayoutPanel2.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 0</value>
   </data>
+  <data name="tableLayoutPanel2.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>6, 6, 6, 6</value>
+  </data>
   <data name="tableLayoutPanel2.RowCount" type="System.Int32, mscorlib">
     <value>9</value>
   </data>
   <data name="tableLayoutPanel2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>381, 290</value>
+    <value>699, 535</value>
   </data>
   <data name="tableLayoutPanel2.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -424,19 +391,19 @@
     <value>0</value>
   </data>
   <data name="tableLayoutPanel2.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="_promptOnBuildError" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_waitOnAbnormalExit" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_waitOnNormalExit" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_teeStdOut" Row="3" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_breakOnSystemExitZero" Row="4" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_debugStdLib" Row="5" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_showFunctionReturnValue" Row="6" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_useLegacyDebugger" Row="7" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,Percent,100" /&gt;&lt;/TableLayoutSettings&gt;</value>
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="_promptOnBuildError" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_waitOnAbnormalExit" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_waitOnNormalExit" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_teeStdOut" Row="3" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_breakOnSystemExitZero" Row="4" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_debugStdLib" Row="5" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_showFunctionReturnValue" Row="6" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,Percent,100" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
-    <value>6, 13</value>
+    <value>11, 24</value>
   </data>
   <data name="$this.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 8, 6, 8</value>
+    <value>11, 15, 11, 15</value>
   </data>
   <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
-    <value>381, 290</value>
+    <value>699, 535</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>PythonDebuggingOptionsControl</value>

--- a/Python/Product/PythonTools/PythonTools/Options/PythonGeneralOptionsControl.Designer.cs
+++ b/Python/Product/PythonTools/PythonTools/Options/PythonGeneralOptionsControl.Designer.cs
@@ -32,11 +32,6 @@ namespace Microsoft.PythonTools.Options {
             this._promptForPytestEnableAndInstall = new System.Windows.Forms.CheckBox();
             this._elevatePip = new System.Windows.Forms.CheckBox();
             this._clearGlobalPythonPath = new System.Windows.Forms.CheckBox();
-            this._updateSearchPathsForLinkedFiles = new System.Windows.Forms.CheckBox();
-            this._unresolvedImportWarning = new System.Windows.Forms.CheckBox();
-            this._invalidEncodingWarning = new System.Windows.Forms.CheckBox();
-            this._indentationInconsistentLabel = new System.Windows.Forms.Label();
-            this._indentationInconsistentCombo = new System.Windows.Forms.ComboBox();
             this._resetSuppressDialog = new System.Windows.Forms.Button();
             this.tableLayoutPanel3.SuspendLayout();
             this.SuspendLayout();
@@ -51,11 +46,6 @@ namespace Microsoft.PythonTools.Options {
             this.tableLayoutPanel3.Controls.Add(this._promptForPytestEnableAndInstall, 0, 4);
             this.tableLayoutPanel3.Controls.Add(this._elevatePip, 0, 5);
             this.tableLayoutPanel3.Controls.Add(this._clearGlobalPythonPath, 0, 6);
-            this.tableLayoutPanel3.Controls.Add(this._updateSearchPathsForLinkedFiles, 0, 7);
-            this.tableLayoutPanel3.Controls.Add(this._unresolvedImportWarning, 0, 8);
-            this.tableLayoutPanel3.Controls.Add(this._invalidEncodingWarning, 0, 9);
-            this.tableLayoutPanel3.Controls.Add(this._indentationInconsistentLabel, 0, 10);
-            this.tableLayoutPanel3.Controls.Add(this._indentationInconsistentCombo, 1, 10);
             this.tableLayoutPanel3.Controls.Add(this._resetSuppressDialog, 0, 11);
             this.tableLayoutPanel3.Name = "tableLayoutPanel3";
             // 
@@ -109,46 +99,6 @@ namespace Microsoft.PythonTools.Options {
             this._clearGlobalPythonPath.Name = "_clearGlobalPythonPath";
             this._clearGlobalPythonPath.UseVisualStyleBackColor = true;
             // 
-            // _updateSearchPathsForLinkedFiles
-            // 
-            resources.ApplyResources(this._updateSearchPathsForLinkedFiles, "_updateSearchPathsForLinkedFiles");
-            this._updateSearchPathsForLinkedFiles.AutoEllipsis = true;
-            this.tableLayoutPanel3.SetColumnSpan(this._updateSearchPathsForLinkedFiles, 2);
-            this._updateSearchPathsForLinkedFiles.Name = "_updateSearchPathsForLinkedFiles";
-            this._updateSearchPathsForLinkedFiles.UseVisualStyleBackColor = true;
-            // 
-            // _unresolvedImportWarning
-            // 
-            resources.ApplyResources(this._unresolvedImportWarning, "_unresolvedImportWarning");
-            this._unresolvedImportWarning.AutoEllipsis = true;
-            this.tableLayoutPanel3.SetColumnSpan(this._unresolvedImportWarning, 2);
-            this._unresolvedImportWarning.Name = "_unresolvedImportWarning";
-            this._unresolvedImportWarning.UseVisualStyleBackColor = true;
-            // 
-            // _invalidEncodingWarning
-            // 
-            resources.ApplyResources(this._invalidEncodingWarning, "_invalidEncodingWarning");
-            this.tableLayoutPanel3.SetColumnSpan(this._invalidEncodingWarning, 2);
-            this._invalidEncodingWarning.Name = "_invalidEncodingWarning";
-            this._invalidEncodingWarning.UseVisualStyleBackColor = true;
-            // 
-            // _indentationInconsistentLabel
-            // 
-            resources.ApplyResources(this._indentationInconsistentLabel, "_indentationInconsistentLabel");
-            this._indentationInconsistentLabel.AutoEllipsis = true;
-            this._indentationInconsistentLabel.Name = "_indentationInconsistentLabel";
-            // 
-            // _indentationInconsistentCombo
-            // 
-            resources.ApplyResources(this._indentationInconsistentCombo, "_indentationInconsistentCombo");
-            this._indentationInconsistentCombo.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this._indentationInconsistentCombo.FormattingEnabled = true;
-            this._indentationInconsistentCombo.Items.AddRange(new object[] {
-            resources.GetString("_indentationInconsistentCombo.Items"),
-            resources.GetString("_indentationInconsistentCombo.Items1"),
-            resources.GetString("_indentationInconsistentCombo.Items2")});
-            this._indentationInconsistentCombo.Name = "_indentationInconsistentCombo";
-            // 
             // _resetSuppressDialog
             // 
             resources.ApplyResources(this._resetSuppressDialog, "_resetSuppressDialog");
@@ -177,14 +127,9 @@ namespace Microsoft.PythonTools.Options {
         private System.Windows.Forms.CheckBox _showOutputWindowForPackageInstallation;
         private System.Windows.Forms.CheckBox _promptForEnvCreate;
         private System.Windows.Forms.CheckBox _promptForPackageInstallation;
-        private System.Windows.Forms.CheckBox _updateSearchPathsForLinkedFiles;
-        private System.Windows.Forms.Label _indentationInconsistentLabel;
-        private System.Windows.Forms.ComboBox _indentationInconsistentCombo;
         private System.Windows.Forms.CheckBox _promptForPytestEnableAndInstall;
         private System.Windows.Forms.CheckBox _elevatePip;
-        private System.Windows.Forms.CheckBox _unresolvedImportWarning;
         private System.Windows.Forms.CheckBox _clearGlobalPythonPath;
         private System.Windows.Forms.Button _resetSuppressDialog;
-        private System.Windows.Forms.CheckBox _invalidEncodingWarning;
     }
 }

--- a/Python/Product/PythonTools/PythonTools/Options/PythonGeneralOptionsControl.cs
+++ b/Python/Product/PythonTools/PythonTools/Options/PythonGeneralOptionsControl.cs
@@ -16,44 +16,12 @@
 
 using System;
 using System.Windows.Forms;
-using Microsoft.Python.Parsing;
 
 namespace Microsoft.PythonTools.Options {
     public partial class PythonGeneralOptionsControl : UserControl {
-        private const int ErrorIndex = 0;
-        private const int WarningIndex = 1;
-        private const int DontIndex = 2;
 
         public PythonGeneralOptionsControl() {
             InitializeComponent();
-        }
-
-        internal Severity IndentationInconsistencySeverity {
-            get {
-                switch (_indentationInconsistentCombo.SelectedIndex) {
-                    case ErrorIndex: 
-                        return Severity.Error;
-                    case WarningIndex: 
-                        return Severity.Warning;
-                    case DontIndex: 
-                        return Severity.Suppressed;
-                    default:
-                        return Severity.Suppressed;
-                }
-            }
-            set {
-                switch (value) {
-                    case Severity.Error: 
-                        _indentationInconsistentCombo.SelectedIndex = ErrorIndex; 
-                        break;
-                    case Severity.Warning: 
-                        _indentationInconsistentCombo.SelectedIndex = WarningIndex; 
-                        break;
-                    default: 
-                        _indentationInconsistentCombo.SelectedIndex = DontIndex; 
-                        break;
-                }
-            }
         }
 
         internal void SyncControlWithPageSettings(PythonToolsService pyService) {
@@ -63,11 +31,7 @@ namespace Microsoft.PythonTools.Options {
             _promptForPackageInstallation.Checked = pyService.GeneralOptions.PromptForPackageInstallation;
             _promptForPytestEnableAndInstall.Checked = pyService.GeneralOptions.PromptForTestFrameWorkInfoBar;
             _elevatePip.Checked = pyService.GeneralOptions.ElevatePip;
-            _updateSearchPathsForLinkedFiles.Checked = pyService.GeneralOptions.UpdateSearchPathsWhenAddingLinkedFiles;
-            _unresolvedImportWarning.Checked = pyService.GeneralOptions.UnresolvedImportWarning;
-            _invalidEncodingWarning.Checked = pyService.GeneralOptions.InvalidEncodingWarning;
             _clearGlobalPythonPath.Checked = pyService.GeneralOptions.ClearGlobalPythonPath;
-            IndentationInconsistencySeverity = pyService.GeneralOptions.IndentationInconsistencySeverity;
         }
 
         internal void SyncPageWithControlSettings(PythonToolsService pyService) {
@@ -77,10 +41,6 @@ namespace Microsoft.PythonTools.Options {
             pyService.GeneralOptions.PromptForPackageInstallation = _promptForPackageInstallation.Checked;
             pyService.GeneralOptions.PromptForTestFrameWorkInfoBar = _promptForPytestEnableAndInstall.Checked;
             pyService.GeneralOptions.ElevatePip = _elevatePip.Checked;
-            pyService.GeneralOptions.UpdateSearchPathsWhenAddingLinkedFiles = _updateSearchPathsForLinkedFiles.Checked;
-            pyService.GeneralOptions.IndentationInconsistencySeverity = IndentationInconsistencySeverity;
-            pyService.GeneralOptions.UnresolvedImportWarning = _unresolvedImportWarning.Checked;
-            pyService.GeneralOptions.InvalidEncodingWarning = _invalidEncodingWarning.Checked;
             pyService.GeneralOptions.ClearGlobalPythonPath = _clearGlobalPythonPath.Checked;
         }
 

--- a/Python/Product/PythonTools/PythonTools/Options/PythonGeneralOptionsControl.resx
+++ b/Python/Product/PythonTools/PythonTools/Options/PythonGeneralOptionsControl.resx
@@ -133,13 +133,13 @@
   </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="_showOutputWindowForVirtualEnvCreate.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 3</value>
+    <value>11, 6</value>
   </data>
   <data name="_showOutputWindowForVirtualEnvCreate.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 3, 6, 3</value>
+    <value>11, 6, 11, 6</value>
   </data>
   <data name="_showOutputWindowForVirtualEnvCreate.Size" type="System.Drawing.Size, System.Drawing">
-    <value>315, 17</value>
+    <value>564, 29</value>
   </data>
   <data name="_showOutputWindowForVirtualEnvCreate.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -163,13 +163,13 @@
     <value>True</value>
   </data>
   <data name="_showOutputWindowForPackageInstallation.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 26</value>
+    <value>11, 47</value>
   </data>
   <data name="_showOutputWindowForPackageInstallation.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 3, 6, 3</value>
+    <value>11, 6, 11, 6</value>
   </data>
   <data name="_showOutputWindowForPackageInstallation.Size" type="System.Drawing.Size, System.Drawing">
-    <value>328, 17</value>
+    <value>589, 29</value>
   </data>
   <data name="_showOutputWindowForPackageInstallation.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -196,13 +196,13 @@
     <value>NoControl</value>
   </data>
   <data name="_promptForEnvCreate.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 49</value>
+    <value>11, 88</value>
   </data>
   <data name="_promptForEnvCreate.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 3, 6, 3</value>
+    <value>11, 6, 11, 6</value>
   </data>
   <data name="_promptForEnvCreate.Size" type="System.Drawing.Size, System.Drawing">
-    <value>236, 17</value>
+    <value>420, 29</value>
   </data>
   <data name="_promptForEnvCreate.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -229,13 +229,13 @@
     <value>NoControl</value>
   </data>
   <data name="_promptForPackageInstallation.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 72</value>
+    <value>11, 129</value>
   </data>
   <data name="_promptForPackageInstallation.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 3, 6, 3</value>
+    <value>11, 6, 11, 6</value>
   </data>
   <data name="_promptForPackageInstallation.Size" type="System.Drawing.Size, System.Drawing">
-    <value>216, 17</value>
+    <value>383, 29</value>
   </data>
   <data name="_promptForPackageInstallation.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -259,13 +259,13 @@
     <value>True</value>
   </data>
   <data name="_promptForPytestEnableAndInstall.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 95</value>
+    <value>11, 170</value>
   </data>
   <data name="_promptForPytestEnableAndInstall.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 3, 6, 3</value>
+    <value>11, 6, 11, 6</value>
   </data>
   <data name="_promptForPytestEnableAndInstall.Size" type="System.Drawing.Size, System.Drawing">
-    <value>253, 17</value>
+    <value>455, 29</value>
   </data>
   <data name="_promptForPytestEnableAndInstall.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -289,13 +289,13 @@
     <value>True</value>
   </data>
   <data name="_elevatePip.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 118</value>
+    <value>11, 211</value>
   </data>
   <data name="_elevatePip.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 3, 6, 3</value>
+    <value>11, 6, 11, 6</value>
   </data>
   <data name="_elevatePip.Size" type="System.Drawing.Size, System.Drawing">
-    <value>248, 17</value>
+    <value>451, 29</value>
   </data>
   <data name="_elevatePip.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -322,13 +322,13 @@
     <value>True</value>
   </data>
   <data name="_clearGlobalPythonPath.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 141</value>
+    <value>11, 252</value>
   </data>
   <data name="_clearGlobalPythonPath.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 3, 6, 3</value>
+    <value>11, 6, 11, 6</value>
   </data>
   <data name="_clearGlobalPythonPath.Size" type="System.Drawing.Size, System.Drawing">
-    <value>238, 17</value>
+    <value>432, 29</value>
   </data>
   <data name="_clearGlobalPythonPath.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
@@ -348,180 +348,6 @@
   <data name="&gt;&gt;_clearGlobalPythonPath.ZOrder" xml:space="preserve">
     <value>6</value>
   </data>
-  <data name="_updateSearchPathsForLinkedFiles.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Left</value>
-  </data>
-  <data name="_updateSearchPathsForLinkedFiles.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="_updateSearchPathsForLinkedFiles.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 164</value>
-  </data>
-  <data name="_updateSearchPathsForLinkedFiles.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 3, 6, 3</value>
-  </data>
-  <data name="_updateSearchPathsForLinkedFiles.Size" type="System.Drawing.Size, System.Drawing">
-    <value>241, 17</value>
-  </data>
-  <data name="_updateSearchPathsForLinkedFiles.TabIndex" type="System.Int32, mscorlib">
-    <value>7</value>
-  </data>
-  <data name="_updateSearchPathsForLinkedFiles.Text" xml:space="preserve">
-    <value>&amp;Update search paths when adding linked files</value>
-  </data>
-  <data name="&gt;&gt;_updateSearchPathsForLinkedFiles.Name" xml:space="preserve">
-    <value>_updateSearchPathsForLinkedFiles</value>
-  </data>
-  <data name="&gt;&gt;_updateSearchPathsForLinkedFiles.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;_updateSearchPathsForLinkedFiles.Parent" xml:space="preserve">
-    <value>tableLayoutPanel3</value>
-  </data>
-  <data name="&gt;&gt;_updateSearchPathsForLinkedFiles.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
-  <data name="_unresolvedImportWarning.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Left</value>
-  </data>
-  <data name="_unresolvedImportWarning.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="_unresolvedImportWarning.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 187</value>
-  </data>
-  <data name="_unresolvedImportWarning.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 3, 6, 3</value>
-  </data>
-  <data name="_unresolvedImportWarning.Size" type="System.Drawing.Size, System.Drawing">
-    <value>242, 17</value>
-  </data>
-  <data name="_unresolvedImportWarning.TabIndex" type="System.Int32, mscorlib">
-    <value>8</value>
-  </data>
-  <data name="_unresolvedImportWarning.Text" xml:space="preserve">
-    <value>&amp;Warn when imported module cannot be found</value>
-  </data>
-  <data name="&gt;&gt;_unresolvedImportWarning.Name" xml:space="preserve">
-    <value>_unresolvedImportWarning</value>
-  </data>
-  <data name="&gt;&gt;_unresolvedImportWarning.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;_unresolvedImportWarning.Parent" xml:space="preserve">
-    <value>tableLayoutPanel3</value>
-  </data>
-  <data name="&gt;&gt;_unresolvedImportWarning.ZOrder" xml:space="preserve">
-    <value>8</value>
-  </data>
-  <data name="_invalidEncodingWarning.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Left</value>
-  </data>
-  <data name="_invalidEncodingWarning.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="_invalidEncodingWarning.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="_invalidEncodingWarning.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 210</value>
-  </data>
-  <data name="_invalidEncodingWarning.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 3, 6, 3</value>
-  </data>
-  <data name="_invalidEncodingWarning.Size" type="System.Drawing.Size, System.Drawing">
-    <value>297, 17</value>
-  </data>
-  <data name="_invalidEncodingWarning.TabIndex" type="System.Int32, mscorlib">
-    <value>9</value>
-  </data>
-  <data name="_invalidEncodingWarning.Text" xml:space="preserve">
-    <value>Warn when file &amp;encoding does not match magic comment</value>
-  </data>
-  <data name="&gt;&gt;_invalidEncodingWarning.Name" xml:space="preserve">
-    <value>_invalidEncodingWarning</value>
-  </data>
-  <data name="&gt;&gt;_invalidEncodingWarning.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;_invalidEncodingWarning.Parent" xml:space="preserve">
-    <value>tableLayoutPanel3</value>
-  </data>
-  <data name="&gt;&gt;_invalidEncodingWarning.ZOrder" xml:space="preserve">
-    <value>9</value>
-  </data>
-  <data name="_indentationInconsistentLabel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Left</value>
-  </data>
-  <data name="_indentationInconsistentLabel.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="_indentationInconsistentLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 237</value>
-  </data>
-  <data name="_indentationInconsistentLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 0, 6, 0</value>
-  </data>
-  <data name="_indentationInconsistentLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>167, 13</value>
-  </data>
-  <data name="_indentationInconsistentLabel.TabIndex" type="System.Int32, mscorlib">
-    <value>10</value>
-  </data>
-  <data name="_indentationInconsistentLabel.Text" xml:space="preserve">
-    <value>&amp;Report inconsistent indentation as</value>
-  </data>
-  <data name="_indentationInconsistentLabel.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-    <value>MiddleLeft</value>
-  </data>
-  <data name="&gt;&gt;_indentationInconsistentLabel.Name" xml:space="preserve">
-    <value>_indentationInconsistentLabel</value>
-  </data>
-  <data name="&gt;&gt;_indentationInconsistentLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;_indentationInconsistentLabel.Parent" xml:space="preserve">
-    <value>tableLayoutPanel3</value>
-  </data>
-  <data name="&gt;&gt;_indentationInconsistentLabel.ZOrder" xml:space="preserve">
-    <value>10</value>
-  </data>
-  <data name="_indentationInconsistentCombo.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Left, Right</value>
-  </data>
-  <data name="_indentationInconsistentCombo.Items" xml:space="preserve">
-    <value>Errors</value>
-  </data>
-  <data name="_indentationInconsistentCombo.Items1" xml:space="preserve">
-    <value>Warnings</value>
-  </data>
-  <data name="_indentationInconsistentCombo.Items2" xml:space="preserve">
-    <value>Don't</value>
-  </data>
-  <data name="_indentationInconsistentCombo.Location" type="System.Drawing.Point, System.Drawing">
-    <value>185, 233</value>
-  </data>
-  <data name="_indentationInconsistentCombo.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 3, 6, 3</value>
-  </data>
-  <data name="_indentationInconsistentCombo.Size" type="System.Drawing.Size, System.Drawing">
-    <value>190, 21</value>
-  </data>
-  <data name="_indentationInconsistentCombo.TabIndex" type="System.Int32, mscorlib">
-    <value>11</value>
-  </data>
-  <data name="&gt;&gt;_indentationInconsistentCombo.Name" xml:space="preserve">
-    <value>_indentationInconsistentCombo</value>
-  </data>
-  <data name="&gt;&gt;_indentationInconsistentCombo.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;_indentationInconsistentCombo.Parent" xml:space="preserve">
-    <value>tableLayoutPanel3</value>
-  </data>
-  <data name="&gt;&gt;_indentationInconsistentCombo.ZOrder" xml:space="preserve">
-    <value>11</value>
-  </data>
   <data name="_resetSuppressDialog.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top</value>
   </data>
@@ -535,10 +361,13 @@
     <value>NoControl</value>
   </data>
   <data name="_resetSuppressDialog.Location" type="System.Drawing.Point, System.Drawing">
-    <value>96, 260</value>
+    <value>180, 293</value>
+  </data>
+  <data name="_resetSuppressDialog.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>6, 6, 6, 6</value>
   </data>
   <data name="_resetSuppressDialog.Size" type="System.Drawing.Size, System.Drawing">
-    <value>189, 23</value>
+    <value>339, 35</value>
   </data>
   <data name="_resetSuppressDialog.TabIndex" type="System.Int32, mscorlib">
     <value>12</value>
@@ -556,7 +385,7 @@
     <value>tableLayoutPanel3</value>
   </data>
   <data name="&gt;&gt;_resetSuppressDialog.ZOrder" xml:space="preserve">
-    <value>12</value>
+    <value>7</value>
   </data>
   <data name="tableLayoutPanel3.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
@@ -565,13 +394,13 @@
     <value>0, 0</value>
   </data>
   <data name="tableLayoutPanel3.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 4, 3, 4</value>
+    <value>6, 7, 6, 7</value>
   </data>
   <data name="tableLayoutPanel3.RowCount" type="System.Int32, mscorlib">
     <value>14</value>
   </data>
   <data name="tableLayoutPanel3.Size" type="System.Drawing.Size, System.Drawing">
-    <value>381, 313</value>
+    <value>699, 602</value>
   </data>
   <data name="tableLayoutPanel3.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -589,19 +418,19 @@
     <value>0</value>
   </data>
   <data name="tableLayoutPanel3.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="_showOutputWindowForVirtualEnvCreate" Row="0" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="_showOutputWindowForPackageInstallation" Row="1" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="_promptForEnvCreate" Row="2" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="_promptForPackageInstallation" Row="3" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="_promptForPytestEnableAndInstall" Row="4" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="_elevatePip" Row="5" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="_clearGlobalPythonPath" Row="6" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="_updateSearchPathsForLinkedFiles" Row="7" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="_unresolvedImportWarning" Row="8" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="_invalidEncodingWarning" Row="9" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="_indentationInconsistentLabel" Row="10" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_indentationInconsistentCombo" Row="10" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="_resetSuppressDialog" Row="11" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,Absolute,32,Absolute,8,Absolute,20" /&gt;&lt;/TableLayoutSettings&gt;</value>
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="_showOutputWindowForVirtualEnvCreate" Row="0" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="_showOutputWindowForPackageInstallation" Row="1" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="_promptForEnvCreate" Row="2" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="_promptForPackageInstallation" Row="3" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="_promptForPytestEnableAndInstall" Row="4" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="_elevatePip" Row="5" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="_clearGlobalPythonPath" Row="6" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="_resetSuppressDialog" Row="11" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,Absolute,59,Absolute,15,Absolute,37" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
-    <value>6, 13</value>
+    <value>11, 24</value>
   </data>
   <data name="$this.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 8, 6, 8</value>
+    <value>11, 15, 11, 15</value>
   </data>
   <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
-    <value>381, 326</value>
+    <value>699, 602</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>PythonGeneralOptionsControl</value>

--- a/Python/Product/PythonTools/PythonTools/PythonAutomation.cs
+++ b/Python/Product/PythonTools/PythonTools/PythonAutomation.cs
@@ -104,11 +104,9 @@ namespace Microsoft.PythonTools {
 
         public bool UseLegacyDebugger {
             get {
-                return _pyService.DebuggerOptions.UseLegacyDebugger;
+                return false;
             }
             set {
-                _pyService.DebuggerOptions.UseLegacyDebugger = value;
-                _pyService.DebuggerOptions.Save();
             }
         }
 

--- a/Python/Product/PythonTools/PythonTools/Repl/PythonDebugReplEvaluator.cs
+++ b/Python/Product/PythonTools/PythonTools/Repl/PythonDebugReplEvaluator.cs
@@ -606,7 +606,7 @@ namespace Microsoft.PythonTools.Repl {
         }
 
         private void NotSupported() {
-            CurrentWindow.WriteError(Strings.DebugReplFeatureNotSupportedWithExperimentalDebugger);
+            CurrentWindow.WriteError(Strings.DebugReplFeatureNotSupported);
         }
 
         private void NoExecutionIfNotStoppedInDebuggerError() {
@@ -614,7 +614,7 @@ namespace Microsoft.PythonTools.Repl {
         }
 
         public Task<ExecutionResult> InitializeAsync() {
-            _commands = PythonInteractiveEvaluator.GetInteractiveCommands(_serviceProvider, CurrentWindow, this);
+            _commands = PythonCommonInteractiveEvaluator.GetInteractiveCommands(_serviceProvider, CurrentWindow, this);
 
             CurrentWindow.TextView.Options.SetOptionValue(InteractiveWindowOptions.SmartUpDown, CurrentOptions.UseSmartHistory);
             CurrentWindow.WriteLine(Strings.DebugReplHelpMessage);

--- a/Python/Product/PythonTools/PythonToolsService.cs
+++ b/Python/Product/PythonTools/PythonToolsService.cs
@@ -132,10 +132,6 @@ namespace Microsoft.PythonTools {
                         { "IronPython", installedIronPython },
                     });
                 }
-
-                Logger.LogEvent(PythonLogEvent.Experiments, new Dictionary<string, object> {
-                    { "UseVsCodeDebugger", !DebuggerOptions.UseLegacyDebugger }
-                });
             } catch (Exception ex) {
                 Debug.Fail(ex.ToUnhandledExceptionMessage(GetType()));
             }


### PR DESCRIPTION
Remove legacy debugger option. Does not remove actual code, only Tools | Options related part. Also removes options that are configured in Pylance differently.