### PR TITLE
Minor add environment dialog style cleanup

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Environments/AddCondaEnvironmentControl.xaml
+++ b/Python/Product/PythonTools/PythonTools/Environments/AddCondaEnvironmentControl.xaml
@@ -153,8 +153,7 @@
                         ItemTemplate="{StaticResource ProjectTemplate}"
                         AutomationProperties.LabeledBy="{Binding ElementName=ProjectLabel}"
                         AutomationProperties.IsRequiredForForm="{Binding Path=Projects, Converter={x:Static wpf:Converters.NullOrEmptyIsFalse}}"
-                        AutomationProperties.AutomationId="Project"
-                        Style="{DynamicResource {x:Static ptwpf:ModernStyles.ThemedDialogComboBoxStyleKey}}"/>
+                        AutomationProperties.AutomationId="Project"/>
 
                     <Label
                         x:Name="EnvNameLabel"
@@ -198,8 +197,7 @@
                         Content="{x:Static common:Strings.AddCondaEnvironmentFileRadioButton}"
                         IsChecked="{Binding Path=IsEnvFile}"
                         GroupName="SourceType"
-                        AutomationProperties.AutomationId="EnvFileMode"
-                        Style="{DynamicResource {x:Static ptwpf:ModernStyles.ThemedDialogRadioButtonStyleKey}}"/>
+                        AutomationProperties.AutomationId="EnvFileMode"/>
 
                     <wpf:ConfigurationTextBoxWithHelp
                         Margin="36 0 0 9"
@@ -220,8 +218,7 @@
                         Content="{x:Static common:Strings.AddCondaPackagesRadioButton}"
                         IsChecked="{Binding Path=IsPackages}"
                         GroupName="SourceType"
-                        AutomationProperties.AutomationId="PackagesMode"
-                        Style="{DynamicResource {x:Static ptwpf:ModernStyles.ThemedDialogRadioButtonStyleKey}}"/>
+                        AutomationProperties.AutomationId="PackagesMode"/>
 
                     <wpf:ConfigurationTextBoxWithHelp
                         Margin="36 0 0 19"
@@ -243,24 +240,21 @@
                         IsEnabled="{Binding Path=SelectedProject, Converter={x:Static wpf:Converters.NullIsFalse}}"
                         Content="{x:Static common:Strings.AddEnvironmentSetAsCurrentLabel}"
                         AutomationProperties.AutomationId="SetAsCurrent"
-                        AutomationProperties.Name="{x:Static common:Strings.AddEnvironmentSetAsCurrentLabel}"
-                        Style="{DynamicResource {x:Static ptwpf:ModernStyles.ThemedDialogCheckBoxStyleKey}}"/>
+                        AutomationProperties.Name="{x:Static common:Strings.AddEnvironmentSetAsCurrentLabel}"/>
 
                     <CheckBox
                         Margin="0 0 0 10"
                         IsChecked="{Binding Path=SetAsDefault}"
                         Content="{x:Static common:Strings.AddEnvironmentSetAsDefaultLabel}"
                         AutomationProperties.AutomationId="SetAsDefault"
-                        AutomationProperties.Name="{x:Static common:Strings.AddEnvironmentSetAsDefaultLabel}"
-                        Style="{DynamicResource {x:Static ptwpf:ModernStyles.ThemedDialogCheckBoxStyleKey}}"/>
+                        AutomationProperties.Name="{x:Static common:Strings.AddEnvironmentSetAsDefaultLabel}"/>
 
                     <CheckBox
                         Margin="0 0 0 10"
                         IsChecked="{Binding Path=ViewInEnvironmentWindow}"
                         Content="{x:Static common:Strings.AddEnvironmentViewInEnvWindowLabel}"
                         AutomationProperties.AutomationId="ViewInEnvironmentWindow"
-                        AutomationProperties.Name="{x:Static common:Strings.AddEnvironmentViewInEnvWindowLabel}"
-                        Style="{DynamicResource {x:Static ptwpf:ModernStyles.ThemedDialogCheckBoxStyleKey}}"/>
+                        AutomationProperties.Name="{x:Static common:Strings.AddEnvironmentViewInEnvWindowLabel}"/>
                 </StackPanel>
             </ScrollViewer>
 

--- a/Python/Product/PythonTools/PythonTools/Environments/AddExistingEnvironmentControl.xaml
+++ b/Python/Product/PythonTools/PythonTools/Environments/AddExistingEnvironmentControl.xaml
@@ -60,7 +60,6 @@
 
             <ComboBox
                 x:Name="ProjectComboBox"
-                Style="{DynamicResource {x:Static ptwpf:ModernStyles.ThemedDialogComboBoxStyleKey}}"
                 Margin="0 0 0 17"
                 MinHeight="29"
                 Width="249"
@@ -80,7 +79,6 @@
 
             <ComboBox
                 x:Name="InterpretersComboBox"
-                Style="{DynamicResource {x:Static ptwpf:ModernStyles.ThemedDialogComboBoxStyleKey}}"
                 Margin="0 0 0 17"
                 MinHeight="29"
                 Width="249"
@@ -124,8 +122,7 @@
                         IsEnabled="{Binding Path=IsRegisterCustomEnvEnabled}"
                         IsChecked="{Binding Path=RegisterCustomEnv}"
                         Content="{x:Static common:Strings.AddExistingEnvironmentRegisterGloballyCheckBox}"
-                        AutomationProperties.AutomationId="RegisterGlobally"
-                        Style="{DynamicResource {x:Static ptwpf:ModernStyles.ThemedDialogCheckBoxStyleKey}}"/>
+                        AutomationProperties.AutomationId="RegisterGlobally"/>
 
                     <Grid>
                         <Grid.ColumnDefinitions>

--- a/Python/Product/PythonTools/PythonTools/Environments/AddVirtualEnvironmentControl.xaml
+++ b/Python/Product/PythonTools/PythonTools/Environments/AddVirtualEnvironmentControl.xaml
@@ -70,7 +70,6 @@
 
                     <ComboBox
                         x:Name="ProjectComboBox"
-                        Style="{DynamicResource {x:Static ptwpf:ModernStyles.ThemedDialogComboBoxStyleKey}}"
                         Margin="0 0 0 17"
                         MinHeight="29"
                         Width="249"
@@ -122,7 +121,6 @@
                                 MinHeight="29"
                                 Width="249"
                                 HorizontalAlignment="Left"
-                                Style="{DynamicResource {x:Static ptwpf:ModernStyles.ThemedDialogComboBoxStyleKey}}"
                                 AutomationProperties.AutomationId="BaseInterpreter"
                                 AutomationProperties.IsRequiredForForm="True"
                                 AutomationProperties.LabeledBy="{Binding ElementName=BaseInterpreterLabel}"
@@ -173,8 +171,7 @@
                         IsEnabled="{Binding Path=SelectedProject, Converter={x:Static wpf:Converters.NullIsFalse}}"
                         Content="{x:Static common:Strings.AddEnvironmentSetAsCurrentLabel}"
                         AutomationProperties.AutomationId="SetAsCurrent"
-                        AutomationProperties.Name="{x:Static common:Strings.AddEnvironmentSetAsCurrentLabel}"
-                        Style="{DynamicResource {x:Static ptwpf:ModernStyles.ThemedDialogCheckBoxStyleKey}}"/>
+                        AutomationProperties.Name="{x:Static common:Strings.AddEnvironmentSetAsCurrentLabel}"/>
 
                     <CheckBox
                         Margin="0 0 0 10"
@@ -182,24 +179,21 @@
                         IsEnabled="{Binding Path=IsRegisterCustomEnv}"
                         Content="{x:Static common:Strings.AddEnvironmentSetAsDefaultLabel}"
                         AutomationProperties.AutomationId="SetAsDefault"
-                        AutomationProperties.Name="{x:Static common:Strings.AddEnvironmentSetAsDefaultLabel}"
-                        Style="{DynamicResource {x:Static ptwpf:ModernStyles.ThemedDialogCheckBoxStyleKey}}"/>
+                        AutomationProperties.Name="{x:Static common:Strings.AddEnvironmentSetAsDefaultLabel}"/>
 
                     <CheckBox
                         Margin="0 0 0 10"
                         IsChecked="{Binding Path=ViewInEnvironmentWindow}"
                         Content="{x:Static common:Strings.AddEnvironmentViewInEnvWindowLabel}"
                         AutomationProperties.AutomationId="ViewInEnvironmentWindow"
-                        AutomationProperties.Name="{x:Static common:Strings.AddEnvironmentViewInEnvWindowLabel}"
-                        Style="{DynamicResource {x:Static ptwpf:ModernStyles.ThemedDialogCheckBoxStyleKey}}"/>
+                        AutomationProperties.Name="{x:Static common:Strings.AddEnvironmentViewInEnvWindowLabel}"/>
 
                     <CheckBox
                         Margin="0 0 0 3"
                         IsEnabled="{Binding Path=IsRegisterCustomEnvEnabled}"
                         IsChecked="{Binding Path=IsRegisterCustomEnv}"
                         Content="{x:Static common:Strings.AddExistingEnvironmentRegisterGloballyCheckBox}"
-                        AutomationProperties.AutomationId="RegisterGlobally"
-                        Style="{DynamicResource {x:Static ptwpf:ModernStyles.ThemedDialogCheckBoxStyleKey}}"/>
+                        AutomationProperties.AutomationId="RegisterGlobally"/>
 
                     <wpf:ConfigurationTextBoxWithHelp
                         Margin="23 0 0 24"

--- a/Python/Product/PythonTools/PythonTools/Wpf/ModernStyles.xaml
+++ b/Python/Product/PythonTools/PythonTools/Wpf/ModernStyles.xaml
@@ -366,22 +366,7 @@
         </Style.Triggers>
     </Style>
 
-    <Style TargetType="{x:Type TextBox}" BasedOn="{StaticResource ControlNoHover}">
-        <Setter Property="CaretBrush" Value="{DynamicResource {x:Static l:ModernStyles.ForegroundKey}}" />
-        <Setter Property="FocusVisualStyle" Value="{x:Null}" />
-        <Setter Property="Template">
-            <Setter.Value>
-                <ControlTemplate TargetType="{x:Type TextBoxBase}">
-                    <Border Name="Border"
-                            Padding="2"
-                            Background="{TemplateBinding Background}"
-                            BorderBrush="{TemplateBinding BorderBrush}"
-                            BorderThickness="{TemplateBinding BorderThickness}">
-                        <ScrollViewer Margin="0" x:Name="PART_ContentHost" Background="{x:Null}" />
-                    </Border>
-                </ControlTemplate>
-            </Setter.Value>
-        </Setter>
+    <Style TargetType="{x:Type TextBox}" BasedOn="{StaticResource {x:Static l:ModernStyles.ThemedDialogTextBoxStyleKey}}">
         <Style.Triggers>
             <Trigger Property="AcceptsReturn" Value="False">
                 <Setter Property="VerticalContentAlignment" Value="Center" />


### PR DESCRIPTION
VS fixed the use of ThemedDialogTextBoxStyleKey in 16.9 (internal bug 1198412) so we can now use it.
Also remove some unnecessary style attributes.