### PR TITLE
Use global debug options instead of project-specific ones

### DIFF
--- a/Python/Product/Debugger/Debugger.csproj
+++ b/Python/Product/Debugger/Debugger.csproj
@@ -98,6 +98,7 @@
     <Compile Include="AssemblyInfo.cs" />
     <Compile Include="Debugger\DebugConnection.cs" />
     <Compile Include="Debugger\IPythonDebugOptionsService.cs" />
+    <Compile Include="Debugger\PresentationMode.cs" />
     <Compile Include="Debugger\PythonDebugOptionsServiceHelper.cs" />
     <Compile Include="Debugger\LegacyDebuggerProtocol.cs" />
     <Compile Include="Debugger\BreakpointHitEventArgs.cs" />

--- a/Python/Product/Debugger/Debugger/IPythonDebugOptionsService.cs
+++ b/Python/Product/Debugger/Debugger/IPythonDebugOptionsService.cs
@@ -65,5 +65,10 @@ namespace Microsoft.PythonTools.Debugger {
         /// True to use the legacy debugger. Default is false.
         /// </summary>
         bool UseLegacyDebugger { get; }
+
+        PresentationMode VariablePresentationForClasses { get; }
+        PresentationMode VariablePresentationForFunctions { get; }
+        PresentationMode VariablePresentationForProtected { get; }
+        PresentationMode VariablePresentationForSpecial { get; }
     }
 }

--- a/Python/Product/Debugger/Debugger/PresentationMode.cs
+++ b/Python/Product/Debugger/Debugger/PresentationMode.cs
@@ -1,0 +1,41 @@
+// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System.Runtime.Serialization;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace Microsoft.PythonTools.Debugger {
+
+    /// <summary>
+    /// How variables can be presented through the IDE.
+    /// 
+    /// Group means variables of this type are grouped under their own collapsable element.
+    /// Hide means variables of this type are not shown.
+    /// Inline means variables of this type are expanded into a single flat level.
+    /// </summary>
+    [JsonConverter(typeof(StringEnumConverter))]
+    public enum PresentationMode {
+        [EnumMember(Value = "group")]
+        Group,
+
+        [EnumMember(Value = "hide")]
+        Hide,
+
+        [EnumMember(Value = "inline")]
+        Inline,
+    }
+}

--- a/Python/Product/PythonTools/PythonTools/Debugger/DebugAdapter/DebugAdapterLauncher.cs
+++ b/Python/Product/PythonTools/PythonTools/Debugger/DebugAdapter/DebugAdapterLauncher.cs
@@ -203,12 +203,16 @@ namespace Microsoft.PythonTools.Debugger {
             launchJson.DebugStdLib = debugService.DebugStdLib;
             launchJson.ShowReturnValue = debugService.ShowFunctionReturnValue;
 
-            try {
-                var adapterLaunchInfoJson = JObject.Parse(adapterLaunchInfo.LaunchJson);
-                AddVariablePresentationOptions(adapterLaunchInfoJson, launchJson);
-            } catch (JsonReaderException) {
-                // this should never happen
-                Debug.Fail("adapterLaunchInfo is not valid json");
+            // adapterLaunchInfo.LaunchJson can be null when attaching to a remote process
+            if (adapterLaunchInfo.LaunchJson != null) {
+
+                try {
+                    var adapterLaunchInfoJson = JObject.Parse(adapterLaunchInfo.LaunchJson);
+                    AddVariablePresentationOptions(adapterLaunchInfoJson, launchJson);
+                } catch (JsonReaderException) {
+                    // this should never happen
+                    Debug.Fail("adapterLaunchInfo is not valid json");
+                }
             }
 
             var excludePTVSInstallDirectory = new PathRule() {

--- a/Python/Product/PythonTools/PythonTools/Debugger/DebugAdapter/DebugAdapterLauncher.cs
+++ b/Python/Product/PythonTools/PythonTools/Debugger/DebugAdapter/DebugAdapterLauncher.cs
@@ -203,17 +203,12 @@ namespace Microsoft.PythonTools.Debugger {
             launchJson.DebugStdLib = debugService.DebugStdLib;
             launchJson.ShowReturnValue = debugService.ShowFunctionReturnValue;
 
-            // adapterLaunchInfo.LaunchJson can be null when attaching to a remote process
-            if (adapterLaunchInfo.LaunchJson != null) {
-
-                try {
-                    var adapterLaunchInfoJson = JObject.Parse(adapterLaunchInfo.LaunchJson);
-                    AddVariablePresentationOptions(adapterLaunchInfoJson, launchJson);
-                } catch (JsonReaderException) {
-                    // this should never happen
-                    Debug.Fail("adapterLaunchInfo is not valid json");
-                }
-            }
+            var variablePresentation = new VariablePresentation();
+            variablePresentation.Class = debugService.VariablePresentationForClasses;
+            variablePresentation.Function = debugService.VariablePresentationForFunctions;
+            variablePresentation.Protected = debugService.VariablePresentationForProtected;
+            variablePresentation.Special = debugService.VariablePresentationForSpecial;
+            launchJson.VariablePresentation = variablePresentation;
 
             var excludePTVSInstallDirectory = new PathRule() {
                 Path = PathUtils.GetParent(typeof(DebugAdapterLauncher).Assembly.Location),
@@ -245,56 +240,6 @@ namespace Microsoft.PythonTools.Debugger {
 
             } finally {
                 Marshal.FreeHGlobal(argPointer);
-            }
-        }
-
-        /// <summary>
-        /// Adds variable presentation options to the json that will be passed to the debugger when launched.
-        /// </summary>
-        /// <param name="adapterLaunchInfoJson">Launch info json that comes from the interpreter and/or the user</param>
-        /// <param name="launchJson">The json that will be passed to the debugger</param>
-        private static void AddVariablePresentationOptions(JObject adapterLaunchInfoJson, DebugInfo launchJson) {
-
-            if (adapterLaunchInfoJson == null) throw new ArgumentNullException(nameof(adapterLaunchInfoJson));
-            if (launchJson == null) throw new ArgumentNullException(nameof(launchJson));
-
-            // create a default variable presentation and add it to the launchJson
-            var variablePresentation = new VariablePresentation();
-            launchJson.VariablePresentation = variablePresentation;
-
-            // if no variable presentation is provided, we're done
-            var varPresJson = adapterLaunchInfoJson.Value<JObject>("variablePresentation");
-            if (varPresJson == null) {
-                return;
-            }
-
-            // otherwise, update the launchJson with the provided presentation values
-            var classModeStr = varPresJson.Value<string>("class");
-            if (classModeStr != null) {
-                if (Enum.TryParse(classModeStr, ignoreCase: true, out PresentationMode classMode)) {
-                    variablePresentation.Class = classMode;
-                }
-            }
-
-            var functionModeStr = varPresJson.Value<string>("function");
-            if (functionModeStr != null) {
-                if (Enum.TryParse(functionModeStr, ignoreCase: true, out PresentationMode functionMode)) {
-                    variablePresentation.Function = functionMode;
-                }
-            }
-
-            var protectedModeStr = varPresJson.Value<string>("protected");
-            if (protectedModeStr != null) {
-                if (Enum.TryParse(protectedModeStr, ignoreCase: true, out PresentationMode protectedMode)) {
-                    variablePresentation.Protected = protectedMode;
-                }
-            }
-
-            var specialModeStr = varPresJson.Value<string>("special");
-            if (specialModeStr != null) {
-                if (Enum.TryParse(specialModeStr, ignoreCase: true, out PresentationMode specialMode)) {
-                    variablePresentation.Special = specialMode;
-                }
             }
         }
     }

--- a/Python/Product/PythonTools/PythonTools/Debugger/DebugAdapter/DebugInfo.cs
+++ b/Python/Product/PythonTools/PythonTools/Debugger/DebugAdapter/DebugInfo.cs
@@ -16,9 +16,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.Runtime.Serialization;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
 
 namespace Microsoft.PythonTools.Debugger {
 
@@ -136,17 +134,5 @@ namespace Microsoft.PythonTools.Debugger {
             Protected = DefaultPresentationMode;
             Special = DefaultPresentationMode;
         }
-    }
-
-    [JsonConverter(typeof(StringEnumConverter))]
-    public enum PresentationMode {
-        [EnumMember(Value = "group")]
-        Group,
-
-        [EnumMember(Value = "hide")]
-        Hide,
-
-        [EnumMember(Value = "inline")]
-        Inline,
     }
 }

--- a/Python/Product/PythonTools/PythonTools/Options/PythonDebugOptionsService.cs
+++ b/Python/Product/PythonTools/PythonTools/Options/PythonDebugOptionsService.cs
@@ -34,5 +34,10 @@ namespace Microsoft.PythonTools.Options {
         public bool DebugStdLib => debugOptions.DebugStdLib;
         public bool ShowFunctionReturnValue => debugOptions.ShowFunctionReturnValue;
         public bool UseLegacyDebugger => debugOptions.UseLegacyDebugger;
+
+        public PresentationMode VariablePresentationForClasses => debugOptions.VariablePresentationForClasses;
+        public PresentationMode VariablePresentationForFunctions => debugOptions.VariablePresentationForFunctions;
+        public PresentationMode VariablePresentationForProtected => debugOptions.VariablePresentationForProtected;
+        public PresentationMode VariablePresentationForSpecial => debugOptions.VariablePresentationForSpecial;
     }
 }


### PR DESCRIPTION
Fixes #6369 

This is a fix for a regression I introduced when reading variable presentation options from the options page. The bug occurs when attaching to a remote debugpy process instead of launching the debugger directly, which is a case I did not test.