### PR TITLE
Added azure-pipelines.yml to replace the classic AzDO pipeline

### DIFF
--- a/Build/16.0/nuget.config
+++ b/Build/16.0/nuget.config
@@ -1,10 +1,10 @@
 <configuration>
   <packageSources>
     <clear />
-    <!--<add key="PLS" value="https://pvsc.blob.core.windows.net/vs-python-ls/index.json" protocolVersion="3" />-->
+    <add key="PLS" value="https://pvsc.blob.core.windows.net/vs-python-ls/index.json" protocolVersion="3" />
     <add key="VS Editor" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vssdk/nuget/v3/index.json" protocolVersion="3" />
     <add key="VS Editor Impl" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-impl/nuget/v3/index.json" protocolVersion="3" />
     <add key="VSIDEPublicFeed" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/VSIDEPublicFeed/nuget/v3/index.json" protocolVersion="3" />
-    <!--<add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />-->
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
   </packageSources>
 </configuration>

--- a/Build/16.0/nuget.config
+++ b/Build/16.0/nuget.config
@@ -1,9 +1,10 @@
 <configuration>
   <packageSources>
-    <add key="PLS" value="https://pvsc.blob.core.windows.net/vs-python-ls/index.json" protocolVersion="3" />
+    <clear />
+    <!--<add key="PLS" value="https://pvsc.blob.core.windows.net/vs-python-ls/index.json" protocolVersion="3" />-->
     <add key="VS Editor" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vssdk/nuget/v3/index.json" protocolVersion="3" />
     <add key="VS Editor Impl" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-impl/nuget/v3/index.json" protocolVersion="3" />
     <add key="VSIDEPublicFeed" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/VSIDEPublicFeed/nuget/v3/index.json" protocolVersion="3" />
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+    <!--<add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />-->
   </packageSources>
 </configuration>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,13 +4,14 @@ name: $(date:yy)$(DayOfYear)$(rev:.r)
 # Trigger ci builds for commits into master and any release branches
 trigger:
 - master
-- yaml
 - release/*
+- yaml # TODO: remove this branch
 
 # Trigger pr builds for commits into master and any release branches
 pr:
 - master
 - release/*
+- yaml # TODO: remove this branch
 
 # The agent pool the build will run on
 pool:
@@ -89,9 +90,6 @@ steps:
   inputs:
     signType: 'Test' # TODO: Change this to $(SignType) once Real signing is approved for this AzDO project ID
     feedSource: 'https://devdiv.pkgs.visualstudio.com/DefaultCollection/_packaging/MicroBuildToolset/nuget/v3/index.json'
-  enabled: true # Disable signing since it only works in approved project ids.
-  # TODO: remove the line above once the rest of the build is working, will need to get approval
-  # once the new build pipeline is created before this step will work.
 
 - task: MicroBuildLocalizationPlugin@3
   displayName: 'Install localization plugin'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -109,7 +109,7 @@ steps:
 
 # Publish buld artifact: raw
 - task: PublishBuildArtifacts@1
-  displayName: 'Publish raw build artifact (if build failed)
+  displayName: '[If build failed] Publish raw build artifact'
   inputs:
     PathtoPublish: '$(Build.BinariesDirectory)\raw'
     ArtifactName: raw

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,13 +5,11 @@ name: $(date:yy)$(DayOfYear)$(rev:.r)
 trigger:
 - master
 - release/*
-- yaml # TODO: remove this branch
 
 # Trigger pr builds for commits into master and any release branches
 pr:
 - master
 - release/*
-- yaml # TODO: remove this branch
 
 # The agent pool the build will run on
 pool:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,146 @@
+pool:
+  name: VSEng-MicroBuildVS2019
+  demands: msbuild
+
+#Your build pipeline references the ‘SignType’ variable, which you’ve selected to be settable at queue time. Create or edit the build pipeline for this YAML file, define the variable on the Variables tab, and then select the option to make it settable at queue time. See https://go.microsoft.com/fwlink/?linkid=865971
+#Your build pipeline references the ‘LocType’ variable, which you’ve selected to be settable at queue time. Create or edit the build pipeline for this YAML file, define the variable on the Variables tab, and then select the option to make it settable at queue time. See https://go.microsoft.com/fwlink/?linkid=865971
+#Your build pipeline references the ‘VSTarget’ variable, which you’ve selected to be settable at queue time. Create or edit the build pipeline for this YAML file, define the variable on the Variables tab, and then select the option to make it settable at queue time. See https://go.microsoft.com/fwlink/?linkid=865971
+variables:
+  BuildConfiguration: 'Release'
+
+steps:
+- powershell: 'Write-Host "##vso[build.addbuildtag]$env:VSTarget"'
+  displayName: 'Add VSTarget Tag'
+
+- task: ms-vseng.MicroBuildTasks.32f78468-e895-4f47-962c-58a699361df8.MicroBuildSwixPlugin@1
+  displayName: 'Install Swix Plugin'
+  inputs:
+    feedSource: 'https://mseng.pkgs.visualstudio.com/DefaultCollection/_packaging/MicroBuildToolset/nuget/v3/index.json'
+
+- task: ms-vseng.MicroBuildTasks.30666190-6959-11e5-9f96-f56098202fef.MicroBuildSigningPlugin@1
+  displayName: 'Install Signing Plugin'
+  inputs:
+    signType: '$(SignType)'
+
+- task: ms-vseng.MicroBuildTasks.a0262b21-fb8f-46f8-bb9a-60ed560d4a87.MicroBuildLocalizationPlugin@1
+  displayName: 'Install Localization Plugin'
+  inputs:
+    type: '$(LocType)'
+    feedSource: 'https://mseng.pkgs.visualstudio.com/DefaultCollection/_packaging/MicroBuildToolset/nuget/v3/index.json'
+
+- task: PowerShell@1
+  displayName: 'Powershell Script'
+  inputs:
+    scriptName: Build/PreBuild.ps1
+    arguments: '-vstarget $(VSTarget)'
+
+- task: DeleteFiles@1
+  displayName: 'Clean old SWIX outputs'
+  inputs:
+    SourceFolder: '$(Build.BinariesDirectory)\raw\setup\swix'
+    Contents: '**'
+  continueOnError: true
+
+- task: MSBuild@1
+  displayName: 'Build solution Python/Product/dirs.proj'
+  inputs:
+    solution: Python/Product/dirs.proj
+    msbuildVersion: 16.0
+    platform: 'any cpu'
+    configuration: '$(BuildConfiguration)'
+
+- task: MSBuild@1
+  displayName: 'Build solution Python/Setup/dirs.proj'
+  inputs:
+    solution: Python/Setup/dirs.proj
+    msbuildVersion: 16.0
+    platform: 'any cpu'
+    configuration: '$(BuildConfiguration)'
+    msbuildArguments: '/p:SkipProduct=true'
+
+- task: PublishBuildArtifacts@1
+  displayName: '[If Build Failed] Publish Artifact: raw'
+  inputs:
+    PathtoPublish: '$(Build.BinariesDirectory)\raw'
+    ArtifactName: raw
+  condition: failed()
+
+- task: ms-vseng.MicroBuildTasks.4305a8de-ba66-4d8b-b2d1-0dc4ecbbf5e8.MicroBuildUploadVstsDropFolder@1
+  displayName: 'Upload VSTS Drop'
+  inputs:
+    DropFolder: '$(Build.StagingDirectory)\release'
+    DropServiceUri: 'https://devdiv.artifacts.visualstudio.com/DefaultCollection'
+  continueOnError: true
+
+- task: CopyFiles@2
+  displayName: 'Copy Source Files to: $(Build.ArtifactStagingDirectory)/src'
+  inputs:
+    SourceFolder: '$(Build.SourcesDirectory)'
+    TargetFolder: '$(Build.ArtifactStagingDirectory)/src'
+    CleanTargetFolder: true
+
+- task: CopyFiles@2
+  displayName: 'Copy Layout $(Build.BinariesDirectory)/layout to: $(Build.ArtifactStagingDirectory)/layout'
+  inputs:
+    SourceFolder: '$(Build.BinariesDirectory)/layout'
+    TargetFolder: '$(Build.ArtifactStagingDirectory)/layout'
+    CleanTargetFolder: true
+
+- task: CopyFiles@2
+  displayName: 'Copy Binaries $(Build.BinariesDirectory)/raw/binaries to: $(Build.ArtifactStagingDirectory)/binaries'
+  inputs:
+    SourceFolder: '$(Build.BinariesDirectory)/raw/binaries'
+    TargetFolder: '$(Build.ArtifactStagingDirectory)/binaries'
+    CleanTargetFolder: true
+
+- task: CopyFiles@2
+  displayName: 'Copy Files $(Build.ArtifactStagingDirectory)/binaries to: $(Build.ArtifactStagingDirectory)/symbols_and_binaries'
+  inputs:
+    SourceFolder: '$(Build.ArtifactStagingDirectory)/binaries'
+    Contents: |
+     Microsoft.PythonTools*.pdb
+     Microsoft.PythonTools*.dll
+     Microsoft.PythonTools*.exe
+     Microsoft.CookiecutterTools.pdb
+     Microsoft.CookiecutterTools.dll
+     Microsoft.IronPythonTools.Resolver.pdb
+     Microsoft.IronPythonTools.Resolver.dll
+     Microsoft.Python.Analysis.Engine.dll
+     Microsoft.Python.Analysis.Engine.pdb
+     Microsoft.Python.LanguageServer.Core.dll
+     Microsoft.Python.LanguageServer.Core.pdb
+     PyDebugAttach*.pdb
+     PyDebugAttach*.dll
+     VsPyProf*.pdb
+     VsPyProf*.dll
+    TargetFolder: '$(Build.ArtifactStagingDirectory)/symbols_and_binaries'
+
+- task: ms-vscs-artifact.build-tasks.artifactSymbolTask-1.artifactSymbolTask@0
+  displayName: 'Publish to Symbols and Binaries to Artifact Services'
+  inputs:
+    symbolServiceURI: 'https://microsoft.artifacts.visualstudio.com/DefaultCollection'
+    sourcePath: '$(Build.ArtifactStagingDirectory)/symbols_and_binaries'
+    usePat: false
+
+- task: ms-vseng.MicroBuildTasks.521a94ea-9e68-468a-8167-6dcf361ea776.MicroBuildCleanup@1
+  displayName: 'Execute cleanup tasks'
+  condition: succeededOrFailed()
+
+- task: ArchiveFiles@2
+  displayName: 'Compress $(Build.ArtifactStagingDirectory)'
+  inputs:
+    rootFolderOrFile: '$(Build.ArtifactStagingDirectory)'
+    includeRootFolder: false
+    archiveFile: '$(Build.ArtifactStagingDirectory)/PTVSBuildArchive.zip'
+
+- task: PublishBuildArtifacts@1
+  displayName: 'Upload Binaries Directory'
+  inputs:
+    PathtoPublish: '$(Build.BinariesDirectory)/raw/binaries'
+    ArtifactName: Binaries
+
+- task: PublishBuildArtifacts@1
+  displayName: 'Upload Staging Directory copy'
+  inputs:
+    PathtoPublish: '$(Build.ArtifactStagingDirectory)/PTVSBuildArchive.zip'
+    ArtifactName: 'PTVS Staging Output'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,3 +1,14 @@
+# trigger ci builds for commits into master and any release branches
+trigger:
+- master
+- release/*
+
+# trigger pr builds for commits into master and any release branches
+pr:
+- master
+- release/*
+
+# the agent pool the build will run on
 pool:
   name: VSEng-MicroBuildVS2019
   demands: msbuild

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -49,6 +49,13 @@ variables:
     value: 16.0
   - name: VSTarget
     value: 16.0
+
+  # This is used to suppress warnings from the auto-injected Nuget Security Analysis step.
+  # The internal packages we use that are not available externally all start with "Microsoft",
+  # which mitigates the package injection vulnerability, since nobody outside the company can publish them to nuget.org.
+  # See https://docs.opensource.microsoft.com/tools/nuget_security_analysis.html for more info.
+  - name: NugetSecurityAnalysisWarningLevel
+    value: none
   
   # PTVS variable group, for secrets
   # This group contains an AzDO Personal Access Token (ArtifactServices.Symbol.PAT) that expires on 4/15/2021 which is used to publish symbols to symweb.

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -157,14 +157,14 @@ steps:
      VsPyProf*.dll
     TargetFolder: '$(Build.ArtifactStagingDirectory)/symbols_and_binaries'
 
-- task: ms-vscs-artifact.build-tasks.artifactSymbolTask-1.artifactSymbolTask@0
-  displayName: 'Publish to Symbols and Binaries to Artifact Services'
+- task: artifactSymbolTask@0
   inputs:
     symbolServiceURI: 'https://microsoft.artifacts.visualstudio.com/DefaultCollection'
+    requestName: '$(System.TeamProject)/$(Build.BuildNumber)/$(Build.BuildId)'
     sourcePath: '$(Build.ArtifactStagingDirectory)/symbols_and_binaries'
     usePat: false
 
-- task: ms-vseng.MicroBuildTasks.521a94ea-9e68-468a-8167-6dcf361ea776.MicroBuildCleanup@1
+- task: MicroBuildCleanup@1
   displayName: 'Execute cleanup tasks'
   condition: succeededOrFailed()
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,3 +1,6 @@
+# build number format
+name: $(date:yy)$(DayOfYear)$(rev:.r)
+
 # Trigger ci builds for commits into master and any release branches
 trigger:
 - master

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -160,7 +160,7 @@ steps:
 
 # Publish symbols
 - task: artifactSymbolTask@0
-  diaplayName: 'Publish to Symbols and Binaries to Artifact Services'
+  displayName: 'Publish to Symbols and Binaries to Artifact Services'
   inputs:
     symbolServiceURI: 'https://microsoft.artifacts.visualstudio.com/DefaultCollection'
     requestName: '$(System.TeamProject)/$(Build.BuildNumber)/$(Build.BuildId)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -54,6 +54,9 @@ steps:
   inputs:
     signType: $(SignType)
     feedSource: 'https://devdiv.pkgs.visualstudio.com/DefaultCollection/_packaging/MicroBuildToolset/nuget/v3/index.json'
+  enabled: false # Disable signing since it only works in approved project ids.
+  # TODO: remove the line above once the rest of the build is working, will need to get approval
+  # once the new build pipeline is created before this step will work.
 
 - task: MicroBuildLocalizationPlugin@3
   displayName: 'Install Localization Plugin'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -97,7 +97,7 @@ steps:
     configuration: '$(BuildConfiguration)'
     msbuildArguments: '/p:SkipProduct=true'
 
-# Publish build artifacts if something failed
+# Publish buld artifact: raw
 - task: PublishBuildArtifacts@1
   displayName: '[If Build Failed] Publish Artifact: raw'
   inputs:
@@ -105,7 +105,7 @@ steps:
     ArtifactName: raw
   condition: failed()
 
-# Upload vs drop
+# Upload vsts drop
 - task: MicroBuildUploadVstsDropFolder@1
   displayName: 'Upload VSTS Drop'
   inputs:
@@ -114,6 +114,7 @@ steps:
     VSDropServiceUri: 'https://vsdrop.corp.microsoft.com/file/v1'
   continueOnError: true
 
+# copy some files around to prepare for publishing build artifacts
 - task: CopyFiles@2
   displayName: 'Copy Source Files to: $(Build.ArtifactStagingDirectory)/src'
   inputs:
@@ -157,32 +158,40 @@ steps:
      VsPyProf*.dll
     TargetFolder: '$(Build.ArtifactStagingDirectory)/symbols_and_binaries'
 
+# Publish symbols
 - task: artifactSymbolTask@0
+  diaplayName: 'Publish to Symbols and Binaries to Artifact Services'
   inputs:
     symbolServiceURI: 'https://microsoft.artifacts.visualstudio.com/DefaultCollection'
     requestName: '$(System.TeamProject)/$(Build.BuildNumber)/$(Build.BuildId)'
     sourcePath: '$(Build.ArtifactStagingDirectory)/symbols_and_binaries'
     usePat: false
 
+# MicroBuild cleanup
 - task: MicroBuildCleanup@1
   displayName: 'Execute cleanup tasks'
   condition: succeededOrFailed()
 
+# Compress staging output
 - task: ArchiveFiles@2
   displayName: 'Compress $(Build.ArtifactStagingDirectory)'
   inputs:
     rootFolderOrFile: '$(Build.ArtifactStagingDirectory)'
     includeRootFolder: false
+    archiveType: 'zip'
     archiveFile: '$(Build.ArtifactStagingDirectory)/PTVSBuildArchive.zip'
+    replaceExistingArchive: true
 
+# Publish build artifact: binaries
 - task: PublishBuildArtifacts@1
   displayName: 'Upload Binaries Directory'
   inputs:
     PathtoPublish: '$(Build.BinariesDirectory)/raw/binaries'
     ArtifactName: Binaries
 
+# Publish build artifact: staging output
 - task: PublishBuildArtifacts@1
-  displayName: 'Upload Staging Directory copy'
+  displayName: 'Upload Staging Directory zip'
   inputs:
     PathtoPublish: '$(Build.ArtifactStagingDirectory)/PTVSBuildArchive.zip'
     ArtifactName: 'PTVS Staging Output'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,20 +33,24 @@ steps:
 - powershell: 'Write-Host "##vso[build.addbuildtag]$env:VSTarget"'
   displayName: 'Add VSTarget Tag'
 
-- task: ms-vseng.MicroBuildTasks.32f78468-e895-4f47-962c-58a699361df8.MicroBuildSwixPlugin@1
+- task: MicroBuildSwixPlugin@3
   displayName: 'Install Swix Plugin'
   inputs:
+    dropName: 'Products/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildNumber)'
+    dropServiceUri: 'https://vsdrop.corp.microsoft.com/file/v1'
     feedSource: 'https://mseng.pkgs.visualstudio.com/DefaultCollection/_packaging/MicroBuildToolset/nuget/v3/index.json'
 
-- task: ms-vseng.MicroBuildTasks.30666190-6959-11e5-9f96-f56098202fef.MicroBuildSigningPlugin@1
+- task: MicroBuildSigningPlugin@3
   displayName: 'Install Signing Plugin'
   inputs:
-    signType: '$(SignType)'
+    signType: $(SignType)
+    feedSource: 'https://devdiv.pkgs.visualstudio.com/DefaultCollection/_packaging/MicroBuildToolset/nuget/v3/index.json'
 
-- task: ms-vseng.MicroBuildTasks.a0262b21-fb8f-46f8-bb9a-60ed560d4a87.MicroBuildLocalizationPlugin@1
+- task: MicroBuildLocalizationPlugin@3
   displayName: 'Install Localization Plugin'
   inputs:
-    type: '$(LocType)'
+    type: $(LocType)
+    languages: 'VS'
     feedSource: 'https://mseng.pkgs.visualstudio.com/DefaultCollection/_packaging/MicroBuildToolset/nuget/v3/index.json'
 
 - task: PowerShell@1
@@ -86,11 +90,12 @@ steps:
     ArtifactName: raw
   condition: failed()
 
-- task: ms-vseng.MicroBuildTasks.4305a8de-ba66-4d8b-b2d1-0dc4ecbbf5e8.MicroBuildUploadVstsDropFolder@1
+- task: MicroBuildUploadVstsDropFolder@1
   displayName: 'Upload VSTS Drop'
   inputs:
     DropFolder: '$(Build.StagingDirectory)\release'
     DropServiceUri: 'https://devdiv.artifacts.visualstudio.com/DefaultCollection'
+    VSDropServiceUri: 'https://vsdrop.corp.microsoft.com/file/v1'
   continueOnError: true
 
 - task: CopyFiles@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,20 +21,35 @@ pool:
 # None of these are settable at build queue time. To do that, remove the variable from this list,
 # browse to the pipeline editor in AzDO, add the variable there, and make it settable at queue time.
 variables:
-  BuildConfiguration: Release
-  DropRoot: \\cpvsbuild\Drops\DSTools\PTVS\$(Build.SourceBranchName)\$(Build.BuildNumber)\
-  FileVersionPrefix: 16.9
-  IncludeDjangoHtmlExtensions: true
-  IncludeLiveShare: true
-  IncludeMiniconda: true
-  IncludeMSI: false
-  IncludeUWP: false
-  LocType: Full
-  SignType: Real
-  TeamName: DSTools
-  TrackFileAccess: false
-  VisualStudioVersion: 16.0
-  VSTarget: 16.0
+  - name: BuildConfiguration
+    value: Release
+  - name: DropRoot
+    value: \\cpvsbuild\Drops\DSTools\PTVS\$(Build.SourceBranchName)\$(Build.BuildNumber)\
+  - name: FileVersionPrefix
+    value: 16.9
+  - name: IncludeDjangoHtmlExtensions
+    value: true
+  - name: IncludeLiveShare
+    value: true
+  - name: IncludeMiniconda
+    value: true
+  - name: IncludeMSI
+    value: false
+  - name: IncludeUWP
+    value: false
+  - name: LocType
+    value: Full
+  - name: SignType
+    value: Real
+  - name: TeamName
+    value: DSTools
+  - name: TrackFileAccess
+    value: false
+  - name: VisualStudioVersion
+    value: 16.0
+  - name: VSTarget
+    value: 16.0
+  - group: PTVS # ptvs variable group, for secrets
 
 # TODO:
 # For PR builds, don't real sign. Test sign instead.
@@ -60,7 +75,7 @@ steps:
 - task: MicroBuildSigningPlugin@3
   displayName: 'Install signing plugin'
   inputs:
-    signType: $(SignType)
+    signType: 'Test' # TODO: Change this to $(SignType) once Real signing is approved for this AzDO project ID
     feedSource: 'https://devdiv.pkgs.visualstudio.com/DefaultCollection/_packaging/MicroBuildToolset/nuget/v3/index.json'
   enabled: false # Disable signing since it only works in approved project ids.
   # TODO: remove the line above once the rest of the build is working, will need to get approval

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -46,18 +46,18 @@ steps:
 
 # add build tag
 - powershell: 'Write-Host "##vso[build.addbuildtag]$env:VSTarget"'
-  displayName: 'Add VSTarget Tag'
+  displayName: 'Add vstarget build tag'
 
 # install plugins needed for swixproj/vsmanproj, signing, and localization
 - task: MicroBuildSwixPlugin@3
-  displayName: 'Install Swix Plugin'
+  displayName: 'Install swix plugin'
   inputs:
     dropName: 'Products/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildNumber)'
     dropServiceUri: 'https://vsdrop.corp.microsoft.com/file/v1'
     feedSource: 'https://mseng.pkgs.visualstudio.com/DefaultCollection/_packaging/MicroBuildToolset/nuget/v3/index.json'
 
 - task: MicroBuildSigningPlugin@3
-  displayName: 'Install Signing Plugin'
+  displayName: 'Install signing plugin'
   inputs:
     signType: $(SignType)
     feedSource: 'https://devdiv.pkgs.visualstudio.com/DefaultCollection/_packaging/MicroBuildToolset/nuget/v3/index.json'
@@ -66,7 +66,7 @@ steps:
   # once the new build pipeline is created before this step will work.
 
 - task: MicroBuildLocalizationPlugin@3
-  displayName: 'Install Localization Plugin'
+  displayName: 'Install localization plugin'
   inputs:
     type: $(LocType)
     languages: 'VS'
@@ -82,7 +82,7 @@ steps:
 # Clean the old swix outputs
 # (This shouldn't be required since the build performs a clean when getting sources)
 - task: DeleteFiles@1
-  displayName: 'Clean old SWIX outputs'
+  displayName: 'Clean old swix outputs'
   inputs:
     SourceFolder: '$(Build.BinariesDirectory)\raw\setup\swix'
     Contents: '**'
@@ -109,7 +109,7 @@ steps:
 
 # Publish buld artifact: raw
 - task: PublishBuildArtifacts@1
-  displayName: '[If Build Failed] Publish Artifact: raw'
+  displayName: 'Publish raw build artifact (if build failed)
   inputs:
     PathtoPublish: '$(Build.BinariesDirectory)\raw'
     ArtifactName: raw
@@ -117,7 +117,7 @@ steps:
 
 # Upload vsts drop
 - task: MicroBuildUploadVstsDropFolder@1
-  displayName: 'Upload VSTS Drop'
+  displayName: 'Upload vsts drop'
   inputs:
     DropFolder: '$(Build.StagingDirectory)\release'
     DropServiceUri: 'https://devdiv.artifacts.visualstudio.com/DefaultCollection'
@@ -126,28 +126,28 @@ steps:
 
 # copy some files around to prepare for publishing build artifacts
 - task: CopyFiles@2
-  displayName: 'Copy Source Files to: $(Build.ArtifactStagingDirectory)/src'
+  displayName: 'Copy source to staging/src'
   inputs:
     SourceFolder: '$(Build.SourcesDirectory)'
     TargetFolder: '$(Build.ArtifactStagingDirectory)/src'
     CleanTargetFolder: true
 
 - task: CopyFiles@2
-  displayName: 'Copy Layout $(Build.BinariesDirectory)/layout to: $(Build.ArtifactStagingDirectory)/layout'
+  displayName: 'Copy layout to staging'
   inputs:
     SourceFolder: '$(Build.BinariesDirectory)/layout'
     TargetFolder: '$(Build.ArtifactStagingDirectory)/layout'
     CleanTargetFolder: true
 
 - task: CopyFiles@2
-  displayName: 'Copy Binaries $(Build.BinariesDirectory)/raw/binaries to: $(Build.ArtifactStagingDirectory)/binaries'
+  displayName: 'Copy binaries to staging'
   inputs:
     SourceFolder: '$(Build.BinariesDirectory)/raw/binaries'
     TargetFolder: '$(Build.ArtifactStagingDirectory)/binaries'
     CleanTargetFolder: true
 
 - task: CopyFiles@2
-  displayName: 'Copy Files $(Build.ArtifactStagingDirectory)/binaries to: $(Build.ArtifactStagingDirectory)/symbols_and_binaries'
+  displayName: 'Prepare for symbol publishing'
   inputs:
     SourceFolder: '$(Build.ArtifactStagingDirectory)/binaries'
     Contents: |
@@ -170,7 +170,7 @@ steps:
 
 # Publish symbols
 - task: artifactSymbolTask@0
-  displayName: 'Publish to Symbols and Binaries to Artifact Services'
+  displayName: 'Publish symbols'
   inputs:
     symbolServiceURI: 'https://microsoft.artifacts.visualstudio.com/DefaultCollection'
     requestName: '$(System.TeamProject)/$(Build.BuildNumber)/$(Build.BuildId)'
@@ -184,7 +184,7 @@ steps:
 
 # Compress staging output
 - task: ArchiveFiles@2
-  displayName: 'Compress $(Build.ArtifactStagingDirectory)'
+  displayName: 'Compress staging dir'
   inputs:
     rootFolderOrFile: '$(Build.ArtifactStagingDirectory)'
     includeRootFolder: false
@@ -194,14 +194,14 @@ steps:
 
 # Publish build artifact: binaries
 - task: PublishBuildArtifacts@1
-  displayName: 'Upload Binaries Directory'
+  displayName: 'Upload binaries to build artifacts'
   inputs:
     PathtoPublish: '$(Build.BinariesDirectory)/raw/binaries'
     ArtifactName: Binaries
 
 # Publish build artifact: staging output
 - task: PublishBuildArtifacts@1
-  displayName: 'Upload Staging Directory zip'
+  displayName: 'Upload staging zip to build artifacts'
   inputs:
     PathtoPublish: '$(Build.ArtifactStagingDirectory)/PTVSBuildArchive.zip'
     ArtifactName: 'PTVS Staging Output'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -48,6 +48,10 @@ variables:
     value: 16.0
   - name: VSTarget
     value: 16.0
+  - name: MsBuildVersion
+    value: 16.0
+  - name: Platform
+    value: 'AnyCPU'
 
   # This is used to suppress warnings from the auto-injected Nuget Security Analysis step.
   # The internal packages we use that are not available externally all start with "Microsoft",
@@ -119,8 +123,8 @@ steps:
   displayName: 'Build product'
   inputs:
     solution: Python/Product/dirs.proj
-    msbuildVersion: 16.0
-    platform: 'AnyCPU'
+    msbuildVersion: $(MsBuildVersion)
+    platform: '$(Platform)'
     configuration: '$(BuildConfiguration)'
 
 # Build the installer
@@ -128,8 +132,8 @@ steps:
   displayName: 'Build installer'
   inputs:
     solution: Python/Setup/dirs.proj
-    msbuildVersion: 16.0
-    platform: 'AnyCPU'
+    msbuildVersion: $(MsBuildVersion)
+    platform: '$(Platform)'
     configuration: '$(BuildConfiguration)'
     msbuildArguments: '/p:SkipProduct=true'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,18 +1,21 @@
-# trigger ci builds for commits into master and any release branches
+# Trigger ci builds for commits into master and any release branches
 trigger:
 - master
 - release/*
 
-# trigger pr builds for commits into master and any release branches
+# Trigger pr builds for commits into master and any release branches
 pr:
 - master
 - release/*
 
-# the agent pool the build will run on
+# The agent pool the build will run on
 pool:
   name: VSEng-MicroBuildVS2019
   demands: msbuild
 
+# Build variables
+# None of these are settable at build queue time. To do that, remove the variable from this list,
+# browse to the pipeline editor in AzDO, add the variable there, and make it settable at queue time.
 variables:
   BuildConfiguration: Release
   DropRoot: \\cpvsbuild\Drops\DSTools\PTVS\$(Build.SourceBranchName)\$(Build.BuildNumber)\
@@ -29,10 +32,16 @@ variables:
   VisualStudioVersion: 16.0
   VSTarget: 16.0
 
+# TODO:
+# For PR builds, don't real sign. Test sign instead.
+
 steps:
+
+# add build tag
 - powershell: 'Write-Host "##vso[build.addbuildtag]$env:VSTarget"'
   displayName: 'Add VSTarget Tag'
 
+# install plugins needed for swixproj/vsmanproj, signing, and localization
 - task: MicroBuildSwixPlugin@3
   displayName: 'Install Swix Plugin'
   inputs:
@@ -53,12 +62,15 @@ steps:
     languages: 'VS'
     feedSource: 'https://mseng.pkgs.visualstudio.com/DefaultCollection/_packaging/MicroBuildToolset/nuget/v3/index.json'
 
+# Run a powershell script that does a package restore, some symlinking, and installs debugpy
 - task: PowerShell@1
-  displayName: 'Powershell Script'
+  displayName: 'Restore packages'
   inputs:
     scriptName: Build/PreBuild.ps1
     arguments: '-vstarget $(VSTarget)'
 
+# Clean the old swix outputs
+# (This shouldn't be required since the build performs a clean when getting sources)
 - task: DeleteFiles@1
   displayName: 'Clean old SWIX outputs'
   inputs:
@@ -66,16 +78,18 @@ steps:
     Contents: '**'
   continueOnError: true
 
+# Build the product
 - task: MSBuild@1
-  displayName: 'Build solution Python/Product/dirs.proj'
+  displayName: 'Build product'
   inputs:
     solution: Python/Product/dirs.proj
     msbuildVersion: 16.0
     platform: 'any cpu'
     configuration: '$(BuildConfiguration)'
 
+# Build the installer
 - task: MSBuild@1
-  displayName: 'Build solution Python/Setup/dirs.proj'
+  displayName: 'Build installer'
   inputs:
     solution: Python/Setup/dirs.proj
     msbuildVersion: 16.0
@@ -83,6 +97,7 @@ steps:
     configuration: '$(BuildConfiguration)'
     msbuildArguments: '/p:SkipProduct=true'
 
+# Publish build artifacts if something failed
 - task: PublishBuildArtifacts@1
   displayName: '[If Build Failed] Publish Artifact: raw'
   inputs:
@@ -90,6 +105,7 @@ steps:
     ArtifactName: raw
   condition: failed()
 
+# Upload vs drop
 - task: MicroBuildUploadVstsDropFolder@1
   displayName: 'Upload VSTS Drop'
   inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -74,7 +74,7 @@ steps:
   clean: true
 
 # skip some steps if this is a PR build
-${{ if notin(variables['Build.Reason'], 'PullRequest') }}:
+- ${{ if notin(variables['Build.Reason'], 'PullRequest') }}:
 
   # add build tag
   - powershell: 'Write-Host "##vso[build.addbuildtag]$env:VSTarget"'
@@ -144,7 +144,7 @@ ${{ if notin(variables['Build.Reason'], 'PullRequest') }}:
   condition: failed()
 
 # skip some steps if this is a PR build
-${{ if notin(variables['Build.Reason'], 'PullRequest') }}:
+- ${{ if notin(variables['Build.Reason'], 'PullRequest') }}:
 
   # Upload vsts drop
   - task: MicroBuildUploadVstsDropFolder@1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,6 +37,10 @@ variables:
 
 steps:
 
+# check out code clean from source control
+- checkout: self
+  clean: true
+
 # add build tag
 - powershell: 'Write-Host "##vso[build.addbuildtag]$env:VSTarget"'
   displayName: 'Add VSTarget Tag'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -87,7 +87,7 @@ steps:
   inputs:
     solution: Python/Product/dirs.proj
     msbuildVersion: 16.0
-    platform: 'any cpu'
+    platform: 'AnyCPU'
     configuration: '$(BuildConfiguration)'
 
 # Build the installer
@@ -96,7 +96,7 @@ steps:
   inputs:
     solution: Python/Setup/dirs.proj
     msbuildVersion: 16.0
-    platform: 'any cpu'
+    platform: 'AnyCPU'
     configuration: '$(BuildConfiguration)'
     msbuildArguments: '/p:SkipProduct=true'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -96,7 +96,7 @@ steps:
   - task: MicroBuildLocalizationPlugin@3
     displayName: 'Install localization plugin'
     inputs:
-      type: 'Full'
+      #type: 'Full'
       languages: 'VS'
       #feedSource: 'https://mseng.pkgs.visualstudio.com/DefaultCollection/_packaging/MicroBuildToolset/nuget/v3/index.json'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -173,6 +173,7 @@ steps:
   displayName: 'Publish symbols'
   inputs:
     symbolsFolder: '$(Build.ArtifactStagingDirectory)/symbols_and_binaries'
+    searchPattern: '*.pdb'
     symbolServerType: TeamServices
 
 # MicroBuild cleanup

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -182,21 +182,21 @@ steps:
     inputs:
       SourceFolder: '$(Build.ArtifactStagingDirectory)/binaries'
       Contents: |
-      Microsoft.PythonTools*.pdb
-      Microsoft.PythonTools*.dll
-      Microsoft.PythonTools*.exe
-      Microsoft.CookiecutterTools.pdb
-      Microsoft.CookiecutterTools.dll
-      Microsoft.IronPythonTools.Resolver.pdb
-      Microsoft.IronPythonTools.Resolver.dll
-      Microsoft.Python.Analysis.Engine.dll
-      Microsoft.Python.Analysis.Engine.pdb
-      Microsoft.Python.LanguageServer.Core.dll
-      Microsoft.Python.LanguageServer.Core.pdb
-      PyDebugAttach*.pdb
-      PyDebugAttach*.dll
-      VsPyProf*.pdb
-      VsPyProf*.dll
+        Microsoft.PythonTools*.pdb
+        Microsoft.PythonTools*.dll
+        Microsoft.PythonTools*.exe
+        Microsoft.CookiecutterTools.pdb
+        Microsoft.CookiecutterTools.dll
+        Microsoft.IronPythonTools.Resolver.pdb
+        Microsoft.IronPythonTools.Resolver.dll
+        Microsoft.Python.Analysis.Engine.dll
+        Microsoft.Python.Analysis.Engine.pdb
+        Microsoft.Python.LanguageServer.Core.dll
+        Microsoft.Python.LanguageServer.Core.pdb
+        PyDebugAttach*.pdb
+        PyDebugAttach*.dll
+        VsPyProf*.pdb
+        VsPyProf*.dll
       TargetFolder: '$(Build.ArtifactStagingDirectory)/symbols_and_binaries'
 
   # Index sources and publish symbols

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,11 +2,21 @@ pool:
   name: VSEng-MicroBuildVS2019
   demands: msbuild
 
-#Your build pipeline references the ‘SignType’ variable, which you’ve selected to be settable at queue time. Create or edit the build pipeline for this YAML file, define the variable on the Variables tab, and then select the option to make it settable at queue time. See https://go.microsoft.com/fwlink/?linkid=865971
-#Your build pipeline references the ‘LocType’ variable, which you’ve selected to be settable at queue time. Create or edit the build pipeline for this YAML file, define the variable on the Variables tab, and then select the option to make it settable at queue time. See https://go.microsoft.com/fwlink/?linkid=865971
-#Your build pipeline references the ‘VSTarget’ variable, which you’ve selected to be settable at queue time. Create or edit the build pipeline for this YAML file, define the variable on the Variables tab, and then select the option to make it settable at queue time. See https://go.microsoft.com/fwlink/?linkid=865971
 variables:
-  BuildConfiguration: 'Release'
+  BuildConfiguration: Release
+  DropRoot: \\cpvsbuild\Drops\DSTools\PTVS\$(Build.SourceBranchName)\$(Build.BuildNumber)\
+  FileVersionPrefix: 16.9
+  IncludeDjangoHtmlExtensions: true
+  IncludeLiveShare: true
+  IncludeMiniconda: true
+  IncludeMSI: false
+  IncludeUWP: false
+  LocType: Full
+  SignType: Real
+  TeamName: DSTools
+  TrackFileAccess: false
+  VisualStudioVersion: 16.0
+  VSTarget: 16.0
 
 steps:
 - powershell: 'Write-Host "##vso[build.addbuildtag]$env:VSTarget"'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -73,30 +73,33 @@ steps:
 - checkout: self
   clean: true
 
-# add build tag
-- powershell: 'Write-Host "##vso[build.addbuildtag]$env:VSTarget"'
-  displayName: 'Add vstarget build tag'
+# skip some steps if this is a PR build
+${{ if notin(variables['Build.Reason'], 'PullRequest') }}:
 
-# install plugins needed for swixproj/vsmanproj, signing, and localization
-- task: MicroBuildSwixPlugin@3
-  displayName: 'Install swix plugin'
-  inputs:
-    dropName: 'Products/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildNumber)'
-    dropServiceUri: 'https://vsdrop.corp.microsoft.com/file/v1'
-    feedSource: 'https://mseng.pkgs.visualstudio.com/DefaultCollection/_packaging/MicroBuildToolset/nuget/v3/index.json'
+  # add build tag
+  - powershell: 'Write-Host "##vso[build.addbuildtag]$env:VSTarget"'
+    displayName: 'Add vstarget build tag'
 
-- task: MicroBuildSigningPlugin@3
-  displayName: 'Install signing plugin'
-  inputs:
-    signType: 'Test' # TODO: Change this to $(SignType) once Real signing is approved for this AzDO project ID
-    feedSource: 'https://devdiv.pkgs.visualstudio.com/DefaultCollection/_packaging/MicroBuildToolset/nuget/v3/index.json'
+  # install plugins needed for swixproj/vsmanproj, signing, and localization
+  - task: MicroBuildSwixPlugin@3
+    displayName: 'Install swix plugin'
+    inputs:
+      dropName: 'Products/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildNumber)'
+      dropServiceUri: 'https://vsdrop.corp.microsoft.com/file/v1'
+      feedSource: 'https://mseng.pkgs.visualstudio.com/DefaultCollection/_packaging/MicroBuildToolset/nuget/v3/index.json'
 
-- task: MicroBuildLocalizationPlugin@3
-  displayName: 'Install localization plugin'
-  inputs:
-    type: $(LocType)
-    languages: 'VS'
-    feedSource: 'https://mseng.pkgs.visualstudio.com/DefaultCollection/_packaging/MicroBuildToolset/nuget/v3/index.json'
+  - task: MicroBuildSigningPlugin@3
+    displayName: 'Install signing plugin'
+    inputs:
+      signType: 'Test' # TODO: Change this to $(SignType) once Real signing is approved for this AzDO project ID
+      feedSource: 'https://devdiv.pkgs.visualstudio.com/DefaultCollection/_packaging/MicroBuildToolset/nuget/v3/index.json'
+
+  - task: MicroBuildLocalizationPlugin@3
+    displayName: 'Install localization plugin'
+    inputs:
+      type: $(LocType)
+      languages: 'VS'
+      feedSource: 'https://mseng.pkgs.visualstudio.com/DefaultCollection/_packaging/MicroBuildToolset/nuget/v3/index.json'
 
 # Run a powershell script that does a package restore, some symlinking, and installs debugpy
 - task: PowerShell@1
@@ -106,7 +109,6 @@ steps:
     arguments: '-vstarget $(VSTarget)'
 
 # Clean the old swix outputs
-# (This shouldn't be required since the build performs a clean when getting sources)
 - task: DeleteFiles@1
   displayName: 'Clean old swix outputs'
   inputs:
@@ -141,92 +143,95 @@ steps:
     ArtifactName: raw
   condition: failed()
 
-# Upload vsts drop
-- task: MicroBuildUploadVstsDropFolder@1
-  displayName: 'Upload vsts drop'
-  inputs:
-    DropFolder: '$(Build.StagingDirectory)\release'
-    DropServiceUri: 'https://devdiv.artifacts.visualstudio.com/DefaultCollection'
-    VSDropServiceUri: 'https://vsdrop.corp.microsoft.com/file/v1'
-  continueOnError: true
+# skip some steps if this is a PR build
+${{ if notin(variables['Build.Reason'], 'PullRequest') }}:
 
-# copy some files around to prepare for publishing build artifacts
-- task: CopyFiles@2
-  displayName: 'Copy source to staging/src'
-  inputs:
-    SourceFolder: '$(Build.SourcesDirectory)'
-    TargetFolder: '$(Build.ArtifactStagingDirectory)/src'
-    CleanTargetFolder: true
+  # Upload vsts drop
+  - task: MicroBuildUploadVstsDropFolder@1
+    displayName: 'Upload vsts drop'
+    inputs:
+      DropFolder: '$(Build.StagingDirectory)\release'
+      DropServiceUri: 'https://devdiv.artifacts.visualstudio.com/DefaultCollection'
+      VSDropServiceUri: 'https://vsdrop.corp.microsoft.com/file/v1'
+    continueOnError: true
 
-- task: CopyFiles@2
-  displayName: 'Copy layout to staging'
-  inputs:
-    SourceFolder: '$(Build.BinariesDirectory)/layout'
-    TargetFolder: '$(Build.ArtifactStagingDirectory)/layout'
-    CleanTargetFolder: true
+  # copy some files around to prepare for publishing build artifacts
+  - task: CopyFiles@2
+    displayName: 'Copy source to staging/src'
+    inputs:
+      SourceFolder: '$(Build.SourcesDirectory)'
+      TargetFolder: '$(Build.ArtifactStagingDirectory)/src'
+      CleanTargetFolder: true
 
-- task: CopyFiles@2
-  displayName: 'Copy binaries to staging'
-  inputs:
-    SourceFolder: '$(Build.BinariesDirectory)/raw/binaries'
-    TargetFolder: '$(Build.ArtifactStagingDirectory)/binaries'
-    CleanTargetFolder: true
+  - task: CopyFiles@2
+    displayName: 'Copy layout to staging'
+    inputs:
+      SourceFolder: '$(Build.BinariesDirectory)/layout'
+      TargetFolder: '$(Build.ArtifactStagingDirectory)/layout'
+      CleanTargetFolder: true
 
-- task: CopyFiles@2
-  displayName: 'Prepare for symbol publishing'
-  inputs:
-    SourceFolder: '$(Build.ArtifactStagingDirectory)/binaries'
-    Contents: |
-     Microsoft.PythonTools*.pdb
-     Microsoft.PythonTools*.dll
-     Microsoft.PythonTools*.exe
-     Microsoft.CookiecutterTools.pdb
-     Microsoft.CookiecutterTools.dll
-     Microsoft.IronPythonTools.Resolver.pdb
-     Microsoft.IronPythonTools.Resolver.dll
-     Microsoft.Python.Analysis.Engine.dll
-     Microsoft.Python.Analysis.Engine.pdb
-     Microsoft.Python.LanguageServer.Core.dll
-     Microsoft.Python.LanguageServer.Core.pdb
-     PyDebugAttach*.pdb
-     PyDebugAttach*.dll
-     VsPyProf*.pdb
-     VsPyProf*.dll
-    TargetFolder: '$(Build.ArtifactStagingDirectory)/symbols_and_binaries'
+  - task: CopyFiles@2
+    displayName: 'Copy binaries to staging'
+    inputs:
+      SourceFolder: '$(Build.BinariesDirectory)/raw/binaries'
+      TargetFolder: '$(Build.ArtifactStagingDirectory)/binaries'
+      CleanTargetFolder: true
 
-# Index sources and publish symbols
-- task: PublishSymbols@2
-  displayName: 'Publish symbols'
-  inputs:
-    symbolsFolder: '$(Build.ArtifactStagingDirectory)/symbols_and_binaries'
-    searchPattern: '*.pdb'
-    symbolServerType: TeamServices
+  - task: CopyFiles@2
+    displayName: 'Prepare for symbol publishing'
+    inputs:
+      SourceFolder: '$(Build.ArtifactStagingDirectory)/binaries'
+      Contents: |
+      Microsoft.PythonTools*.pdb
+      Microsoft.PythonTools*.dll
+      Microsoft.PythonTools*.exe
+      Microsoft.CookiecutterTools.pdb
+      Microsoft.CookiecutterTools.dll
+      Microsoft.IronPythonTools.Resolver.pdb
+      Microsoft.IronPythonTools.Resolver.dll
+      Microsoft.Python.Analysis.Engine.dll
+      Microsoft.Python.Analysis.Engine.pdb
+      Microsoft.Python.LanguageServer.Core.dll
+      Microsoft.Python.LanguageServer.Core.pdb
+      PyDebugAttach*.pdb
+      PyDebugAttach*.dll
+      VsPyProf*.pdb
+      VsPyProf*.dll
+      TargetFolder: '$(Build.ArtifactStagingDirectory)/symbols_and_binaries'
 
-# MicroBuild cleanup
-- task: MicroBuildCleanup@1
-  displayName: 'Execute cleanup tasks'
-  condition: succeededOrFailed()
+  # Index sources and publish symbols
+  - task: PublishSymbols@2
+    displayName: 'Publish symbols'
+    inputs:
+      symbolsFolder: '$(Build.ArtifactStagingDirectory)/symbols_and_binaries'
+      searchPattern: '*.pdb'
+      symbolServerType: TeamServices
 
-# Compress staging output
-- task: ArchiveFiles@2
-  displayName: 'Compress staging dir'
-  inputs:
-    rootFolderOrFile: '$(Build.ArtifactStagingDirectory)'
-    includeRootFolder: false
-    archiveType: 'zip'
-    archiveFile: '$(Build.ArtifactStagingDirectory)/PTVSBuildArchive.zip'
-    replaceExistingArchive: true
+  # MicroBuild cleanup
+  - task: MicroBuildCleanup@1
+    displayName: 'Execute cleanup tasks'
+    condition: succeededOrFailed()
 
-# Publish build artifact: binaries
-- task: PublishBuildArtifacts@1
-  displayName: 'Upload binaries to build artifacts'
-  inputs:
-    PathtoPublish: '$(Build.BinariesDirectory)/raw/binaries'
-    ArtifactName: Binaries
+  # Compress staging output
+  - task: ArchiveFiles@2
+    displayName: 'Compress staging dir'
+    inputs:
+      rootFolderOrFile: '$(Build.ArtifactStagingDirectory)'
+      includeRootFolder: false
+      archiveType: 'zip'
+      archiveFile: '$(Build.ArtifactStagingDirectory)/PTVSBuildArchive.zip'
+      replaceExistingArchive: true
 
-# Publish build artifact: staging output
-- task: PublishBuildArtifacts@1
-  displayName: 'Upload staging zip to build artifacts'
-  inputs:
-    PathtoPublish: '$(Build.ArtifactStagingDirectory)/PTVSBuildArchive.zip'
-    ArtifactName: 'PTVS Staging Output'
+  # Publish build artifact: binaries
+  - task: PublishBuildArtifacts@1
+    displayName: 'Upload binaries to build artifacts'
+    inputs:
+      PathtoPublish: '$(Build.BinariesDirectory)/raw/binaries'
+      ArtifactName: Binaries
+
+  # Publish build artifact: staging output
+  - task: PublishBuildArtifacts@1
+    displayName: 'Upload staging zip to build artifacts'
+    inputs:
+      PathtoPublish: '$(Build.ArtifactStagingDirectory)/PTVSBuildArchive.zip'
+      ArtifactName: 'PTVS Staging Output'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -168,14 +168,12 @@ steps:
      VsPyProf*.dll
     TargetFolder: '$(Build.ArtifactStagingDirectory)/symbols_and_binaries'
 
-# Publish symbols
-- task: artifactSymbolTask@0
+# Index sources and publish symbols
+- task: PublishSymbols@2
   displayName: 'Publish symbols'
   inputs:
-    symbolServiceURI: 'https://microsoft.artifacts.visualstudio.com/DefaultCollection'
-    requestName: '$(System.TeamProject)/$(Build.BuildNumber)/$(Build.BuildId)'
-    sourcePath: '$(Build.ArtifactStagingDirectory)/symbols_and_binaries'
-    usePat: false
+    symbolsFolder: '$(Build.ArtifactStagingDirectory)/symbols_and_binaries'
+    symbolServerType: TeamServices
 
 # MicroBuild cleanup
 - task: MicroBuildCleanup@1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,10 +36,6 @@ variables:
     value: false
   - name: IncludeUWP
     value: false
-  - name: LocType
-    value: Full
-  - name: SignType
-    value: Real
   - name: TeamName
     value: DSTools
   - name: TrackFileAccess
@@ -84,24 +80,25 @@ steps:
 
   # install plugins needed for swixproj/vsmanproj, signing, and localization
   - task: MicroBuildSwixPlugin@3
-    displayName: 'Install swix plugin'
+    displayName: 'Install microbuild swix plugin'
     inputs:
       dropName: 'Products/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildNumber)'
-      dropServiceUri: 'https://vsdrop.corp.microsoft.com/file/v1'
-      feedSource: 'https://mseng.pkgs.visualstudio.com/DefaultCollection/_packaging/MicroBuildToolset/nuget/v3/index.json'
+      #dropServiceUri: 'https://vsdrop.corp.microsoft.com/file/v1'
+      #feedSource: 'https://mseng.pkgs.visualstudio.com/DefaultCollection/_packaging/MicroBuildToolset/nuget/v3/index.json'
 
   - task: MicroBuildSigningPlugin@3
-    displayName: 'Install signing plugin'
+    displayName: 'Install microbuild signing plugin'
     inputs:
-      signType: 'Test' # TODO: Change this to $(SignType) once Real signing is approved for this AzDO project ID
-      feedSource: 'https://devdiv.pkgs.visualstudio.com/DefaultCollection/_packaging/MicroBuildToolset/nuget/v3/index.json'
+      signType: 'Test' # TODO: Change this to 'Real' once Real signing is approved for this AzDO project ID
+      zipSources: false
+      #feedSource: 'https://devdiv.pkgs.visualstudio.com/DefaultCollection/_packaging/MicroBuildToolset/nuget/v3/index.json'
 
   - task: MicroBuildLocalizationPlugin@3
     displayName: 'Install localization plugin'
     inputs:
-      type: $(LocType)
+      type: 'Full'
       languages: 'VS'
-      feedSource: 'https://mseng.pkgs.visualstudio.com/DefaultCollection/_packaging/MicroBuildToolset/nuget/v3/index.json'
+      #feedSource: 'https://mseng.pkgs.visualstudio.com/DefaultCollection/_packaging/MicroBuildToolset/nuget/v3/index.json'
 
 # Run a powershell script that does a package restore, some symlinking, and installs debugpy
 - task: PowerShell@1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -49,7 +49,12 @@ variables:
     value: 16.0
   - name: VSTarget
     value: 16.0
-  - group: PTVS # ptvs variable group, for secrets
+  
+  # PTVS variable group, for secrets
+  # This group contains an AzDO Personal Access Token (ArtifactServices.Symbol.PAT) that expires on 4/15/2021 which is used to publish symbols to symweb.
+  # If Visual Studio insertion PRs start failing the Symbol Check step, this token is most likely expired.
+  # See https://www.1eswiki.com/wiki/Using_Azure_DevOps_Symbols for more information about how to create a new PAT and how to update the variable group.
+  - group: PTVS
 
 # TODO:
 # For PR builds, don't real sign. Test sign instead.

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -89,7 +89,7 @@ steps:
   inputs:
     signType: 'Test' # TODO: Change this to $(SignType) once Real signing is approved for this AzDO project ID
     feedSource: 'https://devdiv.pkgs.visualstudio.com/DefaultCollection/_packaging/MicroBuildToolset/nuget/v3/index.json'
-  enabled: false # Disable signing since it only works in approved project ids.
+  enabled: true # Disable signing since it only works in approved project ids.
   # TODO: remove the line above once the rest of the build is working, will need to get approval
   # once the new build pipeline is created before this step will work.
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,6 +4,7 @@ name: $(date:yy)$(DayOfYear)$(rev:.r)
 # Trigger ci builds for commits into master and any release branches
 trigger:
 - master
+- yaml
 - release/*
 
 # Trigger pr builds for commits into master and any release branches


### PR DESCRIPTION
This yaml will drive our CI and PR builds once we create a new AzDO pipeline that consumes it. Right now, the file is not being consumed, but it must be in the repo before it can be used by AzDO 😄 

This yaml should be functionally equivalent to the old classic build definition. The only difference is that both CI and PR builds are enabled, and PR builds only perform a subset of the build steps, for speed.

The yaml build was tested at https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=4442296&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9 and seems to be working just fine.