### PR TITLE
Disable DeferUntilIntellisenseIsReady

### DIFF
--- a/Python/Product/PythonTools/ProvideEditorExtension2Attribute.cs
+++ b/Python/Product/PythonTools/ProvideEditorExtension2Attribute.cs
@@ -205,6 +205,7 @@ namespace Microsoft.PythonTools {
                     editorKey.SetValue("CommonPhysicalViewAttributes", (int)_commonViewAttrs);
                 }
                 editorKey.SetValue("Package", context.ComponentType.GUID.ToString("B"));
+                editorKey.SetValue("DeferUntilIntellisenseIsReady", 0);
             }
 
             using (Key extensionKey = context.CreateKey(RegKeyName + "\\Extensions")) {


### PR DESCRIPTION
Fixes #6304 
Fixes #6402 

Apparently all editors were opted-in by default to this by the Editor team a while ago, and Python was probably missed.

From an email chain: "Basically that means until C# projects are loaded and analyzed (ready to provide intellisense), opening any document whose chosen editor factory has not opted out of DeferUntilIntellisenseIsReady is blocked (by showing the “Waiting for IntelliSense to finish initializing…” wait frame). The recommendation is for all text editor based editor factories (not designers) to opt out of DeferUntilIntellisenseIsReady (even C# editor factory is opting out)."