### PR TITLE
Fix automation name for strikethrough environments

### DIFF
--- a/Python/Product/EnvironmentsList/EnvironmentView.cs
+++ b/Python/Product/EnvironmentsList/EnvironmentView.cs
@@ -54,9 +54,10 @@ namespace Microsoft.PythonTools.EnvironmentsList {
         public string BrokenEnvironmentHelpUrl { get; }
         public bool ExtensionsCreated { get; set; }
 
-        private EnvironmentView(string id, string localizedName, string localizedHelpText) {
+        private EnvironmentView(string id, string localizedName, string localizedAutomationName, string localizedHelpText) {
             Configuration = new VisualStudioInterpreterConfiguration(id, id);
             Description = LocalizedDisplayName = localizedName;
+            LocalizedAutomationName = localizedAutomationName;
             LocalizedHelpText = localizedHelpText ?? "";
             Extensions = new ObservableCollection<object>();
         }
@@ -86,6 +87,7 @@ namespace Microsoft.PythonTools.EnvironmentsList {
             Configuration = Factory.Configuration;
             LocalizedDisplayName = Configuration.Description;
             IsBroken = !Configuration.IsRunnable();
+            LocalizedAutomationName = !IsBroken ? LocalizedDisplayName : String.Format(Resources.BrokenEnvironmentAutomationNameFormat, LocalizedDisplayName);
             BrokenEnvironmentHelpUrl = "https://go.microsoft.com/fwlink/?linkid=863373";
 
             if (_service.IsConfigurable(Factory.Configuration.Id)) {
@@ -115,7 +117,7 @@ namespace Microsoft.PythonTools.EnvironmentsList {
         }
 
         public static EnvironmentView CreateMissingEnvironmentView(string id, string description) {
-            return new EnvironmentView(id, description + Strings.MissingSuffix, null);
+            return new EnvironmentView(id, description + Strings.MissingSuffix, description + Strings.MissingSuffix, null);
         }
 
         public ObservableCollection<object> Extensions { get; private set; }
@@ -164,12 +166,14 @@ namespace Microsoft.PythonTools.EnvironmentsList {
         #region Configuration Dependency Properties
 
         private static readonly DependencyPropertyKey DescriptionPropertyKey = DependencyProperty.RegisterReadOnly("Description", typeof(string), typeof(EnvironmentView), new PropertyMetadata(""));
+        private static readonly DependencyPropertyKey LocalizedAutomationNamePropertyKey = DependencyProperty.RegisterReadOnly("LocalizedAutomationName", typeof(string), typeof(EnvironmentView), new PropertyMetadata(""));
         private static readonly DependencyPropertyKey PrefixPathPropertyKey = DependencyProperty.RegisterReadOnly("PrefixPath", typeof(string), typeof(EnvironmentView), new PropertyMetadata());
         private static readonly DependencyPropertyKey InterpreterPathPropertyKey = DependencyProperty.RegisterReadOnly("InterpreterPath", typeof(string), typeof(EnvironmentView), new PropertyMetadata());
         private static readonly DependencyPropertyKey WindowsInterpreterPathPropertyKey = DependencyProperty.RegisterReadOnly("WindowsInterpreterPath", typeof(string), typeof(EnvironmentView), new PropertyMetadata());
         private static readonly DependencyPropertyKey PathEnvironmentVariablePropertyKey = DependencyProperty.RegisterReadOnly("PathEnvironmentVariable", typeof(string), typeof(EnvironmentView), new PropertyMetadata());
 
         public static readonly DependencyProperty DescriptionProperty = DescriptionPropertyKey.DependencyProperty;
+        public static readonly DependencyProperty LocalizedAutomationNameProperty = LocalizedAutomationNamePropertyKey.DependencyProperty;
         public static readonly DependencyProperty PrefixPathProperty = PrefixPathPropertyKey.DependencyProperty;
         public static readonly DependencyProperty InterpreterPathProperty = InterpreterPathPropertyKey.DependencyProperty;
         public static readonly DependencyProperty WindowsInterpreterPathProperty = WindowsInterpreterPathPropertyKey.DependencyProperty;
@@ -178,6 +182,10 @@ namespace Microsoft.PythonTools.EnvironmentsList {
         public string Description {
             get { return (string)GetValue(DescriptionProperty) ?? ""; }
             set { SetValue(DescriptionPropertyKey, value ?? ""); }
+        }
+        public string LocalizedAutomationName {
+            get { return (string)GetValue(LocalizedAutomationNameProperty) ?? ""; }
+            set { SetValue(LocalizedAutomationNamePropertyKey, value ?? ""); }
         }
 
         public string PrefixPath {

--- a/Python/Product/EnvironmentsList/Resources.Designer.cs
+++ b/Python/Product/EnvironmentsList/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.PythonTools.EnvironmentsList {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Resources {
@@ -57,6 +57,15 @@ namespace Microsoft.PythonTools.EnvironmentsList {
             }
             set {
                 resourceCulture = value;
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0} - broken.
+        /// </summary>
+        public static string BrokenEnvironmentAutomationNameFormat {
+            get {
+                return ResourceManager.GetString("BrokenEnvironmentAutomationNameFormat", resourceCulture);
             }
         }
         

--- a/Python/Product/EnvironmentsList/Resources.resx
+++ b/Python/Product/EnvironmentsList/Resources.resx
@@ -482,4 +482,8 @@ If you are having trouble, you can click the link below and restart Visual Studi
   <data name="NoDBExtensionReactivate" xml:space="preserve">
     <value>Reactivate IntelliSense databases in my next session</value>
   </data>
+  <data name="BrokenEnvironmentAutomationNameFormat" xml:space="preserve">
+    <value>{0} - broken</value>
+    <comment>Used for accessibility to indicate an environment is not usable</comment>
+  </data>
 </root>

--- a/Python/Product/EnvironmentsList/ToolWindow.xaml
+++ b/Python/Product/EnvironmentsList/ToolWindow.xaml
@@ -107,7 +107,7 @@
             </Style>
 
             <Style TargetType="{x:Type ListBoxItem}" BasedOn="{StaticResource {x:Type ListBoxItem}}" x:Key="WithLocalizedName">
-                <Setter Property="AutomationProperties.Name" Value="{Binding LocalizedDisplayName,Mode=OneWay}" />
+                <Setter Property="AutomationProperties.Name" Value="{Binding LocalizedAutomationName,Mode=OneWay}" />
                 <Setter Property="AutomationProperties.HelpText" Value="{Binding LocalizedHelpText,Mode=OneWay}" />
             </Style>
             <Style TargetType="{x:Type ComboBoxItem}" x:Key="Combo_WithLocalizedName">


### PR DESCRIPTION
For bug:
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1243179

Make the automation name for the list view item include the word 'broken' if the environment is busted.