### PR TITLE
Fix project paths not being used by pylance

### DIFF
--- a/Python/Product/PythonTools/PythonTools/LanguageServerClient/PylanceLanguageServer.cs
+++ b/Python/Product/PythonTools/PythonTools/LanguageServerClient/PylanceLanguageServer.cs
@@ -51,6 +51,7 @@ namespace Microsoft.PythonTools.LanguageServerClient {
             var isDebugging = IsDebugging();
             var debugArgs = isDebugging ? GetDebugArguments() : string.Empty;
             var serverFilePath = isDebugging ? GetDebugServerLocation() : GetServerLocation();
+            var debuggerExtra = isDebugging ? "--verbose" : string.Empty;
 
             if (!File.Exists(serverFilePath)) {
                 MessageBox.ShowErrorMessage(_site, Strings.LanguageClientPylanceNotFound);
@@ -69,7 +70,7 @@ namespace Microsoft.PythonTools.LanguageServerClient {
                 RedirectStandardOutput = true,
                 UseShellExecute = false,
                 CreateNoWindow = true,
-                Arguments = $"{debugArgs} \"{serverFilePath}\" -- --stdio --cancellationReceive=file:{this.CancellationFolderName} --verbose",
+                Arguments = $"{debugArgs} \"{serverFilePath}\" -- --stdio --cancellationReceive=file:{this.CancellationFolderName} {debuggerExtra}",
             };
 
             var process = new Process {
@@ -77,7 +78,7 @@ namespace Microsoft.PythonTools.LanguageServerClient {
             };
 
             if (process.Start()) {
-                if (PylanceLanguageServer.IsDebugging()) {
+                if (isDebugging) {
                     // During debugging give us time to attach
                     await Task.Delay(5000);
                 }

--- a/Python/Product/PythonTools/PythonTools/LanguageServerClient/PythonLanguageClient.cs
+++ b/Python/Product/PythonTools/PythonTools/LanguageServerClient/PythonLanguageClient.cs
@@ -188,6 +188,13 @@ namespace Microsoft.PythonTools.LanguageServerClient {
                 PythonConstants.ExtraPathsSetting, null, Site, PythonWorkspaceContextProvider.Workspace, out _)?.Split(';')
                 ?? _analysisOptions.ExtraPaths;
 
+            // Extra paths should include the project paths as well.
+            if (this.ProjectContextProvider != null) {
+                var directories = from n in this.ProjectContextProvider.ProjectNodes
+                                  select n.BaseURI.Directory;
+                extraPaths = extraPaths != null ? extraPaths.Concat(directories).ToArray() : directories.ToArray();
+            }
+
             var stubPath = UserSettings.GetStringSetting(
                 PythonConstants.StubPathSetting, null, Site, PythonWorkspaceContextProvider.Workspace, out _)
                 ?? _analysisOptions.StubPath;


### PR DESCRIPTION
Fixes: https://github.com/microsoft/ptvs-pylance/issues/170

When opening a file that references another, pylance can't find the other file. 

The reason being the relative directory is not part of the extraPaths. 