### PR TITLE
Implement support for watching files

### DIFF
--- a/Common/Product/SharedProject/CommonProjectNodeProperties.cs
+++ b/Common/Product/SharedProject/CommonProjectNodeProperties.cs
@@ -28,9 +28,11 @@ namespace Microsoft.VisualStudioTools.Project {
     [ClassInterface(ClassInterfaceType.AutoDual)]
     public class CommonProjectNodeProperties : ProjectNodeProperties, IVsCfgBrowseObject, VSLangProj.ProjectProperties {
         private OAProjectConfigurationProperties _activeCfgSettings;
+        private string __idStr;
 
         internal CommonProjectNodeProperties(ProjectNode node)
             : base(node) {
+            __idStr = node.ID.ToString();
         }
 
         #region properties
@@ -427,7 +429,7 @@ namespace Microsoft.VisualStudioTools.Project {
 
         [Browsable(false)]
         public string __id {
-            get { throw new NotImplementedException(); }
+            get => __idStr;
         }
 
         [Browsable(false)]

--- a/Common/Tests/Utilities.UI/TestUtilities.UI.csproj
+++ b/Common/Tests/Utilities.UI/TestUtilities.UI.csproj
@@ -40,6 +40,7 @@
     <Reference Include="Microsoft.VisualStudio.ComponentModelHost" />
     <Reference Include="Microsoft.VisualStudio.CoreUtility" />
     <Reference Include="Microsoft.VisualStudio.Editor" />
+    <Reference Include="Microsoft.VisualStudio.Language, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.VisualStudio.Language.Intellisense" />
     <Reference Include="Microsoft.VisualStudio.OLE.Interop, Version=7.1.40304.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
     <Reference Include="Microsoft.VisualStudio.QualityTools.Common" />

--- a/Common/Tests/Utilities.UI/UI/EditorWindow.cs
+++ b/Common/Tests/Utilities.UI/UI/EditorWindow.cs
@@ -24,6 +24,7 @@ using System.Windows.Automation;
 using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.Editor;
 using Microsoft.VisualStudio.Language.Intellisense;
+using Microsoft.VisualStudio.Language.Intellisense.AsyncCompletion;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -233,6 +234,15 @@ namespace TestUtilities.UI {
                 var stackMapService = compModel.GetService<IIntellisenseSessionStackMapService>();
 
                 return stackMapService.GetStackForTextView(TextView);
+            }
+        }
+
+        public IAsyncCompletionBroker2 AsyncCompletionBroker
+        {
+            get
+            {
+                var compModel = (IComponentModel)VisualStudioApp.ServiceProvider.GetService(typeof(SComponentModel));
+                return compModel.GetService<IAsyncCompletionBroker>() as IAsyncCompletionBroker2;
             }
         }
 

--- a/Python/Product/Core/Core.csproj
+++ b/Python/Product/Core/Core.csproj
@@ -28,6 +28,10 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.Extensions.FileSystemGlobbing, Version=3.1.8.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <Private>True</Private>
+      <IncludeInVSIX>true</IncludeInVSIX>
+    </Reference>
     <Reference Include="Microsoft.VisualStudio.Shell.15.0" />
     <Reference Include="Microsoft.VisualStudio.Shell.Framework" />
     <Reference Include="System" />

--- a/Python/Product/Core/Properties/AssemblyInfo.cs
+++ b/Python/Product/Core/Properties/AssemblyInfo.cs
@@ -55,6 +55,7 @@ using Microsoft.VisualStudio.Shell;
 [assembly: ProvideCodeBase(AssemblyName = "Microsoft.PythonTools.VSCommon", CodeBase = "Microsoft.PythonTools.VSCommon.dll", Version = AssemblyVersionInfo.StableVersion)]
 [assembly: ProvideCodeBase(AssemblyName = "Microsoft.PythonTools.VSInterpreters", CodeBase = "Microsoft.PythonTools.VSInterpreters.dll", Version = AssemblyVersionInfo.StableVersion)]
 [assembly: ProvideCodeBase(AssemblyName = "Microsoft.PythonTools.Workspace", CodeBase = "Microsoft.PythonTools.Workspace.dll", Version = AssemblyVersionInfo.StableVersion)]
+[assembly: ProvideCodeBase(AssemblyName = "Microsoft.Extensions.FileSystemGlobbing", CodeBase = "Microsoft.Extensions.FileSystemGlobbing.dll", Version = "3.1.8.0")]
 
 internal static class ParserNuGetPackageInfo {
     // important: keep in sync with Build\16.0\package.config

--- a/Python/Product/Core/source.extension.vsixmanifest
+++ b/Python/Product/Core/source.extension.vsixmanifest
@@ -48,5 +48,6 @@
         <Asset Type="Microsoft.VisualStudio.Assembly" d:Source="File" Path="Microsoft.PythonTools.Ipc.Json.dll" />
         <Asset Type="Microsoft.VisualStudio.Assembly" d:Source="File" Path="Microsoft.PythonTools.Attacher.exe" />
         <Asset Type="Microsoft.VisualStudio.Assembly" d:Source="File" Path="Microsoft.PythonTools.ProjectWizards.dll" />
+        <Asset Type="Microsoft.VisualStudio.Assembly" d:Source="File" Path="Microsoft.Extensions.FileSystemGlobbing.dll" />
     </Assets>
 </PackageManifest>

--- a/Python/Product/PythonTools/PythonTools.csproj
+++ b/Python/Product/PythonTools/PythonTools.csproj
@@ -281,6 +281,7 @@
     <Compile Include="PythonTools\Editor\Formatting\PythonFormatter.cs" />
     <Compile Include="PythonTools\Editor\Formatting\LspDiffTextEditFactory.cs" />
     <Compile Include="PythonTools\LanguageServerClient\CustomCancellationStrategy.cs" />
+    <Compile Include="PythonTools\LanguageServerClient\FileWatcher\Listener.cs" />
     <Compile Include="PythonTools\LanguageServerClient\LiveShareExtensions.cs" />
     <Compile Include="PythonTools\LanguageServerClient\LspEditorUtilities.cs" />
     <Compile Include="PythonTools\Editor\Formatting\PythonFormatterBlack.cs" />

--- a/Python/Product/PythonTools/PythonTools/LanguageServerClient/FileWatcher/Listener.cs
+++ b/Python/Product/PythonTools/PythonTools/LanguageServerClient/FileWatcher/Listener.cs
@@ -1,0 +1,157 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Extensions.FileSystemGlobbing;
+using Microsoft.PythonTools.Interpreter;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+using Microsoft.VisualStudio.Workspace;
+using Microsoft.VisualStudio.Workspace.VSIntegration.Contracts;
+using StreamJsonRpc;
+
+namespace Microsoft.PythonTools.LanguageServerClient.FileWatcher {
+    class Listener : IDisposable {
+        private readonly JsonRpc _rpc;
+        private System.IO.FileSystemWatcher _solutionWatcher;
+        private Microsoft.Extensions.FileSystemGlobbing.Matcher _matcher = new Microsoft.Extensions.FileSystemGlobbing.Matcher(StringComparison.InvariantCultureIgnoreCase);
+        private bool disposedValue;
+
+        public Listener(StreamJsonRpc.JsonRpc rpc, IVsFolderWorkspaceService workspaceService, IServiceProvider site) {
+            this._rpc = rpc;
+
+            // Depending upon if this is a workspace or a solution, listen to different change events.
+            if (workspaceService != null && workspaceService.CurrentWorkspace != null) {
+                workspaceService.CurrentWorkspace.GetService<IFileWatcherService>().OnFileSystemChanged += OnFileChanged;
+            } else {
+                var dte = (EnvDTE80.DTE2)site.GetService(typeof(EnvDTE.DTE));
+                if (dte != null && dte.Solution != null && dte.Solution.FileName != null) {
+                    _solutionWatcher = new System.IO.FileSystemWatcher();
+                    _solutionWatcher.Path = Path.GetDirectoryName(dte.Solution.FileName);
+                    _solutionWatcher.IncludeSubdirectories = true;
+                    _solutionWatcher.NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.CreationTime | NotifyFilters.DirectoryName | NotifyFilters.FileName;
+                    _solutionWatcher.Changed += OnFileChanged_Sync;
+                    _solutionWatcher.Created += OnFileChanged_Sync;
+                    _solutionWatcher.Deleted += OnFileChanged_Sync;
+                    _solutionWatcher.Renamed += OnFileChanged_Sync;
+                    _solutionWatcher.EnableRaisingEvents = true;
+                }
+            }
+        }
+
+        public void AddPatterns(VisualStudio.LanguageServer.Protocol.FileSystemWatcher[] patterns) {
+            Array.ForEach(patterns, p => AddPattern(p));
+        }
+
+        private void AddPattern(VisualStudio.LanguageServer.Protocol.FileSystemWatcher pattern) {
+            // Add to our matcher
+            _matcher.AddInclude(pattern.GlobPattern);
+
+            // Ignoring kind for now. Just tell about everything.
+        }
+
+        private bool Equals(System.IO.FileSystemWatcher l, System.IO.FileSystemWatcher r) {
+            if (l == r) {
+                return true;
+            }
+            if (l.Path == r.Path && l.IncludeSubdirectories == r.IncludeSubdirectories && r.Filter == l.Filter) {
+                return true;
+            }
+            return false;
+        }
+
+        private async void OnFileChanged_Sync(object sender, System.IO.FileSystemEventArgs e) {
+            await OnFileChanged(sender, e);
+        }
+        private async Task OnFileChanged(object sender, System.IO.FileSystemEventArgs e) {
+            // Skip directory change events
+            if (!e.IsDirectoryChanged()) {
+                // Create something to match with
+                var item = new InMemoryDirectoryInfo(Path.GetDirectoryName(e.FullPath), new string[] { e.Name });
+
+                // See if this matches one of our patterns.
+                if (_matcher.Execute(item).HasMatches) {
+                    // Send out the event to the language server
+                    var renamedArgs = e as System.IO.RenamedEventArgs;
+                    var didChangeParams = new DidChangeWatchedFilesParams();
+                    if (renamedArgs == null) {
+                        didChangeParams.Changes = new FileEvent[] { new FileEvent() };
+                        didChangeParams.Changes[0].Uri = new Uri(e.FullPath);
+
+                        switch (e.ChangeType) {
+                            case WatcherChangeTypes.Created:
+                                didChangeParams.Changes[0].FileChangeType = FileChangeType.Created;
+                                break;
+                            case WatcherChangeTypes.Deleted:
+                                didChangeParams.Changes[0].FileChangeType = FileChangeType.Deleted;
+                                break;
+                            case WatcherChangeTypes.Changed:
+                                didChangeParams.Changes[0].FileChangeType = FileChangeType.Changed;
+                                break;
+                            default:
+                                didChangeParams.Changes = Array.Empty<FileEvent>();
+                                break;
+                        }
+                    } else {
+                        // file renamed
+                        var deleteEvent = new FileEvent();
+                        deleteEvent.FileChangeType = FileChangeType.Deleted;
+                        deleteEvent.Uri = new Uri(renamedArgs.OldFullPath);
+
+                        var createEvent = new FileEvent();
+                        createEvent.FileChangeType = FileChangeType.Created;
+                        createEvent.Uri = new Uri(renamedArgs.FullPath);
+
+                        didChangeParams.Changes = new FileEvent[] { deleteEvent, createEvent };
+                    }
+
+                    if (didChangeParams.Changes.Any()) {
+                        await _rpc.NotifyWithParameterObjectAsync(Methods.WorkspaceDidChangeWatchedFiles.Name, didChangeParams);
+                        if (renamedArgs != null) {
+                            var textDocumentIdentifier = new TextDocumentIdentifier();
+                            textDocumentIdentifier.Uri = new Uri(renamedArgs.OldFullPath);
+
+                            var closeParam = new DidCloseTextDocumentParams();
+                            closeParam.TextDocument = textDocumentIdentifier;
+
+                            await _rpc.NotifyWithParameterObjectAsync(Methods.TextDocumentDidClose.Name, closeParam);
+
+                            var textDocumentItem = new TextDocumentItem();
+                            textDocumentItem.Uri = new Uri(renamedArgs.FullPath);
+
+                            var openParam = new DidOpenTextDocumentParams();
+                            openParam.TextDocument = textDocumentItem;
+                            await _rpc.NotifyWithParameterObjectAsync(Methods.TextDocumentDidOpen.Name, openParam);
+                        }
+                    }
+                }
+            }
+        }
+
+        protected virtual void Dispose(bool disposing) {
+            if (!disposedValue) {
+                if (disposing) {
+                    _solutionWatcher?.Dispose();
+                }
+
+                // TODO: free unmanaged resources (unmanaged objects) and override finalizer
+                // TODO: set large fields to null
+                disposedValue = true;
+            }
+        }
+
+        // // TODO: override finalizer only if 'Dispose(bool disposing)' has code to free unmanaged resources
+        // ~Listener()
+        // {
+        //     // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+        //     Dispose(disposing: false);
+        // }
+
+        public void Dispose() {
+            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
+        }
+    }
+}

--- a/Python/Product/PythonTools/PythonTools/LanguageServerClient/LanguageServer.cs
+++ b/Python/Product/PythonTools/PythonTools/LanguageServerClient/LanguageServer.cs
@@ -85,6 +85,7 @@ namespace Microsoft.PythonTools.LanguageServerClient {
 
             if (process.Start()) {
                 if (isDebugging) {
+                    System.Diagnostics.Debug.WriteLine($"Attach to {process.Id} for pylance debugging");
                     // During debugging give us time to attach
                     await Task.Delay(5000);
                 }

--- a/Python/Product/PythonTools/PythonTools/LanguageServerClient/PythonLanguageClient.cs
+++ b/Python/Product/PythonTools/PythonTools/LanguageServerClient/PythonLanguageClient.cs
@@ -430,6 +430,13 @@ namespace Microsoft.PythonTools.LanguageServerClient {
                                 capabilities["workspace"]["workspaceFolders"] = true;
                                 capabilities["workspace"]["didChangeWatchedFiles"]["dynamicRegistration"] = true;
 
+                                // Root path and root URI should not be sent. They're deprecated and will
+                                // just confuse pylance with respect to what is the root folder. 
+                                // https://microsoft.github.io/language-server-protocol/specifications/specification-current/#initialize
+                                // Setting them to empty will make pylance think they're gone.
+                                messageParams["rootPath"] = "";
+                                messageParams["rootUri"] = "";
+
                                 // Need to rewrite the message now
                                 return MessageParser.Serialize(message);
                             }
@@ -444,6 +451,8 @@ namespace Microsoft.PythonTools.LanguageServerClient {
 
         private async Task OnWorkspaceOpening(object sende, EventArgs e) {
             if (_workspaceFoldersSupported && IsInitialized && _sentInitialWorkspaceFolders && WorkspaceService.CurrentWorkspace != null) {
+                // Send just this workspace folder. Assumption here is that the language client will be destroyed/recreated on
+                // each workspace open
                 var folder = new WorkspaceFolder { uri = new System.Uri(WorkspaceService.CurrentWorkspace.Location), name = WorkspaceService.CurrentWorkspace.GetName() };
                 await InvokeDidChangeWorkspaceFoldersAsync(new WorkspaceFolder[] { folder }, new WorkspaceFolder[0]);
             }

--- a/Python/Product/PythonTools/PythonTools/LanguageServerClient/PythonLanguageClient.cs
+++ b/Python/Product/PythonTools/PythonTools/LanguageServerClient/PythonLanguageClient.cs
@@ -321,6 +321,9 @@ namespace Microsoft.PythonTools.LanguageServerClient {
         private StreamData OnSendToServer(StreamData data) {
             var message = MessageParser.Deserialize(data);
             if (message != null) {
+                if (_isDebugging) {
+                    System.Diagnostics.Debug.WriteLine($"*** Sending pylance: {message.ToString()}");
+                }
                 try {
                     // If this is the initialize method, add the workspace folders capability
                     if (message.Value<string>("method") == "initialize") {

--- a/Python/Product/PythonTools/PythonTools/LanguageServerClient/PythonLanguageClient.cs
+++ b/Python/Product/PythonTools/PythonTools/LanguageServerClient/PythonLanguageClient.cs
@@ -79,6 +79,11 @@ namespace Microsoft.PythonTools.LanguageServerClient {
         [Import]
         public ITextDocumentFactoryService TextDocumentFactoryService;
 
+        /// <summary>
+        /// Used for testing. Waits for the language client to be up and connected
+        /// </summary>
+        public static Task ConnectedTask => _connectedTcs.Task;
+
         private readonly DisposableBag _disposables;
         private IPythonLanguageClientContext[] _clientContexts;
         private PythonAnalysisOptions _analysisOptions;
@@ -89,6 +94,7 @@ namespace Microsoft.PythonTools.LanguageServerClient {
         private bool _isDebugging = LanguageServer.IsDebugging();
         private bool _sentInitialWorkspaceFolders = false;
         private FileWatcher.Listener _fileListener;
+        private static TaskCompletionSource<int> _connectedTcs = new System.Threading.Tasks.TaskCompletionSource<int>();
 
         public PythonLanguageClient() {
             _disposables = new DisposableBag(GetType().Name);
@@ -285,6 +291,9 @@ namespace Microsoft.PythonTools.LanguageServerClient {
                     await InvokeTextDocumentDidOpenAsync(param).ConfigureAwait(false);
                 }
             }
+
+            // Indicate to test code that we are up and running.
+            _connectedTcs.TrySetResult(0);
         }
 
         private bool TryGetOpenedDocumentData(RunningDocumentInfo info, out ITextBuffer textBuffer, out string filePath) {

--- a/Python/Product/PythonTools/PythonTools/LanguageServerClient/PythonLanguageClient.cs
+++ b/Python/Product/PythonTools/PythonTools/LanguageServerClient/PythonLanguageClient.cs
@@ -281,6 +281,7 @@ namespace Microsoft.PythonTools.LanguageServerClient {
 
             SVsServiceProvider syncServiceProvider = componentModel.GetService<SVsServiceProvider>();
             RunningDocumentTable rdt = new RunningDocumentTable(syncServiceProvider);
+            var tasks = new List<Task>();
 
             foreach (RunningDocumentInfo info in rdt) {
                 if (this.TryGetOpenedDocumentData(info, out ITextBuffer textBuffer, out string filePath)
@@ -298,9 +299,12 @@ namespace Microsoft.PythonTools.LanguageServerClient {
                     };
                     param.TextDocument.Text = textBuffer.CurrentSnapshot.GetText();
 
-                    await InvokeTextDocumentDidOpenAsync(param).ConfigureAwait(false);
+                    tasks.Add(InvokeTextDocumentDidOpenAsync(param));
                 }
             }
+
+            // Let all the tasks execute in parallel
+            await Task.WhenAll(tasks);
         }
 
         private bool TryGetOpenedDocumentData(RunningDocumentInfo info, out ITextBuffer textBuffer, out string filePath) {

--- a/Python/Product/PythonTools/PythonTools/LanguageServerClient/PythonLanguageClientCustomTarget.cs
+++ b/Python/Product/PythonTools/PythonTools/LanguageServerClient/PythonLanguageClientCustomTarget.cs
@@ -77,7 +77,8 @@ namespace Microsoft.PythonTools.LanguageServerClient {
         internal event EventHandler<DidChangeWatchedFilesRegistrationOptions> WatchedFilesRegistered;
 
         /// <summary>
-        /// Event fired when client/registerCapability didChangeWatchedFiles is called.
+        /// Event fired when telemetry for analysis complete is sent.
+        /// This is used by test code to verify pylance is ready to go.
         /// Has to be internal so JsonRpc doesn't register this as a method.
         /// </summary>
         internal event EventHandler AnalysisComplete;

--- a/Python/Product/PythonTools/PythonTools/LanguageServerClient/PythonLanguageClientCustomTarget.cs
+++ b/Python/Product/PythonTools/PythonTools/LanguageServerClient/PythonLanguageClientCustomTarget.cs
@@ -123,17 +123,17 @@ namespace Microsoft.PythonTools.LanguageServerClient {
         }
 
         [JsonRpcMethod("client/registerCapability")]
-        public async Task OnRegisterCapability(JToken arg) {
+        public void OnRegisterCapability(JToken arg) {
             var regParams = arg.ToObject<VisualStudio.LanguageServer.Protocol.RegistrationParams>();
             if (regParams.Registrations.Any(p => p.Method == "workspace/didChangeWorkspaceFolders")) {
-                await _joinableTaskContext.Factory.RunAsync(async () => this.WorkspaceFolderChangeRegistered.Invoke(this, EventArgs.Empty));
+                _joinableTaskContext.Factory.RunAsync(async () => this.WorkspaceFolderChangeRegistered.Invoke(this, EventArgs.Empty));
             }
-            var watchedFilesReg = regParams.Registrations.First(p => p.Method == "workspace/didChangeWatchedFiles");
+            var watchedFilesReg = regParams.Registrations.FirstOrDefault(p => p.Method == "workspace/didChangeWatchedFiles");
             if (watchedFilesReg != null) { 
                 var optionsObj = watchedFilesReg.RegisterOptions as JObject;
                 var options = optionsObj.ToObject<DidChangeWatchedFilesRegistrationOptions>();
                 if (options != null) {
-                    await _joinableTaskContext.Factory.RunAsync(async () => this.WatchedFilesRegistered.Invoke(this, options));
+                    _joinableTaskContext.Factory.RunAsync(async () => this.WatchedFilesRegistered.Invoke(this, options));
                 }
             }
         }

--- a/Python/Product/PythonTools/PythonTools/LanguageServerClient/PythonLanguageClientCustomTarget.cs
+++ b/Python/Product/PythonTools/PythonTools/LanguageServerClient/PythonLanguageClientCustomTarget.cs
@@ -83,15 +83,19 @@ namespace Microsoft.PythonTools.LanguageServerClient {
             }
 
             Trace.WriteLine(telemetry.ToString());
-            var te = telemetry.ToObject<PylanceTelemetryEvent>();
-            if (te == null) {
-                return;
-            }
+            try {
+                var te = telemetry.ToObject<PylanceTelemetryEvent>();
+                if (te == null) {
+                    return;
+                }
 
-            if (te.Exception == null) {
-                _logger.LogEvent(te.EventName, te.Properties, te.Measurements);
-            } else {
-                _logger.LogFault(new PylanceException(te.EventName, te.Exception.stack), te.EventName, false);
+                if (te.Exception == null) {
+                    _logger.LogEvent(te.EventName, te.Properties, te.Measurements);
+                } else {
+                    _logger.LogFault(new PylanceException(te.EventName, te.Exception.stack), te.EventName, false);
+                }
+            } catch {
+
             }
         }
 

--- a/Python/Product/PythonTools/PythonTools/LanguageServerClient/PythonLanguageClientCustomTarget.cs
+++ b/Python/Product/PythonTools/PythonTools/LanguageServerClient/PythonLanguageClientCustomTarget.cs
@@ -76,6 +76,12 @@ namespace Microsoft.PythonTools.LanguageServerClient {
         /// </summary>
         internal event EventHandler<DidChangeWatchedFilesRegistrationOptions> WatchedFilesRegistered;
 
+        /// <summary>
+        /// Event fired when client/registerCapability didChangeWatchedFiles is called.
+        /// Has to be internal so JsonRpc doesn't register this as a method.
+        /// </summary>
+        internal event EventHandler AnalysisComplete;
+
         [JsonRpcMethod("telemetry/event")]
         public void OnTelemetryEvent(JToken arg) {
             if (!(arg is JObject telemetry)) {
@@ -93,6 +99,12 @@ namespace Microsoft.PythonTools.LanguageServerClient {
                     _logger.LogEvent(te.EventName, te.Properties, te.Measurements);
                 } else {
                     _logger.LogFault(new PylanceException(te.EventName, te.Exception.stack), te.EventName, false);
+                }
+
+                // Special case language_server/analysis_complete. We need this for testing so we 
+                // know when it's okay to try to bring up intellisense
+                if (te.EventName == "language_server/analysis_complete") {
+                    AnalysisComplete.Raise(this, EventArgs.Empty);
                 }
             } catch {
 

--- a/Python/Tests/Core.UI/IntellisenseTests.cs
+++ b/Python/Tests/Core.UI/IntellisenseTests.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Language.Intellisense.AsyncCompletion.Data;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using TestUtilities;
+using TestUtilities.UI;
+using TestUtilities.UI.Python;
+
+namespace PythonToolsUITests {
+    public class IntellisenseTests {
+        private PythonVersion Version => PythonPaths.Python37_x64 ?? PythonPaths.Python38_x64 ?? PythonPaths.Python39_x64;
+
+
+        public void AutoComplete(PythonVisualStudioApp app) {
+            try {
+                var languageName = PythonVisualStudioApp.TemplateLanguageName;
+                var slnPath = PrepareProject(app, Version);
+
+                var project = app.OpenProject(slnPath);
+                var item = project.ProjectItems.Item("document.py");
+                var window = item.Open();
+                window.Activate();
+                var doc = app.GetDocument(item.Document.FullName);
+                doc.Invoke(() => {
+                    using (var e = doc.TextView.TextBuffer.CreateEdit()) {
+                        e.Insert(e.Snapshot.Length, "import sys\r\nsys.");
+                        e.Apply();
+                    }
+
+                    // Move cursor
+                    doc.Select(doc.TextView.TextViewLines.Count - 1, 4, 0);
+                });
+
+                // Wait until pylance is ready
+                Assert.IsTrue(Microsoft.PythonTools.LanguageServerClient.PythonLanguageClient.ConnectedTask.Wait(10000), "Pylance did not start");
+
+                // Bring up auto complete
+                Assert.IsTrue(doc.AsyncCompletionBroker.IsCompletionSupported(doc.TextView.TextBuffer.ContentType));
+                var completion = doc.Invoke(() => {
+                    return doc.AsyncCompletionBroker.TriggerCompletion(
+                        doc.TextView,
+                        new CompletionTrigger(CompletionTriggerReason.Invoke, doc.TextView.TextSnapshot),
+                        new Microsoft.VisualStudio.Text.SnapshotPoint(doc.TextView.TextSnapshot, doc.TextView.TextSnapshot.Length),
+                        CancellationToken.None);
+                });
+                Task.Delay(5000).Wait(); // Debug
+                Assert.IsNotNull(completion, "Completion not triggerable");
+                var items = completion.GetComputedItems(CancellationToken.None);
+                Assert.IsTrue(items.Items.Any(i => i.InsertText == "executable"), "Executable member of sys not found");
+
+            } finally {
+                app.Dte.Solution.Close(false);
+            }
+        }
+
+        private static string PrepareProject(PythonVisualStudioApp app, PythonVersion python) {
+            // Use the formatting tests project.
+            var slnPath = app.CopyProjectForTest(@"TestData\FormattingTests\FormattingTests.sln");
+            var projFolder = Path.GetDirectoryName(slnPath);
+            var projPath = Path.Combine(projFolder, "FormattingTests.pyproj");
+
+            // The project file has a placeholder for the formatter which we must replace
+            var projContents = File.ReadAllText(projPath);
+            projContents = projContents.Replace("$$FORMATTER$$", "black");
+            File.WriteAllText(projPath, projContents);
+
+            // The project references a virtual env in 'env' subfolder,
+            // which we need to create before opening the project.
+            python.CreateVirtualEnv(Path.Combine(projFolder, "env"), new[] { "black" });
+
+            return slnPath;
+        }
+    }
+}

--- a/Python/Tests/Core.UI/PythonToolsUITests.csproj
+++ b/Python/Tests/Core.UI/PythonToolsUITests.csproj
@@ -56,6 +56,7 @@
     <Reference Include="Microsoft.Build, Version=$(MicrosoftBuildAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.VisualStudio.InteractiveWindow" />
+    <Reference Include="Microsoft.VisualStudio.Language, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
     <Reference Include="Microsoft.VisualStudio.VsInteractiveWindow" />
     <Reference Include="Microsoft.VisualStudio.TextManager.Interop, Version=7.1.40304.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
     <Reference Include="Microsoft.VisualStudio.TextManager.Interop.11.0, Version=11.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -123,6 +124,7 @@
   <ItemGroup>
     <Compile Include="AddImportTests.cs" />
     <Compile Include="BraceCompletionUITests.cs" />
+    <Compile Include="IntellisenseTests.cs" />
     <Compile Include="SmartIndentUITests.cs" />
     <Compile Include="SignatureHelpUITests.cs" />
     <Compile Include="InfoBarUITests.cs" />

--- a/Python/Tests/PythonToolsUITestsRunner/IntellisenseTests.cs
+++ b/Python/Tests/PythonToolsUITestsRunner/IntellisenseTests.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using TestRunnerInterop;
+
+namespace PythonToolsUITestsRunner {
+    [TestClass]
+    public class IntellisenseTests {
+        #region UI test boilerplate
+        public VsTestInvoker _vs => new VsTestInvoker(
+            VsTestContext.Instance,
+            // Remote container (DLL) name
+            "Microsoft.PythonTools.Tests.PythonToolsUITests",
+            // Remote class name
+            $"PythonToolsUITests.{GetType().Name}"
+        );
+
+        public TestContext TestContext { get; set; }
+
+        [TestInitialize]
+        public void TestInitialize() => VsTestContext.Instance.TestInitialize(TestContext.DeploymentDirectory);
+        [TestCleanup]
+        public void TestCleanup() => VsTestContext.Instance.TestCleanup();
+        [ClassCleanup]
+        public static void ClassCleanup() => VsTestContext.Instance.Dispose();
+        #endregion
+
+        [TestMethod, Priority(UITestPriority.P0)]
+        [TestCategory("AutoComplete")]
+        public void AutoComplete() {
+            _vs.RunTest(nameof(PythonToolsUITests.IntellisenseTests.AutoComplete));
+        }
+
+    }
+}

--- a/Python/Tests/PythonToolsUITestsRunner/PythonToolsUITestsRunner.csproj
+++ b/Python/Tests/PythonToolsUITestsRunner/PythonToolsUITestsRunner.csproj
@@ -28,6 +28,7 @@
     <Compile Include="BasicProjectTests.cs" />
     <Compile Include="BuildTasksUITests.cs" />
     <Compile Include="BraceCompletionUITests.cs" />
+    <Compile Include="IntellisenseTests.cs" />
     <Compile Include="SmartIndentUITests.cs" />
     <Compile Include="EditorTests.cs" />
     <Compile Include="InfoBarUITests.cs" />


### PR DESCRIPTION
For: https://github.com/microsoft/ptvs-pylance/issues/96

Implemented support for filewatchers with either the workspace object or the System.IO.FileWatcher class (for solutions).

Also fixed a bug when opening a single project that confuses the 'workspace' for pylance (rootPath should not be set when using workspaceFolders)

Added a UI test to verify pylance is working.

I'd like to do more testing after this to verify all scenarios are working, but this is the base file watching support.

