### PR TITLE
VS interop should not be included in our VSIX

### DIFF
--- a/Python/Prerequisites/deploy_test_targets.cmd
+++ b/Python/Prerequisites/deploy_test_targets.cmd
@@ -13,12 +13,9 @@ echo This script should be run as an administrator.
 
 set D=%~dp0
 
-rem Guess some directories for Visual Studio 16
+if NOT EXIST "%VSINSTALLDIR%" call :failure
+
 call :docopy "%VSINSTALLDIR%\MSBuild\Microsoft\VisualStudio\v17.0"
-if errorlevel 1 call :docopy "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Preview\MSBuild\Microsoft\VisualStudio\v16.0"
-if errorlevel 1 call :docopy "%SystemDrive%\VS\MSBuild\Microsoft\VisualStudio\v15.0"
-if errorlevel 1 call :docopy "%ProgramFiles(x86)%\MSBuild\Microsoft\VisualStudio\v15.0"
-if errorlevel 1 call :docopy "%ProgramFiles(x86)%\MSBuild\Microsoft\VisualStudio\v14.0"
 
 pause
 exit /B 0
@@ -38,4 +35,21 @@ if not exist "%TARGET%" mkdir "%TARGET%"
 copy /Y "*.targets" "%TARGET%"
 popd
 
+set TARGET=%VSINSTALLDIR%\MSBuild\Microsoft\VC\v160\Platforms
+pushd "%D%..\Product\VCDebugLauncher\VCTargets"
+echo.
+echo Copying:
+echo     from %CD%
+echo     to %TARGET%
+if not exist "%TARGET%" mkdir "%TARGET%"
+robocopy /E /XO Win32 "%TARGET%\Win32" *.*
+robocopy /E /XO x64 "%TARGET%\X64" *.*
+popd
+
 exit /B 0
+
+:failure
+echo.
+echo VSINSTALLDIR not found. You may need to run this from a Dev command prompt
+echo.
+exit /B 1

--- a/Python/Product/BuildTasks/BuildTasks.csproj
+++ b/Python/Product/BuildTasks/BuildTasks.csproj
@@ -52,7 +52,9 @@
     <Reference Include="Microsoft.Build, Version=$(MicrosoftBuildAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
     <Reference Include="Microsoft.Build.Framework, Version=$(MicrosoftBuildAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
     <Reference Include="Microsoft.Build.Utilities.$(MicrosoftBuildAssemblyVersionSuffix), Version=$(MicrosoftBuildAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-    <Reference Include="Microsoft.VisualStudio.Interop" />
+    <Reference Include="Microsoft.VisualStudio.Interop">
+      <IncludeInVSIX>False</IncludeInVSIX>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Core" />

--- a/Python/Product/Cookiecutter/Cookiecutter.csproj
+++ b/Python/Product/Cookiecutter/Cookiecutter.csproj
@@ -38,7 +38,9 @@
     <Reference Include="Microsoft.VisualStudio.Language.StandardClassification" />
     <Reference Include="Microsoft.VisualStudio.Shell.15.0" />
     <Reference Include="Microsoft.VisualStudio.Shell.Framework" />
-    <Reference Include="Microsoft.VisualStudio.Interop" />
+    <Reference Include="Microsoft.VisualStudio.Interop">
+      <IncludeInVSIX>False</IncludeInVSIX>
+    </Reference>
     <Reference Include="Microsoft.VisualStudio.Telemetry" />
     <Reference Include="Microsoft.VisualStudio.Text.Data" />
     <Reference Include="Microsoft.VisualStudio.Text.Logic" />

--- a/Python/Product/Core/Core.csproj
+++ b/Python/Product/Core/Core.csproj
@@ -34,9 +34,8 @@
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Shell.15.0" />
     <Reference Include="Microsoft.VisualStudio.Shell.Framework" />
-    <Reference Include="Microsoft.VisualStudio.Interop" >
-      <Private>True</Private>
-      <IncludeInVSIX>True</IncludeInVSIX>
+    <Reference Include="Microsoft.VisualStudio.Interop">
+      <IncludeInVSIX>False</IncludeInVSIX>
     </Reference>
     <Reference Include="System" />
   </ItemGroup>
@@ -133,10 +132,8 @@
     <Content Include="License_en-US.rtf" />
     <Content Include="$(PackagesPath)\Newtonsoft.Json\lib\net45\Newtonsoft.Json.dll" />
     <Content Include="$(PackagesPath)\Microsoft.VisualStudio.LanguageServer.Protocol\lib\netstandard2.0\Microsoft.VisualStudio.LanguageServer.Protocol.dll" />
+    <Content Include="D:\Source\PTVS\packages\\Microsoft.VisualStudio.Interop\lib\net20\Microsoft.VisualStudio.Interop.dll" />
     <!-- Temporary workaround for the interop DLL not being available in 17 -->
-    <Content Include="$(PackagesPath)\Microsoft.VisualStudio.Interop\lib\net20\Microsoft.VisualStudio.Interop.dll">
-      <IncludeInVSIX>true</IncludeInVSIX>
-    </Content>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/Python/Product/Core/Core.csproj
+++ b/Python/Product/Core/Core.csproj
@@ -131,9 +131,6 @@
     <None Include="source.extension.vsixmanifest" />
     <Content Include="License_en-US.rtf" />
     <Content Include="$(PackagesPath)\Newtonsoft.Json\lib\net45\Newtonsoft.Json.dll" />
-    <Content Include="$(PackagesPath)\Microsoft.VisualStudio.LanguageServer.Protocol\lib\netstandard2.0\Microsoft.VisualStudio.LanguageServer.Protocol.dll" />
-    <Content Include="D:\Source\PTVS\packages\\Microsoft.VisualStudio.Interop\lib\net20\Microsoft.VisualStudio.Interop.dll" />
-    <!-- Temporary workaround for the interop DLL not being available in 17 -->
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/Python/Product/Core/Properties/AssemblyInfo.cs
+++ b/Python/Product/Core/Properties/AssemblyInfo.cs
@@ -55,11 +55,10 @@ using Microsoft.VisualStudio.Shell;
 [assembly: ProvideCodeBase(AssemblyName = "Microsoft.PythonTools.VSInterpreters", CodeBase = "Microsoft.PythonTools.VSInterpreters.dll", Version = AssemblyVersionInfo.StableVersion)]
 [assembly: ProvideCodeBase(AssemblyName = "Microsoft.PythonTools.Workspace", CodeBase = "Microsoft.PythonTools.Workspace.dll", Version = AssemblyVersionInfo.StableVersion)]
 [assembly: ProvideCodeBase(AssemblyName = "Microsoft.Extensions.FileSystemGlobbing", CodeBase = "Microsoft.Extensions.FileSystemGlobbing.dll", Version = "3.1.8.0")]
-[assembly: ProvideCodeBase(AssemblyName = "Microsoft.VisualStudio.Interop", CodeBase = "Microsoft.VisualStudio.Interop.dll")]
 
 internal static class ParserNuGetPackageInfo {
-    // important: keep in sync with Build\16.0\package.config
-    public const string Version = "0.5.59.0";
+    // important: keep in sync with Build\17.0\package.config
+    public const string Version = "0.646.0";
     public const string Culture = "neutral";
     public const string PublicKeyToken = "b03f5f7f11d50a3a";
 }

--- a/Python/Product/Core/source.extension.vsixmanifest
+++ b/Python/Product/Core/source.extension.vsixmanifest
@@ -51,6 +51,5 @@
         <Asset Type="Microsoft.VisualStudio.Assembly" d:Source="File" Path="Microsoft.PythonTools.Attacher.exe" />
         <Asset Type="Microsoft.VisualStudio.Assembly" d:Source="File" Path="Microsoft.PythonTools.ProjectWizards.dll" />
         <Asset Type="Microsoft.VisualStudio.Assembly" d:Source="File" Path="Microsoft.Extensions.FileSystemGlobbing.dll" />
-        <Asset Type="Microsoft.VisualStudio.Assembly" d:Source="File" Path="Microsoft.VisualStudio.Interop.dll" />
     </Assets>
 </PackageManifest>

--- a/Python/Product/Debugger/Debugger.csproj
+++ b/Python/Product/Debugger/Debugger.csproj
@@ -24,7 +24,9 @@
     <Reference Include="Microsoft.VisualStudio.Debugger.DebugAdapterHost.Interfaces, Version=1.5.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.VisualStudio.Debugger.InteropA" />
     <Reference Include="Microsoft.VisualStudio.Shared.VSCodeDebugProtocol, Version=16.7.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
-    <Reference Include="Microsoft.VisualStudio.Interop" />
+    <Reference Include="Microsoft.VisualStudio.Interop">
+      <IncludeInVSIX>False</IncludeInVSIX>
+    </Reference>
     <Reference Include="Microsoft.Extensions.FileSystemGlobbing" />
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />

--- a/Python/Product/Django/Django.csproj
+++ b/Python/Product/Django/Django.csproj
@@ -65,7 +65,9 @@
     <Reference Include="Microsoft.VisualStudio.ProjectAggregator, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <EmbedInteropTypes>True</EmbedInteropTypes>
     </Reference>
-    <Reference Include="Microsoft.VisualStudio.Interop" />
+    <Reference Include="Microsoft.VisualStudio.Interop">
+      <IncludeInVSIX>False</IncludeInVSIX>
+    </Reference>
     <Reference Include="Microsoft.VisualStudio.Text.Data" />
     <Reference Include="Microsoft.VisualStudio.Text.Logic" />
     <Reference Include="Microsoft.VisualStudio.Text.UI" />

--- a/Python/Product/EnvironmentsList/EnvironmentsList.csproj
+++ b/Python/Product/EnvironmentsList/EnvironmentsList.csproj
@@ -53,7 +53,9 @@
     <Reference Include="Microsoft.VisualStudio.Shell.15.0" />
     <Reference Include="Microsoft.VisualStudio.Shell.Framework" />
     <Reference Include="Microsoft.VisualStudio.Shell.Design" />
-    <Reference Include="Microsoft.VisualStudio.Interop" />
+    <Reference Include="Microsoft.VisualStudio.Interop">
+      <IncludeInVSIX>False</IncludeInVSIX>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Data" />

--- a/Python/Product/Profiling/Profiling.csproj
+++ b/Python/Product/Profiling/Profiling.csproj
@@ -33,7 +33,9 @@
       <EmbedInteropTypes>True</EmbedInteropTypes>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.ComponentModelHost" />
-    <Reference Include="Microsoft.VisualStudio.Interop" />
+    <Reference Include="Microsoft.VisualStudio.Interop">
+      <IncludeInVSIX>False</IncludeInVSIX>
+    </Reference>
     <Reference Include="Microsoft.VisualStudio.Shell.15.0" />
     <Reference Include="Microsoft.VisualStudio.Shell.Framework" />
     <Reference Include="PresentationCore" />

--- a/Python/Product/ProjectWizards/ProjectWizards.csproj
+++ b/Python/Product/ProjectWizards/ProjectWizards.csproj
@@ -50,7 +50,9 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.VisualStudio.ComponentModelHost" />
-    <Reference Include="Microsoft.VisualStudio.Interop" />
+    <Reference Include="Microsoft.VisualStudio.Interop">
+      <IncludeInVSIX>False</IncludeInVSIX>
+    </Reference>
     <Reference Include="Microsoft.VisualStudio.Shell.15.0" />
     <Reference Include="Microsoft.VisualStudio.Shell.Framework" />
     <Reference Include="Microsoft.VisualStudio.TemplateWizardInterface" />

--- a/Python/Product/PythonTools/PythonTools.csproj
+++ b/Python/Product/PythonTools/PythonTools.csproj
@@ -151,7 +151,9 @@
     <Reference Include="Microsoft.VisualStudio.Shell.Interop" />
     <Reference Include="Microsoft.VisualStudio.TextManager.Interop" />
     <Reference Include="Microsoft.VisualStudio.TextManager.Interop.8.0" />
-    <Reference Include="Microsoft.VisualStudio.Interop" />
+    <Reference Include="Microsoft.VisualStudio.Interop">
+      <IncludeInVSIX>False</IncludeInVSIX>
+    </Reference>
     <Reference Include="Microsoft.VisualStudio.TemplateWizardInterface" />
     <Reference Include="Microsoft.VisualStudio.Text.Data" />
     <Reference Include="Microsoft.VisualStudio.Text.Logic" />

--- a/Python/Product/TestAdapter.Executor/TestAdapter.Executor.csproj
+++ b/Python/Product/TestAdapter.Executor/TestAdapter.Executor.csproj
@@ -55,7 +55,9 @@
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Core" />
     <Reference Include="System.Web.Extensions" />
-    <Reference Include="Microsoft.VisualStudio.Interop" />
+    <Reference Include="Microsoft.VisualStudio.Interop">
+      <IncludeInVSIX>False</IncludeInVSIX>
+    </Reference>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.ObjectModel">
       <HintPath>$(DevEnvDir)\CommonExtensions\Microsoft\TestWindow\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll</HintPath>
       <Private>False</Private>

--- a/Python/Product/TestAdapter/TestAdapter.csproj
+++ b/Python/Product/TestAdapter/TestAdapter.csproj
@@ -63,7 +63,9 @@
     <Reference Include="Microsoft.Build.Framework, Version=$(MicrosoftBuildAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
     <Reference Include="Microsoft.Build.Tasks.$(MicrosoftBuildAssemblyVersionSuffix), Version=$(MicrosoftBuildAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
     <Reference Include="Microsoft.Build.Utilities.$(MicrosoftBuildAssemblyVersionSuffix), Version=$(MicrosoftBuildAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-    <Reference Include="Microsoft.VisualStudio.Interop" />
+    <Reference Include="Microsoft.VisualStudio.Interop">
+      <IncludeInVSIX>False</IncludeInVSIX>
+    </Reference>
     <Reference Include="Microsoft.VisualStudio.Shell.15.0" />
     <Reference Include="Microsoft.VisualStudio.Shell.Framework" />
     <Reference Include="Microsoft.VisualStudio.ComponentModelHost" />

--- a/Python/Product/VCDebugLauncher/VCDebugLauncher.csproj
+++ b/Python/Product/VCDebugLauncher/VCDebugLauncher.csproj
@@ -77,7 +77,9 @@
     <Reference Include="Microsoft.VisualStudio.ProjectSystem.VS" />
     <Reference Include="Microsoft.VisualStudio.Shell.15.0" />
     <Reference Include="Microsoft.VisualStudio.Shell.Interop" />
-    <Reference Include="Microsoft.VisualStudio.Interop" />
+    <Reference Include="Microsoft.VisualStudio.Interop">
+      <IncludeInVSIX>False</IncludeInVSIX>
+    </Reference>
     <Reference Include="Microsoft.VisualStudio.Telemetry" />
     <Reference Include="Microsoft.VisualStudio.Text.Data" />
     <Reference Include="Microsoft.VisualStudio.Text.Logic" />

--- a/Python/Product/VSCommon/VSCommon.csproj
+++ b/Python/Product/VSCommon/VSCommon.csproj
@@ -55,7 +55,9 @@
     <Reference Include="Microsoft.VisualStudio.Settings.15.0" />
     <Reference Include="Microsoft.VisualStudio.Shell.15.0" />
     <Reference Include="Microsoft.VisualStudio.Shell.Framework" />
-    <Reference Include="Microsoft.VisualStudio.Interop" />
+    <Reference Include="Microsoft.VisualStudio.Interop">
+      <IncludeInVSIX>False</IncludeInVSIX>
+    </Reference>
     <Reference Include="Microsoft.VisualStudio.Telemetry" />
     <Reference Include="Microsoft.VisualStudio.Text.Data" />
     <Reference Include="Microsoft.VisualStudio.Text.Logic" />

--- a/Python/Product/VSInterpreters/VSInterpreters.csproj
+++ b/Python/Product/VSInterpreters/VSInterpreters.csproj
@@ -72,7 +72,9 @@
     <Reference Include="Microsoft.VisualStudio.ComponentModelHost" />
     <Reference Include="Microsoft.VisualStudio.Shell.Framework" />
     <Reference Include="Microsoft.VisualStudio.Shell.15.0" />
-    <Reference Include="Microsoft.VisualStudio.Interop" />
+    <Reference Include="Microsoft.VisualStudio.Interop">
+      <IncludeInVSIX>False</IncludeInVSIX>
+    </Reference>
     <Reference Include="Microsoft.VisualStudio.Shell.Interop.10.0" />
     <Reference Include="Microsoft.VisualStudio.Threading" />
     <Reference Include="Microsoft.VisualStudio.Workspace" />

--- a/Python/Product/Workspace/Workspace.csproj
+++ b/Python/Product/Workspace/Workspace.csproj
@@ -53,7 +53,9 @@
     <Reference Include="Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <EmbedInteropTypes>False</EmbedInteropTypes>
     </Reference>
-    <Reference Include="Microsoft.VisualStudio.Interop" />
+    <Reference Include="Microsoft.VisualStudio.Interop">
+      <IncludeInVSIX>False</IncludeInVSIX>
+    </Reference>
     <Reference Include="Microsoft.VisualStudio.Shell.15.0" />
     <Reference Include="Microsoft.VisualStudio.Shell.Framework" />
     <Reference Include="Microsoft.VisualStudio.ComponentModelHost" />

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -237,10 +237,6 @@ steps:
       Microsoft.Python.Analysis.Engine.pdb
       Microsoft.Python.LanguageServer.Core.dll
       Microsoft.Python.LanguageServer.Core.pdb
-      Microsoft.Python.Parsing.dll
-      Microsoft.Python.Parsing.pdb
-      Microsoft.Python.Core.dll
-      Microsoft.Python.Core.pdb
       PyDebugAttach*.pdb
       PyDebugAttach*.dll
       VsPyProf*.pdb

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -237,6 +237,10 @@ steps:
       Microsoft.Python.Analysis.Engine.pdb
       Microsoft.Python.LanguageServer.Core.dll
       Microsoft.Python.LanguageServer.Core.pdb
+      Microsoft.Python.Parsing.dll
+      Microsoft.Python.Parsing.pdb
+      Microsoft.Python.Core.dll
+      Microsoft.Python.Core.pdb
       PyDebugAttach*.pdb
       PyDebugAttach*.dll
       VsPyProf*.pdb


### PR DESCRIPTION
This didn't matter when the VS Interop was the same version as was shipped in VS
I upgraded this morning and our VS interop is older and the Solution Explorer broke when our package loads (it was loading the VS interop from our extension folder first)
We don't need to ship this and just consuming the types should be fine.