### PR TITLE
Use single package source

### DIFF
--- a/Build/16.0/nuget.config
+++ b/Build/16.0/nuget.config
@@ -1,10 +1,6 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="PLS" value="https://pvsc.blob.core.windows.net/vs-python-ls/index.json" protocolVersion="3" />
-    <add key="VS Editor" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vssdk/nuget/v3/index.json" protocolVersion="3" />
-    <add key="VS Editor Impl" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-impl/nuget/v3/index.json" protocolVersion="3" />
-    <add key="VSIDEPublicFeed" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/VSIDEPublicFeed/nuget/v3/index.json" protocolVersion="3" />
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+    <add key="PTVS_Packages" value="https://devdiv.pkgs.visualstudio.com/DevDiv/_packaging/PTVS_Packages/nuget/v3/index.json" />  
   </packageSources>
 </configuration>

--- a/Build/17.0/nuget.config
+++ b/Build/17.0/nuget.config
@@ -1,12 +1,7 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="PLS" value="https://pvsc.blob.core.windows.net/vs-python-ls/index.json" protocolVersion="3" />
-    <add key="VS Editor" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vssdk/nuget/v3/index.json" protocolVersion="3" />
-    <add key="VS Editor Impl" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-impl/nuget/v3/index.json" protocolVersion="3" />
-    <add key="VSIDEPublicFeed" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/VSIDEPublicFeed/nuget/v3/index.json" protocolVersion="3" />
-    <add key="vs-impl" value="https://pkgs.dev.azure.com/devdiv/_packaging/vs-impl/nuget/v3/index.json" />    
-    <add key="vssdk" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vssdk/nuget/v3/index.json" />    
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+    <!-- Package feed is managed here: https://devdiv.visualstudio.com/DevDiv/_packaging?_a=feed&feed=PTVS_Packages -->
+    <add key="PTVS_Packages" value="https://devdiv.pkgs.visualstudio.com/DevDiv/_packaging/PTVS_Packages/nuget/v3/index.json" />  
   </packageSources>
 </configuration>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -128,6 +128,16 @@ steps:
     Contents: '**'
   continueOnError: true
 
+# In order for packages to use correct credentials, run the restore portion manually
+- task: NuGetCommand@2
+  inputs:
+    command: 'restore'
+    restoreSolution: 'build/17.0/packages.config'
+    feedsToUse: 'config'
+    nugetConfigPath: 'build/17.0/nuget.config'
+    externalFeedCredentials: 'azure-public/vs-impl, azure-public/vssdk'
+    restoreDirectory: 'packages'
+
 # Run a powershell script that does a package restore, some symlinking, and installs debugpy
 - task: PowerShell@1
   displayName: 'Restore packages'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -130,6 +130,7 @@ steps:
 
 # In order for packages to use correct credentials, run the restore portion manually
 - task: NuGetAuthenticate@0
+  displayName: 'Add authentication'
   inputs:
     nuGetServiceConnections: 'azure-public/vs-impl, azure-public/vssdk'
     

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -132,12 +132,11 @@ steps:
 - task: NuGetCommand@2
   inputs:
     command: 'restore'
-    restoreSolution: 'build/17.0/packages.config'
-    feedsToUse: 'config'
-    nugetConfigPath: 'build/17.0/nuget.config'
-    externalFeedCredentials: 'azure-public/vs-impl, azure-public/vssdk'
+    restoreSolution: 'build\17.0\packages.config'
+    feedsToUse: 'select'
+    vstsFeed: '0bdbc590-a062-4c3f-b0f6-9383f67865ee/4dc31e3f-b0e6-49bf-814b-a664d8c63655'
     restoreDirectory: 'packages'
-
+    
 # Run a powershell script that does a package restore, some symlinking, and installs debugpy
 - task: PowerShell@1
   displayName: 'Restore packages'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -129,15 +129,10 @@ steps:
   continueOnError: true
 
 # In order for packages to use correct credentials, run the restore portion manually
-- task: NuGetCommand@2
+- task: NuGetAuthenticate@0
   inputs:
-    command: 'restore'
-    restoreSolution: 'build/17.0/packages.config'
-    feedsToUse: 'config'
-    nugetConfigPath: 'build/17.0/nuget.config'
-    externalFeedCredentials: 'azure-public/vs-impl, azure-public/vssdk, kzu-nuget.org'
-    restoreDirectory: 'packages'
-        
+    nuGetServiceConnections: 'azure-public/vs-impl, azure-public/vssdk'
+    
 # Run a powershell script that does a package restore, some symlinking, and installs debugpy
 - task: PowerShell@1
   displayName: 'Restore packages'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -132,11 +132,12 @@ steps:
 - task: NuGetCommand@2
   inputs:
     command: 'restore'
-    restoreSolution: 'build\17.0\packages.config'
-    feedsToUse: 'select'
-    vstsFeed: '0bdbc590-a062-4c3f-b0f6-9383f67865ee/4dc31e3f-b0e6-49bf-814b-a664d8c63655'
+    restoreSolution: 'build/17.0/packages.config'
+    feedsToUse: 'config'
+    nugetConfigPath: 'build/17.0/nuget.config'
+    externalFeedCredentials: 'azure-public/vs-impl, azure-public/vssdk, kzu-nuget.org'
     restoreDirectory: 'packages'
-    
+        
 # Run a powershell script that does a package restore, some symlinking, and installs debugpy
 - task: PowerShell@1
   displayName: 'Restore packages'


### PR DESCRIPTION
Make sure to use a single package source for nuget feeds. 

I'll back port this to 16.10 after the build passes.