### PR TITLE
Support the 'workspace/configuration' message from Pylance.

### DIFF
--- a/Python/Product/PythonTools/PythonTools.csproj
+++ b/Python/Product/PythonTools/PythonTools.csproj
@@ -329,6 +329,9 @@
     <Compile Include="PythonTools\LanguageServerClient\StreamHacking\MessageParser.cs" />
     <Compile Include="PythonTools\LanguageServerClient\StreamHacking\StreamData.cs" />
     <Compile Include="PythonTools\LanguageServerClient\StreamHacking\StreamIntercepter.cs" />
+    <Compile Include="PythonTools\LanguageServerClient\WorkspaceConfiguration\ConfigurationArgs.cs" />
+    <Compile Include="PythonTools\LanguageServerClient\WorkspaceConfiguration\ConfigurationItem.cs" />
+    <Compile Include="PythonTools\LanguageServerClient\WorkspaceConfiguration\ConfigurationParams.cs" />
     <Compile Include="PythonTools\LanguageServerClient\WorkspaceFolderChanged\DidChangeWorkspaceFoldersParams.cs" />
     <Compile Include="PythonTools\LanguageServerClient\WorkspaceFolderChanged\WorkspaceFolder.cs" />
     <Compile Include="PythonTools\LanguageServerClient\WorkspaceFolderChanged\WorkspaceFoldersChangeEvent.cs" />

--- a/Python/Product/PythonTools/PythonTools/LanguageServerClient/PythonLanguageClient.cs
+++ b/Python/Product/PythonTools/PythonTools/LanguageServerClient/PythonLanguageClient.cs
@@ -181,7 +181,7 @@ namespace Microsoft.PythonTools.LanguageServerClient {
             // This is where we send the settings for each client context.
             // Pylance will send a workspace/configuration request for each workspace
             // We return the language server settings as a response
-            object[] result = new object[0] { };
+            List<object> result = new List<object>();
 
             // Return the matching results
             foreach (var item in args.requestParams.items) {
@@ -234,15 +234,12 @@ namespace Microsoft.PythonTools.LanguageServerClient {
                     };
                 }
 
-                // Copy settings in order
-                var resultArray = new object[result.Length + 1];
-                result.CopyTo(resultArray, 0);
-                resultArray[result.Length] = settings;
-                result = resultArray;
+                // Add to our results
+                result.Add(settings);
             }
 
-            args.requestResult = result;
-
+            // Convert into an array for serialization
+            args.requestResult = result.ToArray();
         }
 
         public async Task OnServerInitializedAsync() {

--- a/Python/Product/PythonTools/PythonTools/LanguageServerClient/PythonLanguageClient.cs
+++ b/Python/Product/PythonTools/PythonTools/LanguageServerClient/PythonLanguageClient.cs
@@ -362,6 +362,9 @@ namespace Microsoft.PythonTools.LanguageServerClient {
         }
 
         private void OnSettingsChanged(object sender, EventArgs e) => InvokeDidChangeConfigurationAsync(new LSP.DidChangeConfigurationParams() {
+            // If we pass null settings and workspace.configuration is supported, Pylance will ask
+            // us for per workspace configuration settings. Otherwise we can send
+            // global settings here.
             Settings = null
         }).DoNotWait();
 

--- a/Python/Product/PythonTools/PythonTools/LanguageServerClient/WorkspaceConfiguration/ConfigurationArgs.cs
+++ b/Python/Product/PythonTools/PythonTools/LanguageServerClient/WorkspaceConfiguration/ConfigurationArgs.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.PythonTools.LanguageServerClient.WorkspaceConfiguration {
+    /// <summary>
+    /// This object is used to handle workspace/configuration requests
+    /// </summary>
+    internal class ConfigurationArgs {
+        public ConfigurationParams requestParams;
+        public object requestResult;
+    }
+}

--- a/Python/Product/PythonTools/PythonTools/LanguageServerClient/WorkspaceConfiguration/ConfigurationItem.cs
+++ b/Python/Product/PythonTools/PythonTools/LanguageServerClient/WorkspaceConfiguration/ConfigurationItem.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Serialization;
+using System.Text;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+
+namespace Microsoft.PythonTools.LanguageServerClient.WorkspaceConfiguration {
+    /// <summary>
+    /// Until VSSDK supports this, this param is for receiving workspace/configuration events
+    /// </summary>
+    [DataContract]
+    internal class ConfigurationItem {
+        [DataMember]
+        [JsonConverter(typeof(Microsoft.VisualStudio.LanguageServer.Protocol.DocumentUriConverter))]
+        public Uri scopeUri;
+
+        [DataMember]
+        public string section;
+    }
+}

--- a/Python/Product/PythonTools/PythonTools/LanguageServerClient/WorkspaceConfiguration/ConfigurationParams.cs
+++ b/Python/Product/PythonTools/PythonTools/LanguageServerClient/WorkspaceConfiguration/ConfigurationParams.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Serialization;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.PythonTools.LanguageServerClient.WorkspaceConfiguration {
+    /// <summary>
+    /// Until VSSDK supports this, this param is for receiving workspace/configuration events
+    /// </summary>
+    [DataContract]
+    internal class ConfigurationParams {
+        [DataMember]
+        public ConfigurationItem[] items;
+    }
+}

--- a/Python/Product/PythonTools/PythonTools/Repl/PythonCommonInteractiveEvaluator.cs
+++ b/Python/Product/PythonTools/PythonTools/Repl/PythonCommonInteractiveEvaluator.cs
@@ -154,7 +154,7 @@ namespace Microsoft.PythonTools.Repl {
                 await PythonLanguageClient.ReadyTask;
                 var client = _serviceProvider.GetPythonToolsService().LanguageClient;
                 if (client != null) {
-                    client.AddClientContext(new PythonLanguageClientContextRepl(evaluator)); // Don't fire a settings change. This can crash node for some reason
+                    client.AddClientContext(new PythonLanguageClientContextRepl(evaluator));
                     Document = new ReplDocument(_serviceProvider, _window, client);
                     await Document.InitializeAsync();
                 }


### PR DESCRIPTION
Change to responding to 'workspace/configuration' so that we can have a different interpreter per project.