### PR TITLE
Fix building with D17

### DIFF
--- a/Build/17.0/packages.config
+++ b/Build/17.0/packages.config
@@ -78,4 +78,5 @@
   <package id="Microsoft.Build.Utilities.Core" version="16.10.0.0" />
   <package id="Microsoft.VisualStudio.Settings.15.0" version="17.0.0-previews-2-31405-002"/>
   <package id="System.Collections.Immutable" version="5.0.0"/>
+  <package id="Microsoft.NET.StringTools" version="1.0.0" />
 </packages>

--- a/Build/17.0/packages.config
+++ b/Build/17.0/packages.config
@@ -23,6 +23,7 @@
   <package id="Microsoft.VisualStudio.Debugger.Interop.14.0" version = "17.0.0-previews-1-31325-097" />
   <package id="Microsoft.VisualStudio.Debugger.Interop.15.0" version = "17.0.0-previews-1-31325-097" />
   <package id="Microsoft.VisualStudio.Debugger.InteropA" version = "17.0.0-previews-1-31325-097" />
+  <package id="Microsoft.VisualStudio.Debugger.Engine" version = "17.0.1060203-preview" />
   <package id="Microsoft.VisualStudio.Editor" version = "17.0.56-gb3c64827ce" />
   <package id="Microsoft.VisualStudio.ImageCatalog" version = "17.0.0-previews-1-31325-097" />
   <package id="Microsoft.VisualStudio.Imaging" version = "17.0.0-previews-1-31325-097" />
@@ -60,6 +61,8 @@
   <package id="Microsoft.VisualStudio.VsInteractiveWindow" version = "4.0.0-beta.21175.11" />
   <package id="Microsoft.VisualStudio.Workspace" version = "17.0.24-preview-0001-g7838f00ba6" />
   <package id="Microsoft.VisualStudio.Workspace.VSIntegration" version = "17.0.24-preview-0001-g7838f00ba6" />
+  <package id="Microsoft.VisualStudio.Workspace.Extensions" version = "17.0.24-preview-0001-g7838f00ba6" />
+  <package id="Microsoft.VisualStudio.Workspace.Extensions.VS" version = "17.0.24-preview-0001-g7838f00ba6" />
   <package id="Microsoft.VisualStudio.SDK.Analyzers" version = "16.9.2-alpha" />
   <package id="Microsoft.VisualStudio.Threading.Analyzers" version = "16.10.56" />
   <package id="Microsoft.VSSDK.BuildTools" version = "17.0.169-dev17-gae55732a" />
@@ -67,4 +70,12 @@
   <package id="Microsoft.DotNet.PlatformAbstractions" version = "5.0.0-preview.5.20278.1" />
   <package id="Microsoft.VisualStudio.Debugger.Engine" version = "17.0.1050604-preview" />
   <package id="Microsoft.VisualStudio.QualityTools.UnitTestFramework" version = "17.0.0-previews-1-31325-097" />
+  <package id="Microsoft.Build" version="16.10.0.0" />
+  <package id="Microsoft.Build.Framework" version="16.10.0.0" />
+  <package id="Microsoft.Build.Engine" version="16.10.0.0" />
+  <package id="Microsoft.Build.Conversion.Core" version="16.10.0.0" />
+  <package id="Microsoft.Build.Tasks.Core" version="16.10.0.0" />
+  <package id="Microsoft.Build.Utilities.Core" version="16.10.0.0" />
+  <package id="Microsoft.VisualStudio.Settings.15.0" version="17.0.0-previews-2-31405-002"/>
+  <package id="System.Collections.Immutable" version="5.0.0"/>
 </packages>

--- a/Build/Common.Build.CSharp.targets
+++ b/Build/Common.Build.CSharp.targets
@@ -31,6 +31,7 @@
       <_NugetAssemblies Include="$(PackagesPath)\Microsoft.Extensions.*\lib\netstandard2.0\Microsoft.Extensions.*.dll" />
       <_NugetAssemblies Include="$(PackagesPath)\StreamJsonRpc*\lib\netstandard2.0\StreamJsonRpc.dll" />
       <_NugetAssemblies Include="$(PackagesPath)\System.*\lib\netstandard2.0\System.*.dll" />
+      <_NugetAssemblies Include="$(PackagesPath)\Microsoft.NET.*\lib\net472\Microsoft.NET.*.dll" />
     </ItemGroup>
     <PropertyGroup>
       <AssemblySearchPaths>

--- a/Build/Common.Build.CSharp.targets
+++ b/Build/Common.Build.CSharp.targets
@@ -16,16 +16,21 @@
       <_NugetAssemblies Include="$(PackagesPath)\Microsoft.VisualStudio.*\lib\Microsoft.VisualStudio.*.dll" />
       <_NugetAssemblies Include="$(PackagesPath)\Microsoft.VisualStudio.*\lib\net20\Microsoft.VisualStudio.*.dll" />
       <_NugetAssemblies Include="$(PackagesPath)\Microsoft.VisualStudio.*\lib\net35\Microsoft.VisualStudio.*.dll" />
+      <_NugetAssemblies Include="$(PackagesPath)\Microsoft.VisualStudio.*\lib\net40\Microsoft.VisualStudio.*.dll" />
+      <_NugetAssemblies Include="$(PackagesPath)\Microsoft.VisualStudio.*\ref\net45\Microsoft.VisualStudio.*.dll" />
       <_NugetAssemblies Include="$(PackagesPath)\Microsoft.VisualStudio.*\lib\net45\Microsoft.VisualStudio.*.dll" />
       <_NugetAssemblies Include="$(PackagesPath)\Microsoft.VisualStudio.*\lib\net46\Microsoft.VisualStudio.*.dll" />
       <_NugetAssemblies Include="$(PackagesPath)\Microsoft.VisualStudio.*\lib\net461\Microsoft.VisualStudio.*.dll" />
       <_NugetAssemblies Include="$(PackagesPath)\Microsoft.VisualStudio.*\lib\net472\Microsoft.VisualStudio.*.dll" />
       <_NugetAssemblies Include="$(PackagesPath)\Microsoft.VisualStudio.*\lib\netstandard1.0\Microsoft.VisualStudio.*.dll" />
+      <_NugetAssemblies Include="$(PackagesPath)\Microsoft.VisualStudio.*\lib\netstandard2.0\Microsoft.VisualStudio.*.dll" />
       <_NugetAssemblies Include="$(PackagesPath)\Microsoft.VisualStudio.*\lib\vs16\Microsoft.*.dll" />
+      <_NugetAssemblies Include="$(PackagesPath)\Microsoft.Build*\lib\net472\Microsoft.*.dll" />
       <_NugetAssemblies Include="$(PackagesPath)\Microsoft.Internal.VisualStudio.*\lib\net45\Microsoft.Internal.VisualStudio.*.dll" />
       <_NugetAssemblies Include="$(PackagesPath)\Microsoft.Python.*\lib\netstandard2.0\Microsoft.Python.*.dll" />
       <_NugetAssemblies Include="$(PackagesPath)\Microsoft.Extensions.*\lib\netstandard2.0\Microsoft.Extensions.*.dll" />
       <_NugetAssemblies Include="$(PackagesPath)\StreamJsonRpc*\lib\netstandard2.0\StreamJsonRpc.dll" />
+      <_NugetAssemblies Include="$(PackagesPath)\System.*\lib\netstandard2.0\System.*.dll" />
     </ItemGroup>
     <PropertyGroup>
       <AssemblySearchPaths>

--- a/Python/Product/PythonTools/PythonTools/LanguageServerClient/PythonLanguageClientCustomTarget.cs
+++ b/Python/Product/PythonTools/PythonTools/LanguageServerClient/PythonLanguageClientCustomTarget.cs
@@ -163,13 +163,17 @@ namespace Microsoft.PythonTools.LanguageServerClient {
 
         [JsonRpcMethod("workspace/configuration")]
         public async Task<object> OnWorkspaceConfiguration(JToken arg) {
-            var reqParams = arg.ToObject<ConfigurationParams>();
-            if (this.WorkspaceConfiguration != null && reqParams != null) {
-                var eventArgs = new ConfigurationArgs { requestParams = reqParams, requestResult = null };
-                await this.WorkspaceConfiguration.InvokeAsync(this, eventArgs);
-                return eventArgs.requestResult;
+            try {
+                var reqParams = arg.ToObject<ConfigurationParams>();
+                if (this.WorkspaceConfiguration != null && reqParams != null) {
+                    var eventArgs = new ConfigurationArgs { requestParams = reqParams, requestResult = null };
+                    await this.WorkspaceConfiguration.InvokeAsync(this, eventArgs);
+                    return eventArgs.requestResult;
+                }
+                return null;
+            } catch {
+                return null;
             }
-            return null;
         }
     }
 }

--- a/Python/Tests/Core.UI/EnvironmentListTests.cs
+++ b/Python/Tests/Core.UI/EnvironmentListTests.cs
@@ -33,7 +33,6 @@ using Microsoft.PythonTools.Interpreter;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.Win32;
-using PythonToolsTests;
 using TestUtilities;
 using TestUtilities.Mocks;
 using TestUtilities.Python;

--- a/Python/Tests/Core.UI/PythonToolsUITests.csproj
+++ b/Python/Tests/Core.UI/PythonToolsUITests.csproj
@@ -104,6 +104,7 @@
   <ItemGroup>
     <Compile Include="AddImportTests.cs" />
     <Compile Include="BraceCompletionUITests.cs" />
+    <Compile Include="EnvironmentListTests.cs" />
     <Compile Include="IntellisenseTests.cs" />
     <Compile Include="SmartIndentUITests.cs" />
     <Compile Include="SignatureHelpUITests.cs" />

--- a/Python/Tests/Core/PythonToolsTests.csproj
+++ b/Python/Tests/Core/PythonToolsTests.csproj
@@ -71,12 +71,6 @@
     <Reference Include="Microsoft.VisualStudio.ComponentModelHost" />
     <Reference Include="Microsoft.VisualStudio.Composition" />
     <Reference Include="Microsoft.VisualStudio.CoreUtility" />
-    <Reference Include="Microsoft.VisualStudio.Editor.Implementation">
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Microsoft.VisualStudio.Platform.VSEditor">
-      <Private>True</Private>
-    </Reference>
     <Reference Include="Microsoft.VisualStudio.Language" />
     <Reference Include="Microsoft.VisualStudio.Language.Intellisense" />
     <Reference Include="Microsoft.VisualStudio.Language.StandardClassification" />
@@ -117,6 +111,9 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Python.Parsing">
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.NET.StringTools">
       <Private>True</Private>
     </Reference>
   </ItemGroup>

--- a/Python/Tests/Core/PythonToolsTests.csproj
+++ b/Python/Tests/Core/PythonToolsTests.csproj
@@ -80,7 +80,9 @@
     <Reference Include="Microsoft.VisualStudio.Language" />
     <Reference Include="Microsoft.VisualStudio.Language.Intellisense" />
     <Reference Include="Microsoft.VisualStudio.Language.StandardClassification" />
-    <Reference Include="Microsoft.VisualStudio.Interop" />
+    <Reference Include="Microsoft.VisualStudio.Interop">
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.VisualStudio.TemplateWizardInterface" />
     <Reference Include="Microsoft.VisualStudio.Text.Data" />
@@ -142,7 +144,6 @@
     <Compile Include="PathUtilsTests.cs" />
     <Compile Include="CPythonInterpreterTests.cs" />
     <Compile Include="DebugReplEvaluatorTests.cs" />
-    <Compile Include="EnvironmentListTests.cs" />
     <None Include="ExtractMethodTests.cs" />
     <None Include="FuzzyStringMatcherTests.cs" />
     <Compile Include="ImportWizardTests.cs" />


### PR DESCRIPTION
Seems like references can't be found from the actual build environment. We have to explicitly download all of our references now.

This PR adds the missing modules so that you can build locally.