### PR TITLE
Add LogHubLugging for python tools events.

### DIFF
--- a/Build/17.0/packages.config
+++ b/Build/17.0/packages.config
@@ -79,4 +79,9 @@
   <package id="Microsoft.VisualStudio.Settings.15.0" version="17.0.0-previews-2-31405-002"/>
   <package id="System.Collections.Immutable" version="5.0.0"/>
   <package id="Microsoft.NET.StringTools" version="1.0.0" />
+  <package id="Microsoft.ServiceHub.Framework" version="2.8.2019" />
+  <package id="Microsoft.Extensions.Logging" version="5.0.0"/>
+  <package id="Microsoft.Extensions.Logging.Abstractions" version="5.0.0"/>
+  <package id="System.Threading.Tasks.Extensions" version="4.5.4"/>
+  <package id="Microsoft.VisualStudio.RpcContracts" version="17.0.50-preview-0002-0005" />
 </packages>

--- a/Build/Common.Build.CSharp.targets
+++ b/Build/Common.Build.CSharp.targets
@@ -32,6 +32,7 @@
       <_NugetAssemblies Include="$(PackagesPath)\StreamJsonRpc*\lib\netstandard2.0\StreamJsonRpc.dll" />
       <_NugetAssemblies Include="$(PackagesPath)\System.*\lib\netstandard2.0\System.*.dll" />
       <_NugetAssemblies Include="$(PackagesPath)\Microsoft.NET.*\lib\net472\Microsoft.NET.*.dll" />
+      <_NugetAssemblies Include="$(PackagesPath)\Microsoft.ServiceHub.*\lib\netstandard2.0\Microsoft.ServiceHub.*.dll" />
     </ItemGroup>
     <PropertyGroup>
       <AssemblySearchPaths>

--- a/Python/Product/PythonTools/PythonTools.csproj
+++ b/Python/Product/PythonTools/PythonTools.csproj
@@ -214,23 +214,12 @@
     <Reference Include="Microsoft.VisualStudio.Imaging" />
     <Reference Include="Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime">
     </Reference>
-    <Reference Include="Microsoft.VisualStudio.Shell.Interop.14.0.DesignTime">
-      <Aliases>DesignTime14</Aliases>
-    </Reference>
     <Reference Include="Microsoft.VisualStudio.Utilities" />
     <Reference Include="Microsoft.VisualStudio.Settings.15.0">
       <Private>false</Private>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Threading" />
     <Reference Include="Microsoft.VisualStudio.Shell.Framework" />
-    <Reference Include="Microsoft.VisualStudio.Shell.Interop.15.3.DesignTime">
-      <EmbedInteropTypes>False</EmbedInteropTypes>
-      <Aliases>DesignTime153</Aliases>
-    </Reference>
-    <Reference Include="Microsoft.VisualStudio.Shell.Interop.15.6.DesignTime">
-      <EmbedInteropTypes>False</EmbedInteropTypes>
-      <Aliases>DesignTime156</Aliases>
-    </Reference>
     <Reference Include="Microsoft.VisualStudio.LanguageServer.Client" />
     <Reference Include="Microsoft.Internal.VisualStudio.Shell.Embeddable">
       <EmbedInteropTypes>True</EmbedInteropTypes>
@@ -241,6 +230,11 @@
     </Reference>
     <Reference Include="StreamJsonRpc" />
     <Reference Include="System.Net.Http" />
+    <Reference Include="Microsoft.ServiceHub.Framework" />
+    <Reference Include="Microsoft.Extensions.Logging" />
+    <Reference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <Reference Include="System.Threading.Tasks.Extensions" />
+    <Reference Include="Microsoft.VisualStudio.RpcContracts" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Attributes\ProvideNewFileTemplatesAttribute.cs" />
@@ -335,6 +329,7 @@
     <Compile Include="PythonTools\LanguageServerClient\WorkspaceFolderChanged\DidChangeWorkspaceFoldersParams.cs" />
     <Compile Include="PythonTools\LanguageServerClient\WorkspaceFolderChanged\WorkspaceFolder.cs" />
     <Compile Include="PythonTools\LanguageServerClient\WorkspaceFolderChanged\WorkspaceFoldersChangeEvent.cs" />
+    <Compile Include="PythonTools\Logging\LogHubLogger.cs" />
     <Compile Include="PythonTools\Navigation\Navigable\NavigableSymbol.cs" />
     <Compile Include="PythonTools\Navigation\Navigable\NavigableSymbolSource.cs" />
     <Compile Include="PythonTools\Navigation\Navigable\NavigableSymbolSourceProvider.cs" />

--- a/Python/Product/PythonTools/PythonTools/Logging/LogHubLogger.cs
+++ b/Python/Product/PythonTools/PythonTools/Logging/LogHubLogger.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.VisualStudio.LogHub;
+using Microsoft.VisualStudio.RpcContracts.Logging;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.Shell.ServiceBroker;
+
+namespace Microsoft.PythonTools.Logging {
+    [Export(typeof(IPythonToolsLogger))]
+    class LogHubLogger : IPythonToolsLogger {
+        
+        private TraceSource _traceSource;
+        private readonly CancellationTokenSource _tokenSource = new CancellationTokenSource();
+
+        /// <summary>
+        /// See directions here on how to log to the log hub: https://devdiv.visualstudio.com/DevDiv/_wiki/wikis/DevDiv.wiki/23437/Using-LogHub
+        /// </summary>
+        /// <param name="asyncServiceProvider"></param>
+        [ImportingConstructor]
+        public LogHubLogger([Import(typeof(SAsyncServiceProvider))] IAsyncServiceProvider2 asyncServiceProvider) {
+            asyncServiceProvider.GetServiceAsync<SVsBrokeredServiceContainer, IBrokeredServiceContainer>(throwOnFailure: true).ContinueWith(async (t) => {
+                var serviceBroker = t.Result.GetFullAccessServiceBroker();
+                Assumes.NotNull(serviceBroker);
+
+                // Setup logging using the log hub
+                using TraceConfiguration config = await TraceConfiguration.CreateTraceConfigurationInstanceAsync(serviceBroker);
+                SourceLevels sourceLevels = SourceLevels.Information | SourceLevels.ActivityTracing;
+                LoggerOptions logOptions = new(
+                    requestedLoggingLevel: new LoggingLevelSettings(sourceLevels),
+                    privacySetting: PrivacyFlags.MayContainPersonallyIdentifibleInformation | PrivacyFlags.MayContainPrivateInformation);
+
+                this._traceSource = await config.RegisterLogSourceAsync(new LogId("Microsoft.PythonTools", serviceId: null), logOptions, traceSource: null, isBootstrappedService: true, default);
+            });
+        }
+
+        public void LogEvent(PythonLogEvent logEvent, object argument) {
+            if (_traceSource != null) {
+                _traceSource.TraceEvent(TraceEventType.Information, (int)TraceEventType.Information, $"{Enum.GetName(typeof(PythonLogEvent), logEvent)}:{argument?.ToString()}");
+            }
+        }
+        public void LogEvent(string eventName, IReadOnlyDictionary<string, object> properties, IReadOnlyDictionary<string, double> measurements) {
+        }
+        public void LogFault(Exception ex, string description, bool dumpProcess) {
+            if (_traceSource != null) {
+                _traceSource.TraceEvent(TraceEventType.Error, (int)TraceEventType.Error, ex.Message);
+            }
+        }
+    }
+}


### PR DESCRIPTION
At a recent meeting with the LSP team in Visual Studio, it was suggested that all ILanguageClient implementers should use LogHub logging.

I followed the directions here that they suggested:
https://devdiv.visualstudio.com/DevDiv/_wiki/wikis/DevDiv.wiki/23437/Using-LogHub