### PR TITLE
Add conversion step for python.parsing pdbs

### DIFF
--- a/Build/17.0/packages.config
+++ b/Build/17.0/packages.config
@@ -79,4 +79,5 @@
   <package id="Microsoft.VisualStudio.Settings.15.0" version="17.0.0-previews-2-31405-002"/>
   <package id="System.Collections.Immutable" version="5.0.0"/>
   <package id="Microsoft.NET.StringTools" version="1.0.0" />
+  <package id="Microsoft.DiaSymReader.Pdb2Pdb" version="1.1.0-beta2-21181-01" />
 </packages>

--- a/Build/PreBuild.ps1
+++ b/Build/PreBuild.ps1
@@ -70,7 +70,7 @@ try {
     Start-Process -Wait -NoNewWindow "$outdir\python\tools\python.exe" -ErrorAction Stop -ArgumentList $debugpyarglist
 
     Write-Host "Updating Microsoft.Python.*.dll pdbs to be windows format"
-    Get-ChildItem "$PSScriptRoot\..\packages\Microsoft.Python.Parsing\lib\netstandard2.0" -Filter "*.pdb" | ForEach-Object {
+    Get-ChildItem "$outdir\Microsoft.Python.Parsing\lib\netstandard2.0" -Filter "*.pdb" | ForEach-Object {
         # Skip if there's already a pdb2 file
         # Convert each pdb $_.FullName
         $dir = $_.Directory

--- a/Build/PreBuild.ps1
+++ b/Build/PreBuild.ps1
@@ -78,7 +78,7 @@ try {
         $pdb2 = "$dir\$base.pdb2"
         if (!(Test-Path $pdb2)) {
             Write-Host "Modifying" $_.Name
-            Start-Process -Wait -NoNewWindow "packages\Microsoft.DiaSymReader.Pdb2Pdb\tools\Pdb2Pdb.exe" -ErrorAction Stop -ArgumentList "$dir\$base.dll"
+            Start-Process -Wait -NoNewWindow "$outdir\Microsoft.DiaSymReader.Pdb2Pdb\tools\Pdb2Pdb.exe" -ErrorAction Stop -ArgumentList "$dir\$base.dll"
             # That should have created a pdb2 file. Rename it to the .pdb file
             Copy-Item $_.FullName "$dir\$base.old_pdb"
             Copy-Item "$dir\$base.pdb2" $_.FullName -Force

--- a/Build/PreBuild.ps1
+++ b/Build/PreBuild.ps1
@@ -70,7 +70,7 @@ try {
     Start-Process -Wait -NoNewWindow "$outdir\python\tools\python.exe" -ErrorAction Stop -ArgumentList $debugpyarglist
 
     Write-Host "Updating Microsoft.Python.*.dll pdbs to be windows format"
-    Get-ChildItem "..\packages\Microsoft.Python.Parsing\lib\netstandard2.0" -Filter "*.pdb" | ForEach-Object {
+    Get-ChildItem "$PSScriptRoot\..\packages\Microsoft.Python.Parsing\lib\netstandard2.0" -Filter "*.pdb" | ForEach-Object {
         # Convert each pdb $_.FullName
         $dir = $_.Directory
         $base = $_.BaseName

--- a/Build/PreBuild.ps1
+++ b/Build/PreBuild.ps1
@@ -71,14 +71,20 @@ try {
 
     Write-Host "Updating Microsoft.Python.*.dll pdbs to be windows format"
     Get-ChildItem "$PSScriptRoot\..\packages\Microsoft.Python.Parsing\lib\netstandard2.0" -Filter "*.pdb" | ForEach-Object {
+        # Skip if there's already a pdb2 file
         # Convert each pdb $_.FullName
         $dir = $_.Directory
         $base = $_.BaseName
-        Write-Host "Modifying" $_.Name
-        Start-Process -Wait -NoNewWindow "packages\Microsoft.DiaSymReader.Pdb2Pdb\tools\Pdb2Pdb.exe" -ErrorAction Stop -ArgumentList "$dir\$base.dll"
-        # That should have created a pdb2 file. Rename it to the .pdb file
-        Copy-Item $_.FullName "$dir\$base.old_pdb"
-        Copy-Item "$dir\$base.pdb2" $_.FullName -Force
+        $pdb2 = "$dir\$base.pdb2"
+        if (!(Test-Path $pdb2)) {
+            Write-Host "Modifying" $_.Name
+            Start-Process -Wait -NoNewWindow "packages\Microsoft.DiaSymReader.Pdb2Pdb\tools\Pdb2Pdb.exe" -ErrorAction Stop -ArgumentList "$dir\$base.dll"
+            # That should have created a pdb2 file. Rename it to the .pdb file
+            Copy-Item $_.FullName "$dir\$base.old_pdb"
+            Copy-Item "$dir\$base.pdb2" $_.FullName -Force
+        } else {
+            Write-Host "Already updated the pdb for" $_.FullName
+        }
     } | Out-Null
 } finally {
     Pop-Location

--- a/Build/nuget.config
+++ b/Build/nuget.config
@@ -3,7 +3,8 @@
     <clear />
     <add key="PLS" value="https://pvsc.blob.core.windows.net/vs-python-ls/index.json" protocolVersion="3" />
     <add key="vs-impl" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-impl/nuget/v3/index.json" />    
-    <add key="vssdk" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vssdk/nuget/v3/index.json" />    
+    <add key="vssdk" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vssdk/nuget/v3/index.json" />   
+    <add key="dnc" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" /> 
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />  
   </packageSources>
   <trustedSigners>


### PR DESCRIPTION
Hopefully this will fix the symbol publish error here:
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1331578/

The root cause (or at least one of the causes) was that the pdbs for the Microsoft.Python.Parsing dlls were portable pdbs. The symbol archiver in the build doesn't support portable, only windows pdbs.