### PR TITLE
Add support for ILanguageClient new methods

### DIFF
--- a/Build/17.0/packages.config
+++ b/Build/17.0/packages.config
@@ -33,8 +33,8 @@
   <package id="Microsoft.VisualStudio.Language.Intellisense" version = "17.0.56-gb3c64827ce" />
   <package id="Microsoft.VisualStudio.Language.NavigateTo.Interfaces" version = "17.0.56-gb3c64827ce" />
   <package id="Microsoft.VisualStudio.Language.StandardClassification" version = "17.0.56-gb3c64827ce" />
-  <package id="Microsoft.VisualStudio.LanguageServer.Client" version = "17.0.2041-ge9adae51b5" />
-  <package id="Microsoft.VisualStudio.LanguageServer.Protocol" version = "17.0.2041-ge9adae51b5" />
+  <package id="Microsoft.VisualStudio.LanguageServer.Client" version = "17.0.3095-refactor-g2219e36206" />
+  <package id="Microsoft.VisualStudio.LanguageServer.Protocol" version = "17.0.3095-refactor-g2219e36206" />
   <package id="Microsoft.VisualStudio.Package.LanguageService.15.0" version = "17.0.0-previews-1-31325-097" />
   <package id="Microsoft.VisualStudio.ProjectAggregator" version = "17.0.0-previews-1-31325-097" />
   <package id="Microsoft.VisualStudio.ProjectSystem" version = "16.2.133-pre" />

--- a/Python/Product/PythonTools/PythonTools.csproj
+++ b/Python/Product/PythonTools/PythonTools.csproj
@@ -249,6 +249,8 @@
     <Compile Include="PythonTools\Editor\Formatting\PythonFormatter.cs" />
     <Compile Include="PythonTools\Editor\Formatting\LspDiffTextEditFactory.cs" />
     <Compile Include="PythonTools\LanguageServerClient\CustomCancellationStrategy.cs" />
+    <Compile Include="PythonTools\LanguageServerClient\FileWatcher\DidChangeWatchedFilesRegistrationOptions.cs" />
+    <Compile Include="PythonTools\LanguageServerClient\FileWatcher\FileSystemWatcher.cs" />
     <Compile Include="PythonTools\LanguageServerClient\FileWatcher\Listener.cs" />
     <Compile Include="PythonTools\LanguageServerClient\LiveShareExtensions.cs" />
     <Compile Include="PythonTools\LanguageServerClient\LspEditorUtilities.cs" />

--- a/Python/Product/PythonTools/PythonTools/LanguageServerClient/FileWatcher/DidChangeWatchedFilesRegistrationOptions.cs
+++ b/Python/Product/PythonTools/PythonTools/LanguageServerClient/FileWatcher/DidChangeWatchedFilesRegistrationOptions.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Serialization;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.PythonTools.LanguageServerClient.FileWatcher {
+    /// <summary>
+    /// Class representing the options for registering workspace/didChangeWatchedFiles support.
+    /// </summary>
+    [DataContract]
+    public class DidChangeWatchedFilesRegistrationOptions {
+        /// <summary>
+        /// Gets or sets the watchers that should be registered.
+        /// </summary>
+        [DataMember]
+        public FileSystemWatcher[] Watchers {
+            get;
+            set;
+        }
+    }
+}

--- a/Python/Product/PythonTools/PythonTools/LanguageServerClient/FileWatcher/DidChangeWatchedFilesRegistrationOptions.cs
+++ b/Python/Product/PythonTools/PythonTools/LanguageServerClient/FileWatcher/DidChangeWatchedFilesRegistrationOptions.cs
@@ -1,9 +1,20 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
 using System.Runtime.Serialization;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Microsoft.PythonTools.LanguageServerClient.FileWatcher {
     /// <summary>

--- a/Python/Product/PythonTools/PythonTools/LanguageServerClient/FileWatcher/FileSystemWatcher.cs
+++ b/Python/Product/PythonTools/PythonTools/LanguageServerClient/FileWatcher/FileSystemWatcher.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Runtime.Serialization;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.PythonTools.LanguageServerClient.FileWatcher {
+    /// <summary>
+    /// Enum representing the type of changes to watch for.
+    /// </summary>
+    [Flags]
+    [DataContract]
+    public enum WatchKind {
+        /// <summary>
+        /// Create events.
+        /// </summary>
+        Create = 1,
+        /// <summary>
+        /// Change events.
+        /// </summary>
+        Change = 2,
+        /// <summary>
+        /// Delete events.
+        /// </summary>
+        Delete = 4
+    }
+
+    [DataContract]
+    public class FileSystemWatcher {
+        /// <summary>
+        /// Gets or sets the glob pattern to watch.
+        /// </summary>
+        [DataMember]
+        public string GlobPattern {
+            [CompilerGenerated]
+            get;
+            [CompilerGenerated]
+            set;
+        }
+
+        /// <summary>
+        /// Gets or sets the <see cref="T:Microsoft.VisualStudio.LanguageServer.Protocol.WatchKind" /> values that are of interest.
+        /// </summary>
+        [DataMember]
+        public WatchKind Kind {
+            [CompilerGenerated]
+            get;
+            [CompilerGenerated]
+            set;
+        } = WatchKind.Create | WatchKind.Change | WatchKind.Delete;
+    }
+}

--- a/Python/Product/PythonTools/PythonTools/LanguageServerClient/FileWatcher/FileSystemWatcher.cs
+++ b/Python/Product/PythonTools/PythonTools/LanguageServerClient/FileWatcher/FileSystemWatcher.cs
@@ -1,10 +1,22 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
 using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Microsoft.PythonTools.LanguageServerClient.FileWatcher {
     /// <summary>

--- a/Python/Product/PythonTools/PythonTools/LanguageServerClient/FileWatcher/Listener.cs
+++ b/Python/Product/PythonTools/PythonTools/LanguageServerClient/FileWatcher/Listener.cs
@@ -1,11 +1,24 @@
-﻿using System;
-using System.Collections.Generic;
+﻿// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System;
 using System.IO;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Extensions.FileSystemGlobbing;
-using Microsoft.PythonTools.Interpreter;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Microsoft.VisualStudio.Workspace;
 using Microsoft.VisualStudio.Workspace.VSIntegration.Contracts;

--- a/Python/Product/PythonTools/PythonTools/LanguageServerClient/FileWatcher/Listener.cs
+++ b/Python/Product/PythonTools/PythonTools/LanguageServerClient/FileWatcher/Listener.cs
@@ -70,11 +70,11 @@ namespace Microsoft.PythonTools.LanguageServerClient.FileWatcher {
 
         }
 
-        public void AddPatterns(VisualStudio.LanguageServer.Protocol.FileSystemWatcher[] patterns) {
+        public void AddPatterns(FileSystemWatcher[] patterns) {
             Array.ForEach(patterns, p => AddPattern(p));
         }
 
-        private void AddPattern(VisualStudio.LanguageServer.Protocol.FileSystemWatcher pattern) {
+        private void AddPattern(FileSystemWatcher pattern) {
             // Add to our matcher
             _matcher.AddInclude(pattern.GlobPattern);
 

--- a/Python/Product/PythonTools/PythonTools/LanguageServerClient/PythonLanguageClient.cs
+++ b/Python/Product/PythonTools/PythonTools/LanguageServerClient/PythonLanguageClient.cs
@@ -26,6 +26,7 @@ using Microsoft.Python.Core.Disposables;
 using Microsoft.PythonTools.Editor.Core;
 using Microsoft.PythonTools.Infrastructure;
 using Microsoft.PythonTools.Interpreter;
+using Microsoft.PythonTools.LanguageServerClient.FileWatcher;
 using Microsoft.PythonTools.LanguageServerClient.StreamHacking;
 using Microsoft.PythonTools.LanguageServerClient.WorkspaceFolderChanged;
 using Microsoft.PythonTools.Options;
@@ -114,6 +115,8 @@ namespace Microsoft.PythonTools.LanguageServerClient {
         public object MiddleLayer => null;
         public object CustomMessageTarget { get; private set; }
         public bool IsInitialized { get; private set; }
+
+        public bool ShowNotificationOnInitializeFailed => true;
 
         public event AsyncEventHandler<EventArgs> StartAsync;
 #pragma warning disable CS0067
@@ -455,7 +458,7 @@ namespace Microsoft.PythonTools.LanguageServerClient {
             OnWorkspaceOrSolutionOpened();
         }
 
-        private void WatchedFilesRegistered(object sender, LSP.DidChangeWatchedFilesRegistrationOptions e) {
+        private void WatchedFilesRegistered(object sender, DidChangeWatchedFilesRegistrationOptions e) {
             // Add the file globs to our listener. It will listen to the globs
             _fileListener?.AddPatterns(e.Watchers);
         }
@@ -577,6 +580,12 @@ namespace Microsoft.PythonTools.LanguageServerClient {
                     }
                 });
             }
+        }
+
+        public async Task<InitializationFailureContext> OnServerInitializeFailedAsync(LanguageClientInitializationInfoBase initializationState) {
+            var results = new InitializationFailureContext();
+            results.FailureMessage = initializationState.InitializationException.Message;
+            return results;
         }
     }
 }

--- a/Python/Product/PythonTools/PythonTools/LanguageServerClient/PythonLanguageClientCustomTarget.cs
+++ b/Python/Product/PythonTools/PythonTools/LanguageServerClient/PythonLanguageClientCustomTarget.cs
@@ -29,6 +29,7 @@ using StreamJsonRpc;
 using Task = System.Threading.Tasks.Task;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Microsoft.PythonTools.LanguageServerClient.WorkspaceConfiguration;
+using Microsoft.PythonTools.LanguageServerClient.FileWatcher;
 
 namespace Microsoft.PythonTools.LanguageServerClient {
     internal class PythonLanguageClientCustomTarget {


### PR DESCRIPTION
ILanguageClient is changing (well because it can) and we need to change with it.

Fixes: #6609 

Tested with bits here:
https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_build/results?buildId=4998492&view=ms.vss-build-web.run-extensions-tab

However we need to wait for that submission to go into main (or put this submission in at the same time) before we finish the PR into VS main.

Miguel should provide a branch we can insert into after Wednesday.