### PR TITLE
Narrator fix. Modifying the InterpreterView to return both Name and InterpreterPath…

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Environments/InterpreterView.cs
+++ b/Python/Product/PythonTools/PythonTools/Environments/InterpreterView.cs
@@ -22,7 +22,6 @@ using System.Windows;
 using Microsoft.PythonTools.Infrastructure;
 using Microsoft.PythonTools.Interpreter;
 using Microsoft.PythonTools.Project;
-using Microsoft.PythonTools.Project.ImportWizard;
 
 namespace Microsoft.PythonTools.Environments {
     sealed class InterpreterView : DependencyObject {

--- a/Python/Product/PythonTools/PythonTools/Environments/InterpreterView.cs
+++ b/Python/Product/PythonTools/PythonTools/Environments/InterpreterView.cs
@@ -16,11 +16,13 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Windows;
 using Microsoft.PythonTools.Infrastructure;
 using Microsoft.PythonTools.Interpreter;
 using Microsoft.PythonTools.Project;
+using Microsoft.PythonTools.Project.ImportWizard;
 
 namespace Microsoft.PythonTools.Environments {
     sealed class InterpreterView : DependencyObject {
@@ -115,7 +117,7 @@ namespace Microsoft.PythonTools.Environments {
             Project = project;
         }
 
-        public override string ToString() => Name;
+        public override string ToString() => string.Format(CultureInfo.InvariantCulture, "{0}\n{1}", Name, InterpreterPath);
 
         public string Id { get; }
 


### PR DESCRIPTION
… in the ToString() function so that narrator will say the complete strings showing to the user.

Previously we've dont similar fixes on ProjectView, one downside is now both Name and Path strings are shown in the drop box when collapsed

Method #2 suggestion here:
https://docs.microsoft.com/en-us/archive/blogs/winuiautomation/giving-your-xaml-element-an-accessible-name-part-3-other-interesting-ways
"2. Set an accessible name on a list item"

Internal bug 1362537

![image](https://user-images.githubusercontent.com/1946977/128071056-b356fe76-50ac-4e2e-be67-ffd7a2fe137d.png)

