### PR TITLE
Support portrait mode on the add environment dialog

### DIFF
--- a/Python/Product/PythonTools/PythonTools.csproj
+++ b/Python/Product/PythonTools/PythonTools.csproj
@@ -248,6 +248,7 @@
     <Compile Include="PythonTools\Editor\Formatting\PythonFormatterYapf.cs" />
     <Compile Include="PythonTools\Editor\Formatting\PythonFormatter.cs" />
     <Compile Include="PythonTools\Editor\Formatting\LspDiffTextEditFactory.cs" />
+    <Compile Include="PythonTools\Environments\LandscapePortraitConverter.cs" />
     <Compile Include="PythonTools\LanguageServerClient\CustomCancellationStrategy.cs" />
     <Compile Include="PythonTools\LanguageServerClient\FileWatcher\DidChangeWatchedFilesRegistrationOptions.cs" />
     <Compile Include="PythonTools\LanguageServerClient\FileWatcher\FileSystemWatcher.cs" />

--- a/Python/Product/PythonTools/PythonTools/Environments/AddCondaEnvironmentControl.xaml
+++ b/Python/Product/PythonTools/PythonTools/Environments/AddCondaEnvironmentControl.xaml
@@ -66,7 +66,7 @@
                             </Setter.Value>
                         </Setter>
                     </Style>
-                    
+
                     <ContextMenu x:Key="SuggestedPackagesMenu" Style="{StaticResource ThemedContextMenu}">
                         <ContextMenu.Resources>
                             <Style x:Key="PackageItem" TargetType="MenuItem" BasedOn="{StaticResource ThemedMenuItem}">
@@ -113,6 +113,43 @@
                                 Executed="AddPackageNames_Executed" />
                         </ContextMenu.CommandBindings>
                     </ContextMenu>
+                    <Style x:Key="MainGridLandscape" TargetType="ItemsControl" >
+                        <Setter Property="ItemsPanel">
+                            <Setter.Value>
+                                <ItemsPanelTemplate>
+                                    <Grid Visibility="{Binding Path=IsCondaMissing, Converter={x:Static wpf:Converters.TrueIsHidden}}">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="514"/>
+                                            <ColumnDefinition Width="28"/>
+                                            <ColumnDefinition Width="*"/>
+                                        </Grid.ColumnDefinitions>
+                                        <Grid.RowDefinitions>
+                                            <RowDefinition/>
+                                        </Grid.RowDefinitions>
+                                    </Grid>
+                                </ItemsPanelTemplate>
+                            </Setter.Value>
+                        </Setter>
+                    </Style>
+                    <Style x:Key="MainGridPortrait" TargetType="ItemsControl" >
+                        <Setter Property="ItemsPanel">
+                            <Setter.Value>
+                                <ItemsPanelTemplate>
+                                    <Grid Visibility="{Binding Path=IsCondaMissing, Converter={x:Static wpf:Converters.TrueIsHidden}}">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="*"/>
+                                        </Grid.ColumnDefinitions>
+                                        <Grid.RowDefinitions>
+                                            <RowDefinition Height="Auto"/>
+                                            <RowDefinition Height="*"/>
+                                        </Grid.RowDefinitions>
+                                    </Grid>
+                                </ItemsPanelTemplate>
+                            </Setter.Value>
+                        </Setter>
+                    </Style>
+                    <l:LandscapePortraitConverter x:Key="LandscapePortraitConverter" />
+
                 </ResourceDictionary>
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
@@ -125,14 +162,12 @@
                 Text="{x:Static common:Strings.CondaNotFoundError}"
                 TextWrapping="Wrap"/>
         </Grid>
-        <Grid Visibility="{Binding Path=IsCondaMissing, Converter={x:Static wpf:Converters.TrueIsHidden}}">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="514"/>
-                <ColumnDefinition Width="28"/>
-                <ColumnDefinition Width="*"/>
-            </Grid.ColumnDefinitions>
+        <ItemsControl 
+            Style="{Binding 
+                RelativeSource={RelativeSource AncestorType=UserControl},
+                Converter={StaticResource LandscapePortraitConverter}, 
+                ConverterParameter=MainGridLandscape|MainGridPortrait}">
             <ScrollViewer
-                Grid.Column="0"
                 VerticalScrollBarVisibility="Auto">
 
                 <StackPanel>
@@ -191,15 +226,15 @@
                                 </Border>
                             </DataTemplate>
                         </GroupBox.HeaderTemplate>
-                    <StackPanel>
-                    <RadioButton
+                        <StackPanel>
+                            <RadioButton
                         Margin="16 6 0 3"
                         Content="{x:Static common:Strings.AddCondaEnvironmentFileRadioButton}"
                         IsChecked="{Binding Path=IsEnvFile}"
                         GroupName="SourceType"
                         AutomationProperties.AutomationId="EnvFileMode"/>
 
-                    <wpf:ConfigurationTextBoxWithHelp
+                            <wpf:ConfigurationTextBoxWithHelp
                         Margin="36 0 0 9"
                         IsEnabled="{Binding Path=IsEnvFile}"
                         Text="{Binding SelectedEnvFilePath,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged,ValidatesOnNotifyDataErrors=False}"
@@ -213,14 +248,14 @@
                         BrowseCommandParameter="{x:Static common:Strings.AddCondaEnvironmentFileBrowseFilter}"
                         BrowseAutomationName="{x:Static common:Strings.AddCondaEnvironmentFileBrowseButton}"/>
 
-                    <RadioButton
+                            <RadioButton
                         Margin="16 0 0 3"
                         Content="{x:Static common:Strings.AddCondaPackagesRadioButton}"
                         IsChecked="{Binding Path=IsPackages}"
                         GroupName="SourceType"
                         AutomationProperties.AutomationId="PackagesMode"/>
 
-                    <wpf:ConfigurationTextBoxWithHelp
+                            <wpf:ConfigurationTextBoxWithHelp
                         Margin="36 0 0 19"
                         IsEnabled="{Binding Path=IsPackages}"
                         Text="{Binding Packages,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}"
@@ -231,9 +266,9 @@
                         ToolTip="{x:Static common:Strings.AddCondaPackagesHelpText}"
                         AutomationProperties.Name="{x:Static common:Strings.AddCondaPackagesName}"
                         AutomationProperties.AutomationId="Packages"/>
-                    </StackPanel>
+                        </StackPanel>
                     </GroupBox>
-                    
+
                     <CheckBox
                         Margin="0 0 0 10"
                         IsChecked="{Binding Path=SetAsCurrent}"
@@ -259,7 +294,7 @@
             </ScrollViewer>
 
             <!--Preview-->
-            <Grid Grid.Column="2">
+            <Grid Grid.Column="2" Grid.Row="1">
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="*"/>
@@ -336,6 +371,6 @@
                     </StackPanel>
                 </ScrollViewer>
             </Grid>
-        </Grid>
+        </ItemsControl>
     </Grid>
 </UserControl>

--- a/Python/Product/PythonTools/PythonTools/Environments/AddEnvironmentDialog.xaml
+++ b/Python/Product/PythonTools/PythonTools/Environments/AddEnvironmentDialog.xaml
@@ -13,7 +13,10 @@
     mc:Ignorable="d"
     Title="{x:Static common:Strings.AddEnvironmentTitle}"
     WindowStartupLocation="CenterOwner"
-    Height="676" MinHeight="676" Width="1024" MinWidth="1024"
+    Height="{Binding RelativeSource={RelativeSource Self}, Path=WindowHeight}" 
+    MinHeight="{Binding RelativeSource={RelativeSource Self}, Path=MinimumWindowHeight}" 
+    Width="{Binding RelativeSource={RelativeSource Self}, Path=WindowWidth}" 
+    MinWidth="{Binding RelativeSource={RelativeSource Self}, Path=MinimumWindowWidth}"
     Style="{DynamicResource ModernDialogStyle}">
 
     <ptwpf:ModernDialog.CommandBindings>

--- a/Python/Product/PythonTools/PythonTools/Environments/AddEnvironmentDialog.xaml.cs
+++ b/Python/Product/PythonTools/PythonTools/Environments/AddEnvironmentDialog.xaml.cs
@@ -28,11 +28,58 @@ using Microsoft.PythonTools.Interpreter;
 using Microsoft.PythonTools.Project;
 using Microsoft.PythonTools.Wpf;
 using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudioTools.Wpf;
 
 namespace Microsoft.PythonTools.Environments {
     internal partial class AddEnvironmentDialog : ModernDialog, IDisposable {
         public static readonly ICommand MoreInfo = new RoutedCommand();
         private bool _isStartupFocusSet;
+
+        public static readonly DependencyProperty IsLandscapeProperty = DependencyProperty.Register("IsLandscape", typeof(bool), typeof(AddEnvironmentDialog));
+        public static readonly DependencyProperty WindowWidthProperty = DependencyProperty.Register("WindowWidth", typeof(double), typeof(AddEnvironmentDialog));
+        public static readonly DependencyProperty MinimumWindowWidthProperty = DependencyProperty.Register("MinimumWindowWidth", typeof(double), typeof(AddEnvironmentDialog));
+        public static readonly DependencyProperty WindowHeightProperty = DependencyProperty.Register("WindowHeight", typeof(double), typeof(AddEnvironmentDialog));
+        public static readonly DependencyProperty MinimumWindowHeightProperty = DependencyProperty.Register("MinimumWindowHeight", typeof(double), typeof(AddEnvironmentDialog));
+        public bool IsLandscape {
+            get {
+                return (bool)GetValue(IsLandscapeProperty);
+            }
+            set {
+                SetValue(IsLandscapeProperty, value);
+            }
+        }
+        public double WindowWidth {
+            get {
+                return (double)GetValue(WindowWidthProperty);
+            }
+            set {
+                SetValue(WindowWidthProperty, value);
+            }
+        }
+        public double MinimumWindowWidth {
+            get {
+                return (double)GetValue(MinimumWindowWidthProperty);
+            }
+            set {
+                SetValue(MinimumWindowWidthProperty, value);
+            }
+        }
+        public double WindowHeight {
+            get {
+                return (double)GetValue(WindowHeightProperty);
+            }
+            set {
+                SetValue(WindowHeightProperty, value);
+            }
+        }
+        public double MinimumWindowHeight {
+            get {
+                return (double)GetValue(MinimumWindowHeightProperty);
+            }
+            set {
+                SetValue(MinimumWindowHeightProperty, value);
+            }
+        }
 
         public AddEnvironmentDialog(IEnumerable<EnvironmentViewBase> pages, EnvironmentViewBase selected) {
             if (pages == null) {
@@ -40,6 +87,11 @@ namespace Microsoft.PythonTools.Environments {
             }
 
             DataContext = new AddEnvironmentView(pages, selected);
+            IsLandscape = SystemParameters.PrimaryScreenWidth > SystemParameters.PrimaryScreenHeight;
+            WindowWidth = IsLandscape ? 1024 : 700;
+            WindowHeight = IsLandscape ? 700 : 1024;
+            MinimumWindowWidth = WindowWidth;
+            MinimumWindowHeight = WindowHeight;
             InitializeComponent();
         }
 

--- a/Python/Product/PythonTools/PythonTools/Environments/AddVirtualEnvironmentControl.xaml
+++ b/Python/Product/PythonTools/PythonTools/Environments/AddVirtualEnvironmentControl.xaml
@@ -35,6 +35,44 @@
                                    Text="{Binding Name}"
                                    Padding="3"/>
                     </DataTemplate>
+
+                    <Style x:Key="MainGridLandscape" TargetType="ItemsControl" >
+                        <Setter Property="ItemsPanel">
+                            <Setter.Value>
+                                <ItemsPanelTemplate>
+                                    <Grid Visibility="{Binding Path=NoInterpretersInstalled, Converter={x:Static wpf:Converters.TrueIsHidden}}">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="514"/>
+                                            <ColumnDefinition Width="28"/>
+                                            <ColumnDefinition Width="*"/>
+                                        </Grid.ColumnDefinitions>
+                                        <Grid.RowDefinitions>
+                                            <RowDefinition/>
+                                        </Grid.RowDefinitions>
+                                    </Grid>
+                                </ItemsPanelTemplate>
+                            </Setter.Value>
+                        </Setter>
+                    </Style>
+                    <Style x:Key="MainGridPortrait" TargetType="ItemsControl" >
+                        <Setter Property="ItemsPanel">
+                            <Setter.Value>
+                                <ItemsPanelTemplate>
+                                    <Grid Visibility="{Binding Path=NoInterpretersInstalled, Converter={x:Static wpf:Converters.TrueIsHidden}}">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="*"/>
+                                        </Grid.ColumnDefinitions>
+                                        <Grid.RowDefinitions>
+                                            <RowDefinition Height="Auto"/>
+                                            <RowDefinition Height="*"/>
+                                        </Grid.RowDefinitions>
+                                    </Grid>
+                                </ItemsPanelTemplate>
+                            </Setter.Value>
+                        </Setter>
+                    </Style>
+                    <l:LandscapePortraitConverter x:Key="LandscapePortraitConverter" />
+
                 </ResourceDictionary>
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
@@ -48,16 +86,14 @@
                 TextWrapping="Wrap"/>
         </Grid>
 
-        <Grid Visibility="{Binding Path=NoInterpretersInstalled, Converter={x:Static wpf:Converters.TrueIsHidden}}">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="514"/>
-                <ColumnDefinition Width="28"/>
-                <ColumnDefinition Width="*"/>
-            </Grid.ColumnDefinitions>
+        <ItemsControl 
+            Style="{Binding 
+                RelativeSource={RelativeSource AncestorType=UserControl},
+                Converter={StaticResource LandscapePortraitConverter}, 
+                ConverterParameter=MainGridLandscape|MainGridPortrait}">
 
             <!--Main options-->
             <ScrollViewer
-                Grid.Column="0"
                 VerticalScrollBarVisibility="Auto">
 
                 <StackPanel Orientation="Vertical">
@@ -207,7 +243,7 @@
             </ScrollViewer>
 
             <!--Preview-->
-            <Grid Grid.Column="2">
+            <Grid Grid.Column="2" Grid.Row="1">
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="*"/>
@@ -278,6 +314,6 @@
                         Visibility="{Binding CannotCreateVirtualEnv, Converter={x:Static wpf:Converters.FalseIsCollapsed}}"/>
                 </StackPanel>
             </Grid>
-        </Grid>
+        </ItemsControl>
     </Grid>
 </UserControl>

--- a/Python/Product/PythonTools/PythonTools/Environments/LandscapePortraitConverter.cs
+++ b/Python/Product/PythonTools/PythonTools/Environments/LandscapePortraitConverter.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+
+namespace Microsoft.PythonTools.Environments {
+    /// <summary>
+    /// Converts parameters into styles based on landscape or portrait mode
+    /// </summary>
+    public sealed class LandscapePortraitConverter : IValueConverter {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture) {
+            // value should be the user control that owns the styles
+            var userControl = value as UserControl;
+            // Parameter should have names of two different styles. First one is landscape, second one is portrait
+            if (parameter != null && userControl != null) {
+                var styles = parameter.ToString().Split('|');
+                if (styles.Length == 2) {
+                    var style = SystemParameters.PrimaryScreenWidth > SystemParameters.PrimaryScreenHeight ? styles[0] : styles[1];
+                    return userControl.Resources[style];
+                }
+            }
+            return value;
+        }
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => throw new NotImplementedException();
+    }
+}


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1355288

When in portrait mode dialog looks like this:

![image](https://user-images.githubusercontent.com/19672699/128248825-c273dc71-33c6-4941-a691-11469dc414a8.png)

and this

![image](https://user-images.githubusercontent.com/19672699/128248862-4f1070ae-6cb3-40f0-a2a3-f9e1026cac52.png)
