### PR TITLE
Narrator fix. HelpText was being read by the narrator but didn't matc…

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Environments/AddCondaEnvironmentControl.xaml
+++ b/Python/Product/PythonTools/PythonTools/Environments/AddCondaEnvironmentControl.xaml
@@ -204,7 +204,7 @@
                         IsEnabled="{Binding Path=IsEnvFile}"
                         Text="{Binding SelectedEnvFilePath,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged,ValidatesOnNotifyDataErrors=False}"
                         Watermark="{x:Static common:Strings.AddCondaEnvironmentFileWatermark}"
-                        HelpText="{x:Static common:Strings.AddCondaEnvironmentFileHelp}"
+                        HelpText="{x:Static common:Strings.AddCondaEnvironmentFileWatermark}"
                         ToolTip="{x:Static common:Strings.AddCondaEnvironmentFileHelp}"
                         AutomationProperties.AutomationId="EnvFile"
                         AutomationProperties.Name="{x:Static common:Strings.AddCondaEnvironmentFileName}"
@@ -227,7 +227,7 @@
                         BrowseButtonStyle="{StaticResource BrowsePackagesButton}"
                         BrowseAutomationName="{x:Static common:Strings.AddCondaPackagesBrowseButton}"
                         Watermark="{x:Static common:Strings.AddCondaPackagesWatermark}"
-                        HelpText="{x:Static common:Strings.AddCondaPackagesHelpText}"
+                        HelpText="{x:Static common:Strings.AddCondaPackagesWatermark}"
                         ToolTip="{x:Static common:Strings.AddCondaPackagesHelpText}"
                         AutomationProperties.Name="{x:Static common:Strings.AddCondaPackagesName}"
                         AutomationProperties.AutomationId="Packages"/>


### PR DESCRIPTION
…h the watermark text which was shown.

Now set HelpText to watermark Text so that narrator reads it. The tooltip will still show the HelpText

internal bug 1355290

Actual Result:​
Narrator/NVDA is not announcing complete label and place holder text for "One or more anaconda package names" field.
Label: One or more anaconda package names
Placeholder text: Example: "numpy pandas" . If no packages are listed, then python will be installed.

Expected Result:​
Narrator/NVDA should announce the label as "One or more anaconda package names" and place holder text as "Example: "numpy pandas" . If no packages are listed, then python will be installed." when focus lands on the field.

Narrator Now reads watermark/placeholder text
![image](https://user-images.githubusercontent.com/1946977/128262357-7c06b839-cc66-4b6b-b7ce-ed61965ee560.png)


tooltip
![image](https://user-images.githubusercontent.com/1946977/128262423-edfe8616-036b-4c64-8ba9-0639ac8535da.png)
