### PR TITLE
Fix for Narrator not mentioning the corresponding environment 

### DIFF
--- a/Python/Product/EnvironmentsList/EnvironmentView.xaml
+++ b/Python/Product/EnvironmentsList/EnvironmentView.xaml
@@ -63,7 +63,9 @@
                             Command="{x:Static l:EnvironmentView.OpenInteractiveWindow}"
                             CommandParameter="{Binding}"
                             ToolTip="{x:Static l:Resources.EnvironmentViewInteractiveWindowTooltip}"
-                            AutomationProperties.Name="{x:Static l:Resources.EnvironmentViewInteractiveWindowAutomationName}">
+                            AutomationProperties.Name="{Binding LocalizedDisplayName,Mode=OneWay}"
+                            AutomationProperties.HelpText="{x:Static l:Resources.EnvironmentViewInteractiveWindowAutomationName}"
+                            >
                         <Control Style="{StaticResource InteractiveWindowImage}" IsTabStop="False" />
                     </Button>
                 </Grid>

--- a/Python/Product/EnvironmentsList/EnvironmentView.xaml
+++ b/Python/Product/EnvironmentsList/EnvironmentView.xaml
@@ -64,8 +64,7 @@
                             CommandParameter="{Binding}"
                             ToolTip="{x:Static l:Resources.EnvironmentViewInteractiveWindowTooltip}"
                             AutomationProperties.Name="{Binding LocalizedDisplayName,Mode=OneWay}"
-                            AutomationProperties.HelpText="{x:Static l:Resources.EnvironmentViewInteractiveWindowAutomationName}"
-                            >
+                            AutomationProperties.HelpText="{x:Static l:Resources.EnvironmentViewInteractiveWindowAutomationName}">
                         <Control Style="{StaticResource InteractiveWindowImage}" IsTabStop="False" />
                     </Button>
                 </Grid>


### PR DESCRIPTION
for the Open Interactive Window button.

Use the fact that narrator will concat  Automation Name and HelpText automatically if both present

https://docs.microsoft.com/en-us/xamarin/xamarin-forms/app-fundamentals/accessibility/automation-properties

internal bug 1362535