### PR TITLE
fix for narrator in packages windows.

### DIFF
--- a/Python/Product/EnvironmentsList/EnvironmentPathsExtension.xaml
+++ b/Python/Product/EnvironmentsList/EnvironmentPathsExtension.xaml
@@ -56,7 +56,8 @@
                                    Visibility="Collapsed"
                                    Margin="6 9 6 6"
                                    Padding="0"
-                                   AutomationProperties.Name="{x:Static l:Resources.EnvironmentPathsExtensionIsDefaultLabel}">
+                                   AutomationProperties.Name="{x:Static l:Resources.EnvironmentPathsExtensionIsDefaultLabel}"
+                                   AutomationProperties.LiveSetting="Assertive">
                                 <Grid>
                                     <Grid.ColumnDefinitions>
                                         <ColumnDefinition Width="auto" />

--- a/Python/Product/EnvironmentsList/EnvironmentPathsExtension.xaml
+++ b/Python/Product/EnvironmentsList/EnvironmentPathsExtension.xaml
@@ -36,6 +36,7 @@
                                     HorizontalAlignment="Stretch"
                                     Command="{x:Static l:EnvironmentView.MakeGlobalDefault}"
                                     CommandParameter="{Binding}"
+                                    Click="MakeDefaultButton_Click"
                                     AutomationProperties.Name="{x:Static l:Resources.EnvironmentPathsExtensionMakeDefaultLabel}">
                                 <Grid Background="Transparent">
                                     <Grid.ColumnDefinitions>

--- a/Python/Product/EnvironmentsList/EnvironmentPathsExtension.xaml.cs
+++ b/Python/Product/EnvironmentsList/EnvironmentPathsExtension.xaml.cs
@@ -130,7 +130,6 @@ namespace Microsoft.PythonTools.EnvironmentsList {
                 // Delay focus because it relies on visiblity and there seems to be a race condition
                 this.Dispatcher.BeginInvoke((Action)delegate
                 {
-                    Keyboard.Focus(element);
                     FrameworkElementAutomationPeer.FromElement(element)?.RaiseAutomationEvent(AutomationEvents.LiveRegionChanged);
                 }, DispatcherPriority.Render);
             }


### PR DESCRIPTION
Now forcing a selection of label "IsDefaultMessage" after button press, and triggering narrator to update in the code behind so that it reads "This is the default environment for new projects".

fix internal bug 1351252

Actual Result:​
Narrator/NVDA is not announcing the status (This is the default environment for new projects) which is available on screen on selecting 'Make this the default environment for new projects' button.

Expected Result:​
Narrator/NVDA should announce the status as "This is the default environment for new projects" after selecting 'Make this the default environment for new projects' button.