### PR TITLE
Class name was being used for the ListBoxItem's Name field

### DIFF
--- a/Python/Product/EnvironmentsList/EnvironmentPathsExtension.xaml.cs
+++ b/Python/Product/EnvironmentsList/EnvironmentPathsExtension.xaml.cs
@@ -49,6 +49,8 @@ namespace Microsoft.PythonTools.EnvironmentsList {
                 return _wpfObject;
             }
         }
+
+        public override string ToString() => this.LocalizedDisplayName;
     }
 
     public partial class EnvironmentPathsExtension : UserControl {

--- a/Python/Product/EnvironmentsList/EnvironmentView.xaml
+++ b/Python/Product/EnvironmentsList/EnvironmentView.xaml
@@ -34,7 +34,7 @@
                                    TextTrimming="CharacterEllipsis"
                                    FontWeight="Bold"
                                    Margin="0"
-                                   Visibility="Hidden" />
+                                   Visibility="Collapsed" />
                         <TextBlock x:Name="Name_IsNotDefault"
                                    Text="{Binding}"
                                    TextTrimming="CharacterEllipsis"

--- a/Python/Product/EnvironmentsList/PipExtensionProvider.cs
+++ b/Python/Product/EnvironmentsList/PipExtensionProvider.cs
@@ -34,6 +34,8 @@ namespace Microsoft.PythonTools.EnvironmentsList {
             new KeyValuePair<string, string>("PYTHONUNBUFFERED", "1")
         };
 
+        public override string ToString() => this.LocalizedDisplayName;
+
         /// <summary>
         /// Creates a provider for managing packages through pip.
         /// </summary>


### PR DESCRIPTION
there was an accessibility issue around using names that include 'Microsoft.*.*'

Added a ToString() function on the view's to override the Name to the localized version.

ie. "Overview" and "Packages (PyPi)"

Fix #6661