### PR TITLE
Fix size of controls to allow for localization

### DIFF
--- a/Python/Product/PythonTools/PythonTools.csproj
+++ b/Python/Product/PythonTools/PythonTools.csproj
@@ -983,6 +983,7 @@
     </EmbeddedResource>
     <EmbeddedResource Include="PythonTools\Options\PythonGeneralOptionsControl.resx">
       <DependentUpon>PythonGeneralOptionsControl.cs</DependentUpon>
+      <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Include="PythonTools\Options\PythonFormattingOptionsControl.resx">
       <DependentUpon>PythonFormattingOptionsControl.cs</DependentUpon>

--- a/Python/Product/PythonTools/PythonTools/Options/PythonAnalysisOptionsControl.resx
+++ b/Python/Product/PythonTools/PythonTools/Options/PythonAnalysisOptionsControl.resx
@@ -145,13 +145,10 @@
   </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="diagnosticModeLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 6</value>
-  </data>
-  <data name="diagnosticModeLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 0, 6, 0</value>
+    <value>3, 6</value>
   </data>
   <data name="diagnosticModeLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>163, 25</value>
+    <value>89, 13</value>
   </data>
   <data name="diagnosticModeLabel.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -178,10 +175,13 @@
     <value>True</value>
   </metadata>
   <data name="_diagnosticsModeCombo.Location" type="System.Drawing.Point, System.Drawing">
-    <value>214, 3</value>
+    <value>117, 2</value>
+  </data>
+  <data name="_diagnosticsModeCombo.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>2, 2, 2, 2</value>
   </data>
   <data name="_diagnosticsModeCombo.Size" type="System.Drawing.Size, System.Drawing">
-    <value>187, 32</value>
+    <value>253, 21</value>
   </data>
   <data name="_diagnosticsModeCombo.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -211,13 +211,10 @@
     <value>NoControl</value>
   </data>
   <data name="logLevelLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 44</value>
-  </data>
-  <data name="logLevelLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 0, 6, 0</value>
+    <value>3, 31</value>
   </data>
   <data name="logLevelLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>96, 25</value>
+    <value>53, 13</value>
   </data>
   <data name="logLevelLabel.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -241,10 +238,13 @@
     <value>2</value>
   </data>
   <data name="_logLevelCombo.Location" type="System.Drawing.Point, System.Drawing">
-    <value>214, 41</value>
+    <value>117, 27</value>
+  </data>
+  <data name="_logLevelCombo.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>2, 2, 2, 2</value>
   </data>
   <data name="_logLevelCombo.Size" type="System.Drawing.Size, System.Drawing">
-    <value>187, 32</value>
+    <value>253, 21</value>
   </data>
   <data name="_logLevelCombo.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -274,13 +274,10 @@
     <value>NoControl</value>
   </data>
   <data name="typeCheckingModeLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 82</value>
-  </data>
-  <data name="typeCheckingModeLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 0, 6, 0</value>
+    <value>3, 56</value>
   </data>
   <data name="typeCheckingModeLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>146, 25</value>
+    <value>81, 13</value>
   </data>
   <data name="typeCheckingModeLabel.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
@@ -304,10 +301,13 @@
     <value>4</value>
   </data>
   <data name="_typeCheckingMode.Location" type="System.Drawing.Point, System.Drawing">
-    <value>214, 79</value>
+    <value>117, 52</value>
+  </data>
+  <data name="_typeCheckingMode.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>2, 2, 2, 2</value>
   </data>
   <data name="_typeCheckingMode.Size" type="System.Drawing.Size, System.Drawing">
-    <value>187, 32</value>
+    <value>253, 21</value>
   </data>
   <data name="_typeCheckingMode.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
@@ -337,13 +337,10 @@
     <value>NoControl</value>
   </data>
   <data name="stubsPathsLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 119</value>
-  </data>
-  <data name="stubsPathsLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 0, 6, 0</value>
+    <value>3, 80</value>
   </data>
   <data name="stubsPathsLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>112, 25</value>
+    <value>61, 13</value>
   </data>
   <data name="stubsPathsLabel.TabIndex" type="System.Int32, mscorlib">
     <value>8</value>
@@ -367,10 +364,13 @@
     <value>6</value>
   </data>
   <data name="_stubsPath.Location" type="System.Drawing.Point, System.Drawing">
-    <value>214, 117</value>
+    <value>117, 77</value>
+  </data>
+  <data name="_stubsPath.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>2, 2, 2, 2</value>
   </data>
   <data name="_stubsPath.Size" type="System.Drawing.Size, System.Drawing">
-    <value>460, 29</value>
+    <value>253, 20</value>
   </data>
   <data name="_stubsPath.TabIndex" type="System.Int32, mscorlib">
     <value>9</value>
@@ -394,13 +394,13 @@
     <value>NoControl</value>
   </data>
   <data name="_searchPathsLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 155</value>
+    <value>3, 102</value>
   </data>
   <data name="_searchPathsLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 6, 6, 0</value>
+    <value>3, 3, 3, 0</value>
   </data>
   <data name="_searchPathsLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>134, 25</value>
+    <value>73, 13</value>
   </data>
   <data name="_searchPathsLabel.TabIndex" type="System.Int32, mscorlib">
     <value>10</value>
@@ -424,13 +424,16 @@
     <value>8</value>
   </data>
   <data name="_searchPaths.Location" type="System.Drawing.Point, System.Drawing">
-    <value>214, 152</value>
+    <value>117, 101</value>
+  </data>
+  <data name="_searchPaths.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>2, 2, 2, 2</value>
   </data>
   <data name="_searchPaths.Multiline" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
   <data name="_searchPaths.Size" type="System.Drawing.Size, System.Drawing">
-    <value>460, 128</value>
+    <value>253, 71</value>
   </data>
   <data name="_searchPaths.TabIndex" type="System.Int32, mscorlib">
     <value>11</value>
@@ -454,13 +457,13 @@
     <value>NoControl</value>
   </data>
   <data name="_typeShedPathsLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 289</value>
+    <value>3, 177</value>
   </data>
   <data name="_typeShedPathsLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 6, 6, 0</value>
+    <value>3, 3, 3, 0</value>
   </data>
   <data name="_typeShedPathsLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>159, 25</value>
+    <value>86, 13</value>
   </data>
   <data name="_typeShedPathsLabel.TabIndex" type="System.Int32, mscorlib">
     <value>12</value>
@@ -484,13 +487,16 @@
     <value>10</value>
   </data>
   <data name="_typeshedPaths.Location" type="System.Drawing.Point, System.Drawing">
-    <value>214, 286</value>
+    <value>117, 176</value>
+  </data>
+  <data name="_typeshedPaths.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>2, 2, 2, 2</value>
   </data>
   <data name="_typeshedPaths.Multiline" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
   <data name="_typeshedPaths.Size" type="System.Drawing.Size, System.Drawing">
-    <value>460, 121</value>
+    <value>253, 67</value>
   </data>
   <data name="_typeshedPaths.TabIndex" type="System.Int32, mscorlib">
     <value>13</value>
@@ -517,13 +523,13 @@
     <value>NoControl</value>
   </data>
   <data name="_autoSearchPath.Location" type="System.Drawing.Point, System.Drawing">
-    <value>11, 421</value>
+    <value>6, 251</value>
   </data>
   <data name="_autoSearchPath.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>11, 11, 11, 6</value>
+    <value>6, 6, 6, 3</value>
   </data>
   <data name="_autoSearchPath.Size" type="System.Drawing.Size, System.Drawing">
-    <value>462, 29</value>
+    <value>256, 17</value>
   </data>
   <data name="_autoSearchPath.TabIndex" type="System.Int32, mscorlib">
     <value>14</value>
@@ -549,14 +555,11 @@
   <data name="tableLayoutPanel1.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 0</value>
   </data>
-  <data name="tableLayoutPanel1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 6, 6, 6</value>
-  </data>
   <data name="tableLayoutPanel1.RowCount" type="System.Int32, mscorlib">
     <value>9</value>
   </data>
   <data name="tableLayoutPanel1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>699, 535</value>
+    <value>381, 290</value>
   </data>
   <data name="tableLayoutPanel1.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -574,7 +577,7 @@
     <value>0</value>
   </data>
   <data name="tableLayoutPanel1.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="diagnosticModeLabel" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_diagnosticsModeCombo" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="logLevelLabel" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_logLevelCombo" Row="1" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="typeCheckingModeLabel" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_typeCheckingMode" Row="2" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="stubsPathsLabel" Row="3" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_stubsPath" Row="3" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="_searchPathsLabel" Row="4" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_searchPaths" Row="4" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="_typeShedPathsLabel" Row="5" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_typeshedPaths" Row="5" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="_autoSearchPath" Row="7" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,100,Absolute,488" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,Absolute,20,Absolute,20" /&gt;&lt;/TableLayoutSettings&gt;</value>
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="diagnosticModeLabel" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_diagnosticsModeCombo" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="logLevelLabel" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_logLevelCombo" Row="1" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="typeCheckingModeLabel" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_typeCheckingMode" Row="2" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="stubsPathsLabel" Row="3" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_stubsPath" Row="3" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="_searchPathsLabel" Row="4" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_searchPaths" Row="4" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="_typeShedPathsLabel" Row="5" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_typeshedPaths" Row="5" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="_autoSearchPath" Row="7" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,100,Absolute,266" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,Absolute,11,Absolute,11" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <metadata name="_diagnosticModeToolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
@@ -607,13 +610,13 @@
     <value>True</value>
   </metadata>
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
-    <value>11, 24</value>
+    <value>6, 13</value>
   </data>
   <data name="$this.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>11, 15, 11, 15</value>
+    <value>6, 8, 6, 8</value>
   </data>
   <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
-    <value>699, 535</value>
+    <value>381, 290</value>
   </data>
   <data name="&gt;&gt;_diagnosticModeToolTip.Name" xml:space="preserve">
     <value>_diagnosticModeToolTip</value>

--- a/Python/Product/PythonTools/PythonTools/Options/PythonDebuggingOptionsControl.resx
+++ b/Python/Product/PythonTools/PythonTools/Options/PythonDebuggingOptionsControl.resx
@@ -127,13 +127,13 @@
   </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="_promptOnBuildError.Location" type="System.Drawing.Point, System.Drawing">
-    <value>11, 6</value>
+    <value>6, 3</value>
   </data>
   <data name="_promptOnBuildError.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>11, 6, 11, 6</value>
+    <value>6, 3, 6, 3</value>
   </data>
   <data name="_promptOnBuildError.Size" type="System.Drawing.Size, System.Drawing">
-    <value>440, 29</value>
+    <value>244, 17</value>
   </data>
   <data name="_promptOnBuildError.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -160,13 +160,13 @@
     <value>True</value>
   </data>
   <data name="_waitOnAbnormalExit.Location" type="System.Drawing.Point, System.Drawing">
-    <value>11, 47</value>
+    <value>6, 26</value>
   </data>
   <data name="_waitOnAbnormalExit.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>11, 6, 11, 6</value>
+    <value>6, 3, 6, 3</value>
   </data>
   <data name="_waitOnAbnormalExit.Size" type="System.Drawing.Size, System.Drawing">
-    <value>423, 29</value>
+    <value>235, 17</value>
   </data>
   <data name="_waitOnAbnormalExit.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -193,13 +193,13 @@
     <value>True</value>
   </data>
   <data name="_waitOnNormalExit.Location" type="System.Drawing.Point, System.Drawing">
-    <value>11, 88</value>
+    <value>6, 49</value>
   </data>
   <data name="_waitOnNormalExit.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>11, 6, 11, 6</value>
+    <value>6, 3, 6, 3</value>
   </data>
   <data name="_waitOnNormalExit.Size" type="System.Drawing.Size, System.Drawing">
-    <value>401, 29</value>
+    <value>223, 17</value>
   </data>
   <data name="_waitOnNormalExit.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -226,13 +226,13 @@
     <value>True</value>
   </data>
   <data name="_teeStdOut.Location" type="System.Drawing.Point, System.Drawing">
-    <value>11, 129</value>
+    <value>6, 72</value>
   </data>
   <data name="_teeStdOut.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>11, 6, 11, 6</value>
+    <value>6, 3, 6, 3</value>
   </data>
   <data name="_teeStdOut.Size" type="System.Drawing.Size, System.Drawing">
-    <value>427, 29</value>
+    <value>240, 17</value>
   </data>
   <data name="_teeStdOut.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -259,13 +259,13 @@
     <value>True</value>
   </data>
   <data name="_breakOnSystemExitZero.Location" type="System.Drawing.Point, System.Drawing">
-    <value>11, 170</value>
+    <value>6, 95</value>
   </data>
   <data name="_breakOnSystemExitZero.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>11, 6, 11, 6</value>
+    <value>6, 3, 6, 3</value>
   </data>
   <data name="_breakOnSystemExitZero.Size" type="System.Drawing.Size, System.Drawing">
-    <value>494, 29</value>
+    <value>275, 17</value>
   </data>
   <data name="_breakOnSystemExitZero.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -292,13 +292,13 @@
     <value>True</value>
   </data>
   <data name="_debugStdLib.Location" type="System.Drawing.Point, System.Drawing">
-    <value>11, 211</value>
+    <value>6, 118</value>
   </data>
   <data name="_debugStdLib.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>11, 6, 11, 6</value>
+    <value>6, 3, 6, 3</value>
   </data>
   <data name="_debugStdLib.Size" type="System.Drawing.Size, System.Drawing">
-    <value>453, 29</value>
+    <value>252, 17</value>
   </data>
   <data name="_debugStdLib.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -325,13 +325,13 @@
     <value>True</value>
   </data>
   <data name="_showFunctionReturnValue.Location" type="System.Drawing.Point, System.Drawing">
-    <value>11, 252</value>
+    <value>6, 141</value>
   </data>
   <data name="_showFunctionReturnValue.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>11, 6, 11, 6</value>
+    <value>6, 3, 6, 3</value>
   </data>
   <data name="_showFunctionReturnValue.Size" type="System.Drawing.Size, System.Drawing">
-    <value>268, 29</value>
+    <value>153, 17</value>
   </data>
   <data name="_showFunctionReturnValue.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
@@ -367,7 +367,10 @@
     <value>True</value>
   </data>
   <data name="_showVariablesLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 4</value>
+    <value>2, 2</value>
+  </data>
+  <data name="_showVariablesLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>2, 0, 2, 0</value>
   </data>
   <data name="_showVariablesLabel.Size" type="System.Drawing.Size, System.Drawing">
     <value>79, 13</value>
@@ -394,10 +397,13 @@
     <value>NoControl</value>
   </data>
   <data name="_showVariablesDivider.Location" type="System.Drawing.Point, System.Drawing">
-    <value>89, 11</value>
+    <value>49, 6</value>
+  </data>
+  <data name="_showVariablesDivider.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>2, 0, 2, 0</value>
   </data>
   <data name="_showVariablesDivider.Size" type="System.Drawing.Size, System.Drawing">
-    <value>252, 2</value>
+    <value>137, 1</value>
   </data>
   <data name="_showVariablesDivider.TabIndex" type="System.Int32, mscorlib">
     <value>11</value>
@@ -421,7 +427,10 @@
     <value>NoControl</value>
   </data>
   <data name="_showVariablesClassLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>7, 32</value>
+    <value>4, 17</value>
+  </data>
+  <data name="_showVariablesClassLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>2, 0, 2, 0</value>
   </data>
   <data name="_showVariablesClassLabel.Size" type="System.Drawing.Size, System.Drawing">
     <value>35, 13</value>
@@ -448,10 +457,13 @@
     <value>Show class variables ComboBox</value>
   </data>
   <data name="_showVariablesClassComboBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>69, 29</value>
+    <value>103, 14</value>
+  </data>
+  <data name="_showVariablesClassComboBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>2, 2, 2, 2</value>
   </data>
   <data name="_showVariablesClassComboBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>95, 21</value>
+    <value>124, 21</value>
   </data>
   <data name="_showVariablesClassComboBox.TabIndex" type="System.Int32, mscorlib">
     <value>8</value>
@@ -475,7 +487,10 @@
     <value>NoControl</value>
   </data>
   <data name="_showVariablesFunctionLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>189, 32</value>
+    <value>4, 64</value>
+  </data>
+  <data name="_showVariablesFunctionLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>2, 0, 2, 0</value>
   </data>
   <data name="_showVariablesFunctionLabel.Size" type="System.Drawing.Size, System.Drawing">
     <value>51, 13</value>
@@ -502,10 +517,13 @@
     <value>Show function variables ComboBox</value>
   </data>
   <data name="_showVariablesFunctionComboBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>246, 29</value>
+    <value>103, 64</value>
+  </data>
+  <data name="_showVariablesFunctionComboBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>2, 2, 2, 2</value>
   </data>
   <data name="_showVariablesFunctionComboBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>95, 21</value>
+    <value>124, 21</value>
   </data>
   <data name="_showVariablesFunctionComboBox.TabIndex" type="System.Int32, mscorlib">
     <value>9</value>
@@ -529,7 +547,10 @@
     <value>NoControl</value>
   </data>
   <data name="_showVariablesProtectedLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>7, 59</value>
+    <value>4, 39</value>
+  </data>
+  <data name="_showVariablesProtectedLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>2, 0, 2, 0</value>
   </data>
   <data name="_showVariablesProtectedLabel.Size" type="System.Drawing.Size, System.Drawing">
     <value>56, 13</value>
@@ -556,10 +577,13 @@
     <value>Show protected variables ComboBox</value>
   </data>
   <data name="_showVariablesProtectedComboBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>69, 56</value>
+    <value>103, 39</value>
+  </data>
+  <data name="_showVariablesProtectedComboBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>2, 2, 2, 2</value>
   </data>
   <data name="_showVariablesProtectedComboBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>95, 21</value>
+    <value>124, 21</value>
   </data>
   <data name="_showVariablesProtectedComboBox.TabIndex" type="System.Int32, mscorlib">
     <value>10</value>
@@ -583,7 +607,10 @@
     <value>NoControl</value>
   </data>
   <data name="_showVariablesSpecialLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>189, 59</value>
+    <value>4, 89</value>
+  </data>
+  <data name="_showVariablesSpecialLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>2, 0, 2, 0</value>
   </data>
   <data name="_showVariablesSpecialLabel.Size" type="System.Drawing.Size, System.Drawing">
     <value>45, 13</value>
@@ -610,10 +637,13 @@
     <value>Show special variables ComboBox</value>
   </data>
   <data name="_showVariablesSpecialComboBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>246, 56</value>
+    <value>103, 89</value>
+  </data>
+  <data name="_showVariablesSpecialComboBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>2, 2, 2, 2</value>
   </data>
   <data name="_showVariablesSpecialComboBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>95, 21</value>
+    <value>124, 21</value>
   </data>
   <data name="_showVariablesSpecialComboBox.TabIndex" type="System.Int32, mscorlib">
     <value>11</value>
@@ -631,10 +661,13 @@
     <value>9</value>
   </data>
   <data name="_showVariablesPanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 187</value>
+    <value>2, 163</value>
+  </data>
+  <data name="_showVariablesPanel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>2, 2, 2, 2</value>
   </data>
   <data name="_showVariablesPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>351, 88</value>
+    <value>367, 124</value>
   </data>
   <data name="_showVariablesPanel.TabIndex" type="System.Int32, mscorlib">
     <value>9</value>
@@ -649,7 +682,7 @@
     <value>tableLayoutPanel2</value>
   </data>
   <data name="&gt;&gt;_showVariablesPanel.ZOrder" xml:space="preserve">
-    <value>8</value>
+    <value>7</value>
   </data>
   <data name="tableLayoutPanel2.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
@@ -657,14 +690,11 @@
   <data name="tableLayoutPanel2.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 0</value>
   </data>
-  <data name="tableLayoutPanel2.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 6, 6, 6</value>
-  </data>
   <data name="tableLayoutPanel2.RowCount" type="System.Int32, mscorlib">
     <value>10</value>
   </data>
   <data name="tableLayoutPanel2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>357, 585</value>
+    <value>371, 317</value>
   </data>
   <data name="tableLayoutPanel2.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -682,19 +712,19 @@
     <value>0</value>
   </data>
   <data name="tableLayoutPanel2.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="_promptOnBuildError" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_waitOnAbnormalExit" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_waitOnNormalExit" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_teeStdOut" Row="3" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_breakOnSystemExitZero" Row="4" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_debugStdLib" Row="5" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_showFunctionReturnValue" Row="6" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_useLegacyDebugger" Row="7" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_showVariablesPanel" Row="9" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,Percent,100,Absolute,20" /&gt;&lt;/TableLayoutSettings&gt;</value>
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="_promptOnBuildError" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_waitOnAbnormalExit" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_waitOnNormalExit" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_teeStdOut" Row="3" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_breakOnSystemExitZero" Row="4" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_debugStdLib" Row="5" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_showFunctionReturnValue" Row="6" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_showVariablesPanel" Row="9" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
-    <value>11, 24</value>
+    <value>6, 13</value>
   </data>
   <data name="$this.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>11, 15, 11, 15</value>
+    <value>6, 8, 6, 8</value>
   </data>
   <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
-    <value>357, 585</value>
+    <value>371, 317</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>PythonDebuggingOptionsControl</value>

--- a/Python/Product/PythonTools/PythonTools/Options/PythonGeneralOptionsControl.resx
+++ b/Python/Product/PythonTools/PythonTools/Options/PythonGeneralOptionsControl.resx
@@ -133,13 +133,13 @@
   </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="_showOutputWindowForVirtualEnvCreate.Location" type="System.Drawing.Point, System.Drawing">
-    <value>11, 6</value>
+    <value>6, 3</value>
   </data>
   <data name="_showOutputWindowForVirtualEnvCreate.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>11, 6, 11, 6</value>
+    <value>6, 3, 6, 3</value>
   </data>
   <data name="_showOutputWindowForVirtualEnvCreate.Size" type="System.Drawing.Size, System.Drawing">
-    <value>564, 29</value>
+    <value>315, 17</value>
   </data>
   <data name="_showOutputWindowForVirtualEnvCreate.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -163,13 +163,13 @@
     <value>True</value>
   </data>
   <data name="_showOutputWindowForPackageInstallation.Location" type="System.Drawing.Point, System.Drawing">
-    <value>11, 47</value>
+    <value>6, 26</value>
   </data>
   <data name="_showOutputWindowForPackageInstallation.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>11, 6, 11, 6</value>
+    <value>6, 3, 6, 3</value>
   </data>
   <data name="_showOutputWindowForPackageInstallation.Size" type="System.Drawing.Size, System.Drawing">
-    <value>589, 29</value>
+    <value>328, 17</value>
   </data>
   <data name="_showOutputWindowForPackageInstallation.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -196,13 +196,13 @@
     <value>NoControl</value>
   </data>
   <data name="_promptForEnvCreate.Location" type="System.Drawing.Point, System.Drawing">
-    <value>11, 88</value>
+    <value>6, 49</value>
   </data>
   <data name="_promptForEnvCreate.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>11, 6, 11, 6</value>
+    <value>6, 3, 6, 3</value>
   </data>
   <data name="_promptForEnvCreate.Size" type="System.Drawing.Size, System.Drawing">
-    <value>420, 29</value>
+    <value>236, 17</value>
   </data>
   <data name="_promptForEnvCreate.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -229,13 +229,13 @@
     <value>NoControl</value>
   </data>
   <data name="_promptForPackageInstallation.Location" type="System.Drawing.Point, System.Drawing">
-    <value>11, 129</value>
+    <value>6, 72</value>
   </data>
   <data name="_promptForPackageInstallation.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>11, 6, 11, 6</value>
+    <value>6, 3, 6, 3</value>
   </data>
   <data name="_promptForPackageInstallation.Size" type="System.Drawing.Size, System.Drawing">
-    <value>383, 29</value>
+    <value>216, 17</value>
   </data>
   <data name="_promptForPackageInstallation.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -259,13 +259,13 @@
     <value>True</value>
   </data>
   <data name="_promptForPytestEnableAndInstall.Location" type="System.Drawing.Point, System.Drawing">
-    <value>11, 170</value>
+    <value>6, 95</value>
   </data>
   <data name="_promptForPytestEnableAndInstall.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>11, 6, 11, 6</value>
+    <value>6, 3, 6, 3</value>
   </data>
   <data name="_promptForPytestEnableAndInstall.Size" type="System.Drawing.Size, System.Drawing">
-    <value>455, 29</value>
+    <value>256, 17</value>
   </data>
   <data name="_promptForPytestEnableAndInstall.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -289,13 +289,13 @@
     <value>True</value>
   </data>
   <data name="_elevatePip.Location" type="System.Drawing.Point, System.Drawing">
-    <value>11, 211</value>
+    <value>6, 118</value>
   </data>
   <data name="_elevatePip.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>11, 6, 11, 6</value>
+    <value>6, 3, 6, 3</value>
   </data>
   <data name="_elevatePip.Size" type="System.Drawing.Size, System.Drawing">
-    <value>451, 29</value>
+    <value>248, 17</value>
   </data>
   <data name="_elevatePip.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -322,13 +322,13 @@
     <value>True</value>
   </data>
   <data name="_clearGlobalPythonPath.Location" type="System.Drawing.Point, System.Drawing">
-    <value>11, 252</value>
+    <value>6, 141</value>
   </data>
   <data name="_clearGlobalPythonPath.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>11, 6, 11, 6</value>
+    <value>6, 3, 6, 3</value>
   </data>
   <data name="_clearGlobalPythonPath.Size" type="System.Drawing.Size, System.Drawing">
-    <value>432, 29</value>
+    <value>238, 17</value>
   </data>
   <data name="_clearGlobalPythonPath.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
@@ -361,13 +361,10 @@
     <value>NoControl</value>
   </data>
   <data name="_resetSuppressDialog.Location" type="System.Drawing.Point, System.Drawing">
-    <value>180, 293</value>
-  </data>
-  <data name="_resetSuppressDialog.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 6, 6, 6</value>
+    <value>96, 164</value>
   </data>
   <data name="_resetSuppressDialog.Size" type="System.Drawing.Size, System.Drawing">
-    <value>339, 35</value>
+    <value>189, 23</value>
   </data>
   <data name="_resetSuppressDialog.TabIndex" type="System.Int32, mscorlib">
     <value>12</value>
@@ -394,13 +391,13 @@
     <value>0, 0</value>
   </data>
   <data name="tableLayoutPanel3.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 7, 6, 7</value>
+    <value>3, 4, 3, 4</value>
   </data>
   <data name="tableLayoutPanel3.RowCount" type="System.Int32, mscorlib">
     <value>14</value>
   </data>
   <data name="tableLayoutPanel3.Size" type="System.Drawing.Size, System.Drawing">
-    <value>699, 602</value>
+    <value>381, 326</value>
   </data>
   <data name="tableLayoutPanel3.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -418,19 +415,19 @@
     <value>0</value>
   </data>
   <data name="tableLayoutPanel3.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="_showOutputWindowForVirtualEnvCreate" Row="0" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="_showOutputWindowForPackageInstallation" Row="1" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="_promptForEnvCreate" Row="2" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="_promptForPackageInstallation" Row="3" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="_promptForPytestEnableAndInstall" Row="4" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="_elevatePip" Row="5" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="_clearGlobalPythonPath" Row="6" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="_resetSuppressDialog" Row="11" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,Absolute,59,Absolute,15,Absolute,37" /&gt;&lt;/TableLayoutSettings&gt;</value>
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="_showOutputWindowForVirtualEnvCreate" Row="0" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="_showOutputWindowForPackageInstallation" Row="1" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="_promptForEnvCreate" Row="2" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="_promptForPackageInstallation" Row="3" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="_promptForPytestEnableAndInstall" Row="4" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="_elevatePip" Row="5" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="_clearGlobalPythonPath" Row="6" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="_resetSuppressDialog" Row="11" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,Absolute,32,Absolute,8,Absolute,20" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
-    <value>11, 24</value>
+    <value>6, 13</value>
   </data>
   <data name="$this.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>11, 15, 11, 15</value>
+    <value>6, 8, 6, 8</value>
   </data>
   <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
-    <value>699, 602</value>
+    <value>381, 326</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>PythonGeneralOptionsControl</value>


### PR DESCRIPTION
Fixes: #6667

Old dialog looked like this:

![image](https://user-images.githubusercontent.com/19672699/129252530-356ab018-4b1e-4eef-8519-75c68f0a8dd5.png)

New dialog looks like this:

![image](https://user-images.githubusercontent.com/19672699/129252847-a9cd50e1-016a-413d-890b-38ec60b6e09e.png)
