### PR TITLE
REPL window is hanging because of waiting for language server to start

### DIFF
--- a/Python/Product/PythonTools/PythonTools/LanguageServerClient/PythonLanguageClient.cs
+++ b/Python/Product/PythonTools/PythonTools/LanguageServerClient/PythonLanguageClient.cs
@@ -55,6 +55,7 @@ namespace Microsoft.PythonTools.LanguageServerClient {
     /// </remarks>
     [Export(typeof(ILanguageClient))]
     [ContentType(PythonCoreConstants.ContentType)]
+    [PartCreationPolicy(CreationPolicy.Shared)]
     internal sealed class PythonLanguageClient : ILanguageClient, ILanguageClientCustomMessage2, IDisposable {
         [Import(typeof(SVsServiceProvider))]
         public IServiceProvider Site;

--- a/Python/Product/PythonTools/PythonTools/LanguageServerClient/PythonLanguageClient.cs
+++ b/Python/Product/PythonTools/PythonTools/LanguageServerClient/PythonLanguageClient.cs
@@ -97,6 +97,7 @@ namespace Microsoft.PythonTools.LanguageServerClient {
         private FileWatcher.Listener _fileListener;
         private static TaskCompletionSource<int> _readyTcs = new System.Threading.Tasks.TaskCompletionSource<int>();
         private bool _modifiedInitialize = false;
+        private bool _loaded = false;
 
         public PythonLanguageClient() {
             _disposables = new DisposableBag(GetType().Name);
@@ -115,6 +116,7 @@ namespace Microsoft.PythonTools.LanguageServerClient {
         public object MiddleLayer => null;
         public object CustomMessageTarget { get; private set; }
         public bool IsInitialized { get; private set; }
+        public bool Loaded => this._loaded;
 
         public bool ShowNotificationOnInitializeFailed => true;
 
@@ -129,9 +131,8 @@ namespace Microsoft.PythonTools.LanguageServerClient {
                 return null;
             }
             await JoinableTaskContext.Factory.SwitchToMainThreadAsync();
-            Site.GetPythonToolsService().LanguageClient = this;
-
             CreateClientContexts();
+
 
             _analysisOptions = Site.GetPythonToolsService().AnalysisOptions;
             _advancedEditorOptions = Site.GetPythonToolsService().AdvancedEditorOptions;
@@ -166,6 +167,9 @@ namespace Microsoft.PythonTools.LanguageServerClient {
             // Force the package to load, since this is a MEF component,
             // there is no guarantee it has been loaded.
             Site.GetPythonToolsService();
+
+            // Indicate to python tools service we've loaded.
+            _loaded = true;
 
             // Client context cannot be created here since the is no workspace yet
             // and hence we don't know if this is workspace or a loose files case.

--- a/Python/Product/PythonTools/PythonTools/Navigation/Navigable/NavigableSymbolSource.cs
+++ b/Python/Product/PythonTools/PythonTools/Navigation/Navigable/NavigableSymbolSource.cs
@@ -87,8 +87,8 @@ namespace Microsoft.PythonTools.Navigation.Navigable {
         internal async Task<NavigableSymbol[]> GetDefinitionLocationsAsync(SnapshotSpan span, CancellationToken cancellationToken) {
 
             var service = _serviceProvider.GetService(typeof(PythonToolsService)) as PythonToolsService;
-            if (service != null && service.LanguageClient != null) {
-                var result = await service.LanguageClient.InvokeTextDocumentDefinitionAsync(
+            if (service != null && service.GetLanguageClient() != null) {
+                var result = await service.GetLanguageClient().InvokeTextDocumentDefinitionAsync(
                     new LSP.TextDocumentPositionParams {
                         TextDocument = new LSP.TextDocumentIdentifier {
                             Uri = new System.Uri(_buffer.GetFilePath())

--- a/Python/Product/PythonTools/PythonTools/Repl/Completion/AsyncCompletionSourceProvider.cs
+++ b/Python/Product/PythonTools/PythonTools/Repl/Completion/AsyncCompletionSourceProvider.cs
@@ -50,7 +50,7 @@ namespace Microsoft.PythonTools.Repl.Completion {
             if (matches.Count > 0) {
                 // Then make sure we have a language client to use.
                 var service = ServiceProvider.GetService(typeof(PythonToolsService)) as PythonToolsService;
-                var languageClient = service?.LanguageClient;
+                var languageClient = service?.GetLanguageClient();
                 if (languageClient != null && !this.sourceMap.TryGetValue(textView, out source)) {
                     source = new AsyncCompletionSource(
                         textView,

--- a/Python/Product/PythonTools/PythonTools/Repl/InteractiveWindowProvider.cs
+++ b/Python/Product/PythonTools/PythonTools/Repl/InteractiveWindowProvider.cs
@@ -304,8 +304,7 @@ namespace Microsoft.PythonTools.Repl {
                 selectEval.ProvideInteractiveWindowEvents(InteractiveWindowEvents.GetOrCreate(replWindow));
             }
 
-            // Start initializaing the window but we can't wait as some of the work requires
-            // the main thread.
+            // Start repl but don't wait. It will block on the main thread
             replWindow.InteractiveWindow.InitializeAsync().DoNotWait();
 
             return replWindow;

--- a/Python/Product/PythonTools/PythonTools/Repl/InteractiveWindowProvider.cs
+++ b/Python/Product/PythonTools/PythonTools/Repl/InteractiveWindowProvider.cs
@@ -304,7 +304,9 @@ namespace Microsoft.PythonTools.Repl {
                 selectEval.ProvideInteractiveWindowEvents(InteractiveWindowEvents.GetOrCreate(replWindow));
             }
 
-            _serviceProvider.GetUIThread().InvokeTaskSync(() => replWindow.InteractiveWindow.InitializeAsync(), CancellationToken.None);
+            // Start initializaing the window but we can't wait as some of the work requires
+            // the main thread.
+            replWindow.InteractiveWindow.InitializeAsync().DoNotWait();
 
             return replWindow;
         }

--- a/Python/Product/PythonTools/PythonTools/Repl/PythonCommonInteractiveEvaluator.cs
+++ b/Python/Product/PythonTools/PythonTools/Repl/PythonCommonInteractiveEvaluator.cs
@@ -151,8 +151,7 @@ namespace Microsoft.PythonTools.Repl {
 
             // Activation will now be automatic, but we'll still need to maintain a ReplDocument
             if (evaluator != null) {
-                await PythonLanguageClient.ReadyTask;
-                var client = _serviceProvider.GetPythonToolsService().LanguageClient;
+                var client = _serviceProvider.GetPythonToolsService().GetLanguageClient();
                 if (client != null) {
                     client.AddClientContext(new PythonLanguageClientContextRepl(evaluator));
                     Document = new ReplDocument(_serviceProvider, _window, client);


### PR DESCRIPTION
Fixes: #6668 

Basically don't wait on the repl when opening the window.

Also made sure to actually load the language server even when a python file isn't open (the reason I wasn't able to repro this was I had a python file already open in my solution). Prior to this change, the language server would only load for straight .py files and not if you opened the interactive window by itself.