### PR TITLE
Respond to different screen widths and scaling for AddEnvironment dialog

### DIFF
--- a/Python/Product/PythonTools/PythonTools.csproj
+++ b/Python/Product/PythonTools/PythonTools.csproj
@@ -249,6 +249,7 @@
     <Compile Include="PythonTools\Editor\Formatting\PythonFormatter.cs" />
     <Compile Include="PythonTools\Editor\Formatting\LspDiffTextEditFactory.cs" />
     <Compile Include="PythonTools\Environments\LandscapePortraitConverter.cs" />
+    <Compile Include="PythonTools\Environments\ScreenAdjustingConverter.cs" />
     <Compile Include="PythonTools\LanguageServerClient\CustomCancellationStrategy.cs" />
     <Compile Include="PythonTools\LanguageServerClient\FileWatcher\DidChangeWatchedFilesRegistrationOptions.cs" />
     <Compile Include="PythonTools\LanguageServerClient\FileWatcher\FileSystemWatcher.cs" />

--- a/Python/Product/PythonTools/PythonTools/Environments/AddCondaEnvironmentControl.xaml
+++ b/Python/Product/PythonTools/PythonTools/Environments/AddCondaEnvironmentControl.xaml
@@ -149,6 +149,7 @@
                         </Setter>
                     </Style>
                     <l:LandscapePortraitConverter x:Key="LandscapePortraitConverter" />
+                    <l:ScreenAdjustingConverter x:Key="ScreenAdjustingConverter" />
 
                 </ResourceDictionary>
             </ResourceDictionary.MergedDictionaries>
@@ -162,13 +163,13 @@
                 Text="{x:Static common:Strings.CondaNotFoundError}"
                 TextWrapping="Wrap"/>
         </Grid>
-        <ItemsControl 
+        <ScrollViewer VerticalScrollBarVisibility="Auto">
+
+            <ItemsControl 
             Style="{Binding 
                 RelativeSource={RelativeSource AncestorType=UserControl},
                 Converter={StaticResource LandscapePortraitConverter}, 
                 ConverterParameter=MainGridLandscape|MainGridPortrait}">
-            <ScrollViewer
-                VerticalScrollBarVisibility="Auto">
 
                 <StackPanel>
                     <Label
@@ -181,7 +182,10 @@
                         x:Name="ProjectComboBox"
                         Margin="0 0 0 17"
                         MinHeight="29"
-                        Width="249"
+                        Width="{Binding 
+                            RelativeSource={RelativeSource Mode=Self},
+                            Converter={StaticResource ScreenAdjustingConverter}, 
+                            ConverterParameter=249}"
                         HorizontalAlignment="Left"
                         ItemsSource="{Binding Path=Projects}"
                         SelectedItem="{Binding Path=SelectedProject}"
@@ -200,7 +204,10 @@
                         x:Name="EnvNameTextBox"
                         Margin="0 0 0 17"
                         MinHeight="29"
-                        Width="249"
+                        Width="{Binding 
+                            RelativeSource={RelativeSource Mode=Self},
+                            Converter={StaticResource ScreenAdjustingConverter}, 
+                            ConverterParameter=249}"
                         HorizontalAlignment="Left"
                         Text="{Binding Path=EnvName,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged,ValidatesOnNotifyDataErrors=False}"
                         AutomationProperties.AutomationId="EnvName"
@@ -291,86 +298,86 @@
                         AutomationProperties.AutomationId="ViewInEnvironmentWindow"
                         AutomationProperties.Name="{x:Static common:Strings.AddEnvironmentViewInEnvWindowLabel}"/>
                 </StackPanel>
-            </ScrollViewer>
 
-            <!--Preview-->
-            <Grid Grid.Column="2" Grid.Row="1">
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="*"/>
-                </Grid.RowDefinitions>
+                <!--Preview-->
+                <Grid Grid.Column="2" Grid.Row="1">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="*"/>
+                    </Grid.RowDefinitions>
 
-                <Label
+                    <Label
                     Grid.Row="0"
                     Style="{StaticResource ModernLabel}">
-                    <Label.Content>
-                        <AccessText TextWrapping="Wrap" Text="{x:Static common:Strings.AddCondaEnvironmentPreviewLabel}"/>
-                    </Label.Content>
-                </Label>
+                        <Label.Content>
+                            <AccessText TextWrapping="Wrap" Text="{x:Static common:Strings.AddCondaEnvironmentPreviewLabel}"/>
+                        </Label.Content>
+                    </Label>
 
-                <!-- Progress bar, wrap in a grid to avoid accessibility issues when not visible -->
-                <Grid Grid.Row="1" Visibility="{Binding CondaPreview.Progress.IsProgressDisplayed, Converter={x:Static wpf:Converters.FalseIsCollapsed}}">
-                    <vsui:ProgressControl
+                    <!-- Progress bar, wrap in a grid to avoid accessibility issues when not visible -->
+                    <Grid Grid.Row="1" Visibility="{Binding CondaPreview.Progress.IsProgressDisplayed, Converter={x:Static wpf:Converters.FalseIsCollapsed}}">
+                        <vsui:ProgressControl
                         HorizontalAlignment="Center"
                         DataContext="{Binding CondaPreview.Progress}"/>
-                </Grid>
+                    </Grid>
 
-                <!-- Preview results -->
-                <ScrollViewer
+                    <!-- Preview results -->
+                    <ScrollViewer
                     Grid.Row="1"
                     AutomationProperties.AutomationId="PreviewResult"
                     VerticalScrollBarVisibility="Auto"
                     HorizontalScrollBarVisibility="Auto">
 
-                    <StackPanel>
-                        <TextBlock
+                        <StackPanel>
+                            <TextBlock
                             Name="NoPackagesMessage"
                             Text="{x:Static common:Strings.AddCondaEnvironmentPreviewNoPackages}"
                             Visibility="{Binding Path=CondaPreview.IsNoPackages, Converter={x:Static wpf:Converters.FalseIsCollapsed}}"/>
-                        <TextBlock
+                            <TextBlock
                             Name="EnvFileMissing"
                             Text="{x:Static common:Strings.AddCondaEnvironmentPreviewNoEnvFile}"
                             Visibility="{Binding Path=CondaPreview.IsNoEnvFile, Converter={x:Static wpf:Converters.FalseIsCollapsed}}"/>
-                        <TextBlock
+                            <TextBlock
                             Name="EnvFileMessage"
                             Text="{Binding Path=CondaPreview.EnvFileContents}"
                             Visibility="{Binding Path=CondaPreview.IsEnvFile, Converter={x:Static wpf:Converters.FalseIsCollapsed}}"/>
-                        <TextBlock
+                            <TextBlock
                             Name="ErrorMessage"
                             Text="{Binding Path=CondaPreview.ErrorMessage}"
                             Visibility="{Binding Path=CondaPreview.HasPreviewError, Converter={x:Static wpf:Converters.FalseIsCollapsed}}"/>
-                        <ItemsControl
+                            <ItemsControl
                             Name="PackagesList"
                             ItemsSource="{Binding Path=CondaPreview.Packages}"
                             Grid.IsSharedSizeScope="True"
                             Focusable="False"
                             Visibility="{Binding Path=CondaPreview.IsPackages, Converter={x:Static wpf:Converters.FalseIsCollapsed}}">
 
-                            <ItemsControl.ItemTemplate>
-                                <DataTemplate>
-                                    <Grid>
-                                        <Grid.ColumnDefinitions>
-                                            <ColumnDefinition SharedSizeGroup="A" Width="Auto"/>
-                                            <ColumnDefinition Width="8"/>
-                                            <ColumnDefinition SharedSizeGroup="B" Width="Auto"/>
-                                        </Grid.ColumnDefinitions>
-                                        <TextBlock
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate>
+                                        <Grid>
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition SharedSizeGroup="A" Width="Auto"/>
+                                                <ColumnDefinition Width="8"/>
+                                                <ColumnDefinition SharedSizeGroup="B" Width="Auto"/>
+                                            </Grid.ColumnDefinitions>
+                                            <TextBlock
                                             Grid.Column="0"
                                             Margin="0 0 0 7"
                                             HorizontalAlignment="Left"
                                             Text="{Binding Name}"/>
-                                        <TextBlock
+                                            <TextBlock
                                             Grid.Column="2"
                                             Margin="0 0 0 7"
                                             HorizontalAlignment="Left"
                                             Text="{Binding Version}"/>
-                                    </Grid>
-                                </DataTemplate>
-                            </ItemsControl.ItemTemplate>
-                        </ItemsControl>
-                    </StackPanel>
-                </ScrollViewer>
-            </Grid>
-        </ItemsControl>
+                                        </Grid>
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+                        </StackPanel>
+                    </ScrollViewer>
+                </Grid>
+            </ItemsControl>
+        </ScrollViewer>
     </Grid>
 </UserControl>

--- a/Python/Product/PythonTools/PythonTools/Environments/AddEnvironmentDialog.xaml.cs
+++ b/Python/Product/PythonTools/PythonTools/Environments/AddEnvironmentDialog.xaml.cs
@@ -29,6 +29,7 @@ using Microsoft.PythonTools.Project;
 using Microsoft.PythonTools.Wpf;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudioTools.Wpf;
+using Utilities = Microsoft.PythonTools.Wpf.Utilities;
 
 namespace Microsoft.PythonTools.Environments {
     internal partial class AddEnvironmentDialog : ModernDialog, IDisposable {
@@ -87,9 +88,11 @@ namespace Microsoft.PythonTools.Environments {
             }
 
             DataContext = new AddEnvironmentView(pages, selected);
-            IsLandscape = SystemParameters.PrimaryScreenWidth > SystemParameters.PrimaryScreenHeight;
-            WindowWidth = IsLandscape ? 1024 : 700;
-            WindowHeight = IsLandscape ? 700 : 1024;
+            IsLandscape = Utilities.IsLandscape;
+            var startWidth = Math.Min(SystemParameters.PrimaryScreenWidth, IsLandscape ? 1024 : 700);
+            var startHeight = Math.Min(SystemParameters.PrimaryScreenHeight, IsLandscape ? 700 : 1024);
+            WindowWidth = startWidth;
+            WindowHeight = startHeight;
             MinimumWindowWidth = WindowWidth;
             MinimumWindowHeight = WindowHeight;
             InitializeComponent();

--- a/Python/Product/PythonTools/PythonTools/Environments/AddVirtualEnvironmentControl.xaml
+++ b/Python/Product/PythonTools/PythonTools/Environments/AddVirtualEnvironmentControl.xaml
@@ -72,6 +72,7 @@
                         </Setter>
                     </Style>
                     <l:LandscapePortraitConverter x:Key="LandscapePortraitConverter" />
+                    <l:ScreenAdjustingConverter x:Key="ScreenAdjustingConverter" />
 
                 </ResourceDictionary>
             </ResourceDictionary.MergedDictionaries>
@@ -85,16 +86,14 @@
                 Text="{x:Static common:Strings.AddVirtualEnvironmentWindow_NoInterpreterHelp}"
                 TextWrapping="Wrap"/>
         </Grid>
-
-        <ItemsControl 
-            Style="{Binding 
+        <ScrollViewer VerticalScrollBarVisibility="Auto">
+            <ItemsControl 
+                Style="{Binding 
                 RelativeSource={RelativeSource AncestorType=UserControl},
                 Converter={StaticResource LandscapePortraitConverter}, 
                 ConverterParameter=MainGridLandscape|MainGridPortrait}">
 
-            <!--Main options-->
-            <ScrollViewer
-                VerticalScrollBarVisibility="Auto">
+                <!--Main options-->
 
                 <StackPanel Orientation="Vertical">
                     <!--Project-->
@@ -108,7 +107,10 @@
                         x:Name="ProjectComboBox"
                         Margin="0 0 0 17"
                         MinHeight="29"
-                        Width="249"
+                        Width="{Binding 
+                            RelativeSource={RelativeSource Mode=Self},
+                            Converter={StaticResource ScreenAdjustingConverter}, 
+                            ConverterParameter=249}"
                         HorizontalAlignment="Left"
                         ItemsSource="{Binding Path=Projects}"
                         SelectedItem="{Binding Path=SelectedProject}"
@@ -135,7 +137,10 @@
                                 x:Name="EnvNameTextBox"
                                 Margin="0 0 0 17"
                                 MinHeight="29"
-                                Width="249"
+                                Width="{Binding 
+                                    RelativeSource={RelativeSource Mode=Self},
+                                    Converter={StaticResource ScreenAdjustingConverter}, 
+                                    ConverterParameter=249}"
                                 HorizontalAlignment="Left"
                                 Text="{Binding Path=VirtualEnvName,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged,ValidatesOnNotifyDataErrors=False}"
                                 AutomationProperties.AutomationId="EnvName"
@@ -153,7 +158,10 @@
                                 Grid.Row="8"
                                 Margin="0 0 0 17"
                                 MinHeight="29"
-                                Width="249"
+                                Width="{Binding 
+                                    RelativeSource={RelativeSource Mode=Self},
+                                    Converter={StaticResource ScreenAdjustingConverter}, 
+                                    ConverterParameter=249}"
                                 HorizontalAlignment="Left"
                                 AutomationProperties.AutomationId="BaseInterpreter"
                                 AutomationProperties.IsRequiredForForm="True"
@@ -240,80 +248,80 @@
                         AutomationProperties.Name="{x:Static common:Strings.AddVirtualEnvironmentDescriptionName}"
                         AutomationProperties.AutomationId="Description"/>
                 </StackPanel>
-            </ScrollViewer>
 
-            <!--Preview-->
-            <Grid Grid.Column="2" Grid.Row="1">
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="*"/>
-                </Grid.RowDefinitions>
+                <!--Preview-->
+                <Grid Grid.Column="2" Grid.Row="1">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="*"/>
+                    </Grid.RowDefinitions>
 
-                <Label
+                    <Label
                     Grid.Row="0"
                     Style="{StaticResource ModernLabel}">
-                    <Label.Content>
-                        <AccessText TextWrapping="Wrap" Text="{x:Static common:Strings.AddVirtualEnvironmentPreviewLabel}"/>
-                    </Label.Content>
-                </Label>
+                        <Label.Content>
+                            <AccessText TextWrapping="Wrap" Text="{x:Static common:Strings.AddVirtualEnvironmentPreviewLabel}"/>
+                        </Label.Content>
+                    </Label>
 
-                <!-- Progress bar, wrap in a grid to avoid accessibility issues when not visible -->
-                <Grid Grid.Row="1" Visibility="{Binding Progress.IsProgressDisplayed, Converter={x:Static wpf:Converters.FalseIsCollapsed}}">
-                    <vsui:ProgressControl
+                    <!-- Progress bar, wrap in a grid to avoid accessibility issues when not visible -->
+                    <Grid Grid.Row="1" Visibility="{Binding Progress.IsProgressDisplayed, Converter={x:Static wpf:Converters.FalseIsCollapsed}}">
+                        <vsui:ProgressControl
                         HorizontalAlignment="Center"
                         DataContext="{Binding Progress}"/>
-                </Grid>
+                    </Grid>
 
-                <!-- Preview results -->
-                <StackPanel
+                    <!-- Preview results -->
+                    <StackPanel
                     Grid.Row="1"
                     Visibility="{Binding Path=Progress.IsProgressDisplayed, Converter={x:Static wpf:Converters.TrueIsCollapsed}}">
 
-                    <StackPanel.Resources>
-                        <Style TargetType="TextBlock" BasedOn="{StaticResource {x:Type TextBlock}}">
-                            <Setter Property="Margin" Value="0 0 0 7"/>
-                        </Style>
-                    </StackPanel.Resources>
+                        <StackPanel.Resources>
+                            <Style TargetType="TextBlock" BasedOn="{StaticResource {x:Type TextBlock}}">
+                                <Setter Property="Margin" Value="0 0 0 7"/>
+                            </Style>
+                        </StackPanel.Resources>
 
-                    <TextBlock
+                        <TextBlock
                         Text="{x:Static common:Strings.AddVirtualEnvironmentWindow_InstallPip}"
                         Visibility="{Binding Path=WillInstallPip, Converter={x:Static wpf:Converters.FalseIsCollapsed}}"/>
 
-                    <TextBlock
+                        <TextBlock
                         Text="{x:Static common:Strings.AddVirtualEnvironmentWindow_InstallVirtualEnv}"
                         Visibility="{Binding Path=WillInstallVirtualEnv, Converter={x:Static wpf:Converters.FalseIsCollapsed}}"/>
 
-                    <TextBlock Text="{x:Static common:Strings.AddVirtualEnvironmentWindow_CreateVirtualEnv}">
-                        <TextBlock.Visibility>
-                            <MultiBinding Converter="{x:Static wpf:Converters.AllIsNotCollapsed}">
-                                <Binding Path="UseVirtualEnv"/>
-                                <Binding Path="WillCreateVirtualEnv"/>
-                            </MultiBinding>
-                        </TextBlock.Visibility>
-                    </TextBlock>
+                        <TextBlock Text="{x:Static common:Strings.AddVirtualEnvironmentWindow_CreateVirtualEnv}">
+                            <TextBlock.Visibility>
+                                <MultiBinding Converter="{x:Static wpf:Converters.AllIsNotCollapsed}">
+                                    <Binding Path="UseVirtualEnv"/>
+                                    <Binding Path="WillCreateVirtualEnv"/>
+                                </MultiBinding>
+                            </TextBlock.Visibility>
+                        </TextBlock>
 
-                    <TextBlock Text="{x:Static common:Strings.AddVirtualEnvironmentWindow_CreateVEnv}">
-                        <TextBlock.Visibility>
-                            <MultiBinding Converter="{x:Static wpf:Converters.AllIsNotCollapsed}">
-                                <Binding Path="UseVEnv"/>
-                                <Binding Path="WillCreateVirtualEnv"/>
-                            </MultiBinding>
-                        </TextBlock.Visibility>
-                    </TextBlock>
+                        <TextBlock Text="{x:Static common:Strings.AddVirtualEnvironmentWindow_CreateVEnv}">
+                            <TextBlock.Visibility>
+                                <MultiBinding Converter="{x:Static wpf:Converters.AllIsNotCollapsed}">
+                                    <Binding Path="UseVEnv"/>
+                                    <Binding Path="WillCreateVirtualEnv"/>
+                                </MultiBinding>
+                            </TextBlock.Visibility>
+                        </TextBlock>
 
-                    <TextBlock
+                        <TextBlock
                         Text="{x:Static common:Strings.AddVirtualEnvironmentWindow_InstallPackages}"
                         Visibility="{Binding Path=WillInstallRequirementsTxt, Converter={x:Static wpf:Converters.FalseIsCollapsed}}"/>
 
-                    <TextBlock
+                        <TextBlock
                         Text="{x:Static common:Strings.AddVirtualEnvironmentWindow_RegisterGlobally}"
                         Visibility="{Binding Path=WillRegisterGlobally, Converter={x:Static wpf:Converters.FalseIsCollapsed}}"/>
 
-                    <TextBlock
+                        <TextBlock
                         Text="{x:Static common:Strings.AddVirtualEnvironmentWindow_CannotCreate}"
                         Visibility="{Binding CannotCreateVirtualEnv, Converter={x:Static wpf:Converters.FalseIsCollapsed}}"/>
-                </StackPanel>
-            </Grid>
-        </ItemsControl>
+                    </StackPanel>
+                </Grid>
+            </ItemsControl>
+        </ScrollViewer>
     </Grid>
 </UserControl>

--- a/Python/Product/PythonTools/PythonTools/Environments/LandscapePortraitConverter.cs
+++ b/Python/Product/PythonTools/PythonTools/Environments/LandscapePortraitConverter.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Data;
+using Microsoft.PythonTools.Wpf;
 
 namespace Microsoft.PythonTools.Environments {
     /// <summary>
@@ -20,7 +21,7 @@ namespace Microsoft.PythonTools.Environments {
             if (parameter != null && userControl != null) {
                 var styles = parameter.ToString().Split('|');
                 if (styles.Length == 2) {
-                    var style = SystemParameters.PrimaryScreenWidth > SystemParameters.PrimaryScreenHeight ? styles[0] : styles[1];
+                    var style = Utilities.IsLandscape ? styles[0] : styles[1];
                     return userControl.Resources[style];
                 }
             }

--- a/Python/Product/PythonTools/PythonTools/Environments/ScreenAdjustingConverter.cs
+++ b/Python/Product/PythonTools/PythonTools/Environments/ScreenAdjustingConverter.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using Microsoft.PythonTools.Wpf;
+
+namespace Microsoft.PythonTools.Environments {
+    /// <summary>
+    /// Converts parameters into styles based on landscape or portrait mode
+    /// </summary>
+    public sealed class ScreenAdjustingConverter : IValueConverter {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture) {
+            // parameter should be wanted width
+            var width = parameter != null ? System.Convert.ToDouble(parameter) : -1;
+
+            // Parameter should be the width we want
+            if (width > 0) {
+                // Ideally we'd use the actual width of the control, but at this
+                // point the control is not rendered. So instead scale based on screen width
+                // only care for situations where the width is less than 1200 (above 1200 we don't have a problem)
+                if (SystemParameters.PrimaryScreenWidth < 1200) {
+                    // How much less than 1200?
+                    var percentOfBigger = SystemParameters.PrimaryScreenWidth / 1200;
+                    return width * percentOfBigger;
+                }
+
+                return width;
+            }
+            return value;
+        }
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => throw new NotImplementedException();
+    }
+}

--- a/Python/Product/PythonTools/PythonTools/Wpf/Utilities.cs
+++ b/Python/Product/PythonTools/PythonTools/Wpf/Utilities.cs
@@ -38,6 +38,6 @@ namespace Microsoft.PythonTools.Wpf {
         /// <remarks>
         /// Picks portrait mode if screen is too small as well (with assumption scrolling will be used)
         /// </remarks>
-        public static bool IsLandscape => SystemParameters.PrimaryScreenWidth > SystemParameters.PrimaryScreenHeight && SystemParameters.PrimaryScreenWidth > 800;
+        public static bool IsLandscape => (SystemParameters.PrimaryScreenWidth > SystemParameters.PrimaryScreenHeight) && (SystemParameters.PrimaryScreenWidth > 900);
     }
 }

--- a/Python/Product/PythonTools/PythonTools/Wpf/Utilities.cs
+++ b/Python/Product/PythonTools/PythonTools/Wpf/Utilities.cs
@@ -14,6 +14,8 @@
 // See the Apache Version 2.0 License for specific language governing
 // permissions and limitations under the License.
 
+using System.Windows;
+
 namespace Microsoft.PythonTools.Wpf {
     internal static class Utilities {
         /// <summary>
@@ -29,5 +31,13 @@ namespace Microsoft.PythonTools.Wpf {
 
             return msg;
         }
+
+        /// <summary>
+        /// Determines if dialogs should display in landscape or portrait mode
+        /// </summary>
+        /// <remarks>
+        /// Picks portrait mode if screen is too small as well (with assumption scrolling will be used)
+        /// </remarks>
+        public static bool IsLandscape => SystemParameters.PrimaryScreenWidth > SystemParameters.PrimaryScreenHeight && SystemParameters.PrimaryScreenWidth > 800;
     }
 }


### PR DESCRIPTION
Second pass for:
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1355277?src=WorkItemMention&src-action=artifact_link

Here's what it looks like at 200% scaling and 1280x800

![image](https://user-images.githubusercontent.com/19672699/129975740-08503b17-1e90-4d99-865a-19014107820a.png)

1920x1080 and 200%
![image](https://user-images.githubusercontent.com/19672699/129975893-d598e112-e0a2-459a-8ec4-fd144dfdcbe3.png)
