### PR TITLE
disable the automatic showing of TaskStatusCenter until it supports n…

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Environments/AddCondaEnvironmentOperation.cs
+++ b/Python/Product/PythonTools/PythonTools/Environments/AddCondaEnvironmentOperation.cs
@@ -107,7 +107,8 @@ namespace Microsoft.PythonTools.Environments {
 
             var task = Task.Run(() => CreateCondaEnvironmentAsync(ui, taskHandler, taskHandler?.UserCancellation ?? CancellationToken.None));
             taskHandler.RegisterTask(task);
-            _site.ShowTaskStatusCenter();
+            // Disable showing the TaskStatusCenterCommand until it supports narrator
+            //_site.ShowTaskStatusCenter();
         }
 
         private async Task CreateCondaEnvironmentAsync(CondaUI ui, ITaskHandler taskHandler, CancellationToken ct) {

--- a/Python/Product/PythonTools/PythonTools/Environments/AddVirtualEnvironmentOperation.cs
+++ b/Python/Product/PythonTools/PythonTools/Environments/AddVirtualEnvironmentOperation.cs
@@ -101,7 +101,8 @@ namespace Microsoft.PythonTools.Environments {
 
             var task = CreateVirtualEnvironmentAsync(taskHandler);
             taskHandler?.RegisterTask(task);
-            _site.ShowTaskStatusCenter();
+            // Disable showing the TaskStatusCenterCommand until it supports narrator
+            // _site.ShowTaskStatusCenter();
         }
 
         private async Task CreateVirtualEnvironmentAsync(ITaskHandler taskHandler) {

--- a/Python/Product/PythonTools/PythonTools/Environments/InstallPackagesOperation.cs
+++ b/Python/Product/PythonTools/PythonTools/Environments/InstallPackagesOperation.cs
@@ -70,7 +70,8 @@ namespace Microsoft.PythonTools.Environments {
 
             var task = InstallPackagesAsync(taskHandler);
             taskHandler?.RegisterTask(task);
-            _site.ShowTaskStatusCenter();
+            // Disable showing the TaskStatusCenterCommand until it supports narrator
+            // _site.ShowTaskStatusCenter();
         }
 
         private async Task InstallPackagesAsync(ITaskHandler taskHandler) {


### PR DESCRIPTION
…arrator

currently there is a disconnect between what the user sees and narrator.

we still automatically show the output window and status there.


internal issue 1351252


users can still manually traverse the TaskStatusCenter and narrator will read the info