### PR TITLE
set the default typechecking mode to "Off". This is similar to what V…

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Options/PythonAnalysisOptions.cs
+++ b/Python/Product/PythonTools/PythonTools/Options/PythonAnalysisOptions.cs
@@ -64,7 +64,7 @@ namespace Microsoft.PythonTools.Options {
                 changed = true;
             }
 
-            var typeCheckingMode = _service.LoadString(nameof(TypeCheckingMode), Category) ?? PylanceTypeCheckingMode.Basic;
+            var typeCheckingMode = _service.LoadString(nameof(TypeCheckingMode), Category) ?? PylanceTypeCheckingMode.Off;
             if (TypeCheckingMode != typeCheckingMode) {
                 TypeCheckingMode = typeCheckingMode;
                 changed = true;


### PR DESCRIPTION
…SCode does, since most Python users haven't focused on type completness

Fixes #6699