### PR TITLE
fix for missing profiling tools take 2

### DIFF
--- a/Python/Product/Profiling/Profiling/ProfiledProcess.cs
+++ b/Python/Product/Profiling/Profiling/ProfiledProcess.cs
@@ -159,7 +159,7 @@ namespace Microsoft.PythonTools.Profiling {
                 }
 
                 using (var key = baseKey.OpenSubKey(@"Software\Microsoft\VisualStudio\VSPerf")) {
-                    // ie. CollectionToolsDirv2022
+                    // ie. CollectionToolsDir2022
                     var path = key?.GetValue("CollectionToolsDir" + AssemblyVersionInfo.VSName) as string;
 
                     if (!string.IsNullOrEmpty(path)) {


### PR DESCRIPTION
updating regex key for CollectionsToolsDir for vs2022
new regex key is CollectionToolsDir2022

fixes #6564