### PR TITLE
Fix #6712: The option "Python/Native Debugging" is missing.

### DIFF
--- a/Python/Product/VCDebugLauncher/16.0/source.extension.vsixmanifest
+++ b/Python/Product/VCDebugLauncher/16.0/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="PythonVCDebugLauncher.5AF7E179-1406-4804-9267-93F3BD7C7422" Version="16.0.1" Language="en-US" Publisher="Microsoft Corporation" />
+        <Identity Id="PythonVCDebugLauncher.5AF7E179-1406-4804-9267-93F3BD7C7422" Version="17.0.0" Language="en-US" Publisher="Microsoft Corporation" />
         <DisplayName>Python - C++ project debugging support</DisplayName>
         <Description xml:space="preserve">Adds a debug launcher for C++ projects that launches with Python debugging enabled.</Description>
         <MoreInfo>http://aka.ms/ptvs</MoreInfo>

--- a/Python/Product/VCDebugLauncher/17.0/source.extension.vsixmanifest
+++ b/Python/Product/VCDebugLauncher/17.0/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="PythonVCDebugLauncher.5AF7E179-1406-4804-9267-93F3BD7C7422" Version="16.0.1" Language="en-US" Publisher="Microsoft Corporation" />
+        <Identity Id="PythonVCDebugLauncher.5AF7E179-1406-4804-9267-93F3BD7C7422" Version="17.0.0" Language="en-US" Publisher="Microsoft Corporation" />
         <DisplayName>Python - C++ project debugging support</DisplayName>
         <Description xml:space="preserve">Adds a debug launcher for C++ projects that launches with Python debugging enabled.</Description>
         <MoreInfo>http://aka.ms/ptvs</MoreInfo>


### PR DESCRIPTION
Increment version numbers for VCDebugLauncher VSIX manifest.