### PR TITLE
try to fix publish symbols step

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -262,6 +262,9 @@ steps:
     symbolsFolder: '$(Build.ArtifactStagingDirectory)/symbols_and_binaries'
     searchPattern: '*.pdb'
     symbolServerType: TeamServices
+    ArtifactServices.Symbol.AccountName: microsoft
+    ArtifactServices.Symbol.PAT: $(System.AccessToken)
+    ArtifactServices.Symbol.UseAAD: false
 
 # Create bootstrapper for running integration tests. They only run on CI, not PR
 - task: MicroBuildBuildVSBootstrapper@2


### PR DESCRIPTION
Fix an error with publishing symbols. This was suggested over email from VSEng and it seems to be working fine. 

Manually verified by running a full build from the PR branch at https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=5455245&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9&t=8e355ed5-37f3-5c2a-bb8d-5efc727482d6