### PR TITLE
Override target framework version to 4.7.2, since the default (4.0) is not supported in VS2022.

### DIFF
--- a/Python/Product/BuildTasks/Microsoft.PythonTools.targets
+++ b/Python/Product/BuildTasks/Microsoft.PythonTools.targets
@@ -24,7 +24,7 @@ permissions and limitations under the License.
     <_PTVSSupportPath Condition="'$(_PTVSSupportPath)' == ''">$(MSBuildThisFileDirectory)</_PTVSSupportPath>
     <_PTVSSupportPath Condition="!HasTrailingSlash('$(_PTVSSupportPath)')">$(_PTVSSupportPath)\</_PTVSSupportPath>
     <_PTVSBuildTasks Condition="'$(_PTVSBuildTasks)' == ''">$([MSBuild]::Unescape($(_PythonToolsPath)Microsoft.PythonTools.BuildTasks.dll))</_PTVSBuildTasks>
-    <_PTVSBuildTasks Condition="!Exists($(_PTVSBuildTasks))">$([MSBuild]::Unescape($(_PTVSSupportPath)Microsoft.PythonTools.BuildTasks.Core.dll))</_PTVSBuildTasks>  
+    <_PTVSBuildTasks Condition="!Exists($(_PTVSBuildTasks))">$([MSBuild]::Unescape($(_PTVSSupportPath)Microsoft.PythonTools.BuildTasks.Core.dll))</_PTVSBuildTasks>
   </PropertyGroup>
 
   <!-- 

--- a/Python/Product/BuildTasks/Microsoft.PythonTools.targets
+++ b/Python/Product/BuildTasks/Microsoft.PythonTools.targets
@@ -24,7 +24,18 @@ permissions and limitations under the License.
     <_PTVSSupportPath Condition="'$(_PTVSSupportPath)' == ''">$(MSBuildThisFileDirectory)</_PTVSSupportPath>
     <_PTVSSupportPath Condition="!HasTrailingSlash('$(_PTVSSupportPath)')">$(_PTVSSupportPath)\</_PTVSSupportPath>
     <_PTVSBuildTasks Condition="'$(_PTVSBuildTasks)' == ''">$([MSBuild]::Unescape($(_PythonToolsPath)Microsoft.PythonTools.BuildTasks.dll))</_PTVSBuildTasks>
-    <_PTVSBuildTasks Condition="!Exists($(_PTVSBuildTasks))">$([MSBuild]::Unescape($(_PTVSSupportPath)Microsoft.PythonTools.BuildTasks.Core.dll))</_PTVSBuildTasks>
+    <_PTVSBuildTasks Condition="!Exists($(_PTVSBuildTasks))">$([MSBuild]::Unescape($(_PTVSSupportPath)Microsoft.PythonTools.BuildTasks.Core.dll))</_PTVSBuildTasks>  
+  </PropertyGroup>
+
+  <!-- 
+    The global default value for target framework version seems to be v4.0.
+    This is used in various places, but specifically used by the GetReferenceAssemblyPaths target in Microsoft.Common.CurrentVersion.Targets.
+    The default version works with VS 2019 and lower, but it is not supported by VS 2022 and higher. This is causing pyproj files to break in VS2022.
+    Therefore, we're overriding it to 4.7.2, which is supported.
+  -->
+  <PropertyGroup>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkMoniker>.NETFramework,Version=$(TargetFrameworkVersion)</TargetFrameworkMoniker>
   </PropertyGroup>
 
   <!-- Creates a command object that will be displayed in the IDE.


### PR DESCRIPTION
Fixes #6747

This targets file is imported by the pyproj template, so any pyproj files (new or existing) will get the fix once the user updates Visual Studio and gets the latest Python Tools workload.
Tested though both msbuild and visual studio, and the error is now gone.