### PR TITLE
Move to azure artifacts feed

### DIFF
--- a/Build/nuget.config
+++ b/Build/nuget.config
@@ -1,11 +1,7 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="PLS" value="https://pvsc.blob.core.windows.net/vs-python-ls/index.json" protocolVersion="3" />
-    <add key="vs-impl" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-impl/nuget/v3/index.json" />    
-    <add key="vssdk" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vssdk/nuget/v3/index.json" />   
-    <add key="dnc" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" /> 
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />  
+    <add key="PTVS_Packages" value="https://devdiv.pkgs.visualstudio.com/DevDiv/_packaging/PTVS_Packages/nuget/v3/index.json" />
   </packageSources>
   <trustedSigners>
     <repository name="nuget" serviceIndex="https://api.nuget.org/v3/index.json">

--- a/Build/templates/restore_packages.yml
+++ b/Build/templates/restore_packages.yml
@@ -1,0 +1,21 @@
+parameters:
+- name: pylanceVersion
+  displayName: Pylance Version
+  type: string
+  default: latest
+- name: debugpyVersion
+  displayName: Debugpy Version
+  type: string
+  default: latest
+
+steps:
+
+  # nuget authenticate so we can restore from azure artifacts
+  - task: NuGetAuthenticate@0
+
+  # Restore packages and install dependencies (pylance, debugpy)
+  - task: PowerShell@1
+    displayName: 'Restore packages'
+    inputs:
+      scriptName: Build/PreBuild.ps1
+      arguments: '-vstarget $(VSTarget) -pylanceVersion ${{ parameters.pylanceVersion }} -debugpyVersion ${{ parameters.debugpyVersion }}'

--- a/azure-pipelines-policy.yml
+++ b/azure-pipelines-policy.yml
@@ -59,11 +59,10 @@ steps:
 - template: Build/templates/configure_pylance.yml
 
 # Restore packages and install dependencies (pylance, debugpy)
-- task: PowerShell@1
-  displayName: 'Restore packages'
-  inputs:
-    scriptName: Build/PreBuild.ps1
-    arguments: '-vstarget $(VSTarget) -pylanceVersion ${{ parameters.pylanceVersion }} -debugpyVersion ${{ parameters.debugpyVersion }}'
+- template: Build/templates/restore_packages.yml
+  parameters:
+    pylanceVersion: ${{ parameters.pylanceVersion }}
+    debugpyVersion: ${{ parameters.debugpyVersion }}
 
 # Clean the Guardian temp files
 - powershell: Get-ChildItem -Path $env:TEMP -Filter 'MpCmdRun.*' -Recurse -ErrorAction SilentlyContinue | Remove-Item -Recurse -Force

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -89,11 +89,10 @@ steps:
 - template: Build/templates/configure_pylance.yml
 
 # Restore packages and install dependencies (pylance, debugpy)
-- task: PowerShell@1
-  displayName: 'Restore packages'
-  inputs:
-    scriptName: Build/PreBuild.ps1
-    arguments: '-vstarget $(VSTarget) -pylanceVersion ${{ parameters.pylanceVersion }} -debugpyVersion ${{ parameters.debugpyVersion }}'
+- template: Build/templates/restore_packages.yml
+  parameters:
+    pylanceVersion: ${{ parameters.pylanceVersion }}
+    debugpyVersion: ${{ parameters.debugpyVersion }}
 
 # Build and publish logs
 - template: Build/templates/build.yml


### PR DESCRIPTION
Fixes #6866 

This change moves from the nuget multi-feed approach to the single azure artifacts feed, which is safer (and now required).

Build has been tested at https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=5710837&view=results and the restore packages step worked, which is what needed to work.
The build also runs the `Nuget Security Analysis (auto-injected by policy)` step, and shows no errors.