### PR TITLE
Fixing Issue #6636

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Project/PythonProjectNode.cs
+++ b/Python/Product/PythonTools/PythonTools/Project/PythonProjectNode.cs
@@ -278,6 +278,7 @@ namespace Microsoft.PythonTools.Project {
                 if (_active != oldActive || oldActive == null) {
                     ActiveInterpreterChanged?.Invoke(this, EventArgs.Empty);
                 }
+                BoldActiveEnvironment();
             }
         }
 


### PR DESCRIPTION
This commit adds BoldActiveEnvironment() to the end of ActiveInterpreter setter to bold the active environment properly.

I did a few tests to verify the change:

1. Switch from one environment to another:
![Animation](https://user-images.githubusercontent.com/100439259/157530839-a7f67d9a-4435-48b1-8f91-ffd960562f22.gif)


2. The global default interpreter will be activated after deleting all environments.
![Animation2](https://user-images.githubusercontent.com/100439259/157531043-aebd1208-ddd6-4db0-a0f9-7fcefbb5876d.gif)

3. Add a new environment to the list and activate it.
![Animation3](https://user-images.githubusercontent.com/100439259/157534336-e99954fa-24d6-4631-a59d-a9ad2990ee61.gif)

4. Delete all the envs so only the global default remains. Then add a new one. 
![Animation4](https://user-images.githubusercontent.com/100439259/157542882-b74e6e31-abb3-4324-9f8e-f19e2d82b2fb.gif)

