### PR TITLE
Fixes the internal issue where after invoking add environment dialogue box, focus is directly on second element.

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Environments/AddEnvironmentDialog.xaml.cs
+++ b/Python/Product/PythonTools/PythonTools/Environments/AddEnvironmentDialog.xaml.cs
@@ -361,9 +361,8 @@ namespace Microsoft.PythonTools.Environments {
             }
 
             _isStartupFocusSet = true;
-            var textBox = ((AddCondaEnvironmentControl)sender).EnvNameTextBox;
-            textBox.SelectAll();
-            textBox.Focus();
+            var comboBox = ((AddCondaEnvironmentControl)sender).ProjectComboBox;
+            comboBox.Focus();
         }
 
         private void AddVirtualEnvironmentControl_Loaded(object sender, RoutedEventArgs e) {
@@ -372,9 +371,8 @@ namespace Microsoft.PythonTools.Environments {
             }
 
             _isStartupFocusSet = true;
-            var textBox = ((AddVirtualEnvironmentControl)sender).EnvNameTextBox;
-            textBox.SelectAll();
-            textBox.Focus();
+            var comboBox = ((AddVirtualEnvironmentControl)sender).ProjectComboBox;
+            comboBox.Focus();
         }
 
         private void AddExistingEnvironmentControl_Loaded(object sender, RoutedEventArgs e) {


### PR DESCRIPTION
This pull request fixes internal issue #1486766 and #1486787 where after invoking the add environment dialogue box, the focus is on the second element of that page.

The focus is now on the first element after opening the environment dialogue box.
![Animation1](https://user-images.githubusercontent.com/100439259/158279621-56210d23-2f20-4c3e-ae98-56b23169f8dd.gif)

