### PR TITLE
fixes internal issue #1486790

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Environments/AddCondaEnvironmentControl.xaml
+++ b/Python/Product/PythonTools/PythonTools/Environments/AddCondaEnvironmentControl.xaml
@@ -327,6 +327,8 @@
 
                         <!-- Preview results -->
                         <ScrollViewer
+                        x:Name="CondaEnvironmentPreview"
+                        AutomationProperties.Name ="CondaEnvironmentPreview"
                         Grid.Row="1"
                         AutomationProperties.AutomationId="PreviewResult"
                         VerticalScrollBarVisibility="Auto"


### PR DESCRIPTION
This PR fixes internal issue #1486790 where no name property is provided for Packages preview pane.

Previous in Accessibility Insights:
![image](https://user-images.githubusercontent.com/100439259/158490493-bb3bc176-7951-4d50-8fef-da00a5aa3461.png)

Now:
![Capture](https://user-images.githubusercontent.com/100439259/158490514-bb08a24e-c1aa-4e2d-84b7-3eb716a27b74.PNG)

