### PR TITLE
Fix VS crash when creating virtual environment

### DIFF
--- a/Python/Product/PythonTools/PythonTools/LanguageServerClient/FileWatcher/Listener.cs
+++ b/Python/Product/PythonTools/PythonTools/LanguageServerClient/FileWatcher/Listener.cs
@@ -108,56 +108,69 @@ namespace Microsoft.PythonTools.LanguageServerClient.FileWatcher {
             await OnFileChanged(sender, e);
         }
         private async Task OnFileChanged(object sender, System.IO.FileSystemEventArgs e) {
-            // Skip directory change events and when rpc has ben disconnected
-            if (!e.IsDirectoryChanged() && _rpc != null) {
-                // Create something to match with
-                var item = new InMemoryDirectoryInfo(_root, new string[] { e.FullPath });
 
-                // See if this matches one of our patterns.
-                if (_matcher.Execute(item).HasMatches) {
-                    // Send out the event to the language server
-                    var renamedArgs = e as System.IO.RenamedEventArgs;
-                    var didChangeParams = new DidChangeWatchedFilesParams();
+            // Skip directory change events
+            if (e.IsDirectoryChanged()) {
+                return;
+            }
 
-                    // Visual Studio actually does a rename when saving. The rename is from a file ending with '~'
-                    if (renamedArgs == null || renamedArgs.OldFullPath.EndsWith("~")) {
-                        renamedArgs = null;
-                        didChangeParams.Changes = new FileEvent[] { new FileEvent() };
-                        didChangeParams.Changes[0].Uri = new Uri(e.FullPath);
+            // If the rpc has been disconnected, the _rpc_Disconnected callback will set _rpc to null.
+            // So check for null now, and also check before every rpc call to avoid a null reference exception
+            if (_rpc is null) {
+                return;
+            }
 
-                        switch (e.ChangeType) {
-                            case WatcherChangeTypes.Created:
-                                didChangeParams.Changes[0].FileChangeType = FileChangeType.Created;
-                                break;
-                            case WatcherChangeTypes.Deleted:
-                                didChangeParams.Changes[0].FileChangeType = FileChangeType.Deleted;
-                                break;
-                            case WatcherChangeTypes.Changed:
-                                didChangeParams.Changes[0].FileChangeType = FileChangeType.Changed;
-                                break;
-                            case WatcherChangeTypes.Renamed:
-                                didChangeParams.Changes[0].FileChangeType = FileChangeType.Changed;
-                                break;
+            // Create something to match with
+            var item = new InMemoryDirectoryInfo(_root, new string[] { e.FullPath });
 
-                            default:
-                                didChangeParams.Changes = Array.Empty<FileEvent>();
-                                break;
-                        }
-                    } else {
-                        // file renamed
-                        var deleteEvent = new FileEvent();
-                        deleteEvent.FileChangeType = FileChangeType.Deleted;
-                        deleteEvent.Uri = new Uri(renamedArgs.OldFullPath);
+            // See if this matches one of our patterns.
+            if (_matcher.Execute(item).HasMatches) {
+                // Send out the event to the language server
+                var renamedArgs = e as System.IO.RenamedEventArgs;
+                var didChangeParams = new DidChangeWatchedFilesParams();
 
-                        var createEvent = new FileEvent();
-                        createEvent.FileChangeType = FileChangeType.Created;
-                        createEvent.Uri = new Uri(renamedArgs.FullPath);
+                // Visual Studio actually does a rename when saving. The rename is from a file ending with '~'
+                if (renamedArgs == null || renamedArgs.OldFullPath.EndsWith("~")) {
+                    renamedArgs = null;
+                    didChangeParams.Changes = new FileEvent[] { new FileEvent() };
+                    didChangeParams.Changes[0].Uri = new Uri(e.FullPath);
 
-                        didChangeParams.Changes = new FileEvent[] { deleteEvent, createEvent };
+                    switch (e.ChangeType) {
+                        case WatcherChangeTypes.Created:
+                            didChangeParams.Changes[0].FileChangeType = FileChangeType.Created;
+                            break;
+                        case WatcherChangeTypes.Deleted:
+                            didChangeParams.Changes[0].FileChangeType = FileChangeType.Deleted;
+                            break;
+                        case WatcherChangeTypes.Changed:
+                            didChangeParams.Changes[0].FileChangeType = FileChangeType.Changed;
+                            break;
+                        case WatcherChangeTypes.Renamed:
+                            didChangeParams.Changes[0].FileChangeType = FileChangeType.Changed;
+                            break;
+
+                        default:
+                            didChangeParams.Changes = Array.Empty<FileEvent>();
+                            break;
                     }
+                } else {
+                    // file renamed
+                    var deleteEvent = new FileEvent();
+                    deleteEvent.FileChangeType = FileChangeType.Deleted;
+                    deleteEvent.Uri = new Uri(renamedArgs.OldFullPath);
 
-                    if (didChangeParams.Changes.Any()) {
-                        await _rpc.NotifyWithParameterObjectAsync(Methods.WorkspaceDidChangeWatchedFiles.Name, didChangeParams);
+                    var createEvent = new FileEvent();
+                    createEvent.FileChangeType = FileChangeType.Created;
+                    createEvent.Uri = new Uri(renamedArgs.FullPath);
+
+                    didChangeParams.Changes = new FileEvent[] { deleteEvent, createEvent };
+                }
+
+                if (didChangeParams.Changes.Any()) {
+                    try {
+                        if (_rpc != null) {
+                            await _rpc.NotifyWithParameterObjectAsync(Methods.WorkspaceDidChangeWatchedFiles.Name, didChangeParams);
+                        }
                         if (renamedArgs != null) {
                             var textDocumentIdentifier = new TextDocumentIdentifier();
                             textDocumentIdentifier.Uri = new Uri(renamedArgs.OldFullPath);
@@ -165,15 +178,21 @@ namespace Microsoft.PythonTools.LanguageServerClient.FileWatcher {
                             var closeParam = new DidCloseTextDocumentParams();
                             closeParam.TextDocument = textDocumentIdentifier;
 
-                            await _rpc.NotifyWithParameterObjectAsync(Methods.TextDocumentDidClose.Name, closeParam);
-
+                            if (_rpc != null) {
+                                await _rpc.NotifyWithParameterObjectAsync(Methods.TextDocumentDidClose.Name, closeParam);
+                            }
                             var textDocumentItem = new TextDocumentItem();
                             textDocumentItem.Uri = new Uri(renamedArgs.FullPath);
 
                             var openParam = new DidOpenTextDocumentParams();
                             openParam.TextDocument = textDocumentItem;
-                            await _rpc.NotifyWithParameterObjectAsync(Methods.TextDocumentDidOpen.Name, openParam);
+                            if (_rpc != null) {
+                                await _rpc.NotifyWithParameterObjectAsync(Methods.TextDocumentDidOpen.Name, openParam);
+                            }
                         }
+                    } catch (ConnectionLostException) { 
+                        // If the rpc is disposed in the middle of an rpc call, a ConnectionLostException is thrown.
+                        // Catch this to avoid an unhandled exception.
                     }
                 }
             }


### PR DESCRIPTION
Fixes #6904 

This bug seems to be due to a race condition on the _rpc instance in the file listener. Since all calls using the rpc are async, the _rpc_Disconnected callback (which sets _rpc to null) can be triggered at any time during or between these calls.

The crash happens in two different ways, depending on the timing:

1. The _rpc is set to null in between rpc calls. This causes a NullReferenceException the next time the rpc is attempted to be used. 
     * The solution for this is to check for null before using it, every time. While this doesn't technically eliminate the race condition (since we're not using a mutex), the chance of an NRE is very small.
3. The _rpc is disposed during an rpc call. This causes the rpc call to throw a ConnectionLostException, which was unhandled. 
     * The solution for this is to catch all ConnectionLostExceptions and ignore them, since there's nothing to be done on a failure.

After adding these checks, the env creation completes with no additional errors. I also tried modifying an existing file (and saving), and adding a new file, to make sure the file listener was picking up those events, and it is.