### PR TITLE
Fix crashes due to rpc connection being lost

### DIFF
--- a/Python/Product/Common/Common.csproj
+++ b/Python/Product/Common/Common.csproj
@@ -55,10 +55,12 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Windows.Forms" />
+    <Reference Include="StreamJsonRpc" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Infrastructure\BindableBase.cs" />
     <Compile Include="Infrastructure\CancellationTokens.cs" />
+    <Compile Include="Infrastructure\JsonRpcWrapper.cs" />
     <Compile Include="Infrastructure\COMEnumerator.cs" />
     <Compile Include="Infrastructure\DefaultDisposable.cs" />
     <Compile Include="Infrastructure\Disposable.cs" />

--- a/Python/Product/Common/Infrastructure/JsonRpcWrapper.cs
+++ b/Python/Product/Common/Infrastructure/JsonRpcWrapper.cs
@@ -1,0 +1,60 @@
+﻿// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.PythonTools.Infrastructure;
+using StreamJsonRpc;
+
+namespace Microsoft.PythonTools.Common.Infrastructure {
+    internal class JsonRpcWrapper {
+
+        private readonly JsonRpc _rpc;
+
+        // list of exception types to ignore
+        private static readonly Type[] _exceptionsToIgnore = {
+            typeof(ObjectDisposedException),
+            typeof(ConnectionLostException)
+        };
+
+        public JsonRpcWrapper(JsonRpc rpc) {
+            _rpc = rpc;
+        }
+
+        public Task NotifyWithParameterObjectAsync(string targetName, object argument = null) {
+
+            if (_rpc is null) {
+                return Task.CompletedTask;
+            }
+
+            // if the underlying rpc connection was disposed, or the connection was lost, ignore the errors
+            return _rpc.NotifyWithParameterObjectAsync(targetName, argument)
+                .SilenceExceptions(_exceptionsToIgnore);
+        }
+
+        public Task<T> InvokeWithParameterObjectAsync<T>(string request, object parameters, CancellationToken t) {
+
+            if (_rpc is null) {
+                return null;
+            }
+
+            // if the underlying rpc connection was disposed, or the connection was lost, ignore the errors
+            return _rpc.InvokeWithParameterObjectAsync<T>(request, parameters, t)
+                .SilenceExceptions(_exceptionsToIgnore);
+        }
+    }
+}

--- a/Python/Product/Common/Infrastructure/TaskExtensions.cs
+++ b/Python/Product/Common/Infrastructure/TaskExtensions.cs
@@ -15,7 +15,10 @@
 // permissions and limitations under the License.
 
 using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -147,7 +150,34 @@ namespace Microsoft.PythonTools.Infrastructure {
                     return t.Result;
                 } catch (AggregateException ex) {
                     ex.Handle(e => e is T);
-                    return default(U);
+                    return default;
+                }
+            });
+        }
+
+        /// <summary>
+        /// Silently handles a collection of exception types
+        /// </summary>
+        public static Task SilenceExceptions(this Task task, IEnumerable<Type> exceptionTypes) {
+            return task.ContinueWith(t => {
+                try {
+                    t.Wait();
+                } catch (AggregateException ex) {
+                    ex.Handle(e => exceptionTypes.Any(f => e.GetType().Equals(f)));
+                }
+            });
+        }
+
+        /// <summary>
+        /// Silently handles a collection of exception types
+        /// </summary>
+        public static Task<U> SilenceExceptions<U>(this Task<U> task, IEnumerable<Type> exceptionTypes) {
+            return task.ContinueWith(t => {
+                try {
+                    return t.Result;
+                } catch (AggregateException ex) {
+                    ex.Handle(e => exceptionTypes.Any(f => e.GetType().Equals(f)));
+                    return default;
                 }
             });
         }

--- a/Python/Product/Common/Infrastructure/TaskExtensions.cs
+++ b/Python/Product/Common/Infrastructure/TaskExtensions.cs
@@ -94,7 +94,7 @@ namespace Microsoft.PythonTools.Infrastructure {
                 }
                 throw;
             }
-            return default(T);
+            return default;
         }
 
         /// <summary>
@@ -163,7 +163,7 @@ namespace Microsoft.PythonTools.Infrastructure {
                 try {
                     t.Wait();
                 } catch (AggregateException ex) {
-                    ex.Handle(e => exceptionTypes.Any(f => e.GetType().Equals(f)));
+                    ex.Handle(e => exceptionTypes.Any(f => f.IsAssignableFrom(e.GetType())));
                 }
             });
         }
@@ -171,12 +171,12 @@ namespace Microsoft.PythonTools.Infrastructure {
         /// <summary>
         /// Silently handles a collection of exception types
         /// </summary>
-        public static Task<U> SilenceExceptions<U>(this Task<U> task, IEnumerable<Type> exceptionTypes) {
+        public static Task<T> SilenceExceptions<T>(this Task<T> task, IEnumerable<Type> exceptionTypes) {
             return task.ContinueWith(t => {
                 try {
                     return t.Result;
                 } catch (AggregateException ex) {
-                    ex.Handle(e => exceptionTypes.Any(f => e.GetType().Equals(f)));
+                    ex.Handle(e => exceptionTypes.Any(f => f.IsAssignableFrom(e.GetType())));
                     return default;
                 }
             });

--- a/Python/Product/PythonTools/PythonTools/LanguageServerClient/PythonLanguageClient.cs
+++ b/Python/Product/PythonTools/PythonTools/LanguageServerClient/PythonLanguageClient.cs
@@ -329,7 +329,7 @@ namespace Microsoft.PythonTools.LanguageServerClient {
             => NotifyWithParametersAsync("textDocument/didChange", request);
 
         public Task InvokeDidChangeConfigurationAsync(LSP.DidChangeConfigurationParams request) {
-            if (_rpc == null || _rpc.IsDisposed) {
+            if (_rpc == null) {
                 return Task.CompletedTask;
             }
 
@@ -341,7 +341,7 @@ namespace Microsoft.PythonTools.LanguageServerClient {
         }
 
         public async Task InvokeDidChangeWorkspaceFoldersAsync(WorkspaceFolder[] added, WorkspaceFolder[] removed) {
-            if (_rpc == null || _rpc.IsDisposed) {
+            if (_rpc == null) {
                 await Task.CompletedTask;
             }
 
@@ -377,7 +377,7 @@ namespace Microsoft.PythonTools.LanguageServerClient {
 
         private async Task<R> InvokeWithParametersAsync<R>(string request, object parameters, CancellationToken t) where R : class {
             await _readyTcs.Task.ConfigureAwait(false);
-            if (_rpc == null || _rpc.IsDisposed) {
+            if (_rpc == null) {
                 return null;
             }
 
@@ -390,7 +390,7 @@ namespace Microsoft.PythonTools.LanguageServerClient {
 
         private async Task NotifyWithParametersAsync(string request, object parameters) {
             await _readyTcs.Task.ConfigureAwait(false);
-            if (_rpc == null || _rpc.IsDisposed) {
+            if (_rpc == null) {
                 return;
             }
 

--- a/Python/Product/PythonTools/PythonTools/LanguageServerClient/PythonLanguageClient.cs
+++ b/Python/Product/PythonTools/PythonTools/LanguageServerClient/PythonLanguageClient.cs
@@ -23,6 +23,7 @@ using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Python.Core.Disposables;
+using Microsoft.PythonTools.Common.Infrastructure;
 using Microsoft.PythonTools.Editor.Core;
 using Microsoft.PythonTools.Infrastructure;
 using Microsoft.PythonTools.Interpreter;
@@ -86,12 +87,13 @@ namespace Microsoft.PythonTools.LanguageServerClient {
         /// </summary>
         public static Task ReadyTask => _readyTcs.Task;
 
-        private readonly DisposableBag _disposables;
+        private readonly Microsoft.Python.Core.Disposables.DisposableBag _disposables;
         private List<IPythonLanguageClientContext> _clientContexts = new List<IPythonLanguageClientContext>();
         private PythonAnalysisOptions _analysisOptions;
         private PythonAdvancedEditorOptions _advancedEditorOptions;
         private LanguageServer _server;
         private JsonRpc _rpc;
+        private JsonRpcWrapper _rpcWrapper;
         private bool _workspaceFoldersSupported = false;
         private bool _isDebugging = LanguageServer.IsDebugging();
         private bool _sentInitialWorkspaceFolders = false;
@@ -101,7 +103,7 @@ namespace Microsoft.PythonTools.LanguageServerClient {
         private bool _loaded = false;
 
         public PythonLanguageClient() {
-            _disposables = new DisposableBag(GetType().Name);
+            _disposables = new Microsoft.Python.Core.Disposables.DisposableBag(GetType().Name);
         }
 
         public string ContentTypeName => PythonCoreConstants.ContentType;
@@ -311,6 +313,9 @@ namespace Microsoft.PythonTools.LanguageServerClient {
                 // Any exceptions, just skip this part
             }
 
+            // wrap the rpc so we can handle exceptions in a common place
+            _rpcWrapper = new JsonRpcWrapper(_rpc);
+
             return Task.CompletedTask;
         }
 
@@ -329,29 +334,20 @@ namespace Microsoft.PythonTools.LanguageServerClient {
             => NotifyWithParametersAsync("textDocument/didChange", request);
 
         public Task InvokeDidChangeConfigurationAsync(LSP.DidChangeConfigurationParams request) {
-            if (_rpc == null) {
-                return Task.CompletedTask;
-            }
 
-            try {
-                return _rpc.NotifyWithParameterObjectAsync("workspace/didChangeConfiguration", request);
-            } catch (ConnectionLostException) {
-                return Task.CompletedTask;
-            }
+            return _rpcWrapper.NotifyWithParameterObjectAsync("workspace/didChangeConfiguration", request);
         }
 
         public async Task InvokeDidChangeWorkspaceFoldersAsync(WorkspaceFolder[] added, WorkspaceFolder[] removed) {
-            if (_rpc == null) {
-                await Task.CompletedTask;
-            }
 
-            try {
-                await _rpc.NotifyWithParameterObjectAsync("workspace/didChangeWorkspaceFolders",
-                    new DidChangeWorkspaceFoldersParams { changeEvent = new WorkspaceFoldersChangeEvent { added = added, removed = removed } });
-            } catch (ConnectionLostException) {
-                await Task.CompletedTask;
-            }
-
+            await _rpcWrapper.NotifyWithParameterObjectAsync("workspace/didChangeWorkspaceFolders",
+                new DidChangeWorkspaceFoldersParams {
+                    changeEvent = new WorkspaceFoldersChangeEvent {
+                        added = added,
+                        removed = removed
+                    }
+                });
+                   
             // If we send workspace folder updates, we have to resend document opens
             await SendDocumentOpensAsync();
         }
@@ -377,27 +373,14 @@ namespace Microsoft.PythonTools.LanguageServerClient {
 
         private async Task<R> InvokeWithParametersAsync<R>(string request, object parameters, CancellationToken t) where R : class {
             await _readyTcs.Task.ConfigureAwait(false);
-            if (_rpc == null) {
-                return null;
-            }
 
-            try {
-                return await _rpc.InvokeWithParameterObjectAsync<R>(request, parameters, t).ConfigureAwait(false);
-            } catch (ConnectionLostException) {
-                return null;
-            }
+            return await _rpcWrapper.InvokeWithParameterObjectAsync<R>(request, parameters, t).ConfigureAwait(false);
         }
 
         private async Task NotifyWithParametersAsync(string request, object parameters) {
             await _readyTcs.Task.ConfigureAwait(false);
-            if (_rpc == null) {
-                return;
-            }
 
-            try {
-                await _rpc.NotifyWithParameterObjectAsync(request, parameters).ConfigureAwait(false);
-            } catch (ConnectionLostException) {
-            }
+            await _rpcWrapper.NotifyWithParameterObjectAsync(request, parameters).ConfigureAwait(false);
         }
 
         private void OnSettingsChanged(object sender, EventArgs e) => InvokeDidChangeConfigurationAsync(new LSP.DidChangeConfigurationParams() {


### PR DESCRIPTION
I fixed these previously in the Listener but I was able to consistently repro the same issues in the PythonLanguageClient, so these need to be caught there too.

I know there's a better way to generically handle this exception for all these different rpc calls, but that code ended up really messy so I opted to just duplicate the try catch since there's only a few of them. If anyone has any ideas on how to wrap each of the calls without it being super ugly, I'm all ears 😄 