### PR TITLE
Fix UnitTestRootDirectory setting not working in PythonSettings.json 

### DIFF
--- a/Python/Product/TestAdapter.Executor/Pytest/PytestTestDiscoverer.cs
+++ b/Python/Product/TestAdapter.Executor/Pytest/PytestTestDiscoverer.cs
@@ -149,6 +149,7 @@ namespace Microsoft.PythonTools.TestAdapter.Pytest {
             //Note pytest specific arguments go after this separator
             arguments.Add("--");
             arguments.Add("--cache-clear");
+            arguments.Add(String.Format("--rootdir={0}", projSettings.ProjectHome));
             if (string.IsNullOrEmpty(projSettings.UnitTestRootDir)) {
                 arguments.Add(String.Format("{0}", projSettings.ProjectHome));
             } else {

--- a/Python/Product/TestAdapter.Executor/Pytest/PytestTestDiscoverer.cs
+++ b/Python/Product/TestAdapter.Executor/Pytest/PytestTestDiscoverer.cs
@@ -149,7 +149,12 @@ namespace Microsoft.PythonTools.TestAdapter.Pytest {
             //Note pytest specific arguments go after this separator
             arguments.Add("--");
             arguments.Add("--cache-clear");
-            arguments.Add(String.Format("--rootdir={0}", projSettings.ProjectHome));
+            if (string.IsNullOrEmpty(projSettings.UnitTestRootDir)) {
+                arguments.Add(String.Format("{0}", projSettings.ProjectHome));
+            } else {
+                arguments.Add(String.Format("{0}\\{1}", projSettings.ProjectHome, projSettings.UnitTestRootDir));
+            }
+            
             return arguments.ToArray();
         }
 


### PR DESCRIPTION
This PR fixes issue #6836.

Changes made in this PR:
- Follow pytest usage: ```pytest [options] [file_or_dir] [file_or_dir] [...]``` to get rid of ```rootdir=``` when specifying the tests root directory.
- Specify the tests root directory in ```PytestTestDiscoverer``` if ```UnitTestRootDirectory``` is set in config file.

Tests:
- ran the test for RunPytestSubmoduleWithIniAndDiscovery
![image](https://user-images.githubusercontent.com/100439259/161161040-ce5d3843-8b62-441d-b479-1717e087370c.png)

- test pytest.ini in a sub-folder
![Animation2 - withIniFile](https://user-images.githubusercontent.com/100439259/161164056-bca9b2b4-42c4-4019-8d3c-96adef423779.gif)

- config file with no  ```UnitTestRootDirectory``` specified:
![Animation2 - noTestDir](https://user-images.githubusercontent.com/100439259/161145500-9ab9c667-a8ac-41ca-9109-08add7aed1df.gif)

- config file with different  ```UnitTestRootDirectory``` specified:
![Animation2 - withTestDir](https://user-images.githubusercontent.com/100439259/161145511-5ee2b3b6-849e-47e6-a263-5e3789c751a5.gif)
 