### PR TITLE
Undo changes I made for specifying pytest test directory.

### DIFF
--- a/Python/Product/TestAdapter.Executor/Pytest/PytestTestDiscoverer.cs
+++ b/Python/Product/TestAdapter.Executor/Pytest/PytestTestDiscoverer.cs
@@ -150,11 +150,6 @@ namespace Microsoft.PythonTools.TestAdapter.Pytest {
             arguments.Add("--");
             arguments.Add("--cache-clear");
             arguments.Add(String.Format("--rootdir={0}", projSettings.ProjectHome));
-            //if (string.IsNullOrEmpty(projSettings.UnitTestRootDir)) {
-            //    arguments.Add(String.Format("{0}", projSettings.ProjectHome));
-            //} else {
-            //    arguments.Add(String.Format("{0}\\{1}", projSettings.ProjectHome, projSettings.UnitTestRootDir));
-            //}
             
             return arguments.ToArray();
         }

--- a/Python/Product/TestAdapter.Executor/Pytest/PytestTestDiscoverer.cs
+++ b/Python/Product/TestAdapter.Executor/Pytest/PytestTestDiscoverer.cs
@@ -150,11 +150,11 @@ namespace Microsoft.PythonTools.TestAdapter.Pytest {
             arguments.Add("--");
             arguments.Add("--cache-clear");
             arguments.Add(String.Format("--rootdir={0}", projSettings.ProjectHome));
-            if (string.IsNullOrEmpty(projSettings.UnitTestRootDir)) {
-                arguments.Add(String.Format("{0}", projSettings.ProjectHome));
-            } else {
-                arguments.Add(String.Format("{0}\\{1}", projSettings.ProjectHome, projSettings.UnitTestRootDir));
-            }
+            //if (string.IsNullOrEmpty(projSettings.UnitTestRootDir)) {
+            //    arguments.Add(String.Format("{0}", projSettings.ProjectHome));
+            //} else {
+            //    arguments.Add(String.Format("{0}\\{1}", projSettings.ProjectHome, projSettings.UnitTestRootDir));
+            //}
             
             return arguments.ToArray();
         }

--- a/Python/Product/TestAdapter.Executor/Pytest/PytestTestDiscoverer.cs
+++ b/Python/Product/TestAdapter.Executor/Pytest/PytestTestDiscoverer.cs
@@ -139,20 +139,18 @@ namespace Microsoft.PythonTools.TestAdapter.Pytest {
             return null;
         }
 
-        public string[] GetArguments(IEnumerable<string> sources, PythonProjectSettings projSettings, string outputfilename) {
-            var arguments = new List<string>();
-            arguments.Add(DiscoveryAdapterPath);
-            arguments.Add("discover");
-            arguments.Add("pytest");
-            arguments.Add("--output-file");
-            arguments.Add(outputfilename);
+        public string[] GetArguments(IEnumerable<string> sources, PythonProjectSettings projSettings, string outputfilename) =>
+            new[] {
+            DiscoveryAdapterPath,
+            "discover",
+            "pytest",
+            "--output-file",
+            outputfilename,
             //Note pytest specific arguments go after this separator
-            arguments.Add("--");
-            arguments.Add("--cache-clear");
-            arguments.Add(String.Format("--rootdir={0}", projSettings.ProjectHome));
-            
-            return arguments.ToArray();
-        }
+            "--",
+            "--cache-clear",
+            String.Format("--rootdir={0}", projSettings.ProjectHome)
+            };
 
         private Dictionary<string, string> InitializeEnvironment(IEnumerable<string> sources, PythonProjectSettings projSettings) {
             var pythonPathVar = projSettings.PathEnv;


### PR DESCRIPTION
This PR reverts the commit I did for this issue: #6948 and this [PR](https://github.com/microsoft/PTVS/pull/6948).

The `UnitTestRootDirectory` property in PythonSetting.json should only be used to configure unittest, and should be ignored for pytest.

Check [this doc](https://github.com/microsoft/PTVS/pull/6948) for pytest configuration. Tests below use `pytest.ini` as an example to config pytest test directory.

Extra tests are performed to verify pytest works in VS and resolve the issue #6952.

1. Folder View

- ![folder_view_1](https://user-images.githubusercontent.com/100439259/162498929-97d950b3-7d1b-473e-939e-44912a3ded02.png)

- ![folder_view_2](https://user-images.githubusercontent.com/100439259/162498931-a558a400-e84f-42bb-9aca-a617a8e1b094.png)

- ![folder_view_3](https://user-images.githubusercontent.com/100439259/162498943-77912c29-2c90-46d3-8b4b-e4655c90fca5.png)

2. Project View

- ![project_view_1](https://user-images.githubusercontent.com/100439259/162498954-846c9996-e6c9-4026-8614-8a57fba6e6c0.png)

- ![project_view_2](https://user-images.githubusercontent.com/100439259/162498970-d7628025-84a1-4db0-b7a2-fd152195ce9f.png)

3. PTVS Unit Tests

- ![unittestresult](https://user-images.githubusercontent.com/100439259/162498997-db1a1e92-9a0c-499a-88dc-3fabc2f198ee.PNG)

