### PR TITLE
Remove duplicated VSIX asset

### DIFF
--- a/Python/Product/Core/source.extension.vsixmanifest
+++ b/Python/Product/Core/source.extension.vsixmanifest
@@ -48,8 +48,7 @@
         <Asset Type="Microsoft.VisualStudio.Assembly" d:Source="File" Path="Microsoft.Python.Core.dll" />
         <Asset Type="Microsoft.VisualStudio.Assembly" d:Source="File" Path="Microsoft.Python.Parsing.dll" />
         <Asset Type="Microsoft.VisualStudio.Assembly" d:Source="File" Path="Microsoft.PythonTools.Ipc.Json.dll" />
-        <Asset Type="Microsoft.VisualStudio.Assembly" d:Source="File" Path="Microsoft.PythonTools.Attacher.exe" />
-        <Asset Type="Microsoft.VisualStudio.Assembly" d:Source="File" Path="Microsoft.PythonTools.ProjectWizards.dll" />
+        <Asset Type="Microsoft.VisualStudio.Assembly" d:Source="File" Path="Microsoft.PythonTools.Attacher.exe" />        
         <Asset Type="Microsoft.VisualStudio.Assembly" d:Source="File" Path="Microsoft.Extensions.FileSystemGlobbing.dll" />
     </Assets>
 </PackageManifest>


### PR DESCRIPTION
PythonTools were triggering a watson/fault in https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1505871 due to the duplicated Microsoft.VisualStudio.Assembly,Microsoft.PythonTools.ProjectWizards.dll asset. This asset has already been referenced earlier in the file via a reference to the project itself.