### PR TITLE
Fix formatter not formatting special characters

### DIFF
--- a/Python/Product/Common/Infrastructure/ProcessOutput.cs
+++ b/Python/Product/Common/Infrastructure/ProcessOutput.cs
@@ -192,6 +192,10 @@ namespace Microsoft.PythonTools.Infrastructure {
             return Run(filename, arguments, null, null, false, null);
         }
 
+        public static ProcessOutput RunHiddenAndCapture(string filename, Encoding encoding, params string[] arguments) {
+            return Run(filename, arguments, null, null, false, null, true, false, encoding, encoding);
+        }
+
         /// <summary>
         /// Runs the file with the provided settings.
         /// </summary>

--- a/Python/Product/PythonTools/PythonTools/Editor/Formatting/LspDiffTextEditFactory.cs
+++ b/Python/Product/PythonTools/PythonTools/Editor/Formatting/LspDiffTextEditFactory.cs
@@ -39,6 +39,7 @@ namespace Microsoft.PythonTools.Editor.Formatting {
 
             // Diff tools may print a header with the original/modified file names
             // and that header must be removed for diff_match_patch.
+            diffOutputText = diffOutputText.Trim(new char[] { '\uFEFF'});
             if (diffOutputText.StartsWithOrdinal("---")) {
                 var startIndex = diffOutputText.IndexOfOrdinal("@@");
                 if (startIndex >= 0) {

--- a/Python/Product/PythonTools/PythonTools/Editor/Formatting/PythonFormatter.cs
+++ b/Python/Product/PythonTools/PythonTools/Editor/Formatting/PythonFormatter.cs
@@ -61,6 +61,7 @@ namespace Microsoft.PythonTools.Editor.Formatting {
         protected virtual async Task<string> RunToolAsync(string interpreterExePath, string documentFilePath, Range range, string[] extraArgs) {
             var output = ProcessOutput.RunHiddenAndCapture(
                 interpreterExePath,
+                System.Text.Encoding.UTF8,
                 GetToolCommandArgs(documentFilePath, range, extraArgs)
             );
 

--- a/Python/Product/PythonTools/PythonTools/LanguageServerClient/LspEditorUtilities.cs
+++ b/Python/Product/PythonTools/PythonTools/LanguageServerClient/LspEditorUtilities.cs
@@ -55,19 +55,19 @@ namespace Microsoft.PythonTools.LanguageServerClient {
         internal static void ApplyTextEdits(IEnumerable<TextEdit> textEdits, ITextSnapshot snapshot, ITextBuffer textBuffer) {
             var vsTextEdit = textBuffer.CreateEdit();
             foreach (var textEdit in textEdits) {
-                if (textEdit.Range.Start == textEdit.Range.End) {
-                    var position = snapshot.GetSnapshotPositionFromProtocolPosition(textEdit.Range.Start);
-                    if (position > -1) {
-                        var span = GetTranslatedSpan(position, 0, snapshot, vsTextEdit.Snapshot);
-                        vsTextEdit.Insert(span.Start, textEdit.NewText);
-                    }
-                } else if (string.IsNullOrEmpty(textEdit.NewText)) {
+                if (string.IsNullOrEmpty(textEdit.NewText)) {
                     var startPosition = snapshot.GetSnapshotPositionFromProtocolPosition(textEdit.Range.Start);
                     var endPosition = snapshot.GetSnapshotPositionFromProtocolPosition(textEdit.Range.End);
                     var difference = endPosition - startPosition;
                     if (startPosition > -1 && endPosition > -1 && difference > 0) {
                         var span = GetTranslatedSpan(startPosition, difference, snapshot, vsTextEdit.Snapshot);
                         vsTextEdit.Delete(span);
+                    }
+                } else if (textEdit.Range.Start == textEdit.Range.End) {
+                    var position = snapshot.GetSnapshotPositionFromProtocolPosition(textEdit.Range.Start);
+                    if (position > -1) {
+                        var span = GetTranslatedSpan(position, 0, snapshot, vsTextEdit.Snapshot);
+                        vsTextEdit.Insert(span.Start, textEdit.NewText);
                     }
                 } else {
                     var startPosition = snapshot.GetSnapshotPositionFromProtocolPosition(textEdit.Range.Start);


### PR DESCRIPTION
This PR fixes issue #6785 

Formatters in PTVS were not able to format special characters such as Chinese and Germany characters correctly. Not sure what encoding/decoding is used on PTVS/formatter end, which might be the cause, so pass in UTF-8 to decode patch returned from formatters.

Test 1:
![formatter1](https://user-images.githubusercontent.com/100439259/164319608-43a5a3d9-e2bd-4892-b695-f4ab0d86f97e.PNG)

Test 2 with Black:
![Animation2 - formatter1](https://user-images.githubusercontent.com/100439259/164319585-07e9b890-37d8-445b-aaed-f9f74a84ae29.gif)

Test 3 with autopep8:
![Animation2 - pep8](https://user-images.githubusercontent.com/100439259/164319594-b1eaf640-f491-45b2-92a4-527606454033.gif)

Test 4 with yapf:
![Animation2 - y](https://user-images.githubusercontent.com/100439259/164319601-f189515d-874a-4405-82a3-b715d010c300.gif)

