### PR TITLE
Don't try to show conda environments that do not have python installed

### DIFF
--- a/Python/Product/VSInterpreters/Interpreter/CondaEnvironmentFactoryProvider.cs
+++ b/Python/Product/VSInterpreters/Interpreter/CondaEnvironmentFactoryProvider.cs
@@ -383,7 +383,9 @@ namespace Microsoft.PythonTools.Interpreter {
                 }
 
                 var environmentInfo = await CreateEnvironmentInfo(folder, condaPath);
-                condaEnvironments.Add(environmentInfo);
+                if (environmentInfo != null) {
+                    condaEnvironments.Add(environmentInfo);
+                }
             }
 
             return condaEnvironments;


### PR DESCRIPTION
Fixes #6977 

This bug only happens when the user manually installs a conda environment, but doesn't install python that environment. This fix makes it so conda environments that do not have python installed do not show up anywhere. Installing python in the environment and reloading the solution will cause the environment to show up as normal.