### PR TITLE
Fix profiling standalone script error

### DIFF
--- a/Python/Product/Profiling/Profiling.csproj
+++ b/Python/Product/Profiling/Profiling.csproj
@@ -64,6 +64,7 @@
     <Compile Include="Profiling\IPythonProfileSession.cs" />
     <Compile Include="Profiling\IPythonProfiling.cs" />
     <Compile Include="Profiling\ProfilingSessionEditorFactory.cs" />
+    <Compile Include="Profiling\CustomPythonInterpreterView.cs" />
     <Compile Include="Profiling\PythonInterpreterView.cs" />
     <Compile Include="Profiling\ProjectTargetView.cs" />
     <Compile Include="Guids.cs" />

--- a/Python/Product/Profiling/Profiling/CustomPythonInterpreterView.cs
+++ b/Python/Product/Profiling/Profiling/CustomPythonInterpreterView.cs
@@ -1,0 +1,28 @@
+// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+namespace Microsoft.PythonTools.Profiling {
+    class CustomPythonInterpreterView : PythonInterpreterView {
+        public CustomPythonInterpreterView() :
+            base(Strings.LaunchProfiling_OtherInterpreter, "", null) {
+        }
+        public CustomPythonInterpreterView(string path) :
+            base(Strings.LaunchProfiling_OtherInterpreter, "", path) {
+        }
+
+    }
+}
+ 

--- a/Python/Product/Profiling/Profiling/CustomPythonInterpreterView.cs
+++ b/Python/Product/Profiling/Profiling/CustomPythonInterpreterView.cs
@@ -16,10 +16,7 @@
 
 namespace Microsoft.PythonTools.Profiling {
     class CustomPythonInterpreterView : PythonInterpreterView {
-        public CustomPythonInterpreterView() :
-            base(Strings.LaunchProfiling_OtherInterpreter, "", null) {
-        }
-        public CustomPythonInterpreterView(string path) :
+        public CustomPythonInterpreterView(string path = null) :
             base(Strings.LaunchProfiling_OtherInterpreter, "", path) {
         }
 

--- a/Python/Product/Profiling/Profiling/StandaloneTargetView.cs
+++ b/Python/Product/Profiling/Profiling/StandaloneTargetView.cs
@@ -165,7 +165,7 @@ namespace Microsoft.PythonTools.Profiling {
                 if (_interpreterPath != value) {
                     _interpreterPath = value;
                     if (Interpreter.Name == Strings.LaunchProfiling_OtherInterpreter && Interpreter.Path == null) {
-                        Interpreter = new PythonInterpreterView(Strings.LaunchProfiling_OtherInterpreter, "Global|"+ Strings.LaunchProfiling_OtherInterpreter, _interpreterPath);
+                        Interpreter = new PythonInterpreterView(Strings.LaunchProfiling_OtherInterpreter, Strings.LaunchProfiling_OtherInterpreter, _interpreterPath);
                     }
                     OnPropertyChanged("InterpreterPath");
                 }

--- a/Python/Product/Profiling/Profiling/StandaloneTargetView.cs
+++ b/Python/Product/Profiling/Profiling/StandaloneTargetView.cs
@@ -29,6 +29,7 @@ namespace Microsoft.PythonTools.Profiling {
     /// </summary>
     sealed class StandaloneTargetView : INotifyPropertyChanged {
         private readonly ReadOnlyCollection<PythonInterpreterView> _availableInterpreters;
+        private readonly PythonInterpreterView _customInterpreter;
 
         private PythonInterpreterView _interpreter;
         private string _interpreterPath;
@@ -55,7 +56,7 @@ namespace Microsoft.PythonTools.Profiling {
                 )
             ).ToList();
 
-            var _customInterpreter = new CustomPythonInterpreterView();
+            _customInterpreter = new CustomPythonInterpreterView();
             availableInterpreters.Add(_customInterpreter);
             _availableInterpreters = new ReadOnlyCollection<PythonInterpreterView>(availableInterpreters);
 

--- a/Python/Product/Profiling/Profiling/StandaloneTargetView.cs
+++ b/Python/Product/Profiling/Profiling/StandaloneTargetView.cs
@@ -56,7 +56,7 @@ namespace Microsoft.PythonTools.Profiling {
                 )
             ).ToList();
 
-            _customInterpreter = new PythonInterpreterView(Strings.LaunchProfiling_OtherInterpreter, "", null);
+            _customInterpreter = new CustomPythonInterpreterView();
             availableInterpreters.Add(_customInterpreter);
             _availableInterpreters = new ReadOnlyCollection<PythonInterpreterView>(availableInterpreters);
 
@@ -148,7 +148,7 @@ namespace Microsoft.PythonTools.Profiling {
                 if (_interpreter != value) {
                     _interpreter = value ?? _customInterpreter;
                     OnPropertyChanged("Interpreter");
-                    CanSpecifyInterpreterPath = (_interpreter == _customInterpreter);
+                    CanSpecifyInterpreterPath = (_interpreter is CustomPythonInterpreterView);
                 }
             }
         }
@@ -164,9 +164,8 @@ namespace Microsoft.PythonTools.Profiling {
             set {
                 if (_interpreterPath != value) {
                     _interpreterPath = value;
-                    if (Interpreter.Name == Strings.LaunchProfiling_OtherInterpreter && Interpreter.Path == null) {
-                        Interpreter = new PythonInterpreterView(Strings.LaunchProfiling_OtherInterpreter, Strings.LaunchProfiling_OtherInterpreter, _interpreterPath);
-                        CanSpecifyInterpreterPath = (_interpreter.Name == _customInterpreter.Name);
+                    if (Interpreter is CustomPythonInterpreterView) {
+                        Interpreter = new CustomPythonInterpreterView(_interpreterPath);
                     }
                     OnPropertyChanged("InterpreterPath");
                 }

--- a/Python/Product/Profiling/Profiling/StandaloneTargetView.cs
+++ b/Python/Product/Profiling/Profiling/StandaloneTargetView.cs
@@ -108,7 +108,7 @@ namespace Microsoft.PythonTools.Profiling {
             if (IsValid) {
                 return new StandaloneTarget {
                     PythonInterpreter = CanSpecifyInterpreterPath ? null : Interpreter.GetInterpreter(),
-                    InterpreterPath = CanSpecifyInterpreterPath ? InterpreterPath : null,
+                    InterpreterPath = CanSpecifyInterpreterPath ? null : InterpreterPath,
                     Script = ScriptPath ?? string.Empty,
                     WorkingDirectory = WorkingDirectory ?? string.Empty,
                     Arguments = Arguments ?? string.Empty
@@ -164,6 +164,9 @@ namespace Microsoft.PythonTools.Profiling {
             set {
                 if (_interpreterPath != value) {
                     _interpreterPath = value;
+                    if (Interpreter.Name == Strings.LaunchProfiling_OtherInterpreter && Interpreter.Path == null) {
+                        Interpreter = new PythonInterpreterView(Strings.LaunchProfiling_OtherInterpreter, "Global|"+ Strings.LaunchProfiling_OtherInterpreter, _interpreterPath);
+                    }
                     OnPropertyChanged("InterpreterPath");
                 }
             }

--- a/Python/Product/Profiling/Profiling/StandaloneTargetView.cs
+++ b/Python/Product/Profiling/Profiling/StandaloneTargetView.cs
@@ -108,7 +108,7 @@ namespace Microsoft.PythonTools.Profiling {
             if (IsValid) {
                 return new StandaloneTarget {
                     PythonInterpreter = CanSpecifyInterpreterPath ? null : Interpreter.GetInterpreter(),
-                    InterpreterPath = CanSpecifyInterpreterPath ? null : InterpreterPath,
+                    InterpreterPath = CanSpecifyInterpreterPath ? InterpreterPath : null,
                     Script = ScriptPath ?? string.Empty,
                     WorkingDirectory = WorkingDirectory ?? string.Empty,
                     Arguments = Arguments ?? string.Empty
@@ -166,6 +166,7 @@ namespace Microsoft.PythonTools.Profiling {
                     _interpreterPath = value;
                     if (Interpreter.Name == Strings.LaunchProfiling_OtherInterpreter && Interpreter.Path == null) {
                         Interpreter = new PythonInterpreterView(Strings.LaunchProfiling_OtherInterpreter, Strings.LaunchProfiling_OtherInterpreter, _interpreterPath);
+                        CanSpecifyInterpreterPath = (_interpreter.Name == _customInterpreter.Name);
                     }
                     OnPropertyChanged("InterpreterPath");
                 }

--- a/Python/Product/Profiling/Profiling/StandaloneTargetView.cs
+++ b/Python/Product/Profiling/Profiling/StandaloneTargetView.cs
@@ -29,7 +29,6 @@ namespace Microsoft.PythonTools.Profiling {
     /// </summary>
     sealed class StandaloneTargetView : INotifyPropertyChanged {
         private readonly ReadOnlyCollection<PythonInterpreterView> _availableInterpreters;
-        private readonly PythonInterpreterView _customInterpreter;
 
         private PythonInterpreterView _interpreter;
         private string _interpreterPath;
@@ -56,7 +55,7 @@ namespace Microsoft.PythonTools.Profiling {
                 )
             ).ToList();
 
-            _customInterpreter = new CustomPythonInterpreterView();
+            var _customInterpreter = new CustomPythonInterpreterView();
             availableInterpreters.Add(_customInterpreter);
             _availableInterpreters = new ReadOnlyCollection<PythonInterpreterView>(availableInterpreters);
 

--- a/Python/Product/Profiling/PythonProfilingPackage.cs
+++ b/Python/Product/Profiling/PythonProfilingPackage.cs
@@ -287,17 +287,12 @@ namespace Microsoft.PythonTools.Profiling {
         private static void ProfileStandaloneTarget(SessionNode session, StandaloneTarget runTarget, bool openReport) {
             LaunchConfiguration config;
             if (runTarget.PythonInterpreter != null) {
-                if (runTarget.PythonInterpreter.Id == Strings.LaunchProfiling_OtherInterpreter) {
-                    var interpreter = new VisualStudioInterpreterConfiguration(runTarget.PythonInterpreter.Id, runTarget.PythonInterpreter.Id, runTarget.InterpreterPath);
-                    config = new LaunchConfiguration(interpreter);
-                } else {
-                    var registry = session._serviceProvider.GetComponentModel().GetService<IInterpreterRegistryService>();
-                    var interpreter = registry.FindConfiguration(runTarget.PythonInterpreter.Id);
-                    if (interpreter == null) {
-                        return;
-                    }
-                    config = new LaunchConfiguration(interpreter);
+                var registry = session._serviceProvider.GetComponentModel().GetService<IInterpreterRegistryService>();
+                var interpreter = registry.FindConfiguration(runTarget.PythonInterpreter.Id);
+                if (interpreter == null) {
+                    return;
                 }
+                config = new LaunchConfiguration(interpreter);
             } else {
                 config = new LaunchConfiguration(null);
             }

--- a/Python/Product/Profiling/PythonProfilingPackage.cs
+++ b/Python/Product/Profiling/PythonProfilingPackage.cs
@@ -286,16 +286,18 @@ namespace Microsoft.PythonTools.Profiling {
 
         private static void ProfileStandaloneTarget(SessionNode session, StandaloneTarget runTarget, bool openReport) {
             LaunchConfiguration config;
-            if (runTarget.PythonInterpreter != null && runTarget.PythonInterpreter.Id != "Global|Other...") {
-                var registry = session._serviceProvider.GetComponentModel().GetService<IInterpreterRegistryService>();
-                var interpreter = registry.FindConfiguration(runTarget.PythonInterpreter.Id);
-                if (interpreter == null) {
-                    return;
+            if (runTarget.PythonInterpreter != null) {
+                if (runTarget.PythonInterpreter.Id == Strings.LaunchProfiling_OtherInterpreter) {
+                    var interpreter = new VisualStudioInterpreterConfiguration(runTarget.PythonInterpreter.Id, runTarget.PythonInterpreter.Id, runTarget.InterpreterPath);
+                    config = new LaunchConfiguration(interpreter);
+                } else {
+                    var registry = session._serviceProvider.GetComponentModel().GetService<IInterpreterRegistryService>();
+                    var interpreter = registry.FindConfiguration(runTarget.PythonInterpreter.Id);
+                    if (interpreter == null) {
+                        return;
+                    }
+                    config = new LaunchConfiguration(interpreter);
                 }
-                config = new LaunchConfiguration(interpreter);
-            } else if (runTarget.PythonInterpreter.Id == "Global|Other...") {
-                var interpreter = new VisualStudioInterpreterConfiguration(runTarget.PythonInterpreter.Id, runTarget.PythonInterpreter.Id, runTarget.InterpreterPath);
-                config = new LaunchConfiguration(interpreter);
             } else {
                 config = new LaunchConfiguration(null);
             }

--- a/Python/Product/Profiling/PythonProfilingPackage.cs
+++ b/Python/Product/Profiling/PythonProfilingPackage.cs
@@ -286,12 +286,15 @@ namespace Microsoft.PythonTools.Profiling {
 
         private static void ProfileStandaloneTarget(SessionNode session, StandaloneTarget runTarget, bool openReport) {
             LaunchConfiguration config;
-            if (runTarget.PythonInterpreter != null) {
+            if (runTarget.PythonInterpreter != null && runTarget.PythonInterpreter.Id != "Global|Other...") {
                 var registry = session._serviceProvider.GetComponentModel().GetService<IInterpreterRegistryService>();
                 var interpreter = registry.FindConfiguration(runTarget.PythonInterpreter.Id);
                 if (interpreter == null) {
                     return;
                 }
+                config = new LaunchConfiguration(interpreter);
+            } else if (runTarget.PythonInterpreter.Id == "Global|Other...") {
+                var interpreter = new VisualStudioInterpreterConfiguration(runTarget.PythonInterpreter.Id, runTarget.PythonInterpreter.Id, runTarget.InterpreterPath);
                 config = new LaunchConfiguration(interpreter);
             } else {
                 config = new LaunchConfiguration(null);

--- a/Python/Product/VSInterpreters/Interpreter/LaunchConfigurationUtils.cs
+++ b/Python/Product/VSInterpreters/Interpreter/LaunchConfigurationUtils.cs
@@ -26,7 +26,7 @@ namespace Microsoft.PythonTools.Interpreter {
     public class LaunchConfigurationUtils {
         public static Dictionary<string, string> GetFullEnvironment(LaunchConfiguration config, IServiceProvider serviceProvider, UIThreadBase uiThread) {
             if (config.Interpreter == null && config.InterpreterPath == null) {
-                throw new ArgumentNullException(nameof(Interpreter));
+                throw new ArgumentException("Interpreter was invalid");
             }
             if (serviceProvider == null) {
                 throw new ArgumentNullException(nameof(serviceProvider));

--- a/Python/Product/VSInterpreters/Interpreter/LaunchConfigurationUtils.cs
+++ b/Python/Product/VSInterpreters/Interpreter/LaunchConfigurationUtils.cs
@@ -25,7 +25,7 @@ using Microsoft.VisualStudioTools;
 namespace Microsoft.PythonTools.Interpreter {
     public class LaunchConfigurationUtils {
         public static Dictionary<string, string> GetFullEnvironment(LaunchConfiguration config, IServiceProvider serviceProvider, UIThreadBase uiThread) {
-            if (config.Interpreter == null) {
+            if (config.Interpreter == null && config.InterpreterPath == null) {
                 throw new ArgumentNullException(nameof(Interpreter));
             }
             if (serviceProvider == null) {


### PR DESCRIPTION
fixes #6769 

The issue was caused by two reasons:

- The `Interpreter Path` is entered after `Python Interpreter`, so the interpreter properties including id, name, and path never get updated. Manually set the properties in `Interpreter Path` setter to handle to ordering issue.

- The `CanSpecifyInterpreterPath` is not set correctly after constructing the custom python interpreter, so `InterpreterPath` is always returned as `null` from `GetTarget()`

Some tests:

1. Custom interpreter
![Animation2 - profiling others](https://user-images.githubusercontent.com/100439259/165596656-4fae0975-4c85-40aa-860c-7b34fa1d9b5d.gif)

2. Existing interpreter
![Animation2 - profiling python3 8](https://user-images.githubusercontent.com/100439259/165596680-8851dc6f-98b9-40db-81b3-38c31219d42b.gif)

3. Open project
![Animation2 - open project](https://user-images.githubusercontent.com/100439259/165596764-1eb7a158-3ca5-40d4-a35a-2a9b0619e3e0.gif)
 