### PR TITLE
Add python script to detect python architecture

### DIFF
--- a/Python/Product/Profiling/Profiling.csproj
+++ b/Python/Product/Profiling/Profiling.csproj
@@ -118,6 +118,10 @@
     </VSCTCompile>
   </ItemGroup>
   <ItemGroup>
+    <Content Include="getArch.py">
+      <IncludeInVSIX>true</IncludeInVSIX>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="proflaun.py">
       <IncludeInVSIX>true</IncludeInVSIX>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/Python/Product/Profiling/Profiling/ProfiledProcess.cs
+++ b/Python/Product/Profiling/Profiling/ProfiledProcess.cs
@@ -30,7 +30,7 @@ namespace Microsoft.PythonTools.Profiling {
         private readonly ProcessorArchitecture _arch;
         private readonly Process _process;
         private readonly PythonToolsService _pyService;
-        public string pyArch { get; set; }
+        private string _pyArch;
         public ProfiledProcess(PythonToolsService pyService, string exe, string args, string dir, Dictionary<string, string> envVars) {
 
             string pythonInstallDir = Path.GetDirectoryName(PythonToolsInstallPath.GetFile("VsPyProf.dll", typeof(ProfiledProcess).Assembly));
@@ -38,12 +38,12 @@ namespace Microsoft.PythonTools.Profiling {
             var arg = ProcessOutput.QuoteSingleArgument(Path.Combine(pythonInstallDir, "getArch.py"));
             getPyArch(exe, arg);
 
-            if (pyArch == "64") {
+            if (_pyArch == "64") {
                 _arch = ProcessorArchitecture.Amd64;
-            } else if (pyArch == "32") {
+            } else if (_pyArch == "32") {
                 _arch = ProcessorArchitecture.X86;
             } else {
-                throw new InvalidOperationException(Strings.UnsupportedArchitecture.FormatUI(_arch));
+                throw new InvalidOperationException(Strings.UnsupportedArchitecture.FormatUI(_pyArch));
             }
 
             dir = PathUtils.TrimEndSeparator(dir);
@@ -113,7 +113,7 @@ namespace Microsoft.PythonTools.Profiling {
 
         void Process_OutputDataReceived(object sender, DataReceivedEventArgs e) {
             if (!string.IsNullOrEmpty(e.Data)) {
-                pyArch = e.Data;
+                _pyArch = e.Data;
             }  
         }
 

--- a/Python/Product/Profiling/Profiling/ProfiledProcess.cs
+++ b/Python/Product/Profiling/Profiling/ProfiledProcess.cs
@@ -38,12 +38,12 @@ namespace Microsoft.PythonTools.Profiling {
             var arg = ProcessOutput.QuoteSingleArgument(Path.Combine(pythonInstallDir, "getArch.py"));
             getPyArch(exe, arg);
 
-            if (_pyArch == "64") {
-                _arch = ProcessorArchitecture.Amd64;
-            } else if (_pyArch == "32") {
+            if (_pyArch.EndsWith("-arm64")) {
+                throw new InvalidOperationException(Strings.UnsupportedArchitecture.FormatUI(_pyArch));  
+            } else if (_pyArch.EndsWith("-32")) {
                 _arch = ProcessorArchitecture.X86;
             } else {
-                throw new InvalidOperationException(Strings.UnsupportedArchitecture.FormatUI(_pyArch));
+                _arch = ProcessorArchitecture.Amd64;
             }
 
             dir = PathUtils.TrimEndSeparator(dir);

--- a/Python/Product/Profiling/Profiling/ProfiledProcess.cs
+++ b/Python/Product/Profiling/Profiling/ProfiledProcess.cs
@@ -30,11 +30,20 @@ namespace Microsoft.PythonTools.Profiling {
         private readonly ProcessorArchitecture _arch;
         private readonly Process _process;
         private readonly PythonToolsService _pyService;
-
+        public string pyArch { get; set; }
         public ProfiledProcess(PythonToolsService pyService, string exe, string args, string dir, Dictionary<string, string> envVars) {
-            var arch = NativeMethods.GetBinaryType(exe);
-            if (arch != ProcessorArchitecture.X86 && arch != ProcessorArchitecture.Amd64) {
-                throw new InvalidOperationException(Strings.UnsupportedArchitecture.FormatUI(arch));
+
+            string pythonInstallDir = Path.GetDirectoryName(PythonToolsInstallPath.GetFile("VsPyProf.dll", typeof(ProfiledProcess).Assembly));
+
+            var arg = ProcessOutput.QuoteSingleArgument(Path.Combine(pythonInstallDir, "getArch.py"));
+            getPyArch(exe, arg);
+
+            if (pyArch == "64") {
+                _arch = ProcessorArchitecture.Amd64;
+            } else if (pyArch == "32") {
+                _arch = ProcessorArchitecture.X86;
+            } else {
+                throw new InvalidOperationException(Strings.UnsupportedArchitecture.FormatUI(_arch));
             }
 
             dir = PathUtils.TrimEndSeparator(dir);
@@ -46,10 +55,8 @@ namespace Microsoft.PythonTools.Profiling {
             _exe = exe;
             _args = args;
             _dir = dir;
-            _arch = arch;
 
             ProcessStartInfo processInfo;
-            string pythonInstallDir = Path.GetDirectoryName(PythonToolsInstallPath.GetFile("VsPyProf.dll", typeof(ProfiledProcess).Assembly));
 
             string dll = _arch == ProcessorArchitecture.Amd64 ? "VsPyProf.dll" : "VsPyProfX86.dll";
             string arguments = string.Join(" ",
@@ -80,6 +87,34 @@ namespace Microsoft.PythonTools.Profiling {
 
             _process = new Process();
             _process.StartInfo = processInfo;
+        }
+
+        public void getPyArch(string exe, string arg) {
+            var process = new Process {
+                StartInfo = new ProcessStartInfo {
+                    FileName = exe,
+                    Arguments = arg,
+                    UseShellExecute = false,
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    CreateNoWindow = true
+                },
+                EnableRaisingEvents = true
+            };
+
+            process.ErrorDataReceived += Process_OutputDataReceived;
+            process.OutputDataReceived += Process_OutputDataReceived;
+
+            process.Start();
+            process.BeginErrorReadLine();
+            process.BeginOutputReadLine();
+            process.WaitForExit();
+        }
+
+        void Process_OutputDataReceived(object sender, DataReceivedEventArgs e) {
+            if (!string.IsNullOrEmpty(e.Data)) {
+                pyArch = e.Data;
+            }  
         }
 
         public void Dispose() {

--- a/Python/Product/Profiling/getArch.py
+++ b/Python/Product/Profiling/getArch.py
@@ -1,3 +1,3 @@
-﻿import struct
+﻿import sys
 
-print(struct.calcsize("P")*8)
+print(sys.winver)

--- a/Python/Product/Profiling/getArch.py
+++ b/Python/Product/Profiling/getArch.py
@@ -1,0 +1,3 @@
+﻿import struct
+
+print(struct.calcsize("P")*8)


### PR DESCRIPTION
fixes #6775 

The issue was that PTVS tries to get the architecture of the python interpreter and use that to determine which dll to use for profiling, but it's getting an access denied when trying to call `kernel32.GetBinaryTypeW` when pointing at the windows store install. So I added extra call to get Python print out its architecture.

Note that the python script I added can only distinguish between 32bit and 64bit, but it can't distinguish between ARM64 and AMD64.

I have tested with 32bit python from python.org, 64bit python from python.org, python downloaded from Windows Store, python 3.6, 3.7, 3.8, 3.9, 3.10.  Hope that can capture all the scenarios.
![Animation2 - pyarch](https://user-images.githubusercontent.com/100439259/167035328-7775c7c3-e8a5-46eb-b267-46fdc97c4ec3.gif)

