### PR TITLE
Fix VS crash when user's Python version is not in PythonLanguageVersion enum

### DIFF
--- a/Python/Product/Common/Parsing/PythonLanguageVersion.cs
+++ b/Python/Product/Common/Parsing/PythonLanguageVersion.cs
@@ -59,8 +59,9 @@ namespace Microsoft.PythonTools.Common.Parsing {
             if (Enum.IsDefined(typeof(PythonLanguageVersion), value)) {
                 return (PythonLanguageVersion)value;
             }
-            throw new InvalidOperationException("Unsupported Python version: {0}".FormatInvariant(version));
+            else {
+                return PythonLanguageVersion.None;
+            }
         }
-
     }
 }

--- a/Python/Product/Common/Parsing/PythonLanguageVersion.cs
+++ b/Python/Product/Common/Parsing/PythonLanguageVersion.cs
@@ -15,6 +15,7 @@
 // permissions and limitations under the License.
 
 using System;
+using System.Diagnostics;
 using Microsoft.PythonTools.Common.Core;
 using Microsoft.PythonTools.Common.Core.Extensions;
 
@@ -60,6 +61,7 @@ namespace Microsoft.PythonTools.Common.Parsing {
                 return (PythonLanguageVersion)value;
             }
             else {
+                Trace.WriteLine(Strings.PythonVersionNotSupportedTraceText.FormatUI(version));
                 return PythonLanguageVersion.None;
             }
         }

--- a/Python/Product/Common/Strings.Designer.cs
+++ b/Python/Product/Common/Strings.Designer.cs
@@ -6523,11 +6523,20 @@ namespace Microsoft.PythonTools {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to You&apos;re using Python {0}. Some features might not work as expected since Visual Studio no longer supports this version..
+        ///   Looks up a localized string similar to You&apos;re using {0}. Some features might not work as expected since Visual Studio does not officially support this version..
         /// </summary>
         public static string PythonVersionNotSupportedInfoBarText {
             get {
                 return ResourceManager.GetString("PythonVersionNotSupportedInfoBarText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Environment detected using Python version {0}. Some features might not work as expected since Visual Studio does not officially support this version..
+        /// </summary>
+        public static string PythonVersionNotSupportedTraceText {
+            get {
+                return ResourceManager.GetString("PythonVersionNotSupportedTraceText", resourceCulture);
             }
         }
         

--- a/Python/Product/Common/Strings.resx
+++ b/Python/Product/Common/Strings.resx
@@ -2968,8 +2968,8 @@ Please specify at least one package.</value>
     <value>Don't show this message again</value>
   </data>
   <data name="PythonVersionNotSupportedInfoBarText" xml:space="preserve">
-    <value>You're using Python {0}. Some features might not work as expected since Visual Studio no longer supports this version.</value>
-    <comment>{0} is the Python version</comment>
+    <value>You're using {0}. Some features might not work as expected since Visual Studio does not officially support this version.</value>
+    <comment>{0} is the Python description</comment>
   </data>
   <data name="PythonVersionNotSupportMoreInfo" xml:space="preserve">
     <value>More info</value>
@@ -3157,262 +3157,266 @@ Please specify at least one package.</value>
   <data name="AsRequiresPython2dot6OrlaterErrorMsg" xml:space="preserve">
     <value>'as' requires Python 2.6 or later</value>
   </data>
-	<data name="BackslashFStringExpressionErrorMsg" xml:space="preserve">
+  <data name="BackslashFStringExpressionErrorMsg" xml:space="preserve">
     <value>f-string expression part cannot include a backslash</value>
   </data>
-	<data name="BreakOustideLoopErrorMsg" xml:space="preserve">
+  <data name="BreakOustideLoopErrorMsg" xml:space="preserve">
     <value>'break' outside loop</value>
   </data>
-	<data name="CantUseStarredExpErrorMsg" xml:space="preserve">
+  <data name="CantUseStarredExpErrorMsg" xml:space="preserve">
     <value>can't use starred expression here</value>
   </data>
-	<data name="ClassDecoratorsRequireTwodotSixErrorMsg" xml:space="preserve">
+  <data name="ClassDecoratorsRequireTwodotSixErrorMsg" xml:space="preserve">
     <value>invalid syntax, class decorators require 2.6 or later.</value>
   </data>
-	<data name="ClosingParensNotMatchFStringErrorMsg" xml:space="preserve">
+  <data name="ClosingParensNotMatchFStringErrorMsg" xml:space="preserve">
     <value>f-string: closing parenthesis '{0}' does not match opening parenthesis '{1}'</value>
   </data>
-	<data name="ContinueNotInLoopErrorMsg" xml:space="preserve">
+  <data name="ContinueNotInLoopErrorMsg" xml:space="preserve">
     <value>'continue' not properly in loop</value>
   </data>
-	<data name="ContinueNotSupportedInsideFinallyErrorMsg" xml:space="preserve">
+  <data name="ContinueNotSupportedInsideFinallyErrorMsg" xml:space="preserve">
     <value>'continue' not supported inside 'finally' clause</value>
   </data>
-	<data name="DefaultExceptMustBeLastErrorMsg" xml:space="preserve">
+  <data name="DefaultExceptMustBeLastErrorMsg" xml:space="preserve">
     <value>default 'except' must be last</value>
   </data>
-	<data name="DefaultValueMustBeSpecifiedErrorMsg" xml:space="preserve">
+  <data name="DefaultValueMustBeSpecifiedErrorMsg" xml:space="preserve">
     <value>default value must be specified here</value>
   </data>
-	<data name="DuplicateArgsDoubleArgumentErrorMsg" xml:space="preserve">
+  <data name="DuplicateArgsDoubleArgumentErrorMsg" xml:space="preserve">
     <value>duplicate ** args arguments</value>
   </data>
-	<data name="DuplicateArgsSingleArgumentErrorMsg" xml:space="preserve">
+  <data name="DuplicateArgsSingleArgumentErrorMsg" xml:space="preserve">
     <value>duplicate * args arguments</value>
   </data>
-	<data name="DuplicateArgumentInFunctionDefinitionErrorMsg" xml:space="preserve">
+  <data name="DuplicateArgumentInFunctionDefinitionErrorMsg" xml:space="preserve">
     <value>duplicate argument '{0}' in function definition</value>
   </data>
-	<data name="DuplicateArgumentInFunctionErrorMsg" xml:space="preserve">
+  <data name="DuplicateArgumentInFunctionErrorMsg" xml:space="preserve">
     <value>duplicate argument '{0}' in function definition</value>
   </data>
-	<data name="DuplicateKeywordArgumentErrorMsg" xml:space="preserve">
+  <data name="DuplicateKeywordArgumentErrorMsg" xml:space="preserve">
     <value>duplicate keyword argument</value>
   </data>
-	<data name="EmptyExpressionFStringErrorMsg" xml:space="preserve">
+  <data name="EmptyExpressionFStringErrorMsg" xml:space="preserve">
     <value>f-string: empty expression not allowed</value>
   </data>
-	<data name="ExpectedColonErrorMsg" xml:space="preserve">
+  <data name="ExpectedColonErrorMsg" xml:space="preserve">
     <value>expected ':'</value>
   </data>
-	<data name="ExpectedExpressionAfterDelErrorMsg" xml:space="preserve">
+  <data name="ExpectedExpressionAfterDelErrorMsg" xml:space="preserve">
     <value>expected expression after del</value>
   </data>
-	<data name="ExpectedExpressionToBePrintedErrorMsg" xml:space="preserve">
+  <data name="ExpectedExpressionToBePrintedErrorMsg" xml:space="preserve">
     <value>print statement expected expression to be printed</value>
   </data>
-	<data name="ExpectedIndentedBlockErrorMsg" xml:space="preserve">
+  <data name="ExpectedIndentedBlockErrorMsg" xml:space="preserve">
     <value>expected an indented block</value>
   </data>
-	<data name="ExpectedNameErrorMsg" xml:space="preserve">
+  <data name="ExpectedNameErrorMsg" xml:space="preserve">
     <value>expected name</value>
   </data>
-	<data name="ExpectingCharButFoundFStringErrorMsg" xml:space="preserve">
+  <data name="ExpectingCharButFoundFStringErrorMsg" xml:space="preserve">
     <value>f-string: expecting '{0}' but found '{1}'</value>
   </data>
-	<data name="ExpectingCharFStringErrorMsg" xml:space="preserve">
+  <data name="ExpectingCharFStringErrorMsg" xml:space="preserve">
     <value>f-string: expecting '{0}'</value>
   </data>
-	<data name="FromCauseNotAllowedIn2XErrorMsg" xml:space="preserve">
+  <data name="FromCauseNotAllowedIn2XErrorMsg" xml:space="preserve">
     <value>invalid syntax, from cause not allowed in 2.x.</value>
   </data>
-	<data name="FutureFeatureNotDefinedErrorMsg" xml:space="preserve">
+  <data name="FutureFeatureNotDefinedErrorMsg" xml:space="preserve">
     <value>future feature is not defined: </value>
   </data>
-	<data name="FutureImportsMustOccorAtBeginningOfFileErrorMsg" xml:space="preserve">
+  <data name="FutureImportsMustOccorAtBeginningOfFileErrorMsg" xml:space="preserve">
     <value>from __future__ imports must occur at the beginning of the file</value>
   </data>
-	<data name="FutureStatementDoesNotSupportImportErrorMsg" xml:space="preserve">
+  <data name="FutureStatementDoesNotSupportImportErrorMsg" xml:space="preserve">
     <value>future statement does not support import *</value>
   </data>
-	<data name="IllegalTargetAnnotationErrorMsg" xml:space="preserve">
+  <data name="IllegalTargetAnnotationErrorMsg" xml:space="preserve">
     <value>illegal target for annotation</value>
   </data>
-	<data name="ImportOnlyAllowedAtModuleErrorMsg" xml:space="preserve">
+  <data name="ImportOnlyAllowedAtModuleErrorMsg" xml:space="preserve">
     <value>import * only allowed at module level</value>
   </data>
-	<data name="IncorrectStartLocationErrorMsg" xml:space="preserve">
+  <data name="IncorrectStartLocationErrorMsg" xml:space="preserve">
     <value>Start location was not set correctly</value>
   </data>
-	<data name="InvalidConversionCharacterExpectedFStringErrorMsg" xml:space="preserve">
+  <data name="InvalidConversionCharacterExpectedFStringErrorMsg" xml:space="preserve">
     <value>f-string: invalid conversion character: {0} expected 's', 'r', or 'a'</value>
   </data>
-	<data name="InvalidConversionCharacterFStringErrorMsg" xml:space="preserve">
+  <data name="InvalidConversionCharacterFStringErrorMsg" xml:space="preserve">
     <value>f-string: invalid conversion character: expected 's', 'r', or 'a'</value>
   </data>
-	<data name="InvalidExpressionFStringErrorMsg" xml:space="preserve">
+  <data name="InvalidExpressionFStringErrorMsg" xml:space="preserve">
     <value>f-string: invalid expression</value>
   </data>
-	<data name="InvalidParameterErrorMsg" xml:space="preserve">
+  <data name="InvalidParameterErrorMsg" xml:space="preserve">
     <value>invalid parameter</value>
   </data>
-	<data name="InvalidSublistParameterErrorMsg" xml:space="preserve">
+  <data name="InvalidSublistParameterErrorMsg" xml:space="preserve">
     <value>invalid sublist parameter</value>
   </data>
-	<data name="InvalidSyntaxAllowedInVersion3XErrorMsg" xml:space="preserve">
+  <data name="InvalidSyntaxAllowedInVersion3XErrorMsg" xml:space="preserve">
     <value>invalid syntax, only exception value is allowed in 3.x.</value>
   </data>
-	<data name="InvalidSyntaxErrorMsg" xml:space="preserve">
+  <data name="InvalidSyntaxErrorMsg" xml:space="preserve">
     <value>invalid syntax</value>
   </data>
-	<data name="IterableArgumentFollowsKeywordArgumentErrorMsg" xml:space="preserve">
+  <data name="IterableArgumentFollowsKeywordArgumentErrorMsg" xml:space="preserve">
     <value>iterable argument unpacking follows keyword argument unpacking</value>
   </data>
-	<data name="IterableUnpackingErrorMsg" xml:space="preserve">
+  <data name="IterableUnpackingErrorMsg" xml:space="preserve">
     <value>iterable unpacking cannot be used in comprehension</value>
   </data>
-	<data name="KeywordsMustComeBeforeArgsErrorMsg" xml:space="preserve">
+  <data name="KeywordsMustComeBeforeArgsErrorMsg" xml:space="preserve">
     <value>keywords must come before ** args</value>
   </data>
-	<data name="LambdaParenthesesFstringErrorMsg" xml:space="preserve">
+  <data name="LambdaParenthesesFstringErrorMsg" xml:space="preserve">
     <value>f-string: lambda must be inside parentheses</value>
   </data>
-	<data name="MisplacedYieldErrorMsg" xml:space="preserve">
+  <data name="MisplacedYieldErrorMsg" xml:space="preserve">
     <value>misplaced yield</value>
   </data>
-	<data name="MissingModuleNameErrorMsg" xml:space="preserve">
+  <data name="MissingModuleNameErrorMsg" xml:space="preserve">
     <value>missing module name</value>
   </data>
-	<data name="MixingBytesAndNonBytesErrorMsg" xml:space="preserve">
+  <data name="MixingBytesAndNonBytesErrorMsg" xml:space="preserve">
     <value>cannot mix bytes and nonbytes literals</value>
   </data>
-	<data name="NamedArgumentsMustFollowBareErrorMsg" xml:space="preserve">
+  <data name="NamedArgumentsMustFollowBareErrorMsg" xml:space="preserve">
     <value>named arguments must follow bare *</value>
   </data>
-	<data name="NamedAssignmentWithErrorMsg" xml:space="preserve">
+  <data name="NamedAssignmentWithErrorMsg" xml:space="preserve">
     <value>cannot use named assignment with {0}</value>
   </data>
-	<data name="NamedExpressionCtxtErrorMsg" xml:space="preserve">
+  <data name="NamedExpressionCtxtErrorMsg" xml:space="preserve">
     <value>named expression must be parenthesized in this context</value>
   </data>
-	<data name="NamedExpressionInClassBodyErrorMsg" xml:space="preserve">
+  <data name="NamedExpressionInClassBodyErrorMsg" xml:space="preserve">
     <value>assignment expression within a comprehension cannot be used in a class body</value>
   </data>
-	<data name="NamedExpressionInComprehensionIteratorErrorMsg" xml:space="preserve">
+  <data name="NamedExpressionInComprehensionIteratorErrorMsg" xml:space="preserve">
     <value>assignment expression cannot be used in a comprehension iterable expression</value>
   </data>
-	<data name="NamedExpressionIteratorRebindsNamedErrorMsg" xml:space="preserve">
+  <data name="NamedExpressionIteratorRebindsNamedErrorMsg" xml:space="preserve">
     <value>comprehension inner loop cannot rebind assignment expression target '{0}'</value>
   </data>
-	<data name="NamedExpressionRebindIteratorErrorMsg" xml:space="preserve">
+  <data name="NamedExpressionRebindIteratorErrorMsg" xml:space="preserve">
     <value>assignment expression cannot rebind comprehension iteration variable '{0}'</value>
   </data>
-	<data name="NonKeywordArgAfterKeywordArgErrorMsg" xml:space="preserve">
+  <data name="NonKeywordArgAfterKeywordArgErrorMsg" xml:space="preserve">
     <value>non-keyword arg after keyword arg</value>
   </data>
-	<data name="NonLocalDeclarationAtModuleErrorMsg" xml:space="preserve">
+  <data name="NonLocalDeclarationAtModuleErrorMsg" xml:space="preserve">
     <value>nonlocal declaration not allowed at module level</value>
   </data>
-	<data name="NotAChanceErrorMsg" xml:space="preserve">
+  <data name="NotAChanceErrorMsg" xml:space="preserve">
     <value>not a chance</value>
   </data>
-	<data name="NumberSignFStringExpressionErrorMsg" xml:space="preserve">
+  <data name="NumberSignFStringExpressionErrorMsg" xml:space="preserve">
     <value>f-string expression part cannot include '#'</value>
   </data>
-	<data name="OnlyOneAllowedDoubleErrorMsg" xml:space="preserve">
+  <data name="OnlyOneAllowedDoubleErrorMsg" xml:space="preserve">
     <value>only one ** allowed</value>
   </data>
-	<data name="OnlyOneAllowedSingleErrorMsg" xml:space="preserve">
+  <data name="OnlyOneAllowedSingleErrorMsg" xml:space="preserve">
     <value>only one * allowed</value>
   </data>
-	<data name="ParameterAnnotationsRequire3dotXErrorMsg" xml:space="preserve">
+  <data name="ParameterAnnotationsRequire3dotXErrorMsg" xml:space="preserve">
     <value>invalid syntax, parameter annotations require 3.x</value>
   </data>
-	<data name="ParsingAlreadyStartedErrorMsg" xml:space="preserve">
+  <data name="ParsingAlreadyStartedErrorMsg" xml:space="preserve">
     <value>Parsing already started. Use Restart to start again.</value>
   </data>
-	<data name="PositionalArgumentKeywardArgumentErrorMsg" xml:space="preserve">
+  <data name="PositionalArgumentKeywardArgumentErrorMsg" xml:space="preserve">
     <value>positional argument follows keyword argument</value>
   </data>
-	<data name="PositionalArgumentKeywardArgumentUnpackingErrorMsg" xml:space="preserve">
+  <data name="PositionalArgumentKeywardArgumentUnpackingErrorMsg" xml:space="preserve">
     <value>positional argument follows keyword argument unpacking</value>
   </data>
-	<data name="PositionalOnlyMarkerAfterDictArgsErrorMsg" xml:space="preserve">
+  <data name="PositionalOnlyMarkerAfterDictArgsErrorMsg" xml:space="preserve">
     <value>positional only marker after ** args not allowed</value>
   </data>
-	<data name="PositionalOnlyMarkerAfterListArgsErrorMsg" xml:space="preserve">
+  <data name="PositionalOnlyMarkerAfterListArgsErrorMsg" xml:space="preserve">
     <value>positional only marker after * args not allowed</value>
   </data>
-	<data name="PositionalOnlyMarkerAnnotationErrorMsg" xml:space="preserve">
+  <data name="PositionalOnlyMarkerAnnotationErrorMsg" xml:space="preserve">
     <value>positional only marker may not have annotation</value>
   </data>
-	<data name="PositionalOnlyMarkerDefaultErrorMsg" xml:space="preserve">
+  <data name="PositionalOnlyMarkerDefaultErrorMsg" xml:space="preserve">
     <value>positional only marker may not have default</value>
   </data>
-	<data name="PositionalOnlyMarkerDuplicateErrorMsg" xml:space="preserve">
+  <data name="PositionalOnlyMarkerDuplicateErrorMsg" xml:space="preserve">
     <value>duplicate positional only marker</value>
   </data>
-	<data name="PositionalOnlyMarkerFirstParamErrorMessage" xml:space="preserve">
+  <data name="PositionalOnlyMarkerFirstParamErrorMessage" xml:space="preserve">
     <value>positional only marker may not be first parameter</value>
   </data>
-	<data name="PositionalParameterNotAllowedErrorMsg" xml:space="preserve">
+  <data name="PositionalParameterNotAllowedErrorMsg" xml:space="preserve">
     <value>positional parameter after * args not allowed</value>
   </data>
-	<data name="ReturnAnnotationsRequire3dotXErrorMsg" xml:space="preserve">
+  <data name="ReturnAnnotationsRequire3dotXErrorMsg" xml:space="preserve">
     <value>invalid syntax, return annotations require 3.x</value>
   </data>
-	<data name="ReturnOutsideFunctionErrorMsg" xml:space="preserve">
+  <data name="ReturnOutsideFunctionErrorMsg" xml:space="preserve">
     <value>'return' outside function</value>
   </data>
-	<data name="ReturnWithArgumentInGeneratorErrorMsg" xml:space="preserve">
+  <data name="ReturnWithArgumentInGeneratorErrorMsg" xml:space="preserve">
     <value>'return' with argument inside generator</value>
   </data>
-	<data name="SetLiteralsRequirePython2dot7ErrorMsg" xml:space="preserve">
+  <data name="SetLiteralsRequirePython2dot7ErrorMsg" xml:space="preserve">
     <value>invalid syntax, set literals require Python 2.7 or later.</value>
   </data>
-	<data name="SingleClosedBraceFStringErrorMsg" xml:space="preserve">
+  <data name="SingleClosedBraceFStringErrorMsg" xml:space="preserve">
     <value>f-string: single '}' is not allowed</value>
   </data>
-	<data name="SingleTargetCanBeAnnotatedErrorMsg" xml:space="preserve">
+  <data name="SingleTargetCanBeAnnotatedErrorMsg" xml:space="preserve">
     <value>only single target (not tuple) can be annotated</value>
   </data>
-	<data name="SublistParametersNotSupported3dotXErrorMsg" xml:space="preserve">
+  <data name="SublistParametersNotSupported3dotXErrorMsg" xml:space="preserve">
     <value>sublist parameters are not supported in 3.x</value>
   </data>
-	<data name="SyntaxErrorMsg" xml:space="preserve">
+  <data name="SyntaxErrorMsg" xml:space="preserve">
     <value>syntax error</value>
   </data>
-	<data name="TwoStarredExpressionErrorMsg" xml:space="preserve">
+  <data name="TwoStarredExpressionErrorMsg" xml:space="preserve">
     <value>two starred expressions in assignment</value>
   </data>
-	<data name="UnexpectedEndOfFileErrorMsg" xml:space="preserve">
+  <data name="UnexpectedEndOfFileErrorMsg" xml:space="preserve">
     <value>unexpected end of file</value>
   </data>
-	<data name="UnexpectedEndOfFileWhileParsingErrorMsg" xml:space="preserve">
+  <data name="UnexpectedEndOfFileWhileParsingErrorMsg" xml:space="preserve">
     <value>unexpected EOF while parsing</value>
   </data>
-	<data name="UnexpectedIndentErrorMsg" xml:space="preserve">
+  <data name="UnexpectedIndentErrorMsg" xml:space="preserve">
     <value>unexpected indent</value>
   </data>
-	<data name="UnexpectedTokenErrorMsg" xml:space="preserve">
+  <data name="UnexpectedTokenErrorMsg" xml:space="preserve">
     <value>unexpected token '{0}'</value>
   </data>
-	<data name="UnhandledStringTokenErrorMsg" xml:space="preserve">
+  <data name="UnhandledStringTokenErrorMsg" xml:space="preserve">
     <value>Unhandled string token</value>
   </data>
-	<data name="UnknownEncodingErrorMsg" xml:space="preserve">
+  <data name="UnknownEncodingErrorMsg" xml:space="preserve">
     <value>encoding problem: unknown encoding (line {0})</value>
   </data>
-	<data name="UnmatchedFStringErrorMsg" xml:space="preserve">
+  <data name="UnmatchedFStringErrorMsg" xml:space="preserve">
     <value>f-string: unmatched '{0}'</value>
   </data>
-	<data name="Utf8EncodingErrorMsg" xml:space="preserve">
+  <data name="Utf8EncodingErrorMsg" xml:space="preserve">
     <value>file has both Unicode marker and PEP-263 file encoding.  You must use \"utf-8\" as the encoding name when a BOM is present.</value>
   </data>
-	<data name="VariableIn3dotXErrorMsg" xml:space="preserve">
+  <data name="VariableIn3dotXErrorMsg" xml:space="preserve">
     <value>", variable" not allowed in 3.x - use "as variable" instead.</value>
   </data>
-	<data name="YieldInsideAsyncErrorMsg" xml:space="preserve">
+  <data name="YieldInsideAsyncErrorMsg" xml:space="preserve">
     <value>'yield' inside async function</value>
+  </data>
+  <data name="PythonVersionNotSupportedTraceText" xml:space="preserve">
+    <value>Environment detected using Python version {0}. Some features might not work as expected since Visual Studio does not officially support this version.</value>
+    <comment>{0} is the Python version</comment>
   </data>
 </root>

--- a/Python/Product/PythonTools/PythonTools/Commands/ImportCoverageCommand.cs
+++ b/Python/Product/PythonTools/PythonTools/Commands/ImportCoverageCommand.cs
@@ -94,7 +94,7 @@ namespace Microsoft.PythonTools.Commands {
                     foreach (var file in fileInfo) {
                         var factory = GetFactory(_serviceProvider, file.Filename);
                         version = factory?.Configuration.Version.ToLanguageVersion();
-                        if (version.HasValue) {
+                        if (version.HasValue && version != PythonLanguageVersion.None) {
                             break;
                         }
                     }

--- a/Python/Product/PythonTools/PythonTools/LanguageServerClient/PythonLanguageClient.cs
+++ b/Python/Product/PythonTools/PythonTools/LanguageServerClient/PythonLanguageClient.cs
@@ -23,6 +23,7 @@ using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.PythonTools.Common.Infrastructure;
+using Microsoft.PythonTools.Common.Parsing;
 using Microsoft.PythonTools.Editor.Core;
 using Microsoft.PythonTools.Infrastructure;
 using Microsoft.PythonTools.Interpreter;
@@ -223,7 +224,11 @@ namespace Microsoft.PythonTools.LanguageServerClient {
                     ?? _analysisOptions.TypeCheckingMode;
 
                 var ver3 = new Version(3, 0);
-                if (context.InterpreterConfiguration.Version < ver3) {
+                var version = context.InterpreterConfiguration.Version;
+                // show a warning if the python version is not supported
+                if (version.ToLanguageVersion() == PythonLanguageVersion.None) {
+                    MessageBox.ShowWarningMessage(Site, Strings.PythonVersionNotSupportedInfoBarText.FormatUI(context.InterpreterConfiguration.Description));
+                } else if (context.InterpreterConfiguration.Version < ver3) {
                     MessageBox.ShowWarningMessage(Site, Strings.WarningPython2NotSupported);
                 }
 

--- a/Python/Product/PythonTools/PythonTools/Project/PythonNotSupportedInfoBar.cs
+++ b/Python/Product/PythonTools/PythonTools/Project/PythonNotSupportedInfoBar.cs
@@ -52,7 +52,7 @@ namespace Microsoft.PythonTools.Project {
             }
 
             _interpreterTriggeredInfoBar = activeInterpreter;
-            var infoBarTextSpanMessage = new InfoBarTextSpan(Strings.PythonVersionNotSupportedInfoBarText.FormatUI(_interpreterTriggeredInfoBar.Configuration.Version));
+            var infoBarTextSpanMessage = new InfoBarTextSpan(Strings.PythonVersionNotSupportedInfoBarText.FormatUI(_interpreterTriggeredInfoBar.Configuration.Description));
             var infoBarMessage = new List<IVsInfoBarTextSpan> { infoBarTextSpanMessage };
             var actionItems = new List<InfoBarActionItem> {
                 // TODO (Dev17) - link to Python 2.7 support deprecation page.

--- a/Python/Product/VSInterpreters/Interpreter/AstPythonInterpreterFactory.cs
+++ b/Python/Product/VSInterpreters/Interpreter/AstPythonInterpreterFactory.cs
@@ -33,12 +33,7 @@ namespace Microsoft.PythonTools.Interpreter {
         ) {
             Configuration = config ?? throw new ArgumentNullException(nameof(config));
             CreationOptions = options ?? new InterpreterFactoryCreationOptions();
-            try {
-                LanguageVersion = Configuration.Version.ToLanguageVersion();
-            } catch (InvalidOperationException ex) {
-                throw new ArgumentException(ex.Message, ex);
-            }
-
+            LanguageVersion = Configuration.Version.ToLanguageVersion();
             _useDefaultDatabase = useDefaultDatabase;
         }
 

--- a/Python/Product/VSInterpreters/Interpreter/PythonRegistrySearch.cs
+++ b/Python/Product/VSInterpreters/Interpreter/PythonRegistrySearch.cs
@@ -188,9 +188,7 @@ namespace Microsoft.PythonTools.Interpreter {
                 return null; // Python 2.x is no longer supported.
             }
 
-            try {
-                sysVersion.ToLanguageVersion();
-            } catch (InvalidOperationException) {
+            if (sysVersion.ToLanguageVersion() == PythonLanguageVersion.None) {
                 sysVersion = new Version(0, 0);
             }
 

--- a/Python/Product/VSInterpreters/Interpreter/WorkspaceInterpreterFactoryProvider.cs
+++ b/Python/Product/VSInterpreters/Interpreter/WorkspaceInterpreterFactoryProvider.cs
@@ -316,9 +316,7 @@ namespace Microsoft.PythonTools.Interpreter {
             var arch = CPythonInterpreterFactoryProvider.ArchitectureFromExe(interpreterPath);
             var version = CPythonInterpreterFactoryProvider.VersionFromSysVersionInfo(interpreterPath);
 
-            try {
-                version.ToLanguageVersion();
-            } catch (InvalidOperationException) {
+            if (version.ToLanguageVersion() == PythonLanguageVersion.None) {
                 version = new Version(0, 0);
             }
 

--- a/Python/Tests/VSInterpretersTests/VSInterpretersTests.cs
+++ b/Python/Tests/VSInterpretersTests/VSInterpretersTests.cs
@@ -30,23 +30,17 @@ namespace VSInterpretersTests {
 
         [TestMethod, Priority(UnitTestPriority.P0)]
         public void InvalidInterpreterVersion() {
-            try {
-                var lv = new Version(1, 0).ToLanguageVersion();
-                Assert.Fail("Expected InvalidOperationException");
-            } catch (InvalidOperationException) {
-            }
 
-            try {
-                InterpreterFactoryCreator.CreateInterpreterFactory(new VisualStudioInterpreterConfiguration(
+                var lv = new Version(1, 0).ToLanguageVersion();
+                Assert.AreEqual(PythonLanguageVersion.None, lv);
+
+                var factory = InterpreterFactoryCreator.CreateInterpreterFactory(new VisualStudioInterpreterConfiguration(
                     Guid.NewGuid().ToString(),
                     "Test Interpreter",
                     version: new Version(1, 0)
                 ));
-                Assert.Fail("Expected ArgumentException");
-            } catch (ArgumentException ex) {
-                // Expect version number in message
-                AssertUtil.Contains(ex.Message, "1.0");
-            }
+
+                Assert.AreEqual(PythonLanguageVersion.None, factory.Configuration.Version.ToLanguageVersion());
         }
     }
 }


### PR DESCRIPTION
Fixes #7009

To repro this, I installed python 3.11 beta from python.org. Then I commented out `V311` from the `PythonLanguageVersion` enum and verified that `ToLanguageVersion()` returned `PythonLanguageVersion.None`, which is what we would expect if the version is not supported. This breakpoint gets hit when the installed environments are being enumerated (which is used to populate the environments window).

Then I added python 3.11 as an existing environment and activated it. I saw the environment in the project just fine. I got a warning in the debugger output about breakpoints might not hit, but they did. Profiling didn't work, but the error is "graceful"

![image](https://user-images.githubusercontent.com/29436557/169399619-f3834772-31a1-4bc8-93ad-0abb6f41645a.png)

So I think this fix is viable. VS no longer crashes, I'm able to add 3.11 as an existing environment, as well as a virtual environment and debug with both.

I still don't know why the version was being reported as 4.5.5 in the watson crash, but I believe our code can handle this edge case now.