### PR TITLE
Save "Ignore system-wide PYTHONPATH variable" option when closing Visual Studio.

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Options/PythonGeneralOptions.cs
+++ b/Python/Product/PythonTools/PythonTools/Options/PythonGeneralOptions.cs
@@ -31,6 +31,7 @@ namespace Microsoft.PythonTools.Options {
         private const string PromptForPackageInstallationSetting = "PromptForPackageInstallation";
         private const string PromptForTestFrameWorkInfoBarSetting = "PromptForTestFrameWorkInfoBar";
         private const string PromptForPythonVersionNotSupportedInfoBarSetting = "PromptForPythonVersionNotSupportedInfoBarSetting";
+        private const string ClearGlobalPythonPathSetting = "ClearGlobalPythonPathSetting";
         private const string ElevatePipSetting = "ElevatePip";
 
         internal PythonGeneralOptions(PythonToolsService service) {
@@ -44,7 +45,7 @@ namespace Microsoft.PythonTools.Options {
             PromptForPackageInstallation = _pyService.LoadBool(PromptForPackageInstallationSetting, GeneralCategory) ?? true;
             PromptForTestFrameWorkInfoBar = _pyService.LoadBool(PromptForTestFrameWorkInfoBarSetting, GeneralCategory) ?? true;
             PromptForPythonVersionNotSupported = _pyService.LoadBool(PromptForPythonVersionNotSupportedInfoBarSetting, GeneralCategory) ?? true;
-
+            ClearGlobalPythonPath = _pyService.LoadBool(ClearGlobalPythonPathSetting, GeneralCategory) ?? true;
             ElevatePip = _pyService.LoadBool(ElevatePipSetting, GeneralCategory) ?? false;
 
             Changed?.Invoke(this, EventArgs.Empty);
@@ -57,6 +58,7 @@ namespace Microsoft.PythonTools.Options {
             _pyService.SaveBool(PromptForPackageInstallationSetting, GeneralCategory, PromptForPackageInstallation);
             _pyService.SaveBool(PromptForTestFrameWorkInfoBarSetting, GeneralCategory, PromptForTestFrameWorkInfoBar);
             _pyService.SaveBool(PromptForPythonVersionNotSupportedInfoBarSetting, GeneralCategory, PromptForPythonVersionNotSupported);
+            _pyService.SaveBool(ClearGlobalPythonPathSetting, GeneralCategory, ClearGlobalPythonPath);
             _pyService.SaveBool(ElevatePipSetting, GeneralCategory, ElevatePip);
             Changed?.Invoke(this, EventArgs.Empty);
         }


### PR DESCRIPTION
fixes #6831 

This option is now remain checked after restarting Visual Studio.
![Animation2 - option checkbox](https://user-images.githubusercontent.com/100439259/169906020-9bfb5dd4-f83e-45e4-af5e-74aef8c565c4.gif)

