### PR TITLE
fix VS crash with bad conda environments

### DIFF
--- a/Python/Product/VSInterpreters/Interpreter/CondaEnvironmentFactoryProvider.cs
+++ b/Python/Product/VSInterpreters/Interpreter/CondaEnvironmentFactoryProvider.cs
@@ -237,7 +237,8 @@ namespace Microsoft.PythonTools.Interpreter {
             var found = new List<PythonInterpreterInformation>();
 
             try {
-                found.AddRange(await FindCondaEnvironments());
+                var condaEnvs = await FindCondaEnvironments();
+                found.AddRange(condaEnvs.Where(i => i != null && i.Configuration != null));
             } catch (ObjectDisposedException) {
                 // We are aborting, so silently return with no results.
                 return;


### PR DESCRIPTION
Fixes #7013

I was unable to repro this bug, and Watson didn't really give me any more information besides the line that causes the exception. So I just made sure we don't allow the conda environment (nor its associated configuration) to be null. This will prevent the NRE from being thrown.