### PR TITLE
Fix solution load when project contains windows store python environment

### DIFF
--- a/Python/Product/Common/Core/OS/ProcessServices.cs
+++ b/Python/Product/Common/Core/OS/ProcessServices.cs
@@ -15,7 +15,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -40,23 +39,18 @@ namespace Microsoft.PythonTools.Common.Core.OS {
 
         public async Task<string> ExecuteAndCaptureOutputAsync(ProcessStartInfo startInfo, CancellationToken cancellationToken = default) {
             var output = string.Empty;
-            try {
-                using (var process = Start(startInfo)) {
+            using (var process = Start(startInfo)) {
 
-                    if (startInfo.RedirectStandardError && process is PlatformProcess p) {
-                        p.Process.ErrorDataReceived += (s, e) => { };
-                        p.Process.BeginErrorReadLine();
-                    }
-
-                    try {
-                        output = await process.StandardOutput.ReadToEndAsync();
-                        await process.WaitForExitAsync(30000, cancellationToken);
-                    } catch (IOException) { } catch (OperationCanceledException) { }
-
-                    return output;
+                if (startInfo.RedirectStandardError && process is PlatformProcess p) {
+                    p.Process.ErrorDataReceived += (s, e) => { };
+                    p.Process.BeginErrorReadLine();
                 }
-            // Handle the case when trying to call python from the Microsoft store and we get access denied
-            } catch (Win32Exception) {
+
+                try {
+                    output = await process.StandardOutput.ReadToEndAsync();
+                    await process.WaitForExitAsync(30000, cancellationToken);
+                } catch (IOException) { } catch (OperationCanceledException) { }
+
                 return output;
             }
         }

--- a/Python/Product/VSInterpreters/PythonLibraryPath.cs
+++ b/Python/Product/VSInterpreters/PythonLibraryPath.cs
@@ -15,6 +15,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -176,9 +177,12 @@ namespace Microsoft.PythonTools {
                 RedirectStandardOutput = true
             };
 
+            var output = string.Empty;
 
-            var output = await ps.ExecuteAndCaptureOutputAsync(startInfo, cancellationToken);
-            if (string.IsNullOrEmpty(output)) {
+            try {
+                output = await ps.ExecuteAndCaptureOutputAsync(startInfo, cancellationToken);
+            } catch (Win32Exception) {
+                // this can happen when calling into a Microsoft store install of python
                 return noSearchPaths;
             }
 


### PR DESCRIPTION
When trying to open a solution containing a windows store python environment, we get an `Access is denied` when trying to run the python.exe within it. There's no good workaround for this that I know of. This prevents the project from loading in the solution explorer, and the user has to manually reload it.

So this change catches the `Win32Exception` thrown when this happens and defaults to no search paths, similar to what happens if the `get_search_paths.py` file isn't found. This causes the project to load correctly.