### PR TITLE
Deploy TestUtilities.Python vsix so other integration tests packages can see it

### DIFF
--- a/Python/Tests/Utilities.Python/TestUtilities.Python.csproj
+++ b/Python/Tests/Utilities.Python/TestUtilities.Python.csproj
@@ -12,6 +12,13 @@
     <RootNamespace>TestUtilities.Python</RootNamespace>
     <AssemblyName>TestUtilities.Python</AssemblyName>
     <FileAlignment>512</FileAlignment>
+    <UseCodebase>true</UseCodebase>
+    <UseVSSDK>true</UseVSSDK>
+    <CreateVsixContainer>true</CreateVsixContainer>
+    <DeployExtension>$(BuildingInsideVisualStudio)</DeployExtension>
+    <IsProductComponent>true</IsProductComponent>
+    <ExtensionInstallationRoot>Extensions</ExtensionInstallationRoot>
+    <ExtensionInstallationFolder>Microsoft\PythonTests\TestUtilities</ExtensionInstallationFolder>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Platform)' == 'AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -51,6 +58,15 @@
     <Reference Include="UIAutomationTypes" />
     <Reference Include="WindowsBase" />
   </ItemGroup>
+
+  <!-- Include all project reference outputs in the vsix for this project -->
+  <!-- You can also use <IncludeInVsix> under the <ProjectReference> element to override this value -->
+  <ItemDefinitionGroup>
+    <ProjectReference>
+      <IncludeInVsix>true</IncludeInVsix>
+    </ProjectReference>
+  </ItemDefinitionGroup>
+
   <ItemGroup>
     <ProjectReference Include="$(BuildRoot)\Common\Tests\MockVsTests\MockVsTests.csproj">
       <Project>{a390e1c0-0d90-4a9e-8413-3e959bb07292}</Project>


### PR DESCRIPTION
Related to #7039, but does not fix it completely.

This PR contains two fixes:

1. This vsix contains common code referenced by other integration tests packages. It was not being generated nor being installed into the Exp hive, so the other UI tests were erroring out with assembly load errors. Now we do build and deploy it, but the assembly load errors persist, leading to the next step
2. Even with the vsix being deployed, it didn't include dependencies, so we still got the assembly load errors. We had to make sure the project references were included in the vsix as well.

With these two steps done, the assembly load errors are gone. Many integration tests are still failing, but those can be fixed on a case by case basis.