### PR TITLE
Output the error when git is not installed or not on the PATH

### DIFF
--- a/Python/Product/Cookiecutter/Cookiecutter.csproj
+++ b/Python/Product/Cookiecutter/Cookiecutter.csproj
@@ -79,6 +79,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Model\CookiecutterSessionStartInfo.cs" />
+    <Compile Include="Model\GitRunException.cs" />
     <Compile Include="Model\KnownValueSources.cs" />
     <Compile Include="ProjectResources.cs" />
     <Compile Include="Attributes.cs" />

--- a/Python/Product/Cookiecutter/Model/GitClient.cs
+++ b/Python/Product/Cookiecutter/Model/GitClient.cs
@@ -52,6 +52,9 @@ namespace Microsoft.CookiecutterTools.Model {
             }
 
             var arguments = new string[] { "clone", repoUrl };
+            if (!ExistsOnPath(_gitExeFilePath)) {
+                throw new FileNotFoundException();
+            }
             using (var output = ProcessOutput.Run(_gitExeFilePath, arguments, targetParentFolderPath, GetEnvironment(), false, redirector)) {
                 await output;
 
@@ -80,6 +83,23 @@ namespace Microsoft.CookiecutterTools.Model {
 
                 return localTemplateFolder;
             }
+        }   
+        
+        public bool ExistsOnPath(string fileName) {
+            return GetFullPath(fileName) != null;
+        }
+
+        public string GetFullPath(string fileName) {
+            if (File.Exists(fileName)) {
+                return Path.GetFullPath(fileName);
+            }
+            var values = Environment.GetEnvironmentVariable("PATH");
+            foreach (var path in values.Split(Path.PathSeparator)) {
+                var fullPath = Path.Combine(path, fileName);
+                if (File.Exists(fullPath))
+                    return fullPath;
+            }
+            return null;
         }
 
         public async Task<string> GetRemoteOriginAsync(string repoFolderPath) {

--- a/Python/Product/Cookiecutter/Model/GitRunException.cs
+++ b/Python/Product/Cookiecutter/Model/GitRunException.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace Microsoft.CookiecutterTools.Model {
+    [Serializable]
+    class GitRunException : Exception{
+        public GitRunException() { }
+
+        public GitRunException(string message) : base(message) { }
+    }
+}

--- a/Python/Product/Cookiecutter/Model/GitRunException.cs
+++ b/Python/Product/Cookiecutter/Model/GitRunException.cs
@@ -7,5 +7,8 @@ namespace Microsoft.CookiecutterTools.Model {
         public GitRunException() { }
 
         public GitRunException(string message) : base(message) { }
+
+        public GitRunException(string message, Exception innerException)
+            : base(message, innerException) { }
     }
 }

--- a/Python/Product/Cookiecutter/Strings.Designer.cs
+++ b/Python/Product/Cookiecutter/Strings.Designer.cs
@@ -308,20 +308,20 @@ namespace Microsoft.CookiecutterTools {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Git.exe failed to run. Please install Git, add it to PATH and try again..
+        /// </summary>
+        public static string GitFailedToRunError {
+            get {
+                return ResourceManager.GetString("GitFailedToRunError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Could not retrieve results from GitHub.
         /// </summary>
         public static string GitHubSearchError {
             get {
                 return ResourceManager.GetString("GitHubSearchError", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Git.exe is not found. Please install Git, add it to PATH and try again..
-        /// </summary>
-        public static string GitNotFoundError {
-            get {
-                return ResourceManager.GetString("GitNotFoundError", resourceCulture);
             }
         }
         

--- a/Python/Product/Cookiecutter/Strings.Designer.cs
+++ b/Python/Product/Cookiecutter/Strings.Designer.cs
@@ -317,6 +317,15 @@ namespace Microsoft.CookiecutterTools {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Git.exe is not found. Please install Git, add it to PATH and try again..
+        /// </summary>
+        public static string GitNotFoundError {
+            get {
+                return ResourceManager.GetString("GitNotFoundError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Cookiecutter makes it easy to generate code from a template..
         /// </summary>
         public static string InfoBarMessage {

--- a/Python/Product/Cookiecutter/Strings.resx
+++ b/Python/Product/Cookiecutter/Strings.resx
@@ -554,4 +554,7 @@ Please delete the installed template and try again.</value>
     <value>Found redirected environment at '{0}'</value>
     <comment>{0} is a folder path</comment>
   </data>
+  <data name="GitNotFoundError" xml:space="preserve">
+    <value>Git.exe is not found. Please install Git, add it to PATH and try again.</value>
+  </data>
 </root>

--- a/Python/Product/Cookiecutter/Strings.resx
+++ b/Python/Product/Cookiecutter/Strings.resx
@@ -554,7 +554,7 @@ Please delete the installed template and try again.</value>
     <value>Found redirected environment at '{0}'</value>
     <comment>{0} is a folder path</comment>
   </data>
-  <data name="GitNotFoundError" xml:space="preserve">
-    <value>Git.exe is not found. Please install Git, add it to PATH and try again.</value>
+  <data name="GitFailedToRunError" xml:space="preserve">
+    <value>Git.exe failed to run. Please install Git, add it to PATH and try again.</value>
   </data>
 </root>

--- a/Python/Product/Cookiecutter/ViewModel/CookiecutterViewModel.cs
+++ b/Python/Product/Cookiecutter/ViewModel/CookiecutterViewModel.cs
@@ -843,6 +843,9 @@ namespace Microsoft.CookiecutterTools.ViewModel {
                     CloningStatus = OperationStatus.Failed;
 
                     _outputWindow.WriteErrorLine(ex.Message);
+                    if (ex.GetType().Name == "FileNotFoundException") {
+                        _outputWindow.WriteLine(Strings.GitNotFoundError);
+                    }
                     _outputWindow.WriteLine(Strings.CloningTemplateFailed.FormatUI(selection.DisplayName));
 
                     ReportTemplateEvent(CookiecutterTelemetry.TelemetryArea.Template, CookiecutterTelemetry.TemplateEvents.Clone, selection, ex);

--- a/Python/Product/Cookiecutter/ViewModel/CookiecutterViewModel.cs
+++ b/Python/Product/Cookiecutter/ViewModel/CookiecutterViewModel.cs
@@ -843,9 +843,6 @@ namespace Microsoft.CookiecutterTools.ViewModel {
                     CloningStatus = OperationStatus.Failed;
 
                     _outputWindow.WriteErrorLine(ex.Message);
-                    if (ex.GetType().Name == "FileNotFoundException") {
-                        _outputWindow.WriteLine(Strings.GitNotFoundError);
-                    }
                     _outputWindow.WriteLine(Strings.CloningTemplateFailed.FormatUI(selection.DisplayName));
 
                     ReportTemplateEvent(CookiecutterTelemetry.TelemetryArea.Template, CookiecutterTelemetry.TemplateEvents.Clone, selection, ex);


### PR DESCRIPTION
fixes #6872 

Print out the error when user fails to clone Cookiecutter templates because git is not installed or not on the PATH.

Here's what happens after the fix:

When git is installed and on the PATH:
![Animation2 - with git](https://user-images.githubusercontent.com/100439259/174896884-3ae1eb2b-7100-4f06-a6f3-388df618146b.gif)

When it's not installed or on the PATH:
![Animation2 - without git](https://user-images.githubusercontent.com/100439259/174896924-ac67507e-8a6f-4845-9f55-9526781bde69.gif)

