### PR TITLE
Fix intellisense not working in interactive window

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Repl/Completion/AsyncCompletionSource.cs
+++ b/Python/Product/PythonTools/PythonTools/Repl/Completion/AsyncCompletionSource.cs
@@ -453,7 +453,7 @@ namespace Microsoft.PythonTools.Repl.Completion {
 
             // See if this is from a text edit
             if (item?.TextEdit != null) {
-                result = item.TextEdit.Range.ToSnapshotSpan(applicablePoint.Snapshot);
+                result = item.TextEdit.Range.ToSnapshotSpan(owningSnapshot);
             } else {
                 // Fallback to extent of word. At least, it will be a zero-length span at the trigger pointzero-
                 // walk left and right until we reach the end of the word
@@ -476,7 +476,7 @@ namespace Microsoft.PythonTools.Repl.Completion {
             }
 
             // If the original snapshot is a projection snapshot, map up to it
-            if (owningSnapshot is IProjectionSnapshot projectionSnapshot) {
+            if (owningSnapshot is IProjectionSnapshot projectionSnapshot && result.Snapshot != owningSnapshot) {
                 var spans = projectionSnapshot.MapFromSourceSnapshot(result);
                 if (spans != null && spans.Count > 0) {
                     result = new SnapshotSpan(projectionSnapshot, spans[0]);


### PR DESCRIPTION
fixes #6943

See response under this issue. Wrong `ITextSnapshot` object is passed to `ToSnapshotSpan()`, which throws and `ArgumentOutOfRangeException` when the line number and snapshot.length doesn't match.

Now the intellisense is working again properly in interactive window with this fix:
![Animation2 - interactive window](https://user-images.githubusercontent.com/100439259/176301478-7861ed7c-320c-411e-aebc-dfc7e4f45a3c.gif)
 