### PR TITLE
set default startup project to core

### DIFF
--- a/Python/PythonTools.sln
+++ b/Python/PythonTools.sln
@@ -3,6 +3,10 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.31211.46
 MinimumVisualStudioVersion = 10.0.40219.1
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Product", "Product", "{C0C7AD6F-5E39-4D3F-A6B6-FD30713B0464}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Core", "Product\Core\Core.csproj", "{BDCF4A54-00B3-4F20-A76D-DEE4A2D23634}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MockVsTests", "..\Common\Tests\MockVsTests\MockVsTests.csproj", "{A390E1C0-0D90-4A9E-8413-3E959BB07292}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestSccPackage", "..\Common\Tests\SccPackage\TestSccPackage.csproj", "{E75E5DB1-0EA0-4247-A830-FE467C016816}"
@@ -10,8 +14,6 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestUtilities", "..\Common\Tests\Utilities\TestUtilities.csproj", "{D092D54E-FF29-4D32-9AEE-4EF704C92F67}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestUtilities.UI", "..\Common\Tests\Utilities.UI\TestUtilities.UI.csproj", "{E8150EBC-6B62-40BF-BF91-1DC60149B530}"
-EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Product", "Product", "{C0C7AD6F-5E39-4D3F-A6B6-FD30713B0464}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{3D21C7AC-6F9D-448C-8356-44EAFB2D14FC}"
 EndProject
@@ -26,8 +28,6 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Common", "Product\Common\Common.csproj", "{B3DB0521-D9E3-4F48-9E2E-E5ECAE886049}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Cookiecutter", "Product\Cookiecutter\Cookiecutter.csproj", "{376840CF-9F60-4225-8B08-E1D168B6717A}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Core", "Product\Core\Core.csproj", "{BDCF4A54-00B3-4F20-A76D-DEE4A2D23634}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Debugger", "Product\Debugger\Debugger.csproj", "{DECC7971-FA58-4DB0-9561-BFFADD393BBD}"
 EndProject


### PR DESCRIPTION
Get rid of the annoying need to set the default startup project every time you open the .sln with no .suo file present (after a git clean, for example)