### PR TITLE
docs: Fix a few typos

### DIFF
--- a/Python/Product/DebuggerHelper/trace.cpp
+++ b/Python/Product/DebuggerHelper/trace.cpp
@@ -130,7 +130,7 @@ struct DebuggerString {
     }
 };
 
-// Information about active breakpoints, communucated by debugger to be used by TraceFunc.
+// Information about active breakpoints, communicated by debugger to be used by TraceFunc.
 struct BreakpointData {
     // Highest line number for which there is a breakpoint (and therefore an element in lineNumbers).
     int32_t maxLineNumber;
@@ -234,7 +234,7 @@ __declspec(dllexport)
 volatile uint64_t evalLoopExcStr; // pointer to str(exc_value)
 
 __declspec(dllexport)
-volatile uint32_t evalLoopSEHCode; // if a structured exception occured during eval, the return value of GetExceptionCode
+volatile uint32_t evalLoopSEHCode; // if a structured exception occurred during eval, the return value of GetExceptionCode
 
 #pragma pack(pop)
 

--- a/Python/Product/PythonTools/ptvsd/repl/__init__.py
+++ b/Python/Product/PythonTools/ptvsd/repl/__init__.py
@@ -207,7 +207,7 @@ actual inspection and introspection."""
                 except timeout_exc_types: 
                     r, w, x = select.select([], [], [self.conn], 0)
                     if x:
-                        # an exception event has occured on the socket...
+                        # an exception event has occurred on the socket...
                         raise
                     continue
 
@@ -423,7 +423,7 @@ actual inspection and introspection."""
             write_string(self.conn, os.getcwd())
 
     def send_error(self):
-        """reports that an error occured to the interactive window"""
+        """reports that an error occurred to the interactive window"""
         with self.send_lock:
             write_bytes(self.conn, ReplBackend._ERRE)
 


### PR DESCRIPTION
There are small typos in:
- Python/Product/DebuggerHelper/trace.cpp
- Python/Product/PythonTools/ptvsd/repl/__init__.py

Fixes:
- Should read `occurred` rather than `occured`.
- Should read `communicated` rather than `communucated`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md