### PR TITLE
Add some new settings to PTVS

### DIFF
--- a/Python/Product/Common/Strings.Designer.cs
+++ b/Python/Product/Common/Strings.Designer.cs
@@ -4580,6 +4580,33 @@ namespace Microsoft.PythonTools {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Absolute.
+        /// </summary>
+        public static string ImportFormatAbsolute {
+            get {
+                return ResourceManager.GetString("ImportFormatAbsolute", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Relative.
+        /// </summary>
+        public static string ImportFormatRelative {
+            get {
+                return ResourceManager.GetString("ImportFormatRelative", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Defines the default format for import module..
+        /// </summary>
+        public static string ImportFormatToolTip {
+            get {
+                return ResourceManager.GetString("ImportFormatToolTip", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to import * only allowed at module level.
         /// </summary>
         public static string ImportOnlyAllowedAtModuleErrorMsg {

--- a/Python/Product/Common/Strings.resx
+++ b/Python/Product/Common/Strings.resx
@@ -3432,4 +3432,13 @@ Please specify at least one package.</value>
     <value>Virtual environment name can't contain any of the following characters: {0}</value>
     <comment>{0} is a list of invalid path characters, space-delimited.</comment>
   </data>
+  <data name="ImportFormatAbsolute" xml:space="preserve">
+    <value>Absolute</value>
+  </data>
+  <data name="ImportFormatRelative" xml:space="preserve">
+    <value>Relative</value>
+  </data>
+  <data name="ImportFormatToolTip" xml:space="preserve">
+    <value>Defines the default format for import module.</value>
+  </data>
 </root>

--- a/Python/Product/PythonTools/PythonTools.csproj
+++ b/Python/Product/PythonTools/PythonTools.csproj
@@ -959,6 +959,7 @@
     </EmbeddedResource>
     <EmbeddedResource Include="PythonTools\Options\PythonAnalysisOptionsControl.resx">
       <DependentUpon>PythonAnalysisOptionsControl.cs</DependentUpon>
+      <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Include="PythonTools\Options\PythonAdvancedEditorOptionsControl.resx">
       <DependentUpon>PythonAdvancedEditorOptionsControl.cs</DependentUpon>

--- a/Python/Product/PythonTools/PythonTools/LanguageServerClient/LanguageServerSettings.cs
+++ b/Python/Product/PythonTools/PythonTools/LanguageServerClient/LanguageServerSettings.cs
@@ -36,6 +36,11 @@ namespace Microsoft.PythonTools.LanguageServerClient {
         public const string Strict = "strict";
     }
 
+    internal static class PylanceImportFormat {
+        public const string Absolute = "absolute";
+        public const string Relative = "relative";
+    }
+
     [Serializable]
     internal sealed class LanguageServerSettings {
         [Serializable]
@@ -102,6 +107,34 @@ namespace Microsoft.PythonTools.LanguageServerClient {
                 /// Offer auto-import completions.
                 /// </summary>
                 public bool autoImportCompletions;
+
+                /// <summary>
+                /// Index installed third party libraries and user files for language features such as auto-import, add import, workspace symbols and etc.
+                /// </summary>
+                public bool? indexing;
+
+                /// <summary>
+                /// Allow using '.', '(' as commit characters when applicable.
+                /// </summary>
+                public bool? extraCommitChars;
+
+                public PythonAnalysisInlayHintsSettings inlayHints;
+
+                public string importFormat;
+
+                public class PythonAnalysisInlayHintsSettings {
+
+                    /// <summary>
+                    /// Enable/disable inlay hints for variable types:\n```python\nfoo ' :list[str] ' = [\"a\"]\n \n```\n
+                    /// </summary>
+                    public bool variableTypes;
+
+                    /// <summary>
+                    /// Enable/disable inlay hints for function return types:\n```python\ndef foo(x:int) ' -> int ':\n\treturn x\n```\n"
+                    /// </summary>
+                    public bool functionReturnTypes;
+                }
+
             }
             /// <summary>
             /// Analysis settings.

--- a/Python/Product/PythonTools/PythonTools/LanguageServerClient/PythonLanguageClient.cs
+++ b/Python/Product/PythonTools/PythonTools/LanguageServerClient/PythonLanguageClient.cs
@@ -245,7 +245,14 @@ namespace Microsoft.PythonTools.LanguageServerClient {
                         typeCheckingMode = typeCheckingMode,
                         useLibraryCodeForTypes = true,
                         completeFunctionParens = _advancedEditorOptions.CompleteFunctionParens,
-                        autoImportCompletions = _advancedEditorOptions.AutoImportCompletions
+                        autoImportCompletions = _advancedEditorOptions.AutoImportCompletions,
+                        indexing = _analysisOptions.Indexing,
+                        extraCommitChars = false,
+                        importFormat = _analysisOptions.ImportFormat,
+                        inlayHints = new LanguageServerSettings.PythonSettings.PythonAnalysisSettings.PythonAnalysisInlayHintsSettings {
+                            variableTypes = false,
+                            functionReturnTypes = false
+                        }
                     }
                 };
 

--- a/Python/Product/PythonTools/PythonTools/Options/PythonAnalysisOptions.cs
+++ b/Python/Product/PythonTools/PythonTools/Options/PythonAnalysisOptions.cs
@@ -32,6 +32,8 @@ namespace Microsoft.PythonTools.Options {
         public string[] TypeshedPaths { get; set; }
         public bool UseLibraryCodeForTypes { get; set; }
         public string[] ExtraPaths { get; set; }
+        public bool Indexing { get; set; }
+        public string ImportFormat { get; set; }
 
         internal PythonAnalysisOptions(PythonToolsService service) {
             _service = service;
@@ -88,6 +90,18 @@ namespace Microsoft.PythonTools.Options {
                 changed = true;
             }
 
+            var indexing = _service.LoadBool(nameof(Indexing), Category) ?? false;
+            if (Indexing != indexing) {
+                Indexing = indexing;
+                changed = true;
+            }
+
+            var importFormat = _service.LoadString(nameof(ImportFormat), Category) ?? PylanceImportFormat.Absolute;
+            if (ImportFormat != importFormat) {
+                ImportFormat = importFormat;
+                changed = true;
+            }
+
             if (changed) {
                 Changed?.Invoke(this, EventArgs.Empty);
             }
@@ -102,6 +116,8 @@ namespace Microsoft.PythonTools.Options {
             changed |= _service.SaveMultilineString(nameof(TypeshedPaths), Category, TypeshedPaths);
             changed |= _service.SaveMultilineString(nameof(ExtraPaths), Category, ExtraPaths);
             changed |= _service.SaveBool(nameof(UseLibraryCodeForTypes), Category, UseLibraryCodeForTypes);
+            changed |= _service.SaveBool(nameof(Indexing), Category, Indexing);
+            changed |= _service.SaveString(nameof(ImportFormat), Category, ImportFormat);
             if (changed) {
                 Changed?.Invoke(this, EventArgs.Empty);
             }
@@ -115,6 +131,8 @@ namespace Microsoft.PythonTools.Options {
             TypeCheckingMode = PylanceTypeCheckingMode.Basic;
             TypeshedPaths = null;
             UseLibraryCodeForTypes = true;
+            Indexing = false;
+            ImportFormat = PylanceImportFormat.Absolute;
             Changed?.Invoke(this, EventArgs.Empty);
         }
 

--- a/Python/Product/PythonTools/PythonTools/Options/PythonAnalysisOptionsControl.Designer.cs
+++ b/Python/Product/PythonTools/PythonTools/Options/PythonAnalysisOptionsControl.Designer.cs
@@ -33,12 +33,15 @@
             this._diagnosticsModeCombo = new System.Windows.Forms.ComboBox();
             this._logLevelCombo = new System.Windows.Forms.ComboBox();
             this._typeCheckingMode = new System.Windows.Forms.ComboBox();
+            this._importFormatCombo = new System.Windows.Forms.ComboBox();
             this._stubsPath = new System.Windows.Forms.TextBox();
             this._searchPathsLabel = new System.Windows.Forms.Label();
             this._searchPaths = new System.Windows.Forms.TextBox();
             this._typeShedPathsLabel = new System.Windows.Forms.Label();
             this._typeshedPaths = new System.Windows.Forms.TextBox();
             this._autoSearchPath = new System.Windows.Forms.CheckBox();
+            this.importFormatLabel = new System.Windows.Forms.Label();
+            this._indexing = new System.Windows.Forms.CheckBox();
             this._diagnosticModeToolTip = new System.Windows.Forms.ToolTip(this.components);
             this._logLevelToolTip = new System.Windows.Forms.ToolTip(this.components);
             this._typeCheckingToolTip = new System.Windows.Forms.ToolTip(this.components);
@@ -48,6 +51,7 @@
             this._commonSearchPathsToolTip = new System.Windows.Forms.ToolTip(this.components);
             this._searchPathsLabelToolTip = new System.Windows.Forms.ToolTip(this.components);
             this._typeshedPathsLabelToolTip = new System.Windows.Forms.ToolTip(this.components);
+            this._importFormatToolTip = new System.Windows.Forms.ToolTip(this.components);
             tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
             diagnosticModeLabel = new System.Windows.Forms.Label();
             logLevelLabel = new System.Windows.Forms.Label();
@@ -65,13 +69,16 @@
             tableLayoutPanel1.Controls.Add(this._logLevelCombo, 1, 1);
             tableLayoutPanel1.Controls.Add(typeCheckingModeLabel, 0, 2);
             tableLayoutPanel1.Controls.Add(this._typeCheckingMode, 1, 2);
-            tableLayoutPanel1.Controls.Add(stubsPathsLabel, 0, 3);
-            tableLayoutPanel1.Controls.Add(this._stubsPath, 1, 3);
-            tableLayoutPanel1.Controls.Add(this._searchPathsLabel, 0, 4);
-            tableLayoutPanel1.Controls.Add(this._searchPaths, 1, 4);
-            tableLayoutPanel1.Controls.Add(this._typeShedPathsLabel, 0, 5);
-            tableLayoutPanel1.Controls.Add(this._typeshedPaths, 1, 5);
+            tableLayoutPanel1.Controls.Add(this._importFormatCombo, 1, 3);
+            tableLayoutPanel1.Controls.Add(stubsPathsLabel, 0, 4);
+            tableLayoutPanel1.Controls.Add(this._stubsPath, 1, 4);
+            tableLayoutPanel1.Controls.Add(this._searchPathsLabel, 0, 5);
+            tableLayoutPanel1.Controls.Add(this._searchPaths, 1, 5);
+            tableLayoutPanel1.Controls.Add(this._typeShedPathsLabel, 0, 6);
+            tableLayoutPanel1.Controls.Add(this._typeshedPaths, 1, 6);
             tableLayoutPanel1.Controls.Add(this._autoSearchPath, 0, 7);
+            tableLayoutPanel1.Controls.Add(this.importFormatLabel, 0, 3);
+            tableLayoutPanel1.Controls.Add(this._indexing, 0, 8);
             tableLayoutPanel1.Name = "tableLayoutPanel1";
             // 
             // diagnosticModeLabel
@@ -109,6 +116,14 @@
             this._typeCheckingMode.FormattingEnabled = true;
             resources.ApplyResources(this._typeCheckingMode, "_typeCheckingMode");
             this._typeCheckingMode.Name = "_typeCheckingMode";
+            // 
+            // _importFormatCombo
+            // 
+            this._importFormatCombo.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this._importFormatCombo.DropDownWidth = 253;
+            this._importFormatCombo.FormattingEnabled = true;
+            resources.ApplyResources(this._importFormatCombo, "_importFormatCombo");
+            this._importFormatCombo.Name = "_importFormatCombo";
             // 
             // stubsPathsLabel
             // 
@@ -149,6 +164,18 @@
             this._autoSearchPath.Name = "_autoSearchPath";
             this._autoSearchPath.UseVisualStyleBackColor = true;
             // 
+            // importFormatLabel
+            // 
+            resources.ApplyResources(this.importFormatLabel, "importFormatLabel");
+            this.importFormatLabel.Name = "importFormatLabel";
+            // 
+            // _indexing
+            // 
+            resources.ApplyResources(this._indexing, "_indexing");
+            tableLayoutPanel1.SetColumnSpan(this._indexing, 2);
+            this._indexing.Name = "_indexing";
+            this._indexing.UseVisualStyleBackColor = true;
+            // 
             // PythonAnalysisOptionsControl
             // 
             resources.ApplyResources(this, "$this");
@@ -177,9 +204,13 @@
         private System.Windows.Forms.ToolTip _typeshedPathsToolTip;
         private System.Windows.Forms.ToolTip _commonSearchPathsToolTip;
         private System.Windows.Forms.CheckBox _autoSearchPath;
+        private System.Windows.Forms.CheckBox _indexing;
         private System.Windows.Forms.ToolTip _searchPathsLabelToolTip;
         private System.Windows.Forms.ToolTip _typeshedPathsLabelToolTip;
         private System.Windows.Forms.Label _typeShedPathsLabel;
+        private System.Windows.Forms.ToolTip _importFormatToolTip;
         private System.Windows.Forms.Label _searchPathsLabel;
+        private System.Windows.Forms.ComboBox _importFormatCombo;
+        private System.Windows.Forms.Label importFormatLabel;
     }
 }

--- a/Python/Product/PythonTools/PythonTools/Options/PythonAnalysisOptionsControl.Designer.cs
+++ b/Python/Product/PythonTools/PythonTools/Options/PythonAnalysisOptionsControl.Designer.cs
@@ -76,8 +76,8 @@
             tableLayoutPanel1.Controls.Add(this._searchPaths, 1, 5);
             tableLayoutPanel1.Controls.Add(this._typeShedPathsLabel, 0, 6);
             tableLayoutPanel1.Controls.Add(this._typeshedPaths, 1, 6);
-            tableLayoutPanel1.Controls.Add(this._autoSearchPath, 0, 7);
             tableLayoutPanel1.Controls.Add(this.importFormatLabel, 0, 3);
+            tableLayoutPanel1.Controls.Add(this._autoSearchPath, 0, 7);
             tableLayoutPanel1.Controls.Add(this._indexing, 0, 8);
             tableLayoutPanel1.Name = "tableLayoutPanel1";
             // 

--- a/Python/Product/PythonTools/PythonTools/Options/PythonAnalysisOptionsControl.cs
+++ b/Python/Product/PythonTools/PythonTools/Options/PythonAnalysisOptionsControl.cs
@@ -45,6 +45,10 @@ namespace Microsoft.PythonTools.Options {
 
             _typeshedPathsToolTip.SetToolTip(_typeshedPaths, Strings.TypeshedPathsToolTip);
             _typeshedPathsLabelToolTip.SetToolTip(_typeShedPathsLabel, Strings.TypeshedPathsToolTip);
+
+            _importFormatCombo.Items.Add(Strings.ImportFormatAbsolute);
+            _importFormatCombo.Items.Add(Strings.ImportFormatRelative);
+            _importFormatToolTip.SetToolTip(_importFormatCombo, Strings.ImportFormatToolTip);
         }
 
         internal void SyncControlWithPageSettings(PythonToolsService pyService) {
@@ -54,8 +58,11 @@ namespace Microsoft.PythonTools.Options {
             _typeshedPaths.Lines = pyService.AnalysisOptions.TypeshedPaths ?? Array.Empty<string>();
 
             _autoSearchPath.Checked = pyService.AnalysisOptions.AutoSearchPaths;
+            _indexing.Checked = pyService.AnalysisOptions.Indexing;
             _diagnosticsModeCombo.SelectedIndex =
                 pyService.AnalysisOptions.DiagnosticMode == PylanceDiagnosticMode.OpenFilesOnly ? 0 : 1;
+            _importFormatCombo.SelectedIndex =
+                pyService.AnalysisOptions.ImportFormat == PylanceImportFormat.Absolute ? 0 : 1;
 
             if (pyService.AnalysisOptions.TypeCheckingMode == PylanceTypeCheckingMode.Off) {
                 _typeCheckingMode.SelectedIndex = 0;
@@ -90,8 +97,11 @@ namespace Microsoft.PythonTools.Options {
                 .Split(pathsSeparators, StringSplitOptions.RemoveEmptyEntries) ?? Array.Empty<string>();
 
             pyService.AnalysisOptions.AutoSearchPaths = _autoSearchPath.Checked;
+            pyService.AnalysisOptions.Indexing = _indexing.Checked;
             pyService.AnalysisOptions.DiagnosticMode = _diagnosticsModeCombo.SelectedIndex == 0 ?
                 PylanceDiagnosticMode.OpenFilesOnly : PylanceDiagnosticMode.Workspace;
+            pyService.AnalysisOptions.ImportFormat = _importFormatCombo.SelectedIndex == 0 ?
+                PylanceImportFormat.Absolute : PylanceImportFormat.Relative;
 
             switch (_typeCheckingMode.SelectedIndex) {
                 case 0:

--- a/Python/Product/PythonTools/PythonTools/Options/PythonAnalysisOptionsControl.resx
+++ b/Python/Product/PythonTools/PythonTools/Options/PythonAnalysisOptionsControl.resx
@@ -324,6 +324,27 @@
   <data name="&gt;&gt;_typeCheckingMode.ZOrder" xml:space="preserve">
     <value>5</value>
   </data>
+  <data name="_importFormatCombo.Location" type="System.Drawing.Point, System.Drawing">
+    <value>118, 78</value>
+  </data>
+  <data name="_importFormatCombo.Size" type="System.Drawing.Size, System.Drawing">
+    <value>252, 21</value>
+  </data>
+  <data name="_importFormatCombo.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;_importFormatCombo.Name" xml:space="preserve">
+    <value>_importFormatCombo</value>
+  </data>
+  <data name="&gt;&gt;_importFormatCombo.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;_importFormatCombo.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;_importFormatCombo.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
   <metadata name="stubsPathsLabel.GenerateMember" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>False</value>
   </metadata>
@@ -337,7 +358,7 @@
     <value>NoControl</value>
   </data>
   <data name="stubsPathsLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 80</value>
+    <value>3, 107</value>
   </data>
   <data name="stubsPathsLabel.Size" type="System.Drawing.Size, System.Drawing">
     <value>61, 13</value>
@@ -361,10 +382,10 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;stubsPathsLabel.ZOrder" xml:space="preserve">
-    <value>6</value>
+    <value>7</value>
   </data>
   <data name="_stubsPath.Location" type="System.Drawing.Point, System.Drawing">
-    <value>117, 77</value>
+    <value>117, 104</value>
   </data>
   <data name="_stubsPath.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>2, 2, 2, 2</value>
@@ -385,7 +406,7 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;_stubsPath.ZOrder" xml:space="preserve">
-    <value>7</value>
+    <value>8</value>
   </data>
   <data name="_searchPathsLabel.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -394,7 +415,7 @@
     <value>NoControl</value>
   </data>
   <data name="_searchPathsLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 102</value>
+    <value>3, 129</value>
   </data>
   <data name="_searchPathsLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 3, 3, 0</value>
@@ -421,10 +442,10 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;_searchPathsLabel.ZOrder" xml:space="preserve">
-    <value>8</value>
+    <value>9</value>
   </data>
   <data name="_searchPaths.Location" type="System.Drawing.Point, System.Drawing">
-    <value>117, 101</value>
+    <value>117, 128</value>
   </data>
   <data name="_searchPaths.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>2, 2, 2, 2</value>
@@ -433,7 +454,7 @@
     <value>True</value>
   </data>
   <data name="_searchPaths.Size" type="System.Drawing.Size, System.Drawing">
-    <value>253, 71</value>
+    <value>253, 51</value>
   </data>
   <data name="_searchPaths.TabIndex" type="System.Int32, mscorlib">
     <value>11</value>
@@ -448,7 +469,7 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;_searchPaths.ZOrder" xml:space="preserve">
-    <value>9</value>
+    <value>10</value>
   </data>
   <data name="_typeShedPathsLabel.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -457,7 +478,7 @@
     <value>NoControl</value>
   </data>
   <data name="_typeShedPathsLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 177</value>
+    <value>3, 184</value>
   </data>
   <data name="_typeShedPathsLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 3, 3, 0</value>
@@ -484,10 +505,10 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;_typeShedPathsLabel.ZOrder" xml:space="preserve">
-    <value>10</value>
+    <value>11</value>
   </data>
   <data name="_typeshedPaths.Location" type="System.Drawing.Point, System.Drawing">
-    <value>117, 176</value>
+    <value>117, 183</value>
   </data>
   <data name="_typeshedPaths.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>2, 2, 2, 2</value>
@@ -496,7 +517,7 @@
     <value>True</value>
   </data>
   <data name="_typeshedPaths.Size" type="System.Drawing.Size, System.Drawing">
-    <value>253, 67</value>
+    <value>253, 51</value>
   </data>
   <data name="_typeshedPaths.TabIndex" type="System.Int32, mscorlib">
     <value>13</value>
@@ -511,7 +532,7 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;_typeshedPaths.ZOrder" xml:space="preserve">
-    <value>11</value>
+    <value>12</value>
   </data>
   <data name="_autoSearchPath.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Left</value>
@@ -523,7 +544,7 @@
     <value>NoControl</value>
   </data>
   <data name="_autoSearchPath.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 251</value>
+    <value>6, 242</value>
   </data>
   <data name="_autoSearchPath.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>6, 6, 6, 3</value>
@@ -547,7 +568,77 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;_autoSearchPath.ZOrder" xml:space="preserve">
-    <value>12</value>
+    <value>13</value>
+  </data>
+  <data name="importFormatLabel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Left</value>
+  </data>
+  <data name="importFormatLabel.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="importFormatLabel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 82</value>
+  </data>
+  <data name="importFormatLabel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>71, 13</value>
+  </data>
+  <data name="importFormatLabel.TabIndex" type="System.Int32, mscorlib">
+    <value>9</value>
+  </data>
+  <data name="importFormatLabel.Text" xml:space="preserve">
+    <value>&amp;Import format:</value>
+  </data>
+  <data name="importFormatLabel.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleLeft</value>
+  </data>
+  <data name="&gt;&gt;importFormatLabel.Name" xml:space="preserve">
+    <value>importFormatLabel</value>
+  </data>
+  <data name="&gt;&gt;importFormatLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;importFormatLabel.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;importFormatLabel.ZOrder" xml:space="preserve">
+    <value>14</value>
+  </data>
+  <data name="_indexing.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Left</value>
+  </data>
+  <data name="_indexing.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="_indexing.CheckAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>TopLeft</value>
+  </data>
+  <data name="_indexing.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 268</value>
+  </data>
+  <data name="_indexing.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>6, 6, 6, 3</value>
+  </data>
+  <data name="_indexing.Size" type="System.Drawing.Size, System.Drawing">
+    <value>351, 19</value>
+  </data>
+  <data name="_indexing.TabIndex" type="System.Int32, mscorlib">
+    <value>15</value>
+  </data>
+  <data name="_indexing.Text" xml:space="preserve">
+    <value>&amp;Index installed third party libraries and user files for language features 
+such as auto-import, add import, workspace symbols and etc.</value>
+  </data>
+  <data name="&gt;&gt;_indexing.Name" xml:space="preserve">
+    <value>_indexing</value>
+  </data>
+  <data name="&gt;&gt;_indexing.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;_indexing.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;_indexing.ZOrder" xml:space="preserve">
+    <value>15</value>
   </data>
   <data name="tableLayoutPanel1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
@@ -577,34 +668,37 @@
     <value>0</value>
   </data>
   <data name="tableLayoutPanel1.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="diagnosticModeLabel" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_diagnosticsModeCombo" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="logLevelLabel" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_logLevelCombo" Row="1" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="typeCheckingModeLabel" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_typeCheckingMode" Row="2" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="stubsPathsLabel" Row="3" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_stubsPath" Row="3" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="_searchPathsLabel" Row="4" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_searchPaths" Row="4" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="_typeShedPathsLabel" Row="5" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_typeshedPaths" Row="5" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="_autoSearchPath" Row="7" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,100,Absolute,266" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,Absolute,11,Absolute,11" /&gt;&lt;/TableLayoutSettings&gt;</value>
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="diagnosticModeLabel" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_diagnosticsModeCombo" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="logLevelLabel" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_logLevelCombo" Row="1" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="typeCheckingModeLabel" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_typeCheckingMode" Row="2" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="_importFormatCombo" Row="3" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="stubsPathsLabel" Row="4" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_stubsPath" Row="4" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="_searchPathsLabel" Row="5" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_searchPaths" Row="5" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="_typeShedPathsLabel" Row="6" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_typeshedPaths" Row="6" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="_autoSearchPath" Row="7" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="importFormatLabel" Row="3" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_indexing" Row="8" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,100,Absolute,266" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,Absolute,20" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <metadata name="_diagnosticModeToolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 17</value>
+    <value>190, 17</value>
   </metadata>
   <metadata name="_logLevelToolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>162, 17</value>
+    <value>376, 17</value>
   </metadata>
   <metadata name="_typeCheckingToolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>307, 17</value>
+    <value>518, 17</value>
   </metadata>
   <metadata name="_stubsPathToolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>452, 17</value>
+    <value>689, 17</value>
   </metadata>
   <metadata name="_searchPathsToolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>597, 17</value>
+    <value>840, 17</value>
   </metadata>
   <metadata name="_typeshedPathsToolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>742, 17</value>
+    <value>1002, 17</value>
   </metadata>
   <metadata name="_commonSearchPathsToolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>887, 17</value>
+    <value>1179, 17</value>
   </metadata>
   <metadata name="_searchPathsLabelToolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>1234, 17</value>
+    <value>17, 56</value>
   </metadata>
   <metadata name="_typeshedPathsLabelToolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>1544, 17</value>
+    <value>208, 56</value>
+  </metadata>
+  <metadata name="_importFormatToolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
   </metadata>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
@@ -670,6 +764,12 @@
     <value>_typeshedPathsLabelToolTip</value>
   </data>
   <data name="&gt;&gt;_typeshedPathsLabelToolTip.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolTip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;_importFormatToolTip.Name" xml:space="preserve">
+    <value>_importFormatToolTip</value>
+  </data>
+  <data name="&gt;&gt;_importFormatToolTip.Type" xml:space="preserve">
     <value>System.Windows.Forms.ToolTip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">

--- a/Python/Product/PythonTools/PythonTools/Options/PythonAnalysisOptionsControl.resx
+++ b/Python/Product/PythonTools/PythonTools/Options/PythonAnalysisOptionsControl.resx
@@ -325,10 +325,13 @@
     <value>5</value>
   </data>
   <data name="_importFormatCombo.Location" type="System.Drawing.Point, System.Drawing">
-    <value>118, 78</value>
+    <value>117, 77</value>
+  </data>
+  <data name="_importFormatCombo.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>2, 2, 2, 2</value>
   </data>
   <data name="_importFormatCombo.Size" type="System.Drawing.Size, System.Drawing">
-    <value>252, 21</value>
+    <value>253, 21</value>
   </data>
   <data name="_importFormatCombo.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -358,7 +361,7 @@
     <value>NoControl</value>
   </data>
   <data name="stubsPathsLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 107</value>
+    <value>3, 105</value>
   </data>
   <data name="stubsPathsLabel.Size" type="System.Drawing.Size, System.Drawing">
     <value>61, 13</value>
@@ -385,7 +388,7 @@
     <value>7</value>
   </data>
   <data name="_stubsPath.Location" type="System.Drawing.Point, System.Drawing">
-    <value>117, 104</value>
+    <value>117, 102</value>
   </data>
   <data name="_stubsPath.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>2, 2, 2, 2</value>
@@ -415,7 +418,7 @@
     <value>NoControl</value>
   </data>
   <data name="_searchPathsLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 129</value>
+    <value>3, 127</value>
   </data>
   <data name="_searchPathsLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 3, 3, 0</value>
@@ -445,7 +448,7 @@
     <value>9</value>
   </data>
   <data name="_searchPaths.Location" type="System.Drawing.Point, System.Drawing">
-    <value>117, 128</value>
+    <value>117, 126</value>
   </data>
   <data name="_searchPaths.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>2, 2, 2, 2</value>
@@ -478,7 +481,7 @@
     <value>NoControl</value>
   </data>
   <data name="_typeShedPathsLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 184</value>
+    <value>3, 182</value>
   </data>
   <data name="_typeShedPathsLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 3, 3, 0</value>
@@ -508,7 +511,7 @@
     <value>11</value>
   </data>
   <data name="_typeshedPaths.Location" type="System.Drawing.Point, System.Drawing">
-    <value>117, 183</value>
+    <value>117, 181</value>
   </data>
   <data name="_typeshedPaths.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>2, 2, 2, 2</value>
@@ -534,42 +537,6 @@
   <data name="&gt;&gt;_typeshedPaths.ZOrder" xml:space="preserve">
     <value>12</value>
   </data>
-  <data name="_autoSearchPath.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Left</value>
-  </data>
-  <data name="_autoSearchPath.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="_autoSearchPath.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="_autoSearchPath.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 242</value>
-  </data>
-  <data name="_autoSearchPath.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 6, 6, 3</value>
-  </data>
-  <data name="_autoSearchPath.Size" type="System.Drawing.Size, System.Drawing">
-    <value>256, 17</value>
-  </data>
-  <data name="_autoSearchPath.TabIndex" type="System.Int32, mscorlib">
-    <value>14</value>
-  </data>
-  <data name="_autoSearchPath.Text" xml:space="preserve">
-    <value>&amp;Automatically add common search paths like 'src'</value>
-  </data>
-  <data name="&gt;&gt;_autoSearchPath.Name" xml:space="preserve">
-    <value>_autoSearchPath</value>
-  </data>
-  <data name="&gt;&gt;_autoSearchPath.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;_autoSearchPath.Parent" xml:space="preserve">
-    <value>tableLayoutPanel1</value>
-  </data>
-  <data name="&gt;&gt;_autoSearchPath.ZOrder" xml:space="preserve">
-    <value>13</value>
-  </data>
   <data name="importFormatLabel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Left</value>
   </data>
@@ -577,7 +544,7 @@
     <value>True</value>
   </data>
   <data name="importFormatLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 82</value>
+    <value>3, 81</value>
   </data>
   <data name="importFormatLabel.Size" type="System.Drawing.Size, System.Drawing">
     <value>71, 13</value>
@@ -601,10 +568,40 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;importFormatLabel.ZOrder" xml:space="preserve">
+    <value>13</value>
+  </data>
+  <data name="_autoSearchPath.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="_autoSearchPath.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="_autoSearchPath.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 240</value>
+  </data>
+  <data name="_autoSearchPath.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>6, 6, 6, 3</value>
+  </data>
+  <data name="_autoSearchPath.Size" type="System.Drawing.Size, System.Drawing">
+    <value>256, 17</value>
+  </data>
+  <data name="_autoSearchPath.TabIndex" type="System.Int32, mscorlib">
     <value>14</value>
   </data>
-  <data name="_indexing.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Left</value>
+  <data name="_autoSearchPath.Text" xml:space="preserve">
+    <value>&amp;Automatically add common search paths like 'src'</value>
+  </data>
+  <data name="&gt;&gt;_autoSearchPath.Name" xml:space="preserve">
+    <value>_autoSearchPath</value>
+  </data>
+  <data name="&gt;&gt;_autoSearchPath.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;_autoSearchPath.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;_autoSearchPath.ZOrder" xml:space="preserve">
+    <value>14</value>
   </data>
   <data name="_indexing.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -613,13 +610,13 @@
     <value>TopLeft</value>
   </data>
   <data name="_indexing.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 268</value>
+    <value>6, 266</value>
   </data>
   <data name="_indexing.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>6, 6, 6, 3</value>
   </data>
   <data name="_indexing.Size" type="System.Drawing.Size, System.Drawing">
-    <value>351, 19</value>
+    <value>351, 21</value>
   </data>
   <data name="_indexing.TabIndex" type="System.Int32, mscorlib">
     <value>15</value>
@@ -668,7 +665,7 @@ such as auto-import, add import, workspace symbols and etc.</value>
     <value>0</value>
   </data>
   <data name="tableLayoutPanel1.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="diagnosticModeLabel" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_diagnosticsModeCombo" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="logLevelLabel" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_logLevelCombo" Row="1" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="typeCheckingModeLabel" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_typeCheckingMode" Row="2" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="_importFormatCombo" Row="3" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="stubsPathsLabel" Row="4" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_stubsPath" Row="4" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="_searchPathsLabel" Row="5" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_searchPaths" Row="5" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="_typeShedPathsLabel" Row="6" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_typeshedPaths" Row="6" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="_autoSearchPath" Row="7" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="importFormatLabel" Row="3" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_indexing" Row="8" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,100,Absolute,266" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,Absolute,20" /&gt;&lt;/TableLayoutSettings&gt;</value>
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="diagnosticModeLabel" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_diagnosticsModeCombo" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="logLevelLabel" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_logLevelCombo" Row="1" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="typeCheckingModeLabel" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_typeCheckingMode" Row="2" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="_importFormatCombo" Row="3" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="stubsPathsLabel" Row="4" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_stubsPath" Row="4" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="_searchPathsLabel" Row="5" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_searchPaths" Row="5" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="_typeShedPathsLabel" Row="6" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_typeshedPaths" Row="6" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="importFormatLabel" Row="3" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_autoSearchPath" Row="7" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="_indexing" Row="8" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,100,Absolute,266" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,Absolute,20" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <metadata name="_diagnosticModeToolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>190, 17</value>


### PR DESCRIPTION
fixes #7107 
fixes #7105 

Update the settings in PTVS to match what Pylance currently has. See https://github.com/microsoft/pyrx/blob/bcfcc39bdb1fd85fcbf2eb0fc19f657bc2a2f2d3/packages/vscode-pylance/package.json#L883

Two new settings are now visible to users:
- Indexing
![indexing](https://user-images.githubusercontent.com/100439259/184003001-bbb1f939-9809-4598-a152-f17764674f76.gif)

- Import Format (Note that this new enhancement is not in the stable version yet, it's only tested on prerelease pylance)

Absolute:
![absolute](https://user-images.githubusercontent.com/100439259/184003059-19f71e59-0650-4e0d-83c6-060c05b995ac.gif)

Relative:
![relative](https://user-images.githubusercontent.com/100439259/184003071-7e11d032-2cc3-4d04-ad52-4b6c4c07b257.gif)

Just creating the PR for now, will wait until import format is in pylance stable to merge it in.