### PR TITLE
Fix CodeQL static analysis compliance warnings

### DIFF
--- a/Python/Product/Cookiecutter/Model/FeedTemplateSource.cs
+++ b/Python/Product/Cookiecutter/Model/FeedTemplateSource.cs
@@ -56,6 +56,7 @@ namespace Microsoft.CookiecutterTools.Model {
             _cache = new List<Template>();
 
             try {
+                ServicePointManager.CheckCertificateRevocationList = true;
                 var client = new WebClient();
                 var feed = await client.DownloadStringTaskAsync(_feedLocation);
                 var feedUrls = feed.Split(new char[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);

--- a/Python/Product/Cookiecutter/Model/GitHubClient.cs
+++ b/Python/Product/Cookiecutter/Model/GitHubClient.cs
@@ -78,6 +78,7 @@ namespace Microsoft.CookiecutterTools.Model {
         }
 
         private static WebClient CreateClient() {
+            ServicePointManager.CheckCertificateRevocationList = true;
             var wc = new WebClient();
             wc.Encoding = Encoding.UTF8;
             wc.Headers.Add(HttpRequestHeader.UserAgent, UserAgent);

--- a/Python/Product/Debugger/Debugger/Transports/WebSocketTransport.cs
+++ b/Python/Product/Debugger/Debugger/Transports/WebSocketTransport.cs
@@ -32,6 +32,7 @@ namespace Microsoft.PythonTools.Debugger.Transports {
             // of inactivity, making it impossible to attach. So before trying to connect to the debugger, "ping" the website
             // via HTTP to ensure that we have something to connect to.
             try {
+                ServicePointManager.CheckCertificateRevocationList = true;
                 var httpRequest = WebRequest.Create(new UriBuilder(uri) { Scheme = "http", Port = -1, Path = "/" }.Uri);
                 httpRequest.Method = WebRequestMethods.Http.Head;
                 httpRequest.Timeout = 5000;

--- a/Python/Product/DebuggerHelper/trace.cpp
+++ b/Python/Product/DebuggerHelper/trace.cpp
@@ -481,7 +481,7 @@ static void TraceLine(void* frame) {
 
     void* f_code = ReadField<void*>(frame, fieldOffsets.PyFrameObject.f_code);
     void* co_filename = ReadField<void*>(f_code, fieldOffsets.PyCodeObject.co_filename);
-    if (co_filename == NULL) {
+    if (co_filename == nullptr) {
         return;
     }
 

--- a/Python/Product/DebuggerHelper/trace.cpp
+++ b/Python/Product/DebuggerHelper/trace.cpp
@@ -481,6 +481,9 @@ static void TraceLine(void* frame) {
 
     void* f_code = ReadField<void*>(frame, fieldOffsets.PyFrameObject.f_code);
     void* co_filename = ReadField<void*>(f_code, fieldOffsets.PyCodeObject.co_filename);
+    if (co_filename == NULL) {
+        return;
+    }
 
     auto fileNamesOffsets = reinterpret_cast<const int32_t*>(bpData.fileNamesOffsets);
     auto strings = reinterpret_cast<const char*>(bpData.strings);

--- a/Python/Product/ProjectWizards/CookiecutterWizard.cs
+++ b/Python/Product/ProjectWizards/CookiecutterWizard.cs
@@ -143,6 +143,7 @@ namespace Microsoft.PythonTools.ProjectWizards {
                 return uri;
             }
 
+            ServicePointManager.CheckCertificateRevocationList = true;
             var req = WebRequest.CreateHttp(uri);
             req.Method = "HEAD";
             req.AllowAutoRedirect = false;

--- a/Python/Product/PythonTools/PythonTools/Project/FtpPublisher.cs
+++ b/Python/Product/PythonTools/PythonTools/Project/FtpPublisher.cs
@@ -61,6 +61,7 @@ namespace Microsoft.PythonTools.Project {
             EnsureDirectoryExists(rootPath, destinationDir);
 
             // upload the file
+            ServicePointManager.CheckCertificateRevocationList = true;
             FtpWebRequest request = (FtpWebRequest)WebRequest.Create(new Uri(newLoc));
             request.Method = WebRequestMethods.Ftp.UploadFile;
             byte[] buffer = new byte[1024];

--- a/Python/Product/PythonTools/PythonTools/Repl/PythonInteractiveEvaluator.CommandProcessorThread.cs
+++ b/Python/Product/PythonTools/PythonTools/Repl/PythonInteractiveEvaluator.CommandProcessorThread.cs
@@ -440,6 +440,8 @@ namespace Microsoft.PythonTools.Repl {
 
                 _eval.InvokeAsync(() => {
                     try {
+                        // This can potentially instantiate any random subclass of FrameworkElement,
+                        // but that's OK and expected.
                         var fe = XamlReader.Load(new MemoryStream(buffer)) as FrameworkElement;
                         if (fe != null) {
                             _eval.WriteFrameworkElement(fe, fe.DesiredSize);

--- a/Python/Product/VSInterpreters/PackageManager/PipPackageCache.cs
+++ b/Python/Product/VSInterpreters/PackageManager/PipPackageCache.cs
@@ -244,6 +244,7 @@ namespace Microsoft.PythonTools.Interpreter {
             }
 
             try {
+                ServicePointManager.CheckCertificateRevocationList = true;
                 using (var client = new WebClient()) {
                     Stream data;
                     client.Headers[HttpRequestHeader.UserAgent] = UserAgent;


### PR DESCRIPTION
Fix semmle warnings at https://devdiv.visualstudio.com/DevDiv/_queries?tempQueryId=bdca2043-7ac3-4421-93d8-88acb6ee3405

Most have to do with checking the revoked cert list when creating web requests, but there is also a missing null check.