### PR TITLE
Remove TargetFrameworkMoniker from targets file

### DIFF
--- a/Python/Product/BuildTasks/Microsoft.PythonTools.targets
+++ b/Python/Product/BuildTasks/Microsoft.PythonTools.targets
@@ -35,7 +35,6 @@ permissions and limitations under the License.
   -->
   <PropertyGroup>
     <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
-    <TargetFrameworkMoniker>.NETFramework,Version=$(TargetFrameworkVersion)</TargetFrameworkMoniker>
   </PropertyGroup>
 
   <!-- Creates a command object that will be displayed in the IDE.


### PR DESCRIPTION
fixes #6864 

A small PR to close this issue out. 

Tested through both msbuild and visual studio, and Python project can be created and opened without errors.

Also found a reference on targeting an application to run on the specified  .NET framework version: https://docs.microsoft.com/en-us/visualstudio/msbuild/msbuild-target-framework-and-target-platform?view=vs-2019