### PR TITLE
Fix formatter crash when file doesn't end in newline

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Editor/Formatting/LspDiffTextEditFactory.cs
+++ b/Python/Product/PythonTools/PythonTools/Editor/Formatting/LspDiffTextEditFactory.cs
@@ -60,10 +60,6 @@ namespace Microsoft.PythonTools.Editor.Formatting {
 
             var patches = new diff_match_patch().patch_fromText(diffOutputText);
             foreach (var patch in patches ) {
-                //foreach (var diff in patch.diffs) {
-                //    diff.text += Environment.NewLine;
-                //}
-
                 var edits = GetEdits(documentText, patch.diffs, patch.start1);
                 textEdits.AddRange(edits);
             }
@@ -121,7 +117,6 @@ namespace Microsoft.PythonTools.Editor.Formatting {
                         // of the document, so inserts should reset the current line/character
                         // position to the start.
                         line = start.Line;
-                        //character = start.Character;
 
                         //only add newline before text if not inserting at begining of file
                         bool isPatchStart = (line == startLine) && (edit.Range.Start.Character == 0);

--- a/Python/Product/PythonTools/PythonTools/LanguageServerClient/LspEditorUtilities.cs
+++ b/Python/Product/PythonTools/PythonTools/LanguageServerClient/LspEditorUtilities.cs
@@ -53,35 +53,36 @@ namespace Microsoft.PythonTools.LanguageServerClient {
         }
 
         internal static void ApplyTextEdits(IEnumerable<TextEdit> textEdits, ITextSnapshot snapshot, ITextBuffer textBuffer) {
-            var vsTextEdit = textBuffer.CreateEdit();
-            foreach (var textEdit in textEdits) {
-                if (string.IsNullOrEmpty(textEdit.NewText)) {
-                    var startPosition = snapshot.GetSnapshotPositionFromProtocolPosition(textEdit.Range.Start);
-                    var endPosition = snapshot.GetSnapshotPositionFromProtocolPosition(textEdit.Range.End);
-                    var difference = endPosition - startPosition;
-                    if (startPosition > -1 && endPosition > -1 && difference > 0) {
-                        var span = GetTranslatedSpan(startPosition, difference, snapshot, vsTextEdit.Snapshot);
-                        vsTextEdit.Delete(span);
-                    }
-                } else if (textEdit.Range.Start == textEdit.Range.End) {
-                    var position = snapshot.GetSnapshotPositionFromProtocolPosition(textEdit.Range.Start);
-                    if (position > -1) {
-                        var span = GetTranslatedSpan(position, 0, snapshot, vsTextEdit.Snapshot);
-                        vsTextEdit.Insert(span.Start, textEdit.NewText);
-                    }
-                } else {
-                    var startPosition = snapshot.GetSnapshotPositionFromProtocolPosition(textEdit.Range.Start);
-                    var endPosition = snapshot.GetSnapshotPositionFromProtocolPosition(textEdit.Range.End);
-                    var difference = endPosition - startPosition;
+            using (var vsTextEdit = textBuffer.CreateEdit()) {
+                foreach (var textEdit in textEdits) {
+                    if (string.IsNullOrEmpty(textEdit.NewText)) {
+                        var startPosition = snapshot.GetSnapshotPositionFromProtocolPosition(textEdit.Range.Start);
+                        var endPosition = snapshot.GetSnapshotPositionFromProtocolPosition(textEdit.Range.End);
+                        var difference = endPosition - startPosition;
+                        if (startPosition > -1 && endPosition > -1 && difference > 0) {
+                            var span = GetTranslatedSpan(startPosition, difference, snapshot, vsTextEdit.Snapshot);
+                            vsTextEdit.Delete(span);
+                        }
+                    } else if (textEdit.Range.Start == textEdit.Range.End) {
+                        var position = snapshot.GetSnapshotPositionFromProtocolPosition(textEdit.Range.Start);
+                        if (position > -1) {
+                            var span = GetTranslatedSpan(position, 0, snapshot, vsTextEdit.Snapshot);
+                            vsTextEdit.Insert(span.Start, textEdit.NewText);
+                        }
+                    } else {
+                        var startPosition = snapshot.GetSnapshotPositionFromProtocolPosition(textEdit.Range.Start);
+                        var endPosition = snapshot.GetSnapshotPositionFromProtocolPosition(textEdit.Range.End);
+                        var difference = endPosition - startPosition;
 
-                    if (startPosition > -1 && endPosition > -1 && difference > 0) {
-                        var span = GetTranslatedSpan(startPosition, difference, snapshot, vsTextEdit.Snapshot);
-                        vsTextEdit.Replace(span, textEdit.NewText);
+                        if (startPosition > -1 && endPosition > -1 && difference > 0) {
+                            var span = GetTranslatedSpan(startPosition, difference, snapshot, vsTextEdit.Snapshot);
+                            vsTextEdit.Replace(span, textEdit.NewText);
+                        }
                     }
                 }
-            }
 
-            vsTextEdit.Apply();
+                vsTextEdit.Apply();
+            }
         }
 
         internal static void ApplyTextEdit(TextEdit textEdit, ITextSnapshot snapshot, ITextBuffer textBuffer) {


### PR DESCRIPTION
Fixes #6752

- Removes the offending line from the diff we get back from the formatter
- Properly dispose of the ITextEdit when applying edits