### PR TITLE
Remove extra didOpen message sent from our end

### DIFF
--- a/Python/Product/PythonTools/PythonTools/LanguageServerClient/PythonLanguageClient.cs
+++ b/Python/Product/PythonTools/PythonTools/LanguageServerClient/PythonLanguageClient.cs
@@ -360,7 +360,7 @@ namespace Microsoft.PythonTools.LanguageServerClient {
                 });
                    
             // If we send workspace folder updates, we have to resend document opens
-            await SendDocumentOpensAsync();
+            // await SendDocumentOpensAsync();
         }
 
         public Task<object> InvokeTextDocumentCompletionAsync(LSP.CompletionParams request, CancellationToken cancellationToken = default)
@@ -406,39 +406,39 @@ namespace Microsoft.PythonTools.LanguageServerClient {
             _readyTcs.TrySetResult(0);
         }
 
-        private async Task SendDocumentOpensAsync() {
-            // This should be handled by the VSSDK if they ever support workspace folder change notifications
-            // Meaning we shouldn't need to do this if they do it for us.
-            await JoinableTaskContext.Factory.SwitchToMainThreadAsync();
-            IComponentModel componentModel = Site.GetService(typeof(SComponentModel)) as IComponentModel;
+        //private async Task SendDocumentOpensAsync() {
+        //    This should be handled by the VSSDK if they ever support workspace folder change notifications
+        //     Meaning we shouldn't need to do this if they do it for us.
+        //    await JoinableTaskContext.Factory.SwitchToMainThreadAsync();
+        //    IComponentModel componentModel = Site.GetService(typeof(SComponentModel)) as IComponentModel;
 
-            SVsServiceProvider syncServiceProvider = componentModel.GetService<SVsServiceProvider>();
-            RunningDocumentTable rdt = new RunningDocumentTable(syncServiceProvider);
-            var tasks = new List<Task>();
+        //    SVsServiceProvider syncServiceProvider = componentModel.GetService<SVsServiceProvider>();
+        //    RunningDocumentTable rdt = new RunningDocumentTable(syncServiceProvider);
+        //    var tasks = new List<Task>();
 
-            foreach (RunningDocumentInfo info in rdt) {
-                if (this.TryGetOpenedDocumentData(info, out ITextBuffer textBuffer, out string filePath)
-                    && textBuffer != null
-                    && textBuffer.IsPythonContent()) {
+        //    foreach (RunningDocumentInfo info in rdt) {
+        //        if (this.TryGetOpenedDocumentData(info, out ITextBuffer textBuffer, out string filePath)
+        //            && textBuffer != null
+        //            && textBuffer.IsPythonContent()) {
 
-                    var textDocumentItem = new TextDocumentItem {
-                        Uri = new Uri(filePath),
-                        Version = textBuffer.CurrentSnapshot.Version.VersionNumber,
-                        LanguageId = textBuffer.ContentType.DisplayName,
-                    };
+        //            var textDocumentItem = new TextDocumentItem {
+        //                Uri = new Uri(filePath),
+        //                Version = textBuffer.CurrentSnapshot.Version.VersionNumber,
+        //                LanguageId = textBuffer.ContentType.DisplayName,
+        //            };
 
-                    var param = new DidOpenTextDocumentParams {
-                        TextDocument = textDocumentItem,
-                    };
-                    param.TextDocument.Text = textBuffer.CurrentSnapshot.GetText();
+        //            var param = new DidOpenTextDocumentParams {
+        //                TextDocument = textDocumentItem,
+        //            };
+        //            param.TextDocument.Text = textBuffer.CurrentSnapshot.GetText();
 
-                    tasks.Add(InvokeTextDocumentDidOpenAsync(param));
-                }
-            }
+        //            tasks.Add(InvokeTextDocumentDidOpenAsync(param));
+        //        }
+        //    }
 
-            // Let all the tasks execute in parallel
-            await Task.WhenAll(tasks);
-        }
+        //    Let all the tasks execute in parallel
+        //   await Task.WhenAll(tasks);
+        //}
 
         private bool TryGetOpenedDocumentData(RunningDocumentInfo info, out ITextBuffer textBuffer, out string filePath) {
             textBuffer = null;


### PR DESCRIPTION
fixes #7115 

Pylance used to require a new open notification after a workspace folder change (not sure if it still requires now). The code in `PythonLanguageClient.cs` was a requirement of pylance to force a reopen on all documents whenever the current workspace folder changed (opening a solution would provide the base folder for the workspace).

This makes sense in VSCode, because VS Code allows you to open multiple folders at a time. So adding or removing WorkspaceFolders makes sense there. But in VS, it does not support opening multiple workspace folders at the same time. When you close the current workspace (i.e. close all open folders) and open a new one in VS, we just start a new instance of Pylance.

The [LSP spec](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_didChangeWorkspaceFolders) says that the `workspace/didChangeWorkspaceFolders` should be sent for "workspace folder configuration changes" which is not very specific. But the `didChangeWorkspaceFolder` message only contains added/removed arrays of WorkspaceFolder objects, and those objects just contain the folder uri and folder name (to show in UI), so I can't think of another scenario where the message would need to be sent other than opening/closing a solution/workspace.

LSP Client already sends at least one didOpen anytime documents are opened, so it should be ok to remove the extra didOpen from PTVS. It can be sent in whichever of these two places is hit first:

- https://devdiv.visualstudio.com/DevDiv/_git/VSLanguageServerClient?path=/src/product/RemoteLanguage/Impl/Infrastructure/LspProjectionSupportService.cs&version=GBdevelop&line=101&lineEnd=101&lineStartColumn=1&lineEndColumn=120&lineStyle=plain&_a=contents

- https://devdiv.visualstudio.com/DevDiv/_git/VSLanguageServerClient?path=/src/product/RemoteLanguage/Impl/Infrastructure/TextSynchronization/LanguageServerBufferManager.cs&version=GBdevelop&line=95&lineEnd=95&lineStartColumn=1&lineEndColumn=90&lineStyle=plain&_a=contents

Also tested the change in both open folder and project view scenarios, pylance still works well after the change.