### PR TITLE
Dropping support for creating custom environments for older Python versions

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Environments/AddExistingEnvironmentView.cs
+++ b/Python/Product/PythonTools/PythonTools/Environments/AddExistingEnvironmentView.cs
@@ -51,16 +51,8 @@ namespace Microsoft.PythonTools.Environments {
         };
 
         public static IList<string> VersionNames { get; } = new[] {
-            "2.5",
-            "2.6",
-            "2.7",
-            "3.0",
-            "3.1",
-            "3.2",
-            "3.3",
-            "3.4",
-            "3.5",
-            "3.6",
+            // we only support creating environments of offically supported versions
+            // see https://devguide.python.org/versions/
             "3.7",
             "3.8",
             "3.9",


### PR DESCRIPTION
fixes https://github.com/microsoft/PTVS/issues/7172

Per discussion in the scrum meeting, we no longer support creating custom environments for the python versions < 3.7.

Only officially supported python versions are supported: https://devguide.python.org/versions/