### PR TITLE
Action to add new issues to scrum board

### DIFF
--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -23,3 +23,10 @@ jobs:
         if: ${{ steps.no-labels.outcome == 'skipped' && join(github.event.issue.labels.*.name, ',') != 'needs triage' }}
         with:
           remove-labels: 'needs triage'
+
+      - name: If triage-needed, add to scrum board
+        uses: actions/add-to-project@v0.3.0
+        if: ${{ steps.no-labels.outcome == 'success' }}
+        with:
+          github-token: ${{ secrets.PROJECT_BOARD_ACTIONS_TOKEN }}
+          project-url: https://github.com/orgs/microsoft/projects/145/views/17


### PR DESCRIPTION
Add new PTVS issues to the [Triage list](https://github.com/orgs/microsoft/projects/145/views/17) automatically. Logic is the same as [the similar action in pylance-release](https://github.com/microsoft/pylance-release/pull/3427).

I'll request the `PROJECT_BOARD_ACTIONS_TOKEN` secret from github-operations in parallel to this PR.

@judej 