### PR TITLE
Fix set as current option in virtual environment creation

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Environments/AddExistingEnvironmentView.cs
+++ b/Python/Product/PythonTools/PythonTools/Environments/AddExistingEnvironmentView.cs
@@ -51,16 +51,8 @@ namespace Microsoft.PythonTools.Environments {
         };
 
         public static IList<string> VersionNames { get; } = new[] {
-            "2.5",
-            "2.6",
-            "2.7",
-            "3.0",
-            "3.1",
-            "3.2",
-            "3.3",
-            "3.4",
-            "3.5",
-            "3.6",
+            // we only support creating environments of offically supported versions
+            // see https://devguide.python.org/versions/
             "3.7",
             "3.8",
             "3.9",

--- a/Python/Product/PythonTools/PythonTools/Environments/AddVirtualEnvironmentControl.xaml
+++ b/Python/Product/PythonTools/PythonTools/Environments/AddVirtualEnvironmentControl.xaml
@@ -211,7 +211,7 @@
                     <CheckBox
                         Margin="0 0 0 10"
                         IsChecked="{Binding Path=SetAsCurrent}"
-                        IsEnabled="{Binding Path=SelectedProject, Converter={x:Static wpf:Converters.NullIsFalse}}"
+                        IsEnabled="{Binding Path=IsUsingGlobalDefaultEnv}"
                         Content="{x:Static common:Strings.AddEnvironmentSetAsCurrentLabel}"
                         AutomationProperties.AutomationId="SetAsCurrent"
                         AutomationProperties.Name="{x:Static common:Strings.AddEnvironmentSetAsCurrentLabel}"/>

--- a/Python/Product/PythonTools/PythonTools/Environments/AddVirtualEnvironmentOperation.cs
+++ b/Python/Product/PythonTools/PythonTools/Environments/AddVirtualEnvironmentOperation.cs
@@ -122,7 +122,8 @@ namespace Microsoft.PythonTools.Environments {
                     baseInterp,
                     _registerAsCustomEnv,
                     _customEnvName,
-                    _useVEnv
+                    _useVEnv,
+                    _setAsCurrent
                 );
 
                 if (factory != null) {

--- a/Python/Product/PythonTools/PythonTools/Environments/AddVirtualEnvironmentView.cs
+++ b/Python/Product/PythonTools/PythonTools/Environments/AddVirtualEnvironmentView.cs
@@ -104,6 +104,12 @@ namespace Microsoft.PythonTools.Environments {
         public static readonly DependencyProperty WillRegisterGloballyProperty =
             WillRegisterGloballyPropertyKey.DependencyProperty;
 
+        private static readonly DependencyPropertyKey IsUsingGlobalDefaultEnvPropertyKey =
+            DependencyProperty.RegisterReadOnly(nameof(IsUsingGlobalDefaultEnv), typeof(bool), typeof(AddVirtualEnvironmentView), new PropertyMetadata(false));
+
+        public static readonly DependencyProperty IsUsingGlobalDefaultEnvProperty =
+            IsUsingGlobalDefaultEnvPropertyKey.DependencyProperty;
+
         private static readonly DependencyPropertyKey InterpretersPropertyKey =
             DependencyProperty.RegisterReadOnly(nameof(Interpreters), typeof(ObservableCollection<InterpreterView>), typeof(AddVirtualEnvironmentView), new PropertyMetadata());
 
@@ -212,6 +218,11 @@ namespace Microsoft.PythonTools.Environments {
         public bool WillRegisterGlobally {
             get { return (bool)GetValue(WillRegisterGloballyProperty); }
             private set { SetValue(WillRegisterGloballyPropertyKey, value); }
+        }
+
+        public bool IsUsingGlobalDefaultEnv {
+            get { return (bool)GetValue(IsUsingGlobalDefaultEnvProperty); }
+            private set { SetValue(IsUsingGlobalDefaultEnvPropertyKey, value); }
         }
 
         public ObservableCollection<InterpreterView> Interpreters {
@@ -336,6 +347,10 @@ namespace Microsoft.PythonTools.Environments {
             CanInstallRequirementsTxt = File.Exists(RequirementsPath);
             WillInstallRequirementsTxt = CanInstallRequirementsTxt && WillCreateVirtualEnv;
             WillRegisterGlobally = IsRegisterCustomEnv && canRegisterGlobally && WillCreateVirtualEnv;
+            IsUsingGlobalDefaultEnv = true;
+            if (SelectedProject != null && SelectedProject.Node != null && SelectedProject.Node.IsActiveInterpreterGlobalDefault) {
+                IsUsingGlobalDefaultEnv = false;
+            }
             
             // Enable the Create button only if there are no validation errors,
             // and if progress is not already being displayed
@@ -454,6 +469,7 @@ namespace Microsoft.PythonTools.Environments {
                 WillInstallPip = false;
                 WillInstallVirtualEnv = false;
                 WillRegisterGlobally = false;
+                IsUsingGlobalDefaultEnv = false;
                 UseVEnv = false;
                 UseVirtualEnv = false;
                 IsAcceptShieldVisible = false;

--- a/Python/Product/PythonTools/PythonTools/Environments/VirtualEnv.cs
+++ b/Python/Product/PythonTools/PythonTools/Environments/VirtualEnv.cs
@@ -70,7 +70,8 @@ namespace Microsoft.PythonTools.Environments {
             IPythonInterpreterFactory baseInterp,
             bool registerAsCustomEnv,
             string customEnvName,
-            bool preferVEnv = false
+            bool preferVEnv = false,
+            bool setAsCurrent = true
         ) {
             if (site == null) {
                 throw new ArgumentNullException(nameof(site));
@@ -132,7 +133,9 @@ namespace Microsoft.PythonTools.Environments {
                     var workspaceFactoryProvider = site.GetComponentModel().GetService<WorkspaceInterpreterFactoryProvider>();
                     using (workspaceFactoryProvider?.SuppressDiscoverFactories(forceDiscoveryOnDispose: true)) {
                         var relativeInterpExe = PathUtils.GetRelativeFilePath(workspace.Location, interpExe);
-                        await workspace.SetInterpreterAsync(relativeInterpExe);
+                        if (setAsCurrent) {
+                            await workspace.SetInterpreterAsync(relativeInterpExe);
+                        }         
                     }
 
                     var factory = workspaceFactoryProvider?


### PR DESCRIPTION
fixes #6718 

There are 2 separate issues under this ticket.

1. In project view, the newly created environment will always replace the global default, whether "set as current" is checked or not, so I added some checks to disable the checkbox when user is using the global default environment. 

2. In folder view, the newly created environment will always be the current environment, whether "set as current" is checked or not, so I added some checks to fix it.

Some tests I ran:

- Project view - when using global default environment
![project-global default](https://user-images.githubusercontent.com/100439259/195153065-e2a3c6c0-2b3d-42eb-b412-9452099bf289.gif)

- Project view - when not using global default environment & set as current
![project-set as current](https://user-images.githubusercontent.com/100439259/195153233-9aaa0e1d-cd06-4b86-8478-b3ab38db9f0c.gif)

- Project view - when not using global default environment & not set as current
![project-not set as current](https://user-images.githubusercontent.com/100439259/195153251-6dfec7eb-f4dc-42f3-b44b-1ab7a3668115.gif)

- Folder view - set as current
![folder - set as current](https://user-images.githubusercontent.com/100439259/195153367-b89c02a9-92e2-4c03-b43d-62772d20c0a6.gif)

- Folder view - not set as current
![folder - not set as current](https://user-images.githubusercontent.com/100439259/195153377-9f6006f9-7fe5-452a-a10a-b81d6cdcc3ed.gif)
