### PR TITLE
Allow '%', '&', '#' in file names in Python projects

### DIFF
--- a/Common/Product/SharedProject/ProjectResources.resx
+++ b/Common/Product/SharedProject/ProjectResources.resx
@@ -199,7 +199,7 @@ Files and folders cannot be:
 - Empty strings 
 - System reserved names, including 'CON', 'AUX', PRN', 'COM1' or 'LPT2' 
 - contain only '.'
-- have any of the following characters: / ? : &amp;  \ * " &lt; &gt; | # %</value>
+- have any of the following characters: / ? : \ * " &lt; &gt; |</value>
   </data>
   <data name="ErrorInvalidProjectName" xml:space="preserve">
     <value>The name you provided is not a valid project name.</value>

--- a/Common/Product/SharedProject/Utilities.cs
+++ b/Common/Product/SharedProject/Utilities.cs
@@ -511,7 +511,7 @@ namespace Microsoft.VisualStudioTools.Project {
         }
 
         private const string _reservedName = "(\\b(nul|con|aux|prn)\\b)|(\\b((com|lpt)[0-9])\\b)";
-        private const string _invalidChars = "([\\/:*?\"<>|#%])";
+        private const string _invalidChars = "([\\/:*?\"<>|])";
         private const string _regexToUseForFileName = _reservedName + "|" + _invalidChars;
         private static Regex _unsafeFileNameCharactersRegex = new Regex(_regexToUseForFileName, RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
         private static Regex _unsafeCharactersRegex = new Regex(_invalidChars, RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
@@ -535,7 +535,7 @@ namespace Microsoft.VisualStudioTools.Project {
             try {
                 extension = Path.GetExtension(filePart);
             }
-            // We catch the ArgumentException because we want this method to return true if the filename is not valid. FilePart could be for example #¤&%"¤&"% and that would throw ArgumentException on GetExtension
+            // We catch the ArgumentException because we want this method to return true if the filename is not valid. FilePart could be for example #Â¤&%"Â¤&"% and that would throw ArgumentException on GetExtension
             catch (ArgumentException) {
                 return true;
             }

--- a/Python/Product/PythonTools/VisualStudio.Project.resx
+++ b/Python/Product/PythonTools/VisualStudio.Project.resx
@@ -199,7 +199,7 @@ Files and folders cannot be:
 - Empty strings 
 - System reserved names, including 'CON', 'AUX', PRN', 'COM1' or 'LPT2' 
 - contain only '.'
-- have any of the following characters: / ? : &amp;  \ * " &lt; &gt; | # %</value>
+- have any of the following characters: / ? : \ * " &lt; &gt; |</value>
   </data>
   <data name="ErrorInvalidProjectName" xml:space="preserve">
     <value>The name you provided is not a valid project name.</value>


### PR DESCRIPTION
These characters are actually valid in file names, and the restriction is being dropped removed from Solution Explorer which previously blocked this. After that block has been removed, there is a further block inside Python tools that prevents files, folders and projects to be renamed to contain these characters.

Note: Unlike other projects, Python had already allowed "&" despite the error message not being updated to reflect that.

See: https://devdiv.visualstudio.com/DevDiv/_git/VS/pullrequest/431541