### PR TITLE
Add task list tokens to settings retrieved from pylance via getConfiguration

### DIFF
--- a/Python/Product/PythonTools/PythonTools/LanguageServerClient/LanguageServerSettings.cs
+++ b/Python/Product/PythonTools/PythonTools/LanguageServerClient/LanguageServerSettings.cs
@@ -122,6 +122,11 @@ namespace Microsoft.PythonTools.LanguageServerClient {
 
                 public string importFormat;
 
+                /// <summary>
+                /// Tokens that identify comments that should show up in the task list pane
+                /// </summary>
+                public TaskListToken[] taskListTokens;
+
                 public class PythonAnalysisInlayHintsSettings {
 
                     /// <summary>
@@ -133,6 +138,20 @@ namespace Microsoft.PythonTools.LanguageServerClient {
                     /// Enable/disable inlay hints for function return types:\n```python\ndef foo(x:int) ' -> int ':\n\treturn x\n```\n"
                     /// </summary>
                     public bool functionReturnTypes;
+                }
+
+                public class TaskListToken {
+
+                    /// <summary>
+                    /// The text of the token.
+                    /// </summary>
+                    public string text;
+
+                    /// <summary>
+                    /// The priority of the token.
+                    /// This comes from the CommentTaskPriority enum in Microsoft.VisualStudio.Shell
+                    /// </summary>
+                    public string priority;
                 }
 
             }

--- a/Python/Product/PythonTools/PythonTools/LanguageServerClient/PythonLanguageClient.cs
+++ b/Python/Product/PythonTools/PythonTools/LanguageServerClient/PythonLanguageClient.cs
@@ -37,6 +37,7 @@ using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.LanguageServer.Client;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.TextManager.Interop;
 using Microsoft.VisualStudio.Threading;
@@ -232,6 +233,18 @@ namespace Microsoft.PythonTools.LanguageServerClient {
                     MessageBox.ShowWarningMessage(Site, Strings.WarningPython2NotSupported);
                 }
 
+                // get task list tokens from options
+                var taskListTokens = new List<LanguageServerSettings.PythonSettings.PythonAnalysisSettings.TaskListToken>();
+                var taskListService = Site.GetService<SVsTaskList, ITaskList>();
+                if (taskListService != null) {
+                    foreach (var commentToken in taskListService.CommentTokens) {
+                        taskListTokens.Add(new LanguageServerSettings.PythonSettings.PythonAnalysisSettings.TaskListToken() {
+                            text = commentToken.Text,
+                            priority = commentToken.Priority.ToString()
+                        });
+                    }
+                }
+
                 var settings = new LanguageServerSettings.PythonSettings {
                     pythonPath = context.InterpreterConfiguration.InterpreterPath,
                     venvPath = string.Empty,
@@ -252,7 +265,8 @@ namespace Microsoft.PythonTools.LanguageServerClient {
                         inlayHints = new LanguageServerSettings.PythonSettings.PythonAnalysisSettings.PythonAnalysisInlayHintsSettings {
                             variableTypes = false,
                             functionReturnTypes = false
-                        }
+                        },
+                        taskListTokens = taskListTokens.ToArray()
                     }
                 };
 


### PR DESCRIPTION
There are changes needed on the pylance side to pipe these settings through (see https://github.com/microsoft/pyrx/pull/2899).

Adding them to PTVS first won't break anything, since they are not used in pylance yet.