### PR TITLE
Add bot to repo that closes stale issues

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -22,4 +22,4 @@ jobs:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         close-issue-message: 'This issue was closed because it has been stalled for 30 days with no activity. If the issue still persists, please reopen with the information requested. Thanks.'
         days-before-issue-close: 30
-        only-labels: 'waiting for response'
+        any-of-labels: 'waiting for response'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,25 @@
+# This workflow closes issues that have been labeled as 'waiting for response' and had no activity for 30 days.
+#
+# You can adjust the behavior by modifying this file.
+# For more information, see:
+# https://github.com/actions/stale
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+  - cron: '0 0 * * *'
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+
+    steps:
+    - uses: actions/stale@v5
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        close-issue-message: 'This issue was closed because it has been stalled for 30 days with no activity. If the issue still persists, please reopen with the information requested. Thanks.'
+        days-before-issue-close: 30
+        only-labels: 'waiting for response'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -3,7 +3,7 @@
 # You can adjust the behavior by modifying this file.
 # For more information, see:
 # https://github.com/actions/stale
-name: Mark stale issues and pull requests
+name: Close stale 'waiting for response' issues
 
 on:
   schedule:


### PR DESCRIPTION
Add a bot to close the 'waiting for response' issues after 30 days inactivity.

fixes #7344 