### PR TITLE
LSP client changes, fix pylance crashing

### DIFF
--- a/Python/Product/PythonTools/PythonTools/LanguageServerClient/FileWatcher/Listener.cs
+++ b/Python/Product/PythonTools/PythonTools/LanguageServerClient/FileWatcher/Listener.cs
@@ -47,7 +47,9 @@ namespace Microsoft.PythonTools.LanguageServerClient.FileWatcher {
 
             // Ignore files that end with ~ or TMP
             _matcher.AddExclude("**/*~");
+            _matcher.AddExclude("**/~*");
             _matcher.AddExclude("**/*TMP");
+            _matcher.AddExclude("**/__pycache__");
 
             // Depending upon if this is a workspace or a solution, listen to different change events.
             if (workspaceService != null && workspaceService.CurrentWorkspace != null) {
@@ -169,20 +171,7 @@ namespace Microsoft.PythonTools.LanguageServerClient.FileWatcher {
                 if (didChangeParams.Changes.Any()) {
                     await _rpcWrapper.NotifyWithParameterObjectAsync(Methods.WorkspaceDidChangeWatchedFiles.Name, didChangeParams);
 
-                    if (renamedArgs != null) {
-                        var textDocumentIdentifier = new TextDocumentIdentifier();
-                        textDocumentIdentifier.Uri = new Uri(renamedArgs.OldFullPath);
-
-                        var closeParam = new DidCloseTextDocumentParams();
-                        closeParam.TextDocument = textDocumentIdentifier;
-                        await _rpcWrapper.NotifyWithParameterObjectAsync(Methods.TextDocumentDidClose.Name, closeParam);
-
-                        var textDocumentItem = new TextDocumentItem();
-                        textDocumentItem.Uri = new Uri(renamedArgs.FullPath);
-                        var openParam = new DidOpenTextDocumentParams();
-                        openParam.TextDocument = textDocumentItem;
-                        await _rpcWrapper.NotifyWithParameterObjectAsync(Methods.TextDocumentDidOpen.Name, openParam);
-                    }
+                    
                 }
             }
         }

--- a/Python/Product/PythonTools/PythonTools/LanguageServerClient/PythonLanguageClient.cs
+++ b/Python/Product/PythonTools/PythonTools/LanguageServerClient/PythonLanguageClient.cs
@@ -139,7 +139,7 @@ namespace Microsoft.PythonTools.LanguageServerClient {
             await JoinableTaskContext.Factory.SwitchToMainThreadAsync();
             CreateClientContexts();
 
-            _deferredSettingsChangedTimer = _deferredSettingsChangedTimer = new Timer(OnDeferredSettingsChanged, state: null, Timeout.Infinite, Timeout.Infinite);
+            _deferredSettingsChangedTimer = new Timer(OnDeferredSettingsChanged, state: null, Timeout.Infinite, Timeout.Infinite);
             _analysisOptions = Site.GetPythonToolsService().AnalysisOptions;
             _advancedEditorOptions = Site.GetPythonToolsService().AdvancedEditorOptions;
             _analysisOptions.Changed += OnSettingsChanged;


### PR DESCRIPTION
- ignore VS temp files starting with ~
- ignore pycache folders
- fix pylance crash by removing TextDocumentDidClose and TextDocumentDidOpen on rename.. LSP client sends this. Plus we we're sending an incomplete textDocumentItem on open. we were missing the content causing Pylance to crash.
- delay settings change by 5 seconds
- fix dispose crash relayed to calling GetService()

fixes https://github.com/microsoft/PTVS/issues/7068

note: this doesn't fix responding to pip installing modules. Another fix coming