### PR TITLE
Restore missing mixed-mode debugging option

### DIFF
--- a/Python/Product/VCDebugLauncher/17.0/source.extension.vsixmanifest
+++ b/Python/Product/VCDebugLauncher/17.0/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="PythonVCDebugLauncher.5AF7E179-1406-4804-9267-93F3BD7C7422" Version="17.0.0" Language="en-US" Publisher="Microsoft Corporation" />
+        <Identity Id="PythonVCDebugLauncher.5AF7E179-1406-4804-9267-93F3BD7C7422" Version="17.0.1" Language="en-US" Publisher="Microsoft Corporation" />
         <DisplayName>Python - C++ project debugging support</DisplayName>
         <Description xml:space="preserve">Adds a debug launcher for C++ projects that launches with Python debugging enabled.</Description>
         <MoreInfo>http://aka.ms/ptvs</MoreInfo>

--- a/Python/Product/VCDebugLauncher/VCDebugLauncher.csproj
+++ b/Python/Product/VCDebugLauncher/VCDebugLauncher.csproj
@@ -203,13 +203,13 @@
   </ItemGroup>
   <ItemGroup>
     <XamlPropertyRule Include="VCTargets\Win32\ImportAfter\Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml">
-      <VSIXSubPath>Microsoft\VC\v160\Platforms\Win32\ImportAfter</VSIXSubPath>
+      <VSIXSubPath>Microsoft\VC\$(VCTargetVersion)\Platforms\Win32\ImportAfter</VSIXSubPath>
       <InstallRoot>MSBuild</InstallRoot>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <IncludeInVSIX>true</IncludeInVSIX>
     </XamlPropertyRule>
     <Content Include="VCTargets\x64\ImportAfter\Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml">
-      <VSIXSubPath>Microsoft\VC\v160\Platforms\x64\ImportAfter</VSIXSubPath>
+      <VSIXSubPath>Microsoft\VC\$(VCTargetVersion)\Platforms\x64\ImportAfter</VSIXSubPath>
       <InstallRoot>MSBuild</InstallRoot>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <IncludeInVSIX>true</IncludeInVSIX>
@@ -241,12 +241,12 @@
         <IncludeInVSIX>true</IncludeInVSIX>
       </LocContent>
       <LocContent Include="$(LocOutputPath)%(VSLanguages.Identity)\VCTargets\Win32\ImportAfter\Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml">
-        <VSIXSubPath>Microsoft\VC\v160\Platforms\Win32\ImportAfter\%(VSLanguages.LCID)</VSIXSubPath>
+        <VSIXSubPath>Microsoft\VC\$(VCTargetVersion)\Platforms\Win32\ImportAfter\%(VSLanguages.LCID)</VSIXSubPath>
         <InstallRoot>MSBuild</InstallRoot>
         <IncludeInVSIX>true</IncludeInVSIX>
       </LocContent>
       <LocContent Include="$(LocOutputPath)%(VSLanguages.Identity)\VCTargets\x64\ImportAfter\Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml">
-        <VSIXSubPath>Microsoft\VC\v160\Platforms\x64\ImportAfter\%(VSLanguages.LCID)</VSIXSubPath>
+        <VSIXSubPath>Microsoft\VC\$(VCTargetVersion)\Platforms\x64\ImportAfter\%(VSLanguages.LCID)</VSIXSubPath>
         <InstallRoot>MSBuild</InstallRoot>
         <IncludeInVSIX>true</IncludeInVSIX>
       </LocContent>


### PR DESCRIPTION
Fixes #6712

We had a remaining hardcoded `v160` install path for the `VCDebugLauncher` vsix that was causing files to be installed to the wrong location. These files were xaml files that add UI to Visual Studio, and our targets file was trying to include these files from the `v170` location, if they exist.

The problem is that they never exist because they go to the wrong place, which means the mixed mode debugging option is always missing from VS2022. This fixes that problem.

Unfortunately, this problem doesn't repro when building locally and deploying to the exp hive, it's a "VS Setup Only" problem. So I can't really test to make sure that this works before merging in this PR. The steps to test are:
1. Merge in this PR
2. Wait for the CI build to finish from the main branch
3. Wait for the VS insertion PR to trigger after the CI build
4. Wait for the VS insertion PR to generate a VS installer
5. Install VS using the installer from step 4, make sure to select the python workload, then do the steps mentioned in https://github.com/microsoft/PTVS/issues/6712 to verify that the missing debugging option is now present.

There is a related problem (https://github.com/microsoft/PTVS/issues/7260) which I will be looking at next.