### PR TITLE
Fix asynchronous environment discovery and selection

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Project/PythonProjectNode.cs
+++ b/Python/Product/PythonTools/PythonTools/Project/PythonProjectNode.cs
@@ -851,21 +851,11 @@ namespace Microsoft.PythonTools.Project {
                     pythonEnvironmentsNode.AddChild(InterpretersNode.CreateAbsentInterpreterNode(this, id));
                 }
 
-                // Handle the expand/collapse state of the container node, plus each interpreter node
-                // TODO: Is this still needed? We cleared out all the previous nodes so the previous expanded info is gone?
-                if (alwaysCollapse || ParentHierarchy == null) {
-                    OnInvalidateItems(pythonEnvironmentsNode);
-                } else {
-                    bool wasExpanded = pythonEnvironmentsNode.GetIsExpanded();
-                    var expandAfter = pythonEnvironmentsNode.AllChildren.Where(n => n.GetIsExpanded()).ToArray();
-                    OnInvalidateItems(pythonEnvironmentsNode);
-                    if (wasExpanded) {
-                        pythonEnvironmentsNode.ExpandItem(EXPANDFLAGS.EXPF_ExpandFolder);
-                    }
-                    foreach (var child in expandAfter) {
-                        child.ExpandItem(EXPANDFLAGS.EXPF_ExpandFolder);
-                    }
-                }
+                // Expand the Python Environments node, if appropriate
+                OnInvalidateItems(pythonEnvironmentsNode);
+                if (!alwaysCollapse && ParentHierarchy != null) {
+                    pythonEnvironmentsNode.ExpandItem(EXPANDFLAGS.EXPF_ExpandFolder);
+                } 
 
                 // update the active interpreter based on the "InterpreterId" element in the pyproj
                 UpdateActiveInterpreter();

--- a/Python/Product/PythonTools/PythonTools/Project/PythonProjectNode.cs
+++ b/Python/Product/PythonTools/PythonTools/Project/PythonProjectNode.cs
@@ -115,7 +115,7 @@ namespace Microsoft.PythonTools.Project {
             // hooked up.
             InterpreterOptions.DefaultInterpreterChanged += GlobalDefaultInterpreterChanged;
             InterpreterRegistry.InterpretersChanged += OnInterpreterRegistryChanged;
-            InterpreterRegistry.InterpreterDiscoveryCompleted += OnInterpreterDiscoveryCompleted;
+            InterpreterRegistry.AsyncInterpreterDiscoveryCompleted += OnInterpreterDiscoveryCompleted;
             _pythonProject = new VsPythonProject(this);
 
             _condaEnvCreateInfoBar = new CondaEnvCreateProjectInfoBar(Site, this);

--- a/Python/Product/PythonTools/PythonTools/Project/PythonProjectNode.cs
+++ b/Python/Product/PythonTools/PythonTools/Project/PythonProjectNode.cs
@@ -814,7 +814,7 @@ namespace Microsoft.PythonTools.Project {
 
                 // if we have no interpreter factories, and the active interpreter is the global default,
                 // add a node for it
-                if (InterpreterFactories.Count() == 0 && IsActiveInterpreterGlobalDefault && ActiveInterpreter.IsRunnable()) {
+                if (!InterpreterFactories.Any() && IsActiveInterpreterGlobalDefault && ActiveInterpreter.IsRunnable()) {
                     var newNode = new InterpretersNode(
                         this,
                         ActiveInterpreter,

--- a/Python/Product/VSInterpreters/Interpreter/CondaEnvironmentFactoryProvider.cs
+++ b/Python/Product/VSInterpreters/Interpreter/CondaEnvironmentFactoryProvider.cs
@@ -38,7 +38,7 @@ namespace Microsoft.PythonTools.Interpreter {
     [Export(typeof(IPythonInterpreterFactoryProvider))]
     [Export(typeof(CondaEnvironmentFactoryProvider))]
     [PartCreationPolicy(CreationPolicy.Shared)]
-    class CondaEnvironmentFactoryProvider : IPythonInterpreterFactoryProvider, IDisposable {
+    class CondaEnvironmentFactoryProvider : IPythonInterpreterFactoryProvider, IPythonInterpreterFactoryProviderAsync, IDisposable {
         private readonly Dictionary<string, PythonInterpreterInformation> _factories = new Dictionary<string, PythonInterpreterInformation>();
         internal const string FactoryProviderName = "CondaEnv";
         internal const string EnvironmentCompanyName = "CondaEnv";
@@ -62,6 +62,7 @@ namespace Microsoft.PythonTools.Interpreter {
         };
 
         internal event EventHandler DiscoveryStarted;
+        public event EventHandler InterpreterDiscoveryCompleted;
 
         [ImportingConstructor]
         public CondaEnvironmentFactoryProvider(
@@ -267,6 +268,8 @@ namespace Microsoft.PythonTools.Interpreter {
             if (anyChanged) {
                 OnInterpreterFactoriesChanged();
             }
+
+            InterpreterDiscoveryCompleted?.Invoke(this, EventArgs.Empty);
         }
 
         internal async static Task<CondaInfoResult> ExecuteCondaInfoAsync(string condaPath) {

--- a/Python/Product/VSInterpreters/Interpreter/IInterpreterRegistryService.cs
+++ b/Python/Product/VSInterpreters/Interpreter/IInterpreterRegistryService.cs
@@ -64,7 +64,7 @@ namespace Microsoft.PythonTools.Interpreter {
         /// <summary>
         /// Raised when all async interpreter factory providers have completed discovering interpreters
         /// </summary>
-        event EventHandler InterpreterDiscoveryCompleted;
+        event EventHandler AsyncInterpreterDiscoveryCompleted;
 
         /// <summary>
         /// Called to suppress the <see cref="InterpretersChanged"/> event while

--- a/Python/Product/VSInterpreters/Interpreter/IInterpreterRegistryService.cs
+++ b/Python/Product/VSInterpreters/Interpreter/IInterpreterRegistryService.cs
@@ -62,6 +62,11 @@ namespace Microsoft.PythonTools.Interpreter {
         event EventHandler InterpretersChanged;
 
         /// <summary>
+        /// Raised when all async interpreter factory providers have completed discovering interpreters
+        /// </summary>
+        event EventHandler InterpreterDiscoveryCompleted;
+
+        /// <summary>
         /// Called to suppress the <see cref="InterpretersChanged"/> event while
         /// making changes to the registry. If the event is triggered while
         /// suppressed, it will not be raised until suppression is lifted.

--- a/Python/Product/VSInterpreters/Interpreter/IPythonInterpreterFactoryProviderAsync.cs
+++ b/Python/Product/VSInterpreters/Interpreter/IPythonInterpreterFactoryProviderAsync.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.PythonTools.Interpreter {
+    public interface IPythonInterpreterFactoryProviderAsync {
+        /// <summary>
+        /// Raised when interpreter discovery is completed for this provider
+        /// </summary>
+        event EventHandler InterpreterDiscoveryCompleted;
+    }
+}

--- a/Python/Product/VSInterpreters/Interpreter/InterpreterRegistryService.cs
+++ b/Python/Product/VSInterpreters/Interpreter/InterpreterRegistryService.cs
@@ -37,6 +37,7 @@ namespace Microsoft.PythonTools.Interpreter {
         private const string InterpreterFactoryIdMetadata = "InterpreterFactoryId";
 
         private int _asyncInterpreterDiscoveryCompletedCount;
+        private readonly object _asyncInterpreterDiscoveryCompletedCountLock = new object();
         private int _asyncProviderCount;
 
         [ImportingConstructor]
@@ -101,12 +102,14 @@ namespace Microsoft.PythonTools.Interpreter {
         // Called when a single async interpreter factory provider finishes discovering interpreters
         private void Provider_AsyncInterpreterDiscoveryCompleted(object sender, EventArgs e) {
 
-            // Since we know how many async providers we have, keep track of how many times this callback is hit.
-            // Once the number of calls == the number of providers, we know all async interpreter discovery is done.
-            _asyncInterpreterDiscoveryCompletedCount++;
+            lock (_asyncInterpreterDiscoveryCompletedCountLock) {
+                // Since we know how many async providers we have, keep track of how many times this callback is hit.
+                // Once the number of calls == the number of providers, we know all async interpreter discovery is done.
+                _asyncInterpreterDiscoveryCompletedCount++;
 
-            if (_asyncInterpreterDiscoveryCompletedCount < _asyncProviderCount) {
-                return;
+                if (_asyncInterpreterDiscoveryCompletedCount < _asyncProviderCount) {
+                    return;
+                }
             }
 
             // if we get here, interpreter discovery is finished

--- a/Python/Product/VSInterpreters/Interpreter/InterpreterRegistryService.cs
+++ b/Python/Product/VSInterpreters/Interpreter/InterpreterRegistryService.cs
@@ -75,7 +75,7 @@ namespace Microsoft.PythonTools.Interpreter {
             }
         }
 
-        public event EventHandler InterpreterDiscoveryCompleted;
+        public event EventHandler AsyncInterpreterDiscoveryCompleted;
 
         private void EnsureFactoryChangesWatched() {
 
@@ -88,7 +88,7 @@ namespace Microsoft.PythonTools.Interpreter {
                         // if the provider is async, listen for the completed event
                         if (provider is IPythonInterpreterFactoryProviderAsync asyncProvider) {
                             _asyncProviderCount++;
-                            asyncProvider.InterpreterDiscoveryCompleted += Provider_InterpreterDiscoveryCompleted;
+                            asyncProvider.InterpreterDiscoveryCompleted += Provider_AsyncInterpreterDiscoveryCompleted;
                         }
                     }
                 } finally {
@@ -99,7 +99,7 @@ namespace Microsoft.PythonTools.Interpreter {
         }
 
         // Called when a single async interpreter factory provider finishes discovering interpreters
-        private void Provider_InterpreterDiscoveryCompleted(object sender, EventArgs e) {
+        private void Provider_AsyncInterpreterDiscoveryCompleted(object sender, EventArgs e) {
 
             // Since we know how many async providers we have, keep track of how many times this callback is hit.
             // Once the number of calls == the number of providers, we know all async interpreter discovery is done.
@@ -110,7 +110,7 @@ namespace Microsoft.PythonTools.Interpreter {
             }
 
             // if we get here, interpreter discovery is finished
-            InterpreterDiscoveryCompleted?.Invoke(this, EventArgs.Empty);
+            AsyncInterpreterDiscoveryCompleted?.Invoke(this, EventArgs.Empty);
         }
 
         public void BeginSuppressInterpretersChangedEvent() {

--- a/Python/Product/VSInterpreters/VSInterpreters.csproj
+++ b/Python/Product/VSInterpreters/VSInterpreters.csproj
@@ -108,6 +108,7 @@
     </Compile>
     <Compile Include="Interpreter\InterpreterUIMode.cs" />
     <Compile Include="Interpreter\IPythonInterpreterFactory.cs" />
+    <Compile Include="Interpreter\IPythonInterpreterFactoryProviderAsync.cs" />
     <Compile Include="Interpreter\LaunchConfiguration.cs" />
     <Compile Include="Interpreter\NoInterpretersException.cs" />
     <Compile Include="Interpreter\LaunchConfigurationUtils.cs" />

--- a/Python/Tests/Core/WorkspaceTestHelper.cs
+++ b/Python/Tests/Core/WorkspaceTestHelper.cs
@@ -126,6 +126,10 @@ namespace PythonToolsTests {
             public IPythonInterpreterFactory NoInterpretersValue => throw new NotImplementedException();
 
             public event EventHandler InterpretersChanged;
+            public event EventHandler InterpreterDiscoveryCompleted {
+                add { }
+                remove { }
+            }
 
             public void BeginSuppressInterpretersChangedEvent() {
                 throw new NotImplementedException();

--- a/Python/Tests/Core/WorkspaceTestHelper.cs
+++ b/Python/Tests/Core/WorkspaceTestHelper.cs
@@ -126,7 +126,7 @@ namespace PythonToolsTests {
             public IPythonInterpreterFactory NoInterpretersValue => throw new NotImplementedException();
 
             public event EventHandler InterpretersChanged;
-            public event EventHandler InterpreterDiscoveryCompleted {
+            public event EventHandler AsyncInterpreterDiscoveryCompleted {
                 add { }
                 remove { }
             }

--- a/Python/Tests/Utilities.Python.Analysis/MockInterpreterOptionsService.cs
+++ b/Python/Tests/Utilities.Python.Analysis/MockInterpreterOptionsService.cs
@@ -124,7 +124,7 @@ namespace TestUtilities.Python {
         }
 
         public event EventHandler DefaultInterpreterChanged;
-        public event EventHandler InterpreterDiscoveryCompleted {
+        public event EventHandler AsyncInterpreterDiscoveryCompleted {
             add { }
             remove { }
         }

--- a/Python/Tests/Utilities.Python.Analysis/MockInterpreterOptionsService.cs
+++ b/Python/Tests/Utilities.Python.Analysis/MockInterpreterOptionsService.cs
@@ -124,6 +124,10 @@ namespace TestUtilities.Python {
         }
 
         public event EventHandler DefaultInterpreterChanged;
+        public event EventHandler InterpreterDiscoveryCompleted {
+            add { }
+            remove { }
+        }
 
         public bool IsInterpreterGeneratingDatabase(IPythonInterpreterFactory interpreter) {
             throw new NotImplementedException();


### PR DESCRIPTION
Fixes #7444

There are some bugs around environment loading and selection when the environments are discovered asynchronously, like with conda environments. There are lots of edge cases that need to be tested. See comments below for each scenario.

Specifically, conda environments weren't being shown in solution explorer because the currently selected environment was the global default, and the existing conditional was not behaving properly in that case. We were also showing an infobar for "missing conda environment" before they had a chance to be discovered.