### PR TITLE
Create auto-label.yml

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -15,4 +15,4 @@ jobs:
         if: ${{ github.event.comment.user.login == github.event.issue.user.login && contains(github.event.issue.labels.*.name, 'waiting for response') && !contains(github.event.issue.labels.*.name, 'user responded') }}
         with:
           add-labels: 'user responded'
-          remove-labels: 'waiting for user response'
+          remove-labels: 'waiting for response'

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -1,0 +1,18 @@
+name: Auto-label when user responds
+permissions:
+  issues: write
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  run-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add/Remove labels when user responds
+        uses: andymckay/labeler@master
+        if: ${{ github.event.comment.user.login == github.event.issue.user.login && contains(github.event.issue.labels.*.name, 'waiting for response') && !contains(github.event.issue.labels.*.name, 'user responded') }}
+        with:
+          add-labels: 'user responded'
+          remove-labels: 'waiting for user response'


### PR DESCRIPTION
Add a bot that automatically removes the "waiting for response" label and adds a "user responded" label if the original poster replies to avoid accidentally close active issues.