### PR TITLE
Add weekly pipeline schedule to coincide with pylance releases

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,6 +14,17 @@ parameters:
 # build number format 
 name: $(date:yy)$(DayOfYear)$(rev:.r)
 
+# Weekly schedule, as long as there are changes
+# Pylance releses on Wednesdays, so we build on Thursdays at 6pm so we can pull in the latest
+# pylance and get the VS insertion going so we can hopefully merge it in on Fridays.
+# All times are in UTC, so 8AM = Midnight PST
+schedules:
+- cron: "0 18 * * Thu"
+  displayName: Weekly build
+  branches:
+    include:
+    - main
+
 # Trigger ci builds for commits into master and any release branches
 # Ignore changes to other yml files, since they are for different pipelines
 trigger:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,8 +14,9 @@ parameters:
 # build number format 
 name: $(date:yy)$(DayOfYear)$(rev:.r)
 
-# Weekly schedule, as long as there are changes
-# Pylance releses on Wednesdays, so we build on Thursdays at 6pm so we can pull in the latest
+# Weekly schedule. This always runs even if there are no changes, because a pylance release
+# does not generate commits in this repo.
+# Pylance releases on Wednesdays, so we build on Thursdays at 6pm so we can pull in the latest
 # pylance and get the VS insertion going so we can hopefully merge it in on Fridays.
 # All times are in UTC, so 8AM = Midnight PST
 schedules:
@@ -24,6 +25,7 @@ schedules:
   branches:
     include:
     - main
+  always: true
 
 # Trigger ci builds for commits into master and any release branches
 # Ignore changes to other yml files, since they are for different pipelines


### PR DESCRIPTION
Fixes https://github.com/microsoft/PTVS/issues/7601

Add a weekly scheduled run of the PTVS CI pipeline. This is to make sure PTVS ships with the latest pylance / debugpy release.

Note that this will always run even if there are no changes. This is because Pylance/debugpy releases do not generate changes in the PTVS repo.