### PR TITLE
Fix Excessive memory usage in Environments View

### DIFF
--- a/Python/Product/EnvironmentsList/PipExtension.xaml.cs
+++ b/Python/Product/EnvironmentsList/PipExtension.xaml.cs
@@ -109,6 +109,16 @@ namespace Microsoft.PythonTools.EnvironmentsList {
                     }
                     Subcontext.DataContext = new PipEnvironmentView(view, _provider);
                 }
+            } else {
+                // Data context being deleted clean up old Pip info
+                // see ToolWindow.xaml.cs  _extensions.Clear();
+                var oldView = e.OldValue as EnvironmentView;
+                if (oldView != null) {
+                    var current = Subcontext.DataContext as PipEnvironmentView;
+                    if (current != null) {
+                        current.Dispose();
+                    }
+                }
             }
         }
 
@@ -321,6 +331,15 @@ namespace Microsoft.PythonTools.EnvironmentsList {
             _provider.IsPipInstalledChanged -= PipExtensionProvider_IsPipInstalledChanged;
             _provider.InstalledPackagesChanged -= PipExtensionProvider_InstalledPackagesChanged;
             _installableViewRefreshTimer.Dispose();
+            lock (_installed) {
+                _installed.Clear();
+            }
+            lock (_installableFiltered) {
+                _installableFiltered.Clear();
+            }
+            lock (_installable) { 
+                _installable.Clear();
+            }
         }
 
         public EnvironmentView EnvironmentView {

--- a/Python/Product/VSInterpreters/PackageManager/PipPackageCache.cs
+++ b/Python/Product/VSInterpreters/PackageManager/PipPackageCache.cs
@@ -160,7 +160,7 @@ namespace Microsoft.PythonTools.Interpreter {
                     }
                 }
 
-                return _cache.Values.Select(p => p.Clone()).ToList();
+                return _cache.Values.ToList();
             } finally {
                 _cacheLock.Release();
             }


### PR DESCRIPTION
When a new environment was selected we were creating a pip package list around 400k items but we're clearning the previous list.

fixe: https://github.com/microsoft/PTVS/issues/7485