### PR TITLE
Update lsp protocol package and fix compile errors

### DIFF
--- a/Build/17.0/packages.config
+++ b/Build/17.0/packages.config
@@ -33,7 +33,7 @@
   <package id="Microsoft.VisualStudio.Language.NavigateTo.Interfaces" version = "17.0.56-gb3c64827ce" />
   <package id="Microsoft.VisualStudio.Language.StandardClassification" version = "17.0.56-gb3c64827ce" />
   <package id="Microsoft.VisualStudio.LanguageServer.Client" version = "17.3.2062-preview" />
-  <package id="Microsoft.VisualStudio.LanguageServer.Protocol" version = "17.6.4-preview" />
+  <package id="Microsoft.VisualStudio.LanguageServer.Protocol" version = "17.7.7-preview" />
   <package id="Microsoft.VisualStudio.Package.LanguageService.15.0" version = "17.0.0-previews-4-31601-014" />
   <package id="Microsoft.VisualStudio.ProjectAggregator" version = "17.0.0-previews-4-31601-014" />
   <package id="Microsoft.VisualStudio.ProjectSystem" version = "16.2.133-pre" />

--- a/Python/Product/PythonTools/PythonTools/Repl/Completion/AsyncCompletionSource.cs
+++ b/Python/Product/PythonTools/PythonTools/Repl/Completion/AsyncCompletionSource.cs
@@ -40,6 +40,7 @@ using Microsoft.VisualStudio.Shell;
 using Microsoft.PythonTools.Infrastructure;
 using Microsoft.VisualStudio.InteractiveWindow;
 using Microsoft.VisualStudio.Text.Projection;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.PythonTools.Repl.Completion {
     /// <summary>
@@ -249,13 +250,16 @@ namespace Microsoft.PythonTools.Repl.Completion {
                             buffer.Delete(deleteSpan);
                         }
 
-                        if (protocolItem.TextEdit != null) {
-                            Utilities.ApplyTextEdit(protocolItem.TextEdit, triggerLocation.Snapshot, buffer);
-                        } else if (protocolItem.InsertText != null) {
-                            buffer.Replace(session.ApplicableToSpan.GetSpan(buffer.CurrentSnapshot), protocolItem.InsertText);
-                        } else if (protocolItem.Label != null) {
-                            buffer.Replace(session.ApplicableToSpan.GetSpan(buffer.CurrentSnapshot), protocolItem.Label);
-                        }
+                        if (protocolItem.TextEdit != null && protocolItem.TextEdit.HasValue) {
+
+                            if (protocolItem.TextEdit.Value.TryGetFirst(out TextEdit textEdit)) {
+                                Utilities.ApplyTextEdit(textEdit, triggerLocation.Snapshot, buffer);
+                            } else if (protocolItem.TextEdit.Value.TryGetSecond(out InsertReplaceEdit insertReplaceEdit)) {
+                                buffer.Replace(session.ApplicableToSpan.GetSpan(buffer.CurrentSnapshot), protocolItem.InsertText);
+                            } else if (protocolItem.Label != null) {
+                                buffer.Replace(session.ApplicableToSpan.GetSpan(buffer.CurrentSnapshot), protocolItem.Label);
+                            }
+                        } 
 
                         if (protocolItem.AdditionalTextEdits != null) {
                             Utilities.ApplyTextEdits(protocolItem.AdditionalTextEdits, triggerLocation.Snapshot, buffer);
@@ -452,8 +456,10 @@ namespace Microsoft.PythonTools.Repl.Completion {
             SnapshotSpan result = new SnapshotSpan();
 
             // See if this is from a text edit
-            if (item?.TextEdit != null) {
-                result = item.TextEdit.Range.ToSnapshotSpan(owningSnapshot);
+            if (item?.TextEdit != null && item.TextEdit.HasValue) {
+                if (item.TextEdit.Value.TryGetFirst(out TextEdit textEdit)) {
+                    result = textEdit.Range.ToSnapshotSpan(owningSnapshot);
+                }
             } else {
                 // Fallback to extent of word. At least, it will be a zero-length span at the trigger pointzero-
                 // walk left and right until we reach the end of the word

--- a/Python/Product/PythonTools/PythonTools/Repl/Completion/AsyncCompletionSource.cs
+++ b/Python/Product/PythonTools/PythonTools/Repl/Completion/AsyncCompletionSource.cs
@@ -250,7 +250,7 @@ namespace Microsoft.PythonTools.Repl.Completion {
                             buffer.Delete(deleteSpan);
                         }
 
-                        if (protocolItem.TextEdit != null && protocolItem.TextEdit.HasValue) {
+                        if (protocolItem.TextEdit.HasValue) {
 
                             if (protocolItem.TextEdit.Value.TryGetFirst(out TextEdit textEdit)) {
                                 Utilities.ApplyTextEdit(textEdit, triggerLocation.Snapshot, buffer);
@@ -456,7 +456,7 @@ namespace Microsoft.PythonTools.Repl.Completion {
             SnapshotSpan result = new SnapshotSpan();
 
             // See if this is from a text edit
-            if (item?.TextEdit != null && item.TextEdit.HasValue) {
+            if (item?.TextEdit.HasValue) {
                 if (item.TextEdit.Value.TryGetFirst(out TextEdit textEdit)) {
                     result = textEdit.Range.ToSnapshotSpan(owningSnapshot);
                 }

--- a/Python/Product/PythonTools/PythonTools/Repl/Completion/AsyncCompletionSource.cs
+++ b/Python/Product/PythonTools/PythonTools/Repl/Completion/AsyncCompletionSource.cs
@@ -456,7 +456,7 @@ namespace Microsoft.PythonTools.Repl.Completion {
             SnapshotSpan result = new SnapshotSpan();
 
             // See if this is from a text edit
-            if (item?.TextEdit.HasValue) {
+            if (item != null && item.TextEdit.HasValue) {
                 if (item.TextEdit.Value.TryGetFirst(out TextEdit textEdit)) {
                     result = textEdit.Range.ToSnapshotSpan(owningSnapshot);
                 }


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1823538

[CompletionItem.TextEdit](https://devdiv.visualstudio.com/DevDiv/_git/VSLanguageServerClient/pullrequest/462902?path=/src/product/Protocol/LanguageServer.Protocol/CompletionItem.cs&_a=files) has been changed from 
 
```C#
public TextEdit? TextEdit
```
to
```C#
public SumType<TextEdit, InsertReplaceEdit>? TextEdit
```
so I needed to fix up the code a little to account for this breaking change.