### PR TITLE
Fix for Perfathon Bug #1837322

### DIFF
--- a/Build/17.0/packages.config
+++ b/Build/17.0/packages.config
@@ -50,7 +50,7 @@
   <package id="Microsoft.VisualStudio.Shell.Framework" version = "17.0.0-previews-4-31601-014" />
   <package id="Microsoft.VisualStudio.TemplateWizardInterface" version = "17.0.0-previews-2-31424-224" />
   <package id="Microsoft.VisualStudio.Telemetry" version = "16.3.110" />
-  <package id="Microsoft.VisualStudio.Text.Data" version = "17.0.56-gb3c64827ce" />
+  <package id="Microsoft.VisualStudio.Text.Data" version = "17.6.268" />
   <package id="Microsoft.VisualStudio.Text.Logic" version = "17.0.56-gb3c64827ce" />
   <package id="Microsoft.VisualStudio.Text.UI" version = "17.0.56-gb3c64827ce" />
   <package id="Microsoft.VisualStudio.Text.UI.Wpf" version = "17.0.56-gb3c64827ce" />

--- a/Python/Product/PythonTools/PythonTools/Commands/FillParagraphCommand.cs
+++ b/Python/Product/PythonTools/PythonTools/Commands/FillParagraphCommand.cs
@@ -74,8 +74,8 @@ namespace Microsoft.PythonTools.Commands {
             var end = FindParagraphEnd(bufpt, fillPrefix);
             string newLine = view.Options.GetNewLineCharacter();
             using (var edit = view.TextBuffer.CreateEdit()) {
-                int startLine = start.GetContainingLine().LineNumber;
-                string[] lines = new string[end.GetContainingLine().LineNumber - startLine + 1];
+                int startLine = start.GetContainingLineNumber();
+                string[] lines = new string[end.GetContainingLineNumber() - startLine + 1];
                 for (int i = 0; i < lines.Length; i++) {
                     lines[i] = start.Snapshot.GetLineFromLineNumber(startLine + i).GetText();
                 }

--- a/Python/Product/PythonTools/PythonTools/Editor/CodeSnippet/PythonSnippetManager.cs
+++ b/Python/Product/PythonTools/PythonTools/Editor/CodeSnippet/PythonSnippetManager.cs
@@ -157,9 +157,9 @@ namespace Microsoft.PythonTools.Editor {
             var text = tokenSpan.GetText();
 
             var textSpan = new TextSpan[1];
-            textSpan[0].iStartLine = tokenSpan.Start.GetContainingLine().LineNumber;
+            textSpan[0].iStartLine = tokenSpan.Start.GetContainingLineNumber();
             textSpan[0].iStartIndex = tokenSpan.Start.Position - tokenSpan.Start.GetContainingLine().Start;
-            textSpan[0].iEndLine = tokenSpan.End.GetContainingLine().LineNumber;
+            textSpan[0].iEndLine = tokenSpan.End.GetContainingLineNumber();
             textSpan[0].iEndIndex = tokenSpan.End.Position - tokenSpan.End.GetContainingLine().Start;
 
             var client = GetOrCreateExpansionClient(textView);

--- a/Python/Product/PythonTools/PythonTools/Editor/Comment/CommentHelper.cs
+++ b/Python/Product/PythonTools/PythonTools/Editor/Comment/CommentHelper.cs
@@ -91,7 +91,7 @@ namespace Microsoft.PythonTools.Editor {
             using (var edit = snapshot.TextBuffer.CreateEdit()) {
                 int minColumn = Int32.MaxValue;
                 // first pass, determine the position to place the comment
-                for (int i = start.GetContainingLine().LineNumber; i <= end.GetContainingLine().LineNumber; i++) {
+                for (int i = start.GetContainingLineNumber(); i <= end.GetContainingLineNumber(); i++) {
                     var curLine = snapshot.GetLineFromLineNumber(i);
                     var text = curLine.GetText();
 
@@ -103,7 +103,7 @@ namespace Microsoft.PythonTools.Editor {
                 }
 
                 // second pass, place the comment
-                for (int i = start.GetContainingLine().LineNumber; i <= end.GetContainingLine().LineNumber; i++) {
+                for (int i = start.GetContainingLineNumber(); i <= end.GetContainingLineNumber(); i++) {
                     var curLine = snapshot.GetLineFromLineNumber(i);
                     if (String.IsNullOrWhiteSpace(curLine.GetText())) {
                         continue;
@@ -139,7 +139,7 @@ namespace Microsoft.PythonTools.Editor {
             using (var edit = snapshot.TextBuffer.CreateEdit()) {
 
                 // first pass, determine the position to place the comment
-                for (int i = start.GetContainingLine().LineNumber; i <= end.GetContainingLine().LineNumber; i++) {
+                for (int i = start.GetContainingLineNumber(); i <= end.GetContainingLineNumber(); i++) {
                     var curLine = snapshot.GetLineFromLineNumber(i);
 
                     DeleteFirstCommentChar(edit, curLine);

--- a/Python/Product/PythonTools/PythonTools/Editor/EditorExtensions.cs
+++ b/Python/Product/PythonTools/PythonTools/Editor/EditorExtensions.cs
@@ -128,7 +128,7 @@ namespace Microsoft.PythonTools.Editor.Core {
         //public static SourceLocation ToSourceLocation(this SnapshotPoint point) {
         //    return new SourceLocation(
         //        point.Position,
-        //        point.GetContainingLine().LineNumber + 1,
+        //        point.GetContainingLineNumber() + 1,
         //        point.Position - point.GetContainingLine().Start.Position + 1
         //    );
         //}

--- a/Python/Product/PythonTools/PythonTools/Editor/PythonTextBufferInfo.cs
+++ b/Python/Product/PythonTools/PythonTools/Editor/PythonTextBufferInfo.cs
@@ -280,8 +280,8 @@ namespace Microsoft.PythonTools.Editor {
         }
 
         internal IEnumerable<TrackingTokenInfo> GetTrackingTokens(SnapshotSpan span) {
-            int firstLine = span.Start.GetContainingLine().LineNumber;
-            int lastLine = span.End.GetContainingLine().LineNumber;
+            int firstLine = span.Start.GetContainingLineNumber();
+            int lastLine = span.End.GetContainingLineNumber();
 
             int startCol = span.Start - span.Start.GetContainingLine().Start;
             int endCol = span.End - span.End.GetContainingLine().Start;

--- a/Python/Product/PythonTools/PythonTools/Editor/TokenCache.cs
+++ b/Python/Product/PythonTools/PythonTools/Editor/TokenCache.cs
@@ -297,8 +297,8 @@ namespace Microsoft.PythonTools.Editor {
             }
 
             private void ApplyChanges(SnapshotSpan span, Lazy<Tokenizer> lazyTokenizer) {
-                var firstLine = span.Start.GetContainingLine().LineNumber;
-                var lastLine = span.End.GetContainingLine().LineNumber;
+                var firstLine = span.Start.GetContainingLineNumber();
+                var lastLine = span.End.GetContainingLineNumber();
 
                 AssertCapacity(firstLine);
 

--- a/Python/Product/PythonTools/PythonTools/Intellisense/IntellisenseController.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/IntellisenseController.cs
@@ -1260,9 +1260,9 @@ namespace Microsoft.PythonTools.Intellisense {
                     var text = classification.First().Span.GetText();
 
                     TextSpan[] textSpan = new TextSpan[1];
-                    textSpan[0].iStartLine = clsSpan.Start.GetContainingLine().LineNumber;
+                    textSpan[0].iStartLine = clsSpan.Start.GetContainingLineNumber();
                     textSpan[0].iStartIndex = clsSpan.Start.Position - clsSpan.Start.GetContainingLine().Start;
-                    textSpan[0].iEndLine = clsSpan.End.GetContainingLine().LineNumber;
+                    textSpan[0].iEndLine = clsSpan.End.GetContainingLineNumber();
                     textSpan[0].iEndIndex = clsSpan.End.Position - clsSpan.End.GetContainingLine().Start;
 
                     string expansionPath, title;

--- a/Python/Product/PythonTools/PythonTools/Intellisense/ProjectAnalyzer.cs
+++ b/Python/Product/PythonTools/PythonTools/Intellisense/ProjectAnalyzer.cs
@@ -1483,7 +1483,7 @@ namespace Microsoft.PythonTools.Intellisense {
                 var fromPoint = new SnapshotPoint(fromSnapshot, index);
                 var toPoint = fromPoint.TranslateTo(analysisSnapshot, PointTrackingMode.Negative);
                 return new SourceLocation(
-                    toPoint.GetContainingLine().LineNumber + 1,
+                    toPoint.GetContainingLineNumber() + 1,
                     (fromPoint - fromPoint.GetContainingLine().Start) + 1
                 );
             } else if (fromSnapshot != null) {

--- a/Python/Product/PythonTools/PythonTools/LanguageServerClient/LspEditorUtilities.cs
+++ b/Python/Product/PythonTools/PythonTools/LanguageServerClient/LspEditorUtilities.cs
@@ -42,7 +42,7 @@ namespace Microsoft.PythonTools.LanguageServerClient {
 
         internal static Position GetPosition(this SnapshotPoint snapshotPoint) {
             var position = new Position();
-            position.Line = snapshotPoint.GetContainingLine().LineNumber;
+            position.Line = snapshotPoint.GetContainingLineNumber();
             position.Character = snapshotPoint.Position - snapshotPoint.GetContainingLine().Start.Position;
 
             return position;


### PR DESCRIPTION
Fix for Perfathon Bug #1837322

Updated the package for Microsoft.VisualStudio.Text.Data to allow access to GetContainingLineNumber(), then changed instances of GetContainingLine().LineNumber() to GetContainingLineNumber() as per instructed in the bug description.