### PR TITLE
Fix FileWatcher and JsonRPC teardown

### DIFF
--- a/Python/Product/Common/Infrastructure/JsonRpcWrapper.cs
+++ b/Python/Product/Common/Infrastructure/JsonRpcWrapper.cs
@@ -21,39 +21,30 @@ using Microsoft.PythonTools.Infrastructure;
 using StreamJsonRpc;
 
 namespace Microsoft.PythonTools.Common.Infrastructure {
-    internal readonly struct JsonRpcWrapper {
+    internal static class JsonRpcExtensions {
 
-        private readonly JsonRpc _rpc;
-
-        // list of exception types to ignore
         private static readonly Type[] _exceptionsToIgnore = {
             typeof(ObjectDisposedException),
             typeof(ConnectionLostException)
         };
 
-        public JsonRpcWrapper(JsonRpc rpc) {
-            _rpc = rpc;
-        }
+        public static Task NotifyWithParameterObjectAsync(this JsonRpc rpc, string targetName, object argument = null) {
 
-        public Task NotifyWithParameterObjectAsync(string targetName, object argument = null) {
-
-            if (_rpc is null) {
+            if (rpc is null) {
                 return Task.CompletedTask;
             }
 
-            // if the underlying rpc connection was disposed, or the connection was lost, ignore the errors
-            return _rpc.NotifyWithParameterObjectAsync(targetName, argument)
+            return rpc.NotifyWithParameterObjectAsync(targetName, argument)
                 .SilenceExceptions(_exceptionsToIgnore);
         }
 
-        public Task<T> InvokeWithParameterObjectAsync<T>(string request, object parameters, CancellationToken t) {
+        public static Task<T> InvokeWithParameterObjectAsync<T>(this JsonRpc rpc, string request, object parameters, CancellationToken t) {
 
-            if (_rpc is null) {
+            if (rpc is null) {
                 return null;
             }
 
-            // if the underlying rpc connection was disposed, or the connection was lost, ignore the errors
-            return _rpc.InvokeWithParameterObjectAsync<T>(request, parameters, t)
+            return rpc.InvokeWithParameterObjectAsync<T>(request, parameters, t)
                 .SilenceExceptions(_exceptionsToIgnore);
         }
     }

--- a/Python/Product/PythonTools/PythonTools/LanguageServerClient/FileWatcher/Listener.cs
+++ b/Python/Product/PythonTools/PythonTools/LanguageServerClient/FileWatcher/Listener.cs
@@ -19,8 +19,6 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.FileSystemGlobbing;
-using Microsoft.PythonTools.Common.Infrastructure;
-using Microsoft.PythonTools.Infrastructure;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Microsoft.VisualStudio.Workspace;
 using Microsoft.VisualStudio.Workspace.VSIntegration.Contracts;
@@ -29,9 +27,9 @@ using StreamJsonRpc;
 namespace Microsoft.PythonTools.LanguageServerClient.FileWatcher {
     class Listener : IDisposable {
         private JsonRpc _rpc;
-        
+        private readonly IFileWatcherService _WorkspaceFileWatcher;
         private System.IO.FileSystemWatcher _solutionWatcher;
-        private Microsoft.Extensions.FileSystemGlobbing.Matcher _matcher = new Microsoft.Extensions.FileSystemGlobbing.Matcher(StringComparison.OrdinalIgnoreCase);
+        private Matcher _matcher = new Matcher(StringComparison.OrdinalIgnoreCase);
         private bool disposedValue;
         private string _root;
 
@@ -47,10 +45,12 @@ namespace Microsoft.PythonTools.LanguageServerClient.FileWatcher {
             _matcher.AddExclude("**/~*");
             _matcher.AddExclude("**/*TMP");
             _matcher.AddExclude("**/__pycache__");
-
+            
+            _WorkspaceFileWatcher = null;
             // Depending upon if this is a workspace or a solution, listen to different change events.
-            if (workspaceService != null && workspaceService.CurrentWorkspace != null) {
-                workspaceService.CurrentWorkspace.GetService<IFileWatcherService>().OnFileSystemChanged += OnFileChanged;
+            if (workspaceService?.CurrentWorkspace != null) {
+                _WorkspaceFileWatcher = workspaceService.CurrentWorkspace.GetService<IFileWatcherService>();
+                _WorkspaceFileWatcher.OnFileSystemChanged += OnFileChanged;
                 _root = workspaceService.CurrentWorkspace.Location;
             } else {
                 var path = GetSolutionDirectory(site);
@@ -115,7 +115,7 @@ namespace Microsoft.PythonTools.LanguageServerClient.FileWatcher {
         private async Task OnFileChanged(object sender, System.IO.FileSystemEventArgs e) {
 
             // Skip directory change events
-            if (e.IsDirectoryChanged()) {
+            if (e.IsDirectoryChanged() || _rpc == null) {
                 return;
             }
 
@@ -165,7 +165,7 @@ namespace Microsoft.PythonTools.LanguageServerClient.FileWatcher {
                     didChangeParams.Changes = new FileEvent[] { deleteEvent, createEvent };
                 }
 
-                if (didChangeParams.Changes.Any() && this._rpc != null) {
+                if (didChangeParams.Changes.Any()) {
              
                     await _rpc.NotifyWithParameterObjectAsync(Methods.WorkspaceDidChangeWatchedFiles.Name, didChangeParams);
                 }
@@ -176,6 +176,16 @@ namespace Microsoft.PythonTools.LanguageServerClient.FileWatcher {
             if (!disposedValue) {
                 if (disposing) {
                     _solutionWatcher?.Dispose();
+
+                    // Depending upon if this is a workspace or a solution, listen to different change events.
+                    if (_WorkspaceFileWatcher != null) {
+                        _WorkspaceFileWatcher.OnFileSystemChanged -= OnFileChanged;                        
+                    }
+
+                    if (_rpc != null) {
+                        _rpc.Disconnected -= _rpc_Disconnected;
+                        _rpc = null;
+                    }
                 }
 
                 // TODO: free unmanaged resources (unmanaged objects) and override finalizer

--- a/Python/Product/PythonTools/PythonTools/LanguageServerClient/FileWatcher/Listener.cs
+++ b/Python/Product/PythonTools/PythonTools/LanguageServerClient/FileWatcher/Listener.cs
@@ -29,7 +29,7 @@ using StreamJsonRpc;
 namespace Microsoft.PythonTools.LanguageServerClient.FileWatcher {
     class Listener : IDisposable {
         private JsonRpc _rpc;
-        private JsonRpcWrapper _rpcWrapper;
+        
         private System.IO.FileSystemWatcher _solutionWatcher;
         private Microsoft.Extensions.FileSystemGlobbing.Matcher _matcher = new Microsoft.Extensions.FileSystemGlobbing.Matcher(StringComparison.OrdinalIgnoreCase);
         private bool disposedValue;
@@ -38,9 +38,6 @@ namespace Microsoft.PythonTools.LanguageServerClient.FileWatcher {
         public Listener(StreamJsonRpc.JsonRpc rpc, IVsFolderWorkspaceService workspaceService, IServiceProvider site) {
             this._rpc = rpc;
             this._rpc.Disconnected += _rpc_Disconnected;
-
-            // wrap the rpc so we can handle exceptions in a common place
-            this._rpcWrapper = new JsonRpcWrapper(this._rpc);
 
             // Ignore some common directories
             _matcher.AddExclude("**/.vs/**/*.*");
@@ -168,10 +165,9 @@ namespace Microsoft.PythonTools.LanguageServerClient.FileWatcher {
                     didChangeParams.Changes = new FileEvent[] { deleteEvent, createEvent };
                 }
 
-                if (didChangeParams.Changes.Any()) {
-                    await _rpcWrapper.NotifyWithParameterObjectAsync(Methods.WorkspaceDidChangeWatchedFiles.Name, didChangeParams);
-
-                    
+                if (didChangeParams.Changes.Any() && this._rpc != null) {
+             
+                    await _rpc.NotifyWithParameterObjectAsync(Methods.WorkspaceDidChangeWatchedFiles.Name, didChangeParams);
                 }
             }
         }

--- a/Python/Product/PythonTools/PythonTools/LanguageServerClient/PythonLanguageClient.cs
+++ b/Python/Product/PythonTools/PythonTools/LanguageServerClient/PythonLanguageClient.cs
@@ -22,6 +22,7 @@ using System.Linq;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.PythonTools.Common.Core.Disposables;
 using Microsoft.PythonTools.Common.Infrastructure;
 using Microsoft.PythonTools.Common.Parsing;
 using Microsoft.PythonTools.Infrastructure;
@@ -297,9 +298,7 @@ namespace Microsoft.PythonTools.LanguageServerClient {
         }
 
         public Task AttachForCustomMessageAsync(JsonRpc rpc) {
-            _fileListener.Dispose();
-            _rpc.Dispose();
-
+     
             _rpc = rpc;
 
             // This is a workaround until we have proper API from ILanguageClient for now.
@@ -308,6 +307,8 @@ namespace Microsoft.PythonTools.LanguageServerClient {
             _rpc.AllowModificationWhileListening = false;
 
             // Create our listener for file events
+            _fileListener?.Dispose();
+            _fileListener = null;
             _fileListener = new FileWatcher.Listener(_rpc, WorkspaceService, Site);
             _disposables.Add(_fileListener);
 


### PR DESCRIPTION
- also change `JsonRpcWrapper` to an extension class so that we dont have multiple references to the the `JsonRPC` instance


fixes: https://github.com/microsoft/PTVS/issues/7651