### PR TITLE
Update issues.yml

### DIFF
--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -58,7 +58,7 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              labels: ['needs repro']
+              labels: ['needs triage']
             })
       - name: Save assignment to state
         uses: actions/github-script@v6.3.3


### PR DESCRIPTION
Right now the new issues get assigned to the next person in the round robin list and labeled as "needs triage" and "needs repro". This pr gets rid of the duplicate label.