### PR TITLE
Fix PTVS Regressions

### DIFF
--- a/Python/Product/PythonTools/PythonTools/LanguageServerClient/PythonLanguageClient.cs
+++ b/Python/Product/PythonTools/PythonTools/LanguageServerClient/PythonLanguageClient.cs
@@ -369,7 +369,7 @@ namespace Microsoft.PythonTools.LanguageServerClient {
                     return null;
                 }
             }else {
-                var pathFromScopeUri = CommonUtils.NormalizeDirectoryPath(scopeUri.LocalPath).ToLower();
+                var pathFromScopeUri = CommonUtils.NormalizeDirectoryPath(scopeUri.LocalPath).ToLower().TrimStart('\\');
                 // Find the matching context for the item
                 context = _clientContexts.Find(c => scopeUri != null && PathUtils.IsSamePath(c.RootPath.ToLower(), pathFromScopeUri));
             }


### PR DESCRIPTION
The root cause was because the paths that client returns contain leading slashes.

1. **fixes https://github.com/microsoft/PTVS/issues/7827**

![fixmissingimports](https://github.com/microsoft/PTVS/assets/100439259/b29dcff3-e5d9-448b-9970-7a5f4110eb51)

2. **fixes https://github.com/microsoft/PTVS/issues/7830**

![fixcodeactions](https://github.com/microsoft/PTVS/assets/100439259/cf843c9e-474c-4412-b90d-ea6714357efd)

3. **fixes https://github.com/microsoft/PTVS/issues/7832**

![fixtypeshed](https://github.com/microsoft/PTVS/assets/100439259/d99d0693-f827-47b0-9917-fbb03e96798d)

