### PR TITLE
Create and publish bootstrapper for our test team

### DIFF
--- a/Build/templates/create_vs_bootstrapper.yml
+++ b/Build/templates/create_vs_bootstrapper.yml
@@ -11,7 +11,7 @@ steps:
       bootstrapperCoreFeedSource: 'https://devdiv.pkgs.visualstudio.com/_packaging/Setup/nuget/v3/index.json'
       bootstrapperCoreDependenciesFeedSource: 'https://devdiv.pkgs.visualstudio.com/_packaging/Setup-Dependencies/nuget/v3/index.json'
       nugetOrgPublicFeedSource: 'https://api.nuget.org/v3/index.json'
-      outputFolder: $(Build.StagingDirectory)
+      outputFolder: $(Build.StagingDirectory)\release
       manifests: $(Build.StagingDirectory)\release\Microsoft.PythonTools.vsman
 
   # Publish the bootstrapper as a build artifact.
@@ -19,6 +19,6 @@ steps:
   - task: 1ES.PublishBuildArtifacts@1
     displayName: 'Publish Artifact: bootstrapper'
     inputs:
-      PathtoPublish: $(Build.StagingDirectory)\bootstrapper
+      PathtoPublish: $(Build.StagingDirectory)\release\bootstrapper
       ArtifactName: bootstrapper
       sbomEnabled: false

--- a/Build/templates/create_vs_bootstrapper.yml
+++ b/Build/templates/create_vs_bootstrapper.yml
@@ -1,10 +1,5 @@
 steps:
 
-  # create bootstrapper output directory
-  - script: |
-      mkdir $(Build.StagingDirectory)\bootstrapper
-    displayName: 'Create bootstrapper dir'
-
   # Create VS bootstrapper
   # See https://devdiv.visualstudio.com/DevDiv/_wiki/wikis/DevDiv.wiki/643/How-to-Build-a-Bootstrapper for more details.
   # This is the latest IntPreview build of VS with the Python workload (that we just built) installed.
@@ -16,7 +11,7 @@ steps:
       bootstrapperCoreFeedSource: 'https://devdiv.pkgs.visualstudio.com/_packaging/Setup/nuget/v3/index.json'
       bootstrapperCoreDependenciesFeedSource: 'https://devdiv.pkgs.visualstudio.com/_packaging/Setup-Dependencies/nuget/v3/index.json'
       nugetOrgPublicFeedSource: 'https://api.nuget.org/v3/index.json'
-      outputFolder: $(Build.StagingDirectory)\bootstrapper
+      outputFolder: $(Build.StagingDirectory)
       manifests: $(Build.StagingDirectory)\release\Microsoft.PythonTools.vsman
 
   # Publish the bootstrapper as a build artifact.

--- a/Build/templates/create_vs_bootstrapper.yml
+++ b/Build/templates/create_vs_bootstrapper.yml
@@ -11,6 +11,7 @@ steps:
       bootstrapperCoreFeedSource: 'https://devdiv.pkgs.visualstudio.com/_packaging/Setup/nuget/v3/index.json'
       bootstrapperCoreDependenciesFeedSource: 'https://devdiv.pkgs.visualstudio.com/_packaging/Setup-Dependencies/nuget/v3/index.json'
       nugetOrgPublicFeedSource: 'https://api.nuget.org/v3/index.json'
+      # this outputFolder must match the "dropFolder" in the 1ES.MicroBuildVstsDrop@1 task in azure-pipelines.yml
       outputFolder: $(Build.StagingDirectory)\release
       manifests: $(Build.StagingDirectory)\release\Microsoft.PythonTools.vsman
 

--- a/Build/templates/create_vs_bootstrapper.yml
+++ b/Build/templates/create_vs_bootstrapper.yml
@@ -8,7 +8,7 @@ steps:
   # Create VS bootstrapper
   # See https://devdiv.visualstudio.com/DevDiv/_wiki/wikis/DevDiv.wiki/643/How-to-Build-a-Bootstrapper for more details.
   # This is the latest IntPreview build of VS with the Python workload (that we just built) installed.
-  - task: MicroBuildBuildVSBootstrapper@2
+  - task: MicroBuildBuildVSBootstrapper@3
     displayName: 'Build Bootstrapper'
     inputs:
       channelName: 'IntPreview'

--- a/Build/templates/create_vs_bootstrapper.yml
+++ b/Build/templates/create_vs_bootstrapper.yml
@@ -7,11 +7,11 @@ steps:
 
   # Create VS bootstrapper
   # See https://devdiv.visualstudio.com/DevDiv/_wiki/wikis/DevDiv.wiki/643/How-to-Build-a-Bootstrapper for more details.
-  # This is the latest int main build of VS with the Python workload (that we just built) installed.
+  # This is the latest IntPreview build of VS with the Python workload (that we just built) installed.
   - task: MicroBuildBuildVSBootstrapper@2
     displayName: 'Build Bootstrapper'
     inputs:
-      channelName: 'int.main'
+      channelName: 'IntPreview'
       vsMajorVersion: '17'
       bootstrapperCoreFeedSource: 'https://devdiv.pkgs.visualstudio.com/_packaging/Setup/nuget/v3/index.json'
       bootstrapperCoreDependenciesFeedSource: 'https://devdiv.pkgs.visualstudio.com/_packaging/Setup-Dependencies/nuget/v3/index.json'

--- a/Build/templates/create_vs_bootstrapper.yml
+++ b/Build/templates/create_vs_bootstrapper.yml
@@ -1,26 +1,25 @@
 steps:
 
-  # Create VS bootstrapper.
-  # This is essentially a "main" build of VS with the Python workload (that we just built) installed.
+  # Create VS bootstrapper
+  # See https://devdiv.visualstudio.com/DevDiv/_wiki/wikis/DevDiv.wiki/643/How-to-Build-a-Bootstrapper for more details.
 
-  # It will be created under $(Build.StagingDirectory)\release, which is uploaded (in a later step) to a vsts drop.
-  # The URI to the uploaded bootstrapper is contained in the bootstrapper.json, which is consumed by the
-  # integration tests on lab machines.
+  # This is the latest int-preview build of VS with the Python workload (that we just built) installed.
   - task: MicroBuildBuildVSBootstrapper@2
-    displayName: 'Build Bootstrapper.json'
-    condition: notin(variables['Build.Reason'], 'PullRequest')
+    displayName: 'Build Bootstrapper'
     inputs:
-      channelName: 'int.main'
+      channelName: 'int.preview'
       vsMajorVersion: '17'
       bootstrapperCoreFeedSource: 'https://devdiv.pkgs.visualstudio.com/_packaging/Setup/nuget/v3/index.json'
       bootstrapperCoreDependenciesFeedSource: 'https://devdiv.pkgs.visualstudio.com/_packaging/Setup-Dependencies/nuget/v3/index.json'
       nugetOrgPublicFeedSource: 'https://api.nuget.org/v3/index.json'
-      outputFolder: $(Build.StagingDirectory)\release
+      outputFolder: $(Build.StagingDirectory)\bootstrapper
       manifests: $(Build.StagingDirectory)\release\Microsoft.PythonTools.vsman
 
-  # Publish Bootstrapper.json as a build artifact so test pipelines can consume it
-  - task: PublishBuildArtifacts@1
+  # Publish the bootstrapper as a build artifact.
+  # We do this manually instead of using the templateContext outputs because we don't need sbom generation.
+  - task: 1ES.PublishBuildArtifacts@1
+    displayName: 'Publish Artifact: bootstrapper'
     inputs:
-      PathtoPublish: $(Build.StagingDirectory)\MicroBuild\Output
-      ArtifactName: MicroBuildOutputs
-    displayName: 'Publish Artifact: MicroBuildOutputs (Bootstrapper.json)'
+      PathtoPublish: $(Build.StagingDirectory)\bootstrapper
+      ArtifactName: bootstrapper
+      sbomEnabled: false

--- a/Build/templates/create_vs_bootstrapper.yml
+++ b/Build/templates/create_vs_bootstrapper.yml
@@ -7,11 +7,11 @@ steps:
 
   # Create VS bootstrapper
   # See https://devdiv.visualstudio.com/DevDiv/_wiki/wikis/DevDiv.wiki/643/How-to-Build-a-Bootstrapper for more details.
-  # This is the latest int-preview build of VS with the Python workload (that we just built) installed.
+  # This is the latest int main build of VS with the Python workload (that we just built) installed.
   - task: MicroBuildBuildVSBootstrapper@2
     displayName: 'Build Bootstrapper'
     inputs:
-      channelName: 'int.preview'
+      channelName: 'int.main'
       vsMajorVersion: '17'
       bootstrapperCoreFeedSource: 'https://devdiv.pkgs.visualstudio.com/_packaging/Setup/nuget/v3/index.json'
       bootstrapperCoreDependenciesFeedSource: 'https://devdiv.pkgs.visualstudio.com/_packaging/Setup-Dependencies/nuget/v3/index.json'

--- a/Build/templates/create_vs_bootstrapper.yml
+++ b/Build/templates/create_vs_bootstrapper.yml
@@ -3,7 +3,7 @@ steps:
   # create bootstrapper output directory
   - script: |
       mkdir $(Build.StagingDirectory)\bootstrapper
-    displayName: 'Create bootstrapper output directory'
+    displayName: 'Create bootstrapper dir'
 
   # Create VS bootstrapper
   # See https://devdiv.visualstudio.com/DevDiv/_wiki/wikis/DevDiv.wiki/643/How-to-Build-a-Bootstrapper for more details.

--- a/Build/templates/create_vs_bootstrapper.yml
+++ b/Build/templates/create_vs_bootstrapper.yml
@@ -1,8 +1,12 @@
 steps:
 
+  # create bootstrapper output directory
+  - script: |
+      mkdir $(Build.StagingDirectory)\bootstrapper
+    displayName: 'Create bootstrapper output directory'
+
   # Create VS bootstrapper
   # See https://devdiv.visualstudio.com/DevDiv/_wiki/wikis/DevDiv.wiki/643/How-to-Build-a-Bootstrapper for more details.
-
   # This is the latest int-preview build of VS with the Python workload (that we just built) installed.
   - task: MicroBuildBuildVSBootstrapper@2
     displayName: 'Build Bootstrapper'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -161,11 +161,9 @@ extends:
         # Non-PR steps
         - ${{ if notin(variables['Build.Reason'], 'PullRequest') }}:
 
-          # Create VS bootstrapper for tests.
-          # This must happen BEFORE the 1ES.MicroBuildVstsDrop@1 task, since the bootstrapper
-          # needs to be uploaded to the drop as well.
+          # Create VS bootstrapper for testing
           # This step is disabled for now because it's blocking the build and we don't currently use it.
-          # - template: Build/templates/create_vs_bootstrapper.yml
+          - template: Build/templates/create_vs_bootstrapper.yml@self
 
           # Upload vsts drop used by Visual Studio insertions
           - task: 1ES.MicroBuildVstsDrop@1


### PR DESCRIPTION
Related to https://github.com/microsoft/PTVS/issues/7835

The point of the bootstrapper is to avoid having to do a VS insertion for our test team to consume our bits. I'm assuming the team can access our build artifacts, I'm waiting to hear back from them.

I ran a full build from this PR branch and the bootloader artifacts can be found at https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=9371793&view=artifacts&pathAsName=false&type=publishedArtifacts