### PR TITLE
remove publish symbols task so we can get rid of pat

### DIFF
--- a/Build/templates/publish_symbols.yml
+++ b/Build/templates/publish_symbols.yml
@@ -23,32 +23,10 @@ steps:
         VsPyProf*.dll
       TargetFolder: '$(Build.ArtifactStagingDirectory)/symbols'
 
-  # Publish Symbols
-  # This task uses two environment variables from the PTVS-Dev17 library (ArtifactServices.Symbol.AccountName and ArtifactServices.Symbol.PAT)
-  # If this step is failing due to authentication errors, the PAT is most likely expired. To regenerate the PAT:
-  # 1. Go to https://dev.azure.com/microsoft/_usersSettings/tokens (it has to be here in order for the PAT organization to be microsoft, which is required)
-  # 2. Create a new Token, name it whatever you want. Set the expiration as long as possible.
-  # 3. Click on Show more scopes, scroll down to Symbols, select Read & write, and click on Create.
-  # 4. Copy the PAT value to the clipboard.
-  # 5. Browse to the PTVS-Dev17 library at https://devdiv.visualstudio.com/DevDiv/_library?itemType=VariableGroups&view=VariableGroupView&variableGroupId=381&path=PTVS-Dev17
-  # 6. Paste the value from step 4 into the value of ArtifactServices.Symbol.PAT and make sure the variable type is set to secret.
-  # 7. Make sure the SAVE the changes!
-  
-  # Commenting this out to test if symbol publishing still works with just the ArchiveSymbols task.
-  # Need to build the PR branch manually AND kick off the release pipeline manually (since it only triggers on main by default)
-  # If it doesn't, try to add this back in but remove the ArtifactServices.Symbol.AccountName and ArtifactServices.Symbol.PAT
-  # variables from the PTVS-Dev17 library, which will publish symbols to the devdiv organization instead of the microsoft organization.
-  # If it does work, then we can remove this task from the pipeline and also remove the ArtifactServices.Symbol.AccountName and ArtifactServices.Symbol.PAT
-  #- task: PublishSymbols@2
-  #  displayName: 'Publish symbols'
-  #  inputs:
-  #    symbolsFolder: '$(Build.ArtifactStagingDirectory)/symbols'
-  #    searchPattern: '*.pdb'
-  #    symbolServerType: TeamServices
-
   # Archive Symbols
   # When you insert your binaries into VS or ship them to any other client you need to archive your binaries & symbols to MSDL. 
-  # This will ensure that your symbols are available even if the associated build is deleted and will also make them available on the internet so that externals clients can download them.
+  # This will ensure that your symbols are available even if the associated build is deleted and will also make them available 
+  # on the internet so that external clients can download them.
   - task: MicroBuildArchiveSymbols@4
     displayName: 'Archive Symbols'
     inputs:

--- a/Build/templates/publish_symbols.yml
+++ b/Build/templates/publish_symbols.yml
@@ -33,12 +33,18 @@ steps:
   # 5. Browse to the PTVS-Dev17 library at https://devdiv.visualstudio.com/DevDiv/_library?itemType=VariableGroups&view=VariableGroupView&variableGroupId=381&path=PTVS-Dev17
   # 6. Paste the value from step 4 into the value of ArtifactServices.Symbol.PAT and make sure the variable type is set to secret.
   # 7. Make sure the SAVE the changes!
-  - task: PublishSymbols@2
-    displayName: 'Publish symbols'
-    inputs:
-      symbolsFolder: '$(Build.ArtifactStagingDirectory)/symbols'
-      searchPattern: '*.pdb'
-      symbolServerType: TeamServices
+  
+  # Commenting this out to test if symbol publishing still works with just the ArchiveSymbols task.
+  # Need to build the PR branch manually AND kick off the release pipeline manually (since it only triggers on main by default)
+  # If it doesn't, try to add this back in but remove the ArtifactServices.Symbol.AccountName and ArtifactServices.Symbol.PAT
+  # variables from the PTVS-Dev17 library, which will publish symbols to the devdiv organization instead of the microsoft organization.
+  # If it does work, then we can remove this task from the pipeline and also remove the ArtifactServices.Symbol.AccountName and ArtifactServices.Symbol.PAT
+  #- task: PublishSymbols@2
+  #  displayName: 'Publish symbols'
+  #  inputs:
+  #    symbolsFolder: '$(Build.ArtifactStagingDirectory)/symbols'
+  #    searchPattern: '*.pdb'
+  #    symbolServerType: TeamServices
 
   # Archive Symbols
   # When you insert your binaries into VS or ship them to any other client you need to archive your binaries & symbols to MSDL. 


### PR DESCRIPTION
Fixes #7870

I created an insertion PR at https://devdiv.visualstudio.com/DevDiv/_git/VS/pullrequest/544016 and waiting for the Symbol Check task to be done.
The Verify Symbols job is all green at https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=9417375&view=results.