### PR TITLE
Enable ingesting preview builds of pylance

### DIFF
--- a/Build/PreBuild.ps1
+++ b/Build/PreBuild.ps1
@@ -16,8 +16,16 @@ param (
     [string] $outdir, 
     
     # The version of pylance we should download, defaults to "latest"
+    # If "latest" is specified, the script will find the latest release of type $pylanceReleaseType (defaults to "stable")
+    # If an explicit version is specified, the script will always look for that specific version
     [Parameter()]
     [string] $pylanceVersion = "latest", 
+
+    # The type of pylance release we should download, defaults to "stable".
+    # This input is ignored if an explicit version is specified in $pylanceVersion.
+    [Parameter()]
+    [ValidateSet("stable", "pre-release")]
+    [string] $pylanceReleaseType = "stable", 
     
     # The version of debugpy we should download, defaults to "latest"
     [Parameter()]
@@ -70,10 +78,42 @@ $outdir = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPat
 Push-Location "$buildroot\Build"
 try {
 
-    # Install pylance version specified in package.json
+    "Installing Pylance"
+
+    # Install the specified pylance version.
+    # See https://github.com/microsoft/pyrx/wiki/Pylance-release-process#versioning for info about how pylance is versioned and released.
+
     # If this doesn't work, you probably need to set up your .npmrc file or you need permissions to the feed.
     # See https://microsoft.sharepoint.com/teams/python/_layouts/15/Doc.aspx?sourcedoc=%7B30d33826-9f98-4d3e-890e-b7d198bbbcbe%7D&action=edit&wd=target(Python%20VS%2FDev%20Docs.one%7Cd7206ce2-cf40-437b-8ce9-1e55f4bc2f44%2FPylance%20in%20VS%7C6000d391-4e62-4a4d-89d2-7f7c1f005639%2F)&share=IgEmONMwmJ8-TYkOt9GYu7y-AeCM6R8r8Myty0Lj8CeOs4E
-    "Installing Pylance"
+
+    # If the specified version is "latest", find the latest release of pylance based on the specified release type.
+    if ($pylanceVersion -eq "latest") {
+        
+        "Pylance version = $pylanceVersion"
+        "Pylance release type = $pylanceReleaseType"
+
+        # Get all the versions in the feed in descending order
+        $versions = npm view @pylance/pylance versions --json | ConvertFrom-Json
+        [array]::Reverse($versions)
+
+        # Find the highest version with an appropriate patch number.
+        # Stable releases have patch numbers < 100, while pre-releases have patch numbers >= 100.
+        foreach ($version in $versions) {
+            $patchVersion = $version.Split(".")[2]
+
+            if ($patchVersion -lt 100 -and $pylanceReleaseType -eq "stable") {
+                $pylanceVersion = $version
+                "Latest stable Pylance version found: $pylanceVersion"
+                break
+            }
+
+            if ($patchVersion -ge 100 -and $pylanceReleaseType -eq "pre-release") {
+                $pylanceVersion = $version
+                "Latest pre-release Pylance version found: $pylanceVersion"
+                break
+            }
+        }
+    }
 
     # overwrite the pylance version in the package.json with the specified version
     $packageJsonFile = Join-Path $buildroot "package.json"
@@ -85,13 +125,13 @@ try {
         $packageJson | ConvertTo-Json -depth 8 | Set-Content $packageJsonFile
     }
 
-    # delete pylance install folder to make sure we always get latest
+    # delete pylance install folder to blow away local changes
     $nodeModulesPath = Join-Path $buildroot "node_modules"
     if (Test-Path -Path $nodeModulesPath) {
         Remove-Item -Recurse -Force $nodeModulesPath
-    }
+    }  
 
-    # install latest pylance
+    # Install pylance version specified in package.json
     npm install
 
     # exit on error
@@ -115,11 +155,11 @@ try {
         # If the patch version is < 100, this is a stable pylance release. Otherwise, it's a pre-release.
         # The "Pylance Stable" tag is used to trigger releases when the build is successful
         $patchVersion = $installedPylanceVersion.Split(".")[2]
-        $pylanceReleaseType = "Pre-Release"
+        $installedPylanceReleaseType = "Pre-Release"
         if ($patchVersion -lt 100) {
-            $pylanceReleaseType = "Stable"
+            $installedPylanceReleaseType = "Stable"
         }
-        Write-Host "##vso[build.addbuildtag]Pylance $pylanceReleaseType"
+        Write-Host "##vso[build.addbuildtag]Pylance $installedPylanceReleaseType"
     }
 
     "-----"

--- a/Build/PreBuild.ps1
+++ b/Build/PreBuild.ps1
@@ -24,7 +24,7 @@ param (
     # The type of pylance release we should download, defaults to "stable".
     # This input is ignored if an explicit version is specified in $pylanceVersion.
     [Parameter()]
-    [ValidateSet("stable", "pre-release")]
+    [ValidateSet("stable", "preview")]
     [string] $pylanceReleaseType = "stable", 
     
     # The version of debugpy we should download, defaults to "latest"
@@ -97,7 +97,7 @@ try {
         [array]::Reverse($versions)
 
         # Find the highest version with an appropriate patch number.
-        # Stable releases have patch numbers < 100, while pre-releases have patch numbers >= 100.
+        # Stable releases have patch numbers < 100, while preview releases have patch numbers >= 100.
         foreach ($version in $versions) {
             $patchVersion = $version.Split(".")[2]
 
@@ -107,9 +107,9 @@ try {
                 break
             }
 
-            if ($patchVersion -ge 100 -and $pylanceReleaseType -eq "pre-release") {
+            if ($patchVersion -ge 100 -and $pylanceReleaseType -eq "preview") {
                 $pylanceVersion = $version
-                "Latest pre-release Pylance version found: $pylanceVersion"
+                "Latest preview Pylance version found: $pylanceVersion"
                 break
             }
         }
@@ -152,12 +152,12 @@ try {
         # add build tag for pylance version being used
         Write-Host "##vso[build.addbuildtag]Pylance $installedPylanceVersion"
 
-        # If the patch version is < 100, this is a stable pylance release. Otherwise, it's a pre-release.
+        # If the patch version is >= 100, this is a preview release.
         # The "Pylance Stable" tag is used to trigger releases when the build is successful
         $patchVersion = $installedPylanceVersion.Split(".")[2]
-        $installedPylanceReleaseType = "Pre-Release"
-        if ($patchVersion -lt 100) {
-            $installedPylanceReleaseType = "Stable"
+        $installedPylanceReleaseType = "Stable"
+        if ($patchVersion -ge 100) {
+            $installedPylanceReleaseType = "Preview"
         }
         Write-Host "##vso[build.addbuildtag]Pylance $installedPylanceReleaseType"
     }

--- a/Build/PreBuild.ps1
+++ b/Build/PreBuild.ps1
@@ -106,9 +106,20 @@ try {
     $installedPylanceVersion = $installedPylanceVersion.Trim()
     "Installed Pylance $installedPylanceVersion"
     
-    # add azdo build tag for non-pull requests
+    # add azdo build tags for non-pull requests
     if ($env:BUILD_REASON -and -not $env:BUILD_REASON.Contains("PullRequest")) {
+
+        # add build tag for pylance version being used
         Write-Host "##vso[build.addbuildtag]Pylance $installedPylanceVersion"
+
+        # If the patch version is < 100, this is a stable pylance release. Otherwise, it's a pre-release.
+        # The "Pylance Stable" tag is used to trigger releases when the build is successful
+        $patchVersion = $installedPylanceVersion.Split(".")[2]
+        if ($patchVersion -lt 100) {
+            Write-Host "##vso[build.addbuildtag]Pylance Stable"
+        } else {
+            Write-Host "##vso[build.addbuildtag]Pylance Pre-Release"
+        }
     }
 
     "-----"

--- a/Build/PreBuild.ps1
+++ b/Build/PreBuild.ps1
@@ -99,7 +99,7 @@ try {
         # Find the highest version with an appropriate patch number.
         # Stable releases have patch numbers < 100, while preview releases have patch numbers >= 100.
         foreach ($version in $versions) {
-            $patchVersion = $version.Split(".")[2]
+            [int] $patchVersion = $version.Split(".")[2]
 
             if ($patchVersion -lt 100 -and $pylanceReleaseType -eq "stable") {
                 $pylanceVersion = $version
@@ -154,7 +154,7 @@ try {
 
         # If the patch version is >= 100, this is a preview release.
         # The "Pylance Stable" tag is used to trigger releases when the build is successful
-        $patchVersion = $installedPylanceVersion.Split(".")[2]
+        [int] $patchVersion = $installedPylanceVersion.Split(".")[2]
         $installedPylanceReleaseType = "Stable"
         if ($patchVersion -ge 100) {
             $installedPylanceReleaseType = "Preview"

--- a/Build/PreBuild.ps1
+++ b/Build/PreBuild.ps1
@@ -146,8 +146,8 @@ try {
     $installedPylanceVersion = $installedPylanceVersion.Trim()
     "Installed Pylance $installedPylanceVersion"
     
-    # add azdo build tags for non-pull requests
-    if ($env:BUILD_REASON -and -not $env:BUILD_REASON.Contains("PullRequest")) {
+    # add build tag when running from azdo
+    if ($env:BUILD_REASON) {
 
         # add build tag for pylance version being used
         Write-Host "##vso[build.addbuildtag]Pylance $installedPylanceVersion"
@@ -224,8 +224,8 @@ try {
     # write debugpy version out to $buildroot\build\debugpy-version.txt, since that file is used by Debugger.csproj and various other classes
     Set-Content -NoNewline -Force -Path "$buildroot\build\debugpy-version.txt" -Value $installedDebugpyVersion
 
-    # add azdo build tag
-    if ($env:BUILD_REASON -and -not $env:BUILD_REASON.Contains("PullRequest")) {
+    # add build tag when running from azdo
+    if ($env:BUILD_REASON) {
         Write-Host "##vso[build.addbuildtag]Debugpy $installedDebugpyVersion"
     }
 

--- a/Build/PreBuild.ps1
+++ b/Build/PreBuild.ps1
@@ -115,11 +115,11 @@ try {
         # If the patch version is < 100, this is a stable pylance release. Otherwise, it's a pre-release.
         # The "Pylance Stable" tag is used to trigger releases when the build is successful
         $patchVersion = $installedPylanceVersion.Split(".")[2]
+        $pylanceReleaseType = "Pre-Release"
         if ($patchVersion -lt 100) {
-            Write-Host "##vso[build.addbuildtag]Pylance Stable"
-        } else {
-            Write-Host "##vso[build.addbuildtag]Pylance Pre-Release"
+            $pylanceReleaseType = "Stable"
         }
+        Write-Host "##vso[build.addbuildtag]Pylance $pylanceReleaseType"
     }
 
     "-----"

--- a/Build/templates/restore_packages.yml
+++ b/Build/templates/restore_packages.yml
@@ -3,6 +3,13 @@ parameters:
   displayName: Pylance Version
   type: string
   default: latest
+- name: pylanceReleaseType
+  displayName: Pylance Release Type
+  type: string
+  default: stable
+  values:
+    - stable
+    - preview
 - name: debugpyVersion
   displayName: Debugpy Version
   type: string
@@ -25,4 +32,4 @@ steps:
     displayName: 'Restore packages'
     inputs:
       scriptName: Build/PreBuild.ps1
-      arguments: '-vstarget $(VSTarget) -pylanceVersion ${{ parameters.pylanceVersion }} -debugpyVersion ${{ parameters.debugpyVersion }}'
+      arguments: '-vstarget $(VSTarget) -pylanceVersion ${{ parameters.pylanceVersion }} -pylanceReleaseType ${{ parameters.pylanceReleaseType }} -debugpyVersion ${{ parameters.debugpyVersion }}'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,6 +8,13 @@ parameters:
   displayName: Pylance Version
   type: string
   default: latest
+- name: pylanceReleaseType
+  displayName: Pylance Release Type
+  type: string
+  default: stable
+  values:
+    - stable
+    - preview
 - name: debugpyVersion
   displayName: Debugpy Version
   type: string
@@ -153,6 +160,7 @@ extends:
         - template: /Build/templates/restore_packages.yml@self
           parameters:
             pylanceVersion: ${{ parameters.pylanceVersion }}
+            pylanceReleaseType: ${{ parameters.pylanceReleaseType }}
             debugpyVersion: ${{ parameters.debugpyVersion }}
         
         # Build and publish logs    

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "ptvs",
-  "private": true,
-  "devDependencies": {
-    "@pylance/pylance": "latest"
-  }
+    "name":  "ptvs",
+    "private":  true,
+    "devDependencies":  {
+                            "@pylance/pylance":  "2024.4.102"
+                        }
 }

--- a/package.json
+++ b/package.json
@@ -2,6 +2,6 @@
     "name":  "ptvs",
     "private":  true,
     "devDependencies":  {
-                            "@pylance/pylance":  "2024.4.102"
+                            "@pylance/pylance":  "2024.4.1"
                         }
 }


### PR DESCRIPTION
I've changed the logic in PreBuild.ps1 to no longer rely on npm's behavior when specifying "latest" for the version. "Latest" only seems to pull latest stable, which is what we want most of the time. But if there's a stable hotfix, "latest" won't pull it, which is bad.

Here's how the new logic works:

- If the user specifies a specific pylance version, we try to install it. In this case, `pylanceReleaseType` is ignored.
- If the user specifies "latest", we look for the latest version that matches the specified `pylanceReleaseType`. We can tell by the patch number.
- Finally, we tag the build with either `Pylance Stable` or `Pylance Preview`. 
  - This new tag will be used to control triggering of our release pipeline. We will only want to trigger releases (which insert into VS) on builds that are tagged with `Pylance Stable`.

The release pipeline change isn't visible in this PR because it's done directly in azdo. That pipeline is at https://devdiv.visualstudio.com/DevDiv/_releaseDefinition?definitionId=2762&_a=environments-editor-preview

I tested this by running the full build from my PR branch two times.
- The first run was with `stable` selected as the pylance release type. That build is at https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=9501352&view=results. The tagging and logic seems correct.
- The second run was with `preview` selected as the pylance release type. That build is at https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=9501353&view=results. The tagging and logic seems correct.

I still need to modify the pylance release process to pass in the appropriate release type once this PR is merged and to launch the PTVS pipeline on every pylance release (stable, hotfix, and preview)