### PR TITLE
Support inlay hints

### DIFF
--- a/Python/Product/Common/Strings.Designer.cs
+++ b/Python/Product/Common/Strings.Designer.cs
@@ -623,15 +623,6 @@ namespace Microsoft.PythonTools {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The following versions of Python are installed:.
-        /// </summary>
-        public static string AddInstalledEnvironmentVersions {
-            get {
-                return ResourceManager.GetString("AddInstalledEnvironmentVersions", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Python.
         /// </summary>
         public static string AddInstalledEnvironmentInstallationLabel {
@@ -700,6 +691,15 @@ namespace Microsoft.PythonTools {
         public static string AddInstalledEnvironmentTabHeader {
             get {
                 return ResourceManager.GetString("AddInstalledEnvironmentTabHeader", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The following versions of Python are installed:.
+        /// </summary>
+        public static string AddInstalledEnvironmentVersions {
+            get {
+                return ResourceManager.GetString("AddInstalledEnvironmentVersions", resourceCulture);
             }
         }
         
@@ -4922,7 +4922,7 @@ namespace Microsoft.PythonTools {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Enable/disable inlay hints for function return types..
+        ///   Looks up a localized string similar to Toggle inlay hints for function return types..
         /// </summary>
         public static string InlayHintsFunctionReturnTypesToolTip {
             get {
@@ -4931,7 +4931,7 @@ namespace Microsoft.PythonTools {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Enable/disable inlay hints for variable types..
+        ///   Looks up a localized string similar to Toggle inlay hints for variable types..
         /// </summary>
         public static string InlayHintsVariableTypeToolTip {
             get {

--- a/Python/Product/Common/Strings.Designer.cs
+++ b/Python/Product/Common/Strings.Designer.cs
@@ -621,7 +621,7 @@ namespace Microsoft.PythonTools {
                 return ResourceManager.GetString("AddInstalledEnvironmentDescription", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The following versions of Python are installed:.
         /// </summary>
@@ -4918,6 +4918,24 @@ namespace Microsoft.PythonTools {
         public static string IncorrectStartLocationErrorMsg {
             get {
                 return ResourceManager.GetString("IncorrectStartLocationErrorMsg", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Enable/disable inlay hints for function return types..
+        /// </summary>
+        public static string InlayHintsFunctionReturnTypesToolTip {
+            get {
+                return ResourceManager.GetString("InlayHintsFunctionReturnTypesToolTip", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Enable/disable inlay hints for variable types..
+        /// </summary>
+        public static string InlayHintsVariableTypeToolTip {
+            get {
+                return ResourceManager.GetString("InlayHintsVariableTypeToolTip", resourceCulture);
             }
         }
         

--- a/Python/Product/Common/Strings.resx
+++ b/Python/Product/Common/Strings.resx
@@ -3445,9 +3445,9 @@ Please specify at least one package.</value>
     <value>Defines the default format for import module.</value>
   </data>
   <data name="InlayHintsFunctionReturnTypesToolTip" xml:space="preserve">
-    <value>Enable/disable inlay hints for function return types.</value>
+    <value>Toggle inlay hints for function return types.</value>
   </data>
   <data name="InlayHintsVariableTypeToolTip" xml:space="preserve">
-    <value>Enable/disable inlay hints for variable types.</value>
+    <value>Toggle inlay hints for variable types.</value>
   </data>
 </root>

--- a/Python/Product/Common/Strings.resx
+++ b/Python/Product/Common/Strings.resx
@@ -3444,4 +3444,10 @@ Please specify at least one package.</value>
   <data name="ImportFormatToolTip" xml:space="preserve">
     <value>Defines the default format for import module.</value>
   </data>
+  <data name="InlayHintsFunctionReturnTypesToolTip" xml:space="preserve">
+    <value>Enable/disable inlay hints for function return types.</value>
+  </data>
+  <data name="InlayHintsVariableTypeToolTip" xml:space="preserve">
+    <value>Enable/disable inlay hints for variable types.</value>
+  </data>
 </root>

--- a/Python/Product/PythonTools/PythonTools/LanguageServerClient/PythonLanguageClient.cs
+++ b/Python/Product/PythonTools/PythonTools/LanguageServerClient/PythonLanguageClient.cs
@@ -429,8 +429,8 @@ namespace Microsoft.PythonTools.LanguageServerClient {
                     extraCommitChars = false,
                     importFormat = _analysisOptions.ImportFormat,
                     inlayHints = new LanguageServerSettings.PythonSettings.PythonAnalysisSettings.PythonAnalysisInlayHintsSettings {
-                        variableTypes = false,
-                        functionReturnTypes = false
+                        variableTypes = _analysisOptions.InlayHintsVariableTypes,
+                        functionReturnTypes = _analysisOptions.InlayHintsFunctionReturnTypes
                     },
                     taskListTokens = taskListTokens.ToArray()
                 }

--- a/Python/Product/PythonTools/PythonTools/Options/PythonAnalysisOptions.cs
+++ b/Python/Product/PythonTools/PythonTools/Options/PythonAnalysisOptions.cs
@@ -34,6 +34,8 @@ namespace Microsoft.PythonTools.Options {
         public string[] ExtraPaths { get; set; }
         public bool Indexing { get; set; }
         public string ImportFormat { get; set; }
+        public bool InlayHintsVariableTypes { get; set; }
+        public bool InlayHintsFunctionReturnTypes {get; set;}
 
         internal PythonAnalysisOptions(PythonToolsService service) {
             _service = service;
@@ -102,6 +104,18 @@ namespace Microsoft.PythonTools.Options {
                 changed = true;
             }
 
+            var inlayHintsVariableTypes = _service.LoadBool(nameof(InlayHintsVariableTypes), Category) ?? false;
+            if (InlayHintsVariableTypes != inlayHintsVariableTypes) { 
+                InlayHintsVariableTypes = inlayHintsVariableTypes;
+                changed = true;
+            }
+
+            var inlayHintsFunctionReturnTypes = _service.LoadBool(nameof(InlayHintsFunctionReturnTypes), Category) ?? false;
+            if (InlayHintsFunctionReturnTypes != inlayHintsFunctionReturnTypes) {
+                InlayHintsFunctionReturnTypes = inlayHintsFunctionReturnTypes;
+                changed = true;
+            }
+
             if (changed) {
                 Changed?.Invoke(this, EventArgs.Empty);
             }
@@ -118,6 +132,8 @@ namespace Microsoft.PythonTools.Options {
             changed |= _service.SaveBool(nameof(UseLibraryCodeForTypes), Category, UseLibraryCodeForTypes);
             changed |= _service.SaveBool(nameof(Indexing), Category, Indexing);
             changed |= _service.SaveString(nameof(ImportFormat), Category, ImportFormat);
+            changed |= _service.SaveBool(nameof(InlayHintsVariableTypes), Category, InlayHintsVariableTypes);
+            changed |= _service.SaveBool(nameof(InlayHintsFunctionReturnTypes), Category, InlayHintsFunctionReturnTypes);
             if (changed) {
                 Changed?.Invoke(this, EventArgs.Empty);
             }
@@ -133,6 +149,8 @@ namespace Microsoft.PythonTools.Options {
             UseLibraryCodeForTypes = true;
             Indexing = false;
             ImportFormat = PylanceImportFormat.Absolute;
+            InlayHintsVariableTypes = false;
+            InlayHintsFunctionReturnTypes = false;
             Changed?.Invoke(this, EventArgs.Empty);
         }
 

--- a/Python/Product/PythonTools/PythonTools/Options/PythonAnalysisOptionsControl.Designer.cs
+++ b/Python/Product/PythonTools/PythonTools/Options/PythonAnalysisOptionsControl.Designer.cs
@@ -42,6 +42,8 @@
             this._typeshedPaths = new System.Windows.Forms.TextBox();
             this._autoSearchPath = new System.Windows.Forms.CheckBox();
             this._indexing = new System.Windows.Forms.CheckBox();
+            this._inlayHintsVariableTypes = new System.Windows.Forms.CheckBox();
+            this._inlayHintsFunctionReturnTypes = new System.Windows.Forms.CheckBox();
             this._diagnosticModeToolTip = new System.Windows.Forms.ToolTip(this.components);
             this._logLevelToolTip = new System.Windows.Forms.ToolTip(this.components);
             this._typeCheckingToolTip = new System.Windows.Forms.ToolTip(this.components);
@@ -52,6 +54,8 @@
             this._searchPathsLabelToolTip = new System.Windows.Forms.ToolTip(this.components);
             this._typeshedPathsLabelToolTip = new System.Windows.Forms.ToolTip(this.components);
             this._importFormatToolTip = new System.Windows.Forms.ToolTip(this.components);
+            this._inlayHintsVariableTypesToolTip = new System.Windows.Forms.ToolTip(this.components);
+            this._inlayHintsFunctionReturnTypeToolTip = new System.Windows.Forms.ToolTip(this.components);
             tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
             diagnosticModeLabel = new System.Windows.Forms.Label();
             logLevelLabel = new System.Windows.Forms.Label();
@@ -80,6 +84,8 @@
             tableLayoutPanel1.Controls.Add(importFormatLabel, 0, 3);
             tableLayoutPanel1.Controls.Add(this._autoSearchPath, 0, 7);
             tableLayoutPanel1.Controls.Add(this._indexing, 0, 8);
+            tableLayoutPanel1.Controls.Add(this._inlayHintsVariableTypes, 0, 9);
+            tableLayoutPanel1.Controls.Add(this._inlayHintsFunctionReturnTypes, 0, 10);
             tableLayoutPanel1.Name = "tableLayoutPanel1";
             // 
             // diagnosticModeLabel
@@ -117,11 +123,6 @@
             this._typeCheckingMode.FormattingEnabled = true;
             resources.ApplyResources(this._typeCheckingMode, "_typeCheckingMode");
             this._typeCheckingMode.Name = "_typeCheckingMode";
-            // 
-            // importFormatLabel
-            // 
-            resources.ApplyResources(importFormatLabel, "importFormatLabel");
-            importFormatLabel.Name = "importFormatLabel";
             // 
             // _importFormatCombo
             // 
@@ -163,6 +164,11 @@
             resources.ApplyResources(this._typeshedPaths, "_typeshedPaths");
             this._typeshedPaths.Name = "_typeshedPaths";
             // 
+            // importFormatLabel
+            // 
+            resources.ApplyResources(importFormatLabel, "importFormatLabel");
+            importFormatLabel.Name = "importFormatLabel";
+            // 
             // _autoSearchPath
             // 
             resources.ApplyResources(this._autoSearchPath, "_autoSearchPath");
@@ -176,6 +182,20 @@
             tableLayoutPanel1.SetColumnSpan(this._indexing, 2);
             this._indexing.Name = "_indexing";
             this._indexing.UseVisualStyleBackColor = true;
+            // 
+            // _inlayHintsVariableTypes
+            // 
+            resources.ApplyResources(this._inlayHintsVariableTypes, "_inlayHintsVariableTypes");
+            tableLayoutPanel1.SetColumnSpan(this._inlayHintsVariableTypes, 2);
+            this._inlayHintsVariableTypes.Name = "_inlayHintsVariableTypes";
+            this._inlayHintsVariableTypes.UseVisualStyleBackColor = true;
+            // 
+            // _inlayHintsFunctionReturnTypes
+            // 
+            resources.ApplyResources(this._inlayHintsFunctionReturnTypes, "_inlayHintsFunctionReturnTypes");
+            tableLayoutPanel1.SetColumnSpan(this._inlayHintsFunctionReturnTypes, 2);
+            this._inlayHintsFunctionReturnTypes.Name = "_inlayHintsFunctionReturnTypes";
+            this._inlayHintsFunctionReturnTypes.UseVisualStyleBackColor = true;
             // 
             // PythonAnalysisOptionsControl
             // 
@@ -206,10 +226,14 @@
         private System.Windows.Forms.ToolTip _commonSearchPathsToolTip;
         private System.Windows.Forms.CheckBox _autoSearchPath;
         private System.Windows.Forms.CheckBox _indexing;
+        private System.Windows.Forms.CheckBox _inlayHintsVariableTypes;
+        private System.Windows.Forms.CheckBox _inlayHintsFunctionReturnTypes;
         private System.Windows.Forms.ToolTip _searchPathsLabelToolTip;
         private System.Windows.Forms.ToolTip _typeshedPathsLabelToolTip;
         private System.Windows.Forms.Label _typeShedPathsLabel;
         private System.Windows.Forms.ToolTip _importFormatToolTip;
+        private System.Windows.Forms.ToolTip _inlayHintsVariableTypesToolTip;
+        private System.Windows.Forms.ToolTip _inlayHintsFunctionReturnTypeToolTip;
         private System.Windows.Forms.Label _searchPathsLabel;
         private System.Windows.Forms.ComboBox _importFormatCombo;
     }

--- a/Python/Product/PythonTools/PythonTools/Options/PythonAnalysisOptionsControl.cs
+++ b/Python/Product/PythonTools/PythonTools/Options/PythonAnalysisOptionsControl.cs
@@ -49,6 +49,9 @@ namespace Microsoft.PythonTools.Options {
             _importFormatCombo.Items.Add(Strings.ImportFormatAbsolute);
             _importFormatCombo.Items.Add(Strings.ImportFormatRelative);
             _importFormatToolTip.SetToolTip(_importFormatCombo, Strings.ImportFormatToolTip);
+
+            _inlayHintsVariableTypesToolTip.SetToolTip(_inlayHintsVariableTypes, Strings.InlayHintsVariableTypeToolTip);
+            _inlayHintsFunctionReturnTypeToolTip.SetToolTip(_inlayHintsFunctionReturnTypes, Strings.InlayHintsFunctionReturnTypesToolTip);
         }
 
         internal void SyncControlWithPageSettings(PythonToolsService pyService) {
@@ -59,6 +62,8 @@ namespace Microsoft.PythonTools.Options {
 
             _autoSearchPath.Checked = pyService.AnalysisOptions.AutoSearchPaths;
             _indexing.Checked = pyService.AnalysisOptions.Indexing;
+            _inlayHintsVariableTypes.Checked = pyService.AnalysisOptions.InlayHintsVariableTypes;
+            _inlayHintsFunctionReturnTypes.Checked = pyService.AnalysisOptions.InlayHintsFunctionReturnTypes;
             _diagnosticsModeCombo.SelectedIndex =
                 pyService.AnalysisOptions.DiagnosticMode == PylanceDiagnosticMode.OpenFilesOnly ? 0 : 1;
             _importFormatCombo.SelectedIndex =
@@ -98,6 +103,8 @@ namespace Microsoft.PythonTools.Options {
 
             pyService.AnalysisOptions.AutoSearchPaths = _autoSearchPath.Checked;
             pyService.AnalysisOptions.Indexing = _indexing.Checked;
+            pyService.AnalysisOptions.InlayHintsVariableTypes = _inlayHintsVariableTypes.Checked;
+            pyService.AnalysisOptions.InlayHintsFunctionReturnTypes = _inlayHintsFunctionReturnTypes.Checked;
             pyService.AnalysisOptions.DiagnosticMode = _diagnosticsModeCombo.SelectedIndex == 0 ?
                 PylanceDiagnosticMode.OpenFilesOnly : PylanceDiagnosticMode.Workspace;
             pyService.AnalysisOptions.ImportFormat = _importFormatCombo.SelectedIndex == 0 ?

--- a/Python/Product/PythonTools/PythonTools/Options/PythonAnalysisOptionsControl.resx
+++ b/Python/Product/PythonTools/PythonTools/Options/PythonAnalysisOptionsControl.resx
@@ -649,6 +649,9 @@ such as auto-import, add import, workspace symbols and etc.</value>
   <data name="&gt;&gt;_indexing.ZOrder" xml:space="preserve">
     <value>15</value>
   </data>
+  <data name="_inlayHintsVariableTypes.AccessibleName" xml:space="preserve">
+    <value>Enable/disable inlay hints for variable types.</value>
+  </data>
   <data name="_inlayHintsVariableTypes.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -665,7 +668,7 @@ such as auto-import, add import, workspace symbols and etc.</value>
     <value>16</value>
   </data>
   <data name="_inlayHintsVariableTypes.Text" xml:space="preserve">
-    <value>&amp;Enable inlay hints for variable types</value>
+    <value>Ena&amp;ble inlay hints for variable types</value>
   </data>
   <data name="&gt;&gt;_inlayHintsVariableTypes.Name" xml:space="preserve">
     <value>_inlayHintsVariableTypes</value>
@@ -678,6 +681,9 @@ such as auto-import, add import, workspace symbols and etc.</value>
   </data>
   <data name="&gt;&gt;_inlayHintsVariableTypes.ZOrder" xml:space="preserve">
     <value>16</value>
+  </data>
+  <data name="_inlayHintsFunctionReturnTypes.AccessibleName" xml:space="preserve">
+    <value>Enable/disable inlay hints for function return types.</value>
   </data>
   <data name="_inlayHintsFunctionReturnTypes.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -695,7 +701,7 @@ such as auto-import, add import, workspace symbols and etc.</value>
     <value>16</value>
   </data>
   <data name="_inlayHintsFunctionReturnTypes.Text" xml:space="preserve">
-    <value>&amp;Enable inlay hints for function return types</value>
+    <value>E&amp;nable inlay hints for function return types</value>
   </data>
   <data name="&gt;&gt;_inlayHintsFunctionReturnTypes.Name" xml:space="preserve">
     <value>_inlayHintsFunctionReturnTypes</value>
@@ -740,34 +746,40 @@ such as auto-import, add import, workspace symbols and etc.</value>
     <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="diagnosticModeLabel" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_diagnosticsModeCombo" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="logLevelLabel" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_logLevelCombo" Row="1" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="typeCheckingModeLabel" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_typeCheckingMode" Row="2" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="_importFormatCombo" Row="3" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="stubsPathsLabel" Row="4" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_stubsPath" Row="4" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="_searchPathsLabel" Row="5" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_searchPaths" Row="5" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="_typeShedPathsLabel" Row="6" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_typeshedPaths" Row="6" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="importFormatLabel" Row="3" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_autoSearchPath" Row="7" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="_indexing" Row="8" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="_inlayHintsVariableTypes" Row="9" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="_inlayHintsFunctionReturnTypes" Row="10" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,AutoSize,0" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <metadata name="_diagnosticModeToolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>190, 17</value>
+    <value>664, 17</value>
   </metadata>
   <metadata name="_logLevelToolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>376, 17</value>
+    <value>847, 17</value>
   </metadata>
   <metadata name="_typeCheckingToolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>518, 17</value>
+    <value>988, 17</value>
   </metadata>
   <metadata name="_stubsPathToolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>689, 17</value>
+    <value>17, 54</value>
   </metadata>
   <metadata name="_searchPathsToolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>840, 17</value>
+    <value>166, 54</value>
   </metadata>
   <metadata name="_typeshedPathsToolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>1002, 17</value>
+    <value>326, 54</value>
   </metadata>
   <metadata name="_commonSearchPathsToolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>1179, 17</value>
+    <value>500, 54</value>
   </metadata>
   <metadata name="_searchPathsLabelToolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 56</value>
+    <value>710, 54</value>
   </metadata>
   <metadata name="_typeshedPathsLabelToolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>208, 56</value>
+    <value>898, 54</value>
   </metadata>
   <metadata name="_importFormatToolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>493, 17</value>
+  </metadata>
+  <metadata name="_inlayHintsVariableTypesToolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
+  </metadata>
+  <metadata name="_inlayHintsFunctionReturnTypeToolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>237, 17</value>
   </metadata>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
@@ -839,6 +851,18 @@ such as auto-import, add import, workspace symbols and etc.</value>
     <value>_importFormatToolTip</value>
   </data>
   <data name="&gt;&gt;_importFormatToolTip.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolTip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;_inlayHintsVariableTypesToolTip.Name" xml:space="preserve">
+    <value>_inlayHintsVariableTypesToolTip</value>
+  </data>
+  <data name="&gt;&gt;_inlayHintsVariableTypesToolTip.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolTip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;_inlayHintsFunctionReturnTypeToolTip.Name" xml:space="preserve">
+    <value>_inlayHintsFunctionReturnTypeToolTip</value>
+  </data>
+  <data name="&gt;&gt;_inlayHintsFunctionReturnTypeToolTip.Type" xml:space="preserve">
     <value>System.Windows.Forms.ToolTip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">

--- a/Python/Product/PythonTools/PythonTools/Options/PythonAnalysisOptionsControl.resx
+++ b/Python/Product/PythonTools/PythonTools/Options/PythonAnalysisOptionsControl.resx
@@ -662,13 +662,13 @@ such as auto-import, add import, workspace symbols and etc.</value>
     <value>6, 6, 6, 3</value>
   </data>
   <data name="_inlayHintsVariableTypes.Size" type="System.Drawing.Size, System.Drawing">
-    <value>191, 17</value>
+    <value>195, 17</value>
   </data>
   <data name="_inlayHintsVariableTypes.TabIndex" type="System.Int32, mscorlib">
     <value>16</value>
   </data>
   <data name="_inlayHintsVariableTypes.Text" xml:space="preserve">
-    <value>Ena&amp;ble inlay hints for variable types</value>
+    <value>T&amp;urn on inlay hints for variable types</value>
   </data>
   <data name="&gt;&gt;_inlayHintsVariableTypes.Name" xml:space="preserve">
     <value>_inlayHintsVariableTypes</value>
@@ -695,13 +695,13 @@ such as auto-import, add import, workspace symbols and etc.</value>
     <value>6, 6, 6, 3</value>
   </data>
   <data name="_inlayHintsFunctionReturnTypes.Size" type="System.Drawing.Size, System.Drawing">
-    <value>222, 17</value>
+    <value>226, 17</value>
   </data>
   <data name="_inlayHintsFunctionReturnTypes.TabIndex" type="System.Int32, mscorlib">
     <value>16</value>
   </data>
   <data name="_inlayHintsFunctionReturnTypes.Text" xml:space="preserve">
-    <value>E&amp;nable inlay hints for function return types</value>
+    <value>Tu&amp;rn on inlay hints for function return types</value>
   </data>
   <data name="&gt;&gt;_inlayHintsFunctionReturnTypes.Name" xml:space="preserve">
     <value>_inlayHintsFunctionReturnTypes</value>

--- a/Python/Product/PythonTools/PythonTools/Options/PythonAnalysisOptionsControl.resx
+++ b/Python/Product/PythonTools/PythonTools/Options/PythonAnalysisOptionsControl.resx
@@ -121,6 +121,13 @@
     <value>False</value>
   </metadata>
   <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="tableLayoutPanel1.AutoScroll" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="tableLayoutPanel1.AutoScrollMinSize" type="System.Drawing.Size, System.Drawing">
+    <value>5, 5</value>
+  </data>
   <data name="tableLayoutPanel1.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -143,7 +150,6 @@
   <data name="diagnosticModeLabel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="diagnosticModeLabel.Location" type="System.Drawing.Point, System.Drawing">
     <value>3, 6</value>
   </data>
@@ -175,7 +181,7 @@
     <value>True</value>
   </metadata>
   <data name="_diagnosticsModeCombo.Location" type="System.Drawing.Point, System.Drawing">
-    <value>117, 2</value>
+    <value>97, 2</value>
   </data>
   <data name="_diagnosticsModeCombo.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>2, 2, 2, 2</value>
@@ -238,7 +244,7 @@
     <value>2</value>
   </data>
   <data name="_logLevelCombo.Location" type="System.Drawing.Point, System.Drawing">
-    <value>117, 27</value>
+    <value>97, 27</value>
   </data>
   <data name="_logLevelCombo.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>2, 2, 2, 2</value>
@@ -301,7 +307,7 @@
     <value>4</value>
   </data>
   <data name="_typeCheckingMode.Location" type="System.Drawing.Point, System.Drawing">
-    <value>117, 52</value>
+    <value>97, 52</value>
   </data>
   <data name="_typeCheckingMode.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>2, 2, 2, 2</value>
@@ -324,48 +330,8 @@
   <data name="&gt;&gt;_typeCheckingMode.ZOrder" xml:space="preserve">
     <value>5</value>
   </data>
-  <metadata name="importFormatLabel.GenerateMember" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>False</value>
-  </metadata>
-  <data name="importFormatLabel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Left</value>
-  </data>
-  <data name="importFormatLabel.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="importFormatLabel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-  <data name="importFormatLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 81</value>
-  </data>
-  <data name="importFormatLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>71, 13</value>
-  </data>
-  <data name="importFormatLabel.TabIndex" type="System.Int32, mscorlib">
-    <value>8</value>
-  </data>
-  <data name="importFormatLabel.Text" xml:space="preserve">
-    <value>&amp;Import format:</value>
-  </data>
-  <data name="importFormatLabel.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-    <value>MiddleLeft</value>
-  </data>
-  <data name="&gt;&gt;importFormatLabel.Name" xml:space="preserve">
-    <value>importFormatLabel</value>
-  </data>
-  <data name="&gt;&gt;importFormatLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;importFormatLabel.Parent" xml:space="preserve">
-    <value>tableLayoutPanel1</value>
-  </data>
-  <data name="&gt;&gt;importFormatLabel.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
   <data name="_importFormatCombo.Location" type="System.Drawing.Point, System.Drawing">
-    <value>117, 77</value>
+    <value>97, 77</value>
   </data>
   <data name="_importFormatCombo.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>2, 2, 2, 2</value>
@@ -386,7 +352,7 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;_importFormatCombo.ZOrder" xml:space="preserve">
-    <value>7</value>
+    <value>6</value>
   </data>
   <metadata name="stubsPathsLabel.GenerateMember" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>False</value>
@@ -425,10 +391,10 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;stubsPathsLabel.ZOrder" xml:space="preserve">
-    <value>8</value>
+    <value>7</value>
   </data>
   <data name="_stubsPath.Location" type="System.Drawing.Point, System.Drawing">
-    <value>117, 102</value>
+    <value>97, 102</value>
   </data>
   <data name="_stubsPath.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>2, 2, 2, 2</value>
@@ -449,7 +415,7 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;_stubsPath.ZOrder" xml:space="preserve">
-    <value>9</value>
+    <value>8</value>
   </data>
   <data name="_searchPathsLabel.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -485,10 +451,10 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;_searchPathsLabel.ZOrder" xml:space="preserve">
-    <value>10</value>
+    <value>9</value>
   </data>
   <data name="_searchPaths.Location" type="System.Drawing.Point, System.Drawing">
-    <value>117, 126</value>
+    <value>97, 126</value>
   </data>
   <data name="_searchPaths.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>2, 2, 2, 2</value>
@@ -497,7 +463,7 @@
     <value>True</value>
   </data>
   <data name="_searchPaths.Size" type="System.Drawing.Size, System.Drawing">
-    <value>253, 51</value>
+    <value>253, 34</value>
   </data>
   <data name="_searchPaths.TabIndex" type="System.Int32, mscorlib">
     <value>13</value>
@@ -512,7 +478,7 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;_searchPaths.ZOrder" xml:space="preserve">
-    <value>11</value>
+    <value>10</value>
   </data>
   <data name="_typeShedPathsLabel.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -521,7 +487,7 @@
     <value>NoControl</value>
   </data>
   <data name="_typeShedPathsLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 182</value>
+    <value>3, 165</value>
   </data>
   <data name="_typeShedPathsLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 3, 3, 0</value>
@@ -548,10 +514,10 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;_typeShedPathsLabel.ZOrder" xml:space="preserve">
-    <value>12</value>
+    <value>11</value>
   </data>
   <data name="_typeshedPaths.Location" type="System.Drawing.Point, System.Drawing">
-    <value>117, 181</value>
+    <value>97, 164</value>
   </data>
   <data name="_typeshedPaths.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>2, 2, 2, 2</value>
@@ -560,7 +526,7 @@
     <value>True</value>
   </data>
   <data name="_typeshedPaths.Size" type="System.Drawing.Size, System.Drawing">
-    <value>253, 51</value>
+    <value>253, 34</value>
   </data>
   <data name="_typeshedPaths.TabIndex" type="System.Int32, mscorlib">
     <value>15</value>
@@ -575,6 +541,45 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;_typeshedPaths.ZOrder" xml:space="preserve">
+    <value>12</value>
+  </data>
+  <metadata name="importFormatLabel.GenerateMember" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>False</value>
+  </metadata>
+  <data name="importFormatLabel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Left</value>
+  </data>
+  <data name="importFormatLabel.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="importFormatLabel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="importFormatLabel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 81</value>
+  </data>
+  <data name="importFormatLabel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>71, 13</value>
+  </data>
+  <data name="importFormatLabel.TabIndex" type="System.Int32, mscorlib">
+    <value>8</value>
+  </data>
+  <data name="importFormatLabel.Text" xml:space="preserve">
+    <value>&amp;Import format:</value>
+  </data>
+  <data name="importFormatLabel.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleLeft</value>
+  </data>
+  <data name="&gt;&gt;importFormatLabel.Name" xml:space="preserve">
+    <value>importFormatLabel</value>
+  </data>
+  <data name="&gt;&gt;importFormatLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;importFormatLabel.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;importFormatLabel.ZOrder" xml:space="preserve">
     <value>13</value>
   </data>
   <data name="_autoSearchPath.AutoSize" type="System.Boolean, mscorlib">
@@ -584,7 +589,7 @@
     <value>NoControl</value>
   </data>
   <data name="_autoSearchPath.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 240</value>
+    <value>6, 206</value>
   </data>
   <data name="_autoSearchPath.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>6, 6, 6, 3</value>
@@ -617,16 +622,16 @@
     <value>TopLeft</value>
   </data>
   <data name="_indexing.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 266</value>
+    <value>6, 232</value>
   </data>
   <data name="_indexing.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>6, 6, 6, 3</value>
   </data>
   <data name="_indexing.Size" type="System.Drawing.Size, System.Drawing">
-    <value>351, 21</value>
+    <value>351, 30</value>
   </data>
   <data name="_indexing.TabIndex" type="System.Int32, mscorlib">
-    <value>17</value>
+    <value>16</value>
   </data>
   <data name="_indexing.Text" xml:space="preserve">
     <value>&amp;Index installed third party libraries and user files for language features 
@@ -644,6 +649,66 @@ such as auto-import, add import, workspace symbols and etc.</value>
   <data name="&gt;&gt;_indexing.ZOrder" xml:space="preserve">
     <value>15</value>
   </data>
+  <data name="_inlayHintsVariableTypes.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="_inlayHintsVariableTypes.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 271</value>
+  </data>
+  <data name="_inlayHintsVariableTypes.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>6, 6, 6, 3</value>
+  </data>
+  <data name="_inlayHintsVariableTypes.Size" type="System.Drawing.Size, System.Drawing">
+    <value>191, 17</value>
+  </data>
+  <data name="_inlayHintsVariableTypes.TabIndex" type="System.Int32, mscorlib">
+    <value>16</value>
+  </data>
+  <data name="_inlayHintsVariableTypes.Text" xml:space="preserve">
+    <value>&amp;Enable inlay hints for variable types</value>
+  </data>
+  <data name="&gt;&gt;_inlayHintsVariableTypes.Name" xml:space="preserve">
+    <value>_inlayHintsVariableTypes</value>
+  </data>
+  <data name="&gt;&gt;_inlayHintsVariableTypes.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;_inlayHintsVariableTypes.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;_inlayHintsVariableTypes.ZOrder" xml:space="preserve">
+    <value>16</value>
+  </data>
+  <data name="_inlayHintsFunctionReturnTypes.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="_inlayHintsFunctionReturnTypes.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 297</value>
+  </data>
+  <data name="_inlayHintsFunctionReturnTypes.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>6, 6, 6, 3</value>
+  </data>
+  <data name="_inlayHintsFunctionReturnTypes.Size" type="System.Drawing.Size, System.Drawing">
+    <value>222, 17</value>
+  </data>
+  <data name="_inlayHintsFunctionReturnTypes.TabIndex" type="System.Int32, mscorlib">
+    <value>16</value>
+  </data>
+  <data name="_inlayHintsFunctionReturnTypes.Text" xml:space="preserve">
+    <value>&amp;Enable inlay hints for function return types</value>
+  </data>
+  <data name="&gt;&gt;_inlayHintsFunctionReturnTypes.Name" xml:space="preserve">
+    <value>_inlayHintsFunctionReturnTypes</value>
+  </data>
+  <data name="&gt;&gt;_inlayHintsFunctionReturnTypes.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;_inlayHintsFunctionReturnTypes.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;_inlayHintsFunctionReturnTypes.ZOrder" xml:space="preserve">
+    <value>17</value>
+  </data>
   <data name="tableLayoutPanel1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
   </data>
@@ -654,7 +719,7 @@ such as auto-import, add import, workspace symbols and etc.</value>
     <value>9</value>
   </data>
   <data name="tableLayoutPanel1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>381, 290</value>
+    <value>381, 392</value>
   </data>
   <data name="tableLayoutPanel1.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -672,7 +737,7 @@ such as auto-import, add import, workspace symbols and etc.</value>
     <value>0</value>
   </data>
   <data name="tableLayoutPanel1.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="diagnosticModeLabel" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_diagnosticsModeCombo" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="logLevelLabel" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_logLevelCombo" Row="1" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="typeCheckingModeLabel" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_typeCheckingMode" Row="2" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="_importFormatCombo" Row="3" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="stubsPathsLabel" Row="4" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_stubsPath" Row="4" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="_searchPathsLabel" Row="5" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_searchPaths" Row="5" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="_typeShedPathsLabel" Row="6" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_typeshedPaths" Row="6" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="importFormatLabel" Row="3" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_autoSearchPath" Row="7" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="_indexing" Row="8" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,100,Absolute,266" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,Absolute,20" /&gt;&lt;/TableLayoutSettings&gt;</value>
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="diagnosticModeLabel" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_diagnosticsModeCombo" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="logLevelLabel" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_logLevelCombo" Row="1" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="typeCheckingModeLabel" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_typeCheckingMode" Row="2" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="_importFormatCombo" Row="3" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="stubsPathsLabel" Row="4" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_stubsPath" Row="4" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="_searchPathsLabel" Row="5" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_searchPaths" Row="5" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="_typeShedPathsLabel" Row="6" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_typeshedPaths" Row="6" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="importFormatLabel" Row="3" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_autoSearchPath" Row="7" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="_indexing" Row="8" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="_inlayHintsVariableTypes" Row="9" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="_inlayHintsFunctionReturnTypes" Row="10" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,AutoSize,0" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <metadata name="_diagnosticModeToolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>190, 17</value>
@@ -714,7 +779,7 @@ such as auto-import, add import, workspace symbols and etc.</value>
     <value>6, 8, 6, 8</value>
   </data>
   <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
-    <value>381, 290</value>
+    <value>381, 392</value>
   </data>
   <data name="&gt;&gt;_diagnosticModeToolTip.Name" xml:space="preserve">
     <value>_diagnosticModeToolTip</value>

--- a/package.json
+++ b/package.json
@@ -2,6 +2,6 @@
     "name":  "ptvs",
     "private":  true,
     "devDependencies":  {
-                            "@pylance/pylance":  "2024.4.1"
+                            "@pylance/pylance":  "2024.5.1"
                         }
 }


### PR DESCRIPTION
fixes https://github.com/microsoft/PTVS/issues/7888

Added these 2 options with tooltips that allow users to enable inlay hints in PTVS.
![image](https://github.com/microsoft/PTVS/assets/100439259/a0f5b8fe-2859-4849-ad8e-86e67aff8b6f)

Tooltips:
![image](https://github.com/microsoft/PTVS/assets/100439259/88c1bf3c-7439-4fe2-a6c6-421578f3f294)

With inlay hints:
![image](https://github.com/microsoft/PTVS/assets/100439259/77f75aaf-018a-4406-a38a-29755eb93eb4)

Without inlay hints:
![image](https://github.com/microsoft/PTVS/assets/100439259/ffaec271-0639-4573-9037-ca79a1815249)

This UI and behavior is now consistent with other languages that support inlay hints in VS such as typescript.