### PR TITLE
Remove the pytestId patch

### DIFF
--- a/Python/Product/TestAdapter.Executor/PythonFiles/testing_tools/adapter/pytest/_discovery.py
+++ b/Python/Product/TestAdapter.Executor/PythonFiles/testing_tools/adapter/pytest/_discovery.py
@@ -9,27 +9,6 @@ import pytest
 from .. import util, discovery
 from ._pytest_item import parse_item
 
-#note: this must match testlauncher.py
-def patch_translate_non_printable():
-    import _pytest.compat
-    translate_non_printable =  getattr(_pytest.compat, "_translate_non_printable", None)
-
-    if translate_non_printable:
-        def _translate_non_printable_patched(s):
-            s = translate_non_printable(s)
-            s = s.replace(':', '/:')  # pytest testcase not found error and VS TestExplorer FQN parsing
-            s = s.replace('.', '_')   # VS TestExplorer FQN parsing
-            s = s.replace('\n', '/n') # pytest testcase not found error 
-            s = s.replace('\\', '/')  # pytest testcase not found error, fixes cases (actual backslash followed by n)
-            s = s.replace('\r', '/r') # pytest testcase not found error
-            return s
-
-        _pytest.compat._translate_non_printable = _translate_non_printable_patched
-    else:
-        print("ERROR: failed to patch pytest, _pytest.compat._translate_non_printable")
-
-patch_translate_non_printable()
-
 def discover(pytestargs=None, hidestdio=False,
              _pytest_main=pytest.main, _plugin=None, **_ignored):
     """Return the results of test discovery."""

--- a/Python/Product/TestAdapter/testlauncher.py
+++ b/Python/Product/TestAdapter/testlauncher.py
@@ -116,7 +116,6 @@ def run(testRunner, coverage_file, test_file, args):
 
         if testRunner == 'pytest':
             import pytest
-            patch_translate_non_printable()
             _plugin = TestCollector()
             pytest.main(args, [_plugin])
         else:
@@ -129,26 +128,6 @@ def run(testRunner, coverage_file, test_file, args):
             cov.stop()
             cov.save()
             cov.xml_report(outfile = coverage_file + '.xml', omit=__file__)
-
-#note: this must match adapter\pytest\_discovery.py
-def patch_translate_non_printable():
-    import _pytest.compat
-    translate_non_printable =  getattr(_pytest.compat, "_translate_non_printable")
-
-    if translate_non_printable:
-        def _translate_non_printable_patched(s):
-            s = translate_non_printable(s)
-            s = s.replace(':', '/:')  # pytest testcase not found error and VS TestExplorer FQN parsing
-            s = s.replace('.', '_')   # VS TestExplorer FQN parsing
-            s = s.replace('\n', '/n') # pytest testcase not found error 
-            s = s.replace('\\', '/')  # pytest testcase not found error, fixes cases (actual backslash followed by n)
-            s = s.replace('\r', '/r') # pytest testcase not found error
-            return s
-
-        _pytest.compat._translate_non_printable = _translate_non_printable_patched
-    else:
-        print("ERROR: failed to patch pytest, _pytest.compat._translate_non_printable")
-
 
 class TestCollector(object):
     """This is a pytest plugin that prevents notfound errors from ending execution of tests."""

--- a/package.json
+++ b/package.json
@@ -2,6 +2,6 @@
     "name":  "ptvs",
     "private":  true,
     "devDependencies":  {
-                            "@pylance/pylance":  "2024.5.1"
+                            "@pylance/pylance":  "2024.7.1"
                         }
 }


### PR DESCRIPTION
Fixes https://github.com/microsoft/PTVS/issues/7959

The patch was originally added to address the issue where `::` was not supported in pytest parameterized arguments. See https://github.com/microsoft/PTVS/pull/5644

I discovered that pytest now supports `::` in parameterized arguments. See https://github.com/pytest-dev/pytest/pull/9642.

In this PR, I removed the patch that replaced `::` with an alternative syntax compatible with pytest. You may notice that the patch also patched some other special characters such as `.`, `\r`, etc., I have verified that both test discovery and test execution via the Test Explorer work as expected for test names containing those characters.

**Test Discovery:**
![image](https://github.com/user-attachments/assets/1e07ab0d-d827-465c-a103-aaee7320dac1)

**Test Execution:**
![image](https://github.com/user-attachments/assets/2b809d2d-b1c9-43c8-82f4-4c730f770d0d)

Although tests run as expected, the test hierarchy displayed in the Test Explorer seems wrong for tests with `::`, I will send it to the TE team.
