### PR TITLE
Ignore yanked releases when installing debugpy

### DIFF
--- a/Build/install_debugpy.py
+++ b/Build/install_debugpy.py
@@ -59,6 +59,12 @@ def _download_and_extract(root, url, version):
 def main(root, ver):
     data = _get_package_data()
 
+    # We don't yank individual files in our releases; either the whole release
+    # is yanked or it isn't. So go through all releases remove all yanked ones.
+    for release in list(data["releases"].keys()):
+        if any(r["yanked"] for r in data["releases"][release]):
+            del data["releases"][release]
+
     # if version is "latest", use the max version from the data
     if ver == "latest":
         ver = max(data["releases"].keys(), key=version_parser)


### PR DESCRIPTION
We ran into an issue where this script was failing because of an incomplete release to PyPi. I tried yanking the release but this script was still failing.
Upon investigating, it's because this script gets all the releases for debugpy, even the yanked ones. This was causing `latest` to still refer to the yanked release, which is no good.

The new logic removes all yanked releases from the list of available releases, before trying to download anything.