### PR TITLE
Add support for workspace/workspaceFolders request

### DIFF
--- a/Python/Product/PythonTools/PythonTools.csproj
+++ b/Python/Product/PythonTools/PythonTools.csproj
@@ -325,6 +325,7 @@
     <Compile Include="PythonTools\LanguageServerClient\WorkspaceFolderChanged\DidChangeWorkspaceFoldersParams.cs" />
     <Compile Include="PythonTools\LanguageServerClient\WorkspaceFolderChanged\WorkspaceFolder.cs" />
     <Compile Include="PythonTools\LanguageServerClient\WorkspaceFolderChanged\WorkspaceFoldersChangeEvent.cs" />
+    <Compile Include="PythonTools\LanguageServerClient\WorkspaceFolders\WorkspaceFoldersArgs.cs" />
     <Compile Include="PythonTools\Logging\LogHubLogger.cs" />
     <Compile Include="PythonTools\Navigation\Navigable\NavigableSymbol.cs" />
     <Compile Include="PythonTools\Navigation\Navigable\NavigableSymbolSource.cs" />

--- a/Python/Product/PythonTools/PythonTools/LanguageServerClient/PythonLanguageClient.cs
+++ b/Python/Product/PythonTools/PythonTools/LanguageServerClient/PythonLanguageClient.cs
@@ -640,9 +640,10 @@ namespace Microsoft.PythonTools.LanguageServerClient {
         private void OnProjectAdded(EnvDTE.Project project) {
             if (_workspaceFoldersSupported) {
                 JoinableTaskContext.Factory.RunAsync(async () => {
-                    var pythonProject = project as PythonProjectNode;
+                    var pythonProject = project.GetPythonProject() as PythonProjectNode;
                     if (pythonProject != null) {
                         var folder = new WorkspaceFolder { uri = new System.Uri(pythonProject.BaseURI.Directory), name = project.Name };
+                        this._workspaceFolders.Add(folder);
                         await InvokeDidChangeWorkspaceFoldersAsync(new WorkspaceFolder[] { folder }, new WorkspaceFolder[0]);
                     }
                 });
@@ -652,9 +653,13 @@ namespace Microsoft.PythonTools.LanguageServerClient {
         private void OnProjectRemoved(EnvDTE.Project project) {
             if (_workspaceFoldersSupported) {
                 JoinableTaskContext.Factory.RunAsync(async () => {
-                    var pythonProject = project as PythonProjectNode;
+                    var pythonProject = project.GetPythonProject() as PythonProjectNode;
                     if (pythonProject != null) {
                         var folder = new WorkspaceFolder { uri = new System.Uri(pythonProject.BaseURI.Directory), name = project.Name };
+                        var entry = this._workspaceFolders.Find((f) => f.uri.ToString() == folder.uri.ToString());
+                        if (entry != null) {
+                            this._workspaceFolders.Remove(entry);
+                        }
                         await InvokeDidChangeWorkspaceFoldersAsync(new WorkspaceFolder[0], new WorkspaceFolder[] { folder });
                     }
                 });

--- a/Python/Product/PythonTools/PythonTools/LanguageServerClient/PythonLanguageClientCustomTarget.cs
+++ b/Python/Product/PythonTools/PythonTools/LanguageServerClient/PythonLanguageClientCustomTarget.cs
@@ -29,6 +29,7 @@ using Task = System.Threading.Tasks.Task;
 
 using Microsoft.PythonTools.LanguageServerClient.WorkspaceConfiguration;
 using Microsoft.PythonTools.LanguageServerClient.FileWatcher;
+using Microsoft.PythonTools.LanguageServerClient.WorkspaceFolders;
 
 namespace Microsoft.PythonTools.LanguageServerClient {
     internal class PythonLanguageClientCustomTarget {
@@ -88,6 +89,11 @@ namespace Microsoft.PythonTools.LanguageServerClient {
         /// Event fired when pylance sends a workspace/configuration request
         /// </summary>
         internal event AsyncEventHandler<ConfigurationArgs> WorkspaceConfiguration;
+
+        /// <summary>
+        /// Event fired when pylance sends a workspace/workspaceFolders request
+        /// </summary>
+        internal event AsyncEventHandler<WorkspaceFoldersArgs> WorkspaceFolders;
 
         [JsonRpcMethod("telemetry/event")]
         public void OnTelemetryEvent(JToken arg) {
@@ -175,5 +181,23 @@ namespace Microsoft.PythonTools.LanguageServerClient {
                 return null;
             }
         }
+
+        [JsonRpcMethod("workspace/workspaceFolders")]
+        public async Task<object> OnWorkspaceFolders() {
+            try {
+                // Should be no arguments (see request here: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_workspaceFolders)
+                if (this.WorkspaceFolders != null) {
+                    var eventArgs = new WorkspaceFoldersArgs { requestResult = null };
+                    await this.WorkspaceFolders.InvokeAsync(this, eventArgs);
+                    return eventArgs.requestResult;
+                }
+                return null;
+            } catch {
+                return null;
+            }
+        }
+    }
+
+    internal class EmptyEventArgs {
     }
 }

--- a/Python/Product/PythonTools/PythonTools/LanguageServerClient/WorkspaceFolders/WorkspaceFoldersArgs.cs
+++ b/Python/Product/PythonTools/PythonTools/LanguageServerClient/WorkspaceFolders/WorkspaceFoldersArgs.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.PythonTools.LanguageServerClient.WorkspaceFolders {
+    internal class WorkspaceFoldersArgs {
+        public object requestResult;
+    }
+}

--- a/package.json
+++ b/package.json
@@ -2,6 +2,6 @@
     "name":  "ptvs",
     "private":  true,
     "devDependencies":  {
-                            "@pylance/pylance":  "2024.8.1"
+                            "@pylance/pylance":  "2024.8.2"
                         }
 }


### PR DESCRIPTION
Newer versions of pylance make a 'workspace/workspaceFolders' request when workspaces change. This allows for the detection of renames. 

However PTVS wasn't handling this request, which causes Pylance to skip all workspaces and make it behave like it was in single file mode.