### PR TITLE
Exporting translations to new path

### DIFF
--- a/Python/loc/lcl/CHS/Snippets/Python/arg_path.snippet.lcl
+++ b/Python/loc/lcl/CHS/Snippets/Python/arg_path.snippet.lcl
@@ -1,17 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="D:\a\_work\1\b\raw\binaries\Snippets\Python\arg_path.snippet" PsrId="210" SrcCul="en-US" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx" TgtCul="zh-CN">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\21\b\raw\binaries\Snippets\Python\arg_path.snippet" PsrId="210" FileType="1" SrcCul="en-US" TgtCul="zh-CN" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="Dev" />
     <Cmt Name="LcxAdmin" />
     <Cmt Name="Rccx" />
   </OwnedComments>
+  <Settings Name="@SettingsPath@\default.lss" Type="Lss" />
   <Item ItemId=";&lt;Description&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
     <Item ItemId="0;10b5db89840923ed3d0acc5fe287c167" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Code snippet for a path argument for an argparse parser.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[argparse 分析程序的路径参数的代码片段。]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="3" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;Title&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -19,8 +23,11 @@
     <Item ItemId="0;1cf27f1348d9adf9704b2dff0db0d888" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[argparse path argument]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[argparse 路径参数]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="1" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;ToolTip&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -28,26 +35,38 @@
     <Item ItemId="0;69ee1bdf53fb0aeed761c52c8d49693d" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Short argument name, typically only a single letter.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[短参数名称，通常只有一个字母。]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="5" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;75a55c928c79bdb03057db67af054e9e" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Long argument name, typically one or two words separated by a hyphen.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[长参数名称，通常是由连字符分隔的一个或两个单词。]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="7" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;e7b23931982c94194e3886cd424afb72" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Description of the argument to display when called with --help/-h.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[使用 --help/-h 进行调用时显示的参数说明。]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="11" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;ed36fc16d953d88706f27cad66ebb5f2" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Argument variable name.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[参数变量名称。]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="9" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
-<Settings Name="@SettingsPath@\default.lss" Type="Lss" /></LCX>
+</LCX>

--- a/Python/loc/lcl/CHS/Snippets/Python/arg_path_positional.snippet.lcl
+++ b/Python/loc/lcl/CHS/Snippets/Python/arg_path_positional.snippet.lcl
@@ -1,17 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="D:\a\_work\1\b\raw\binaries\Snippets\Python\arg_path_positional.snippet" PsrId="210" SrcCul="en-US" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx" TgtCul="zh-CN">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\21\b\raw\binaries\Snippets\Python\arg_path_positional.snippet" PsrId="210" FileType="1" SrcCul="en-US" TgtCul="zh-CN" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="Dev" />
     <Cmt Name="LcxAdmin" />
     <Cmt Name="Rccx" />
   </OwnedComments>
+  <Settings Name="@SettingsPath@\default.lss" Type="Lss" />
   <Item ItemId=";&lt;Description&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
     <Item ItemId="0;12736a644fe557377d4f44fb250f3cc0" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Code snippet for a positional path argument for an argparse parser.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[argparse 分析程序的位置路径参数的代码片段。]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="3" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;Title&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -19,8 +23,11 @@
     <Item ItemId="0;5cb477ab75463262edfbf537292653c8" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[argparse positional path argument]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[argparse 位置路径参数]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="1" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;ToolTip&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -28,14 +35,20 @@
     <Item ItemId="0;35282756089c336d9b7432ac72d786f1" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Argument name. Start with a hyphen to require a switch, or omit to make it positional.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[参数名称。以连字符开头以要求切换或省略以使其定位。]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="5" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;e7b23931982c94194e3886cd424afb72" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Description of the argument to display when called with --help/-h.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[使用 --help/-h 进行调用时显示的参数说明。]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="7" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
-<Settings Name="@SettingsPath@\default.lss" Type="Lss" /></LCX>
+</LCX>

--- a/Python/loc/lcl/CHS/Snippets/Python/arg_str.snippet.lcl
+++ b/Python/loc/lcl/CHS/Snippets/Python/arg_str.snippet.lcl
@@ -1,17 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="D:\a\_work\1\b\raw\binaries\Snippets\Python\arg_str.snippet" PsrId="210" SrcCul="en-US" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx" TgtCul="zh-CN">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\21\b\raw\binaries\Snippets\Python\arg_str.snippet" PsrId="210" FileType="1" SrcCul="en-US" TgtCul="zh-CN" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="Dev" />
     <Cmt Name="LcxAdmin" />
     <Cmt Name="Rccx" />
   </OwnedComments>
+  <Settings Name="@SettingsPath@\default.lss" Type="Lss" />
   <Item ItemId=";&lt;Description&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
     <Item ItemId="0;5162629d4963116ba811271091fe841d" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Code snippet for a string argument for an argparse parser.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[argparse 分析程序的字符串参数的代码片段。]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="3" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;Title&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -19,8 +23,11 @@
     <Item ItemId="0;8fbb5326dfe0bf71b7361d48e1a445c4" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[argparse string argument]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[argparse 字符串参数]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="1" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;ToolTip&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -28,26 +35,38 @@
     <Item ItemId="0;69ee1bdf53fb0aeed761c52c8d49693d" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Short argument name, typically only a single letter.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[短参数名称，通常只有一个字母。]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="5" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;75a55c928c79bdb03057db67af054e9e" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Long argument name, typically one or two words separated by a hyphen.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[长参数名称，通常是由连字符分隔的一个或两个单词。]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="7" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;e7b23931982c94194e3886cd424afb72" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Description of the argument to display when called with --help/-h.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[使用 --help/-h 进行调用时显示的参数说明。]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="11" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;ed36fc16d953d88706f27cad66ebb5f2" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Argument variable name.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[参数变量名称。]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="9" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
-<Settings Name="@SettingsPath@\default.lss" Type="Lss" /></LCX>
+</LCX>

--- a/Python/loc/lcl/CHS/Snippets/Python/arg_str_positional.snippet.lcl
+++ b/Python/loc/lcl/CHS/Snippets/Python/arg_str_positional.snippet.lcl
@@ -1,17 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="D:\a\_work\1\b\raw\binaries\Snippets\Python\arg_str_positional.snippet" PsrId="210" SrcCul="en-US" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx" TgtCul="zh-CN">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\21\b\raw\binaries\Snippets\Python\arg_str_positional.snippet" PsrId="210" FileType="1" SrcCul="en-US" TgtCul="zh-CN" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="Dev" />
     <Cmt Name="LcxAdmin" />
     <Cmt Name="Rccx" />
   </OwnedComments>
+  <Settings Name="@SettingsPath@\default.lss" Type="Lss" />
   <Item ItemId=";&lt;Description&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
     <Item ItemId="0;69def699f0c2570190c042fc792b38c5" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Code snippet for a positional string argument for an argparse parser.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[argparse 分析程序的位置字符串参数的代码片段。]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="3" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;Title&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -19,8 +23,11 @@
     <Item ItemId="0;9dbaae3dbddf131d3205155271f50641" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[argparse positional string argument]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[argparse 位置字符串参数]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="1" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;ToolTip&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -28,14 +35,20 @@
     <Item ItemId="0;35282756089c336d9b7432ac72d786f1" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Argument name. Start with a hyphen to require a switch, or omit to make it positional.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[参数名称。以连字符开头以要求切换或省略以使其定位。]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="5" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;e7b23931982c94194e3886cd424afb72" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Description of the argument to display when called with --help/-h.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[使用 --help/-h 进行调用时显示的参数说明。]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="7" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
-<Settings Name="@SettingsPath@\default.lss" Type="Lss" /></LCX>
+</LCX>

--- a/Python/loc/lcl/CHS/Snippets/Python/arg_switch.snippet.lcl
+++ b/Python/loc/lcl/CHS/Snippets/Python/arg_switch.snippet.lcl
@@ -1,17 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="D:\a\_work\1\b\raw\binaries\Snippets\Python\arg_switch.snippet" PsrId="210" SrcCul="en-US" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx" TgtCul="zh-CN">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\21\b\raw\binaries\Snippets\Python\arg_switch.snippet" PsrId="210" FileType="1" SrcCul="en-US" TgtCul="zh-CN" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="Dev" />
     <Cmt Name="LcxAdmin" />
     <Cmt Name="Rccx" />
   </OwnedComments>
+  <Settings Name="@SettingsPath@\default.lss" Type="Lss" />
   <Item ItemId=";&lt;Description&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
     <Item ItemId="0;cdf30125985a60ac677caefc318833e8" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Code snippet for a switch argument for an argparse parser.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[argparse 分析程序的开关参数的代码片段。]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="3" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;Title&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -19,8 +23,11 @@
     <Item ItemId="0;277d72dbe38cd017f4b02e7448bf146e" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[argparse switch argument]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[argparse 开关参数]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="1" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;ToolTip&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -28,20 +35,29 @@
     <Item ItemId="0;69ee1bdf53fb0aeed761c52c8d49693d" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Short argument name, typically only a single letter.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[短参数名称，通常只有一个字母。]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="5" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;75a55c928c79bdb03057db67af054e9e" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Long argument name, typically one or two words separated by a hyphen.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[长参数名称，通常是由连字符分隔的一个或两个单词。]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="7" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;e7b23931982c94194e3886cd424afb72" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Description of the argument to display when called with --help/-h.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[使用 --help/-h 进行调用时显示的参数说明。]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="9" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
-<Settings Name="@SettingsPath@\default.lss" Type="Lss" /></LCX>
+</LCX>

--- a/Python/loc/lcl/CHS/Snippets/Python/argparse.snippet.lcl
+++ b/Python/loc/lcl/CHS/Snippets/Python/argparse.snippet.lcl
@@ -1,17 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="D:\a\_work\1\b\raw\binaries\Snippets\Python\argparse.snippet" PsrId="210" SrcCul="en-US" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx" TgtCul="zh-CN">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\21\b\raw\binaries\Snippets\Python\argparse.snippet" PsrId="210" FileType="1" SrcCul="en-US" TgtCul="zh-CN" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="Dev" />
     <Cmt Name="LcxAdmin" />
     <Cmt Name="Rccx" />
   </OwnedComments>
+  <Settings Name="@SettingsPath@\default.lss" Type="Lss" />
   <Item ItemId=";&lt;Description&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
     <Item ItemId="0;efc9719c9afe3a8265e2a7e511a1cdc6" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Code snippet for a function to parse arguments using argparse]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[使用 argparse 分析参数的函数的代码片段]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="3" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;Title&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -19,8 +23,11 @@
     <Item ItemId="0;4365422194f5997a16d7a169524e3d10" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[argparse block]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[argparse 块]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="1" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;ToolTip&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -28,8 +35,11 @@
     <Item ItemId="0;62568bc5e481b7c2bf94f72978c34da4" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Short description of your script]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[脚本的简短说明]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="5" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
-<Settings Name="@SettingsPath@\default.lss" Type="Lss" /></LCX>
+</LCX>

--- a/Python/loc/lcl/CHS/VCTargets/Win32/ImportAfter/Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml.lcl
+++ b/Python/loc/lcl/CHS/VCTargets/Win32/ImportAfter/Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml.lcl
@@ -1,23 +1,30 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="D:\a\_work\1\b\raw\binaries\VCTargets\Win32\ImportAfter\Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml" PsrId="22" SrcCul="en-US" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx" TgtCul="zh-CN">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\20\b\raw\binaries\VCTargets\Win32\ImportAfter\Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml" PsrId="22" FileType="1" SrcCul="en-US" TgtCul="zh-CN" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="Dev" />
     <Cmt Name="LcxAdmin" />
     <Cmt Name="Rccx" />
   </OwnedComments>
+  <Settings Name="@SettingsPath@\default.lss" Type="Lss" />
   <Item ItemId=";&lt;BoolProperty&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
     <Item ItemId="0;localdebuggermergeenvironment@BoolProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Merge specified environment variables with existing environment.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[将指定的环境变量与现有环境合并。]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="27" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggermergeenvironment@BoolProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Merge Environment]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[合并环境]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="25" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;Rule&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -25,14 +32,20 @@
     <Item ItemId="0;pythondebuglaunchprovider@Rule@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Python/Native debugging options]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Python/本机调试选项]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="3" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;pythondebuglaunchprovider@Rule@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Python/Native Debugging]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Python/本机调试]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="1" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;StringListProperty&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -40,14 +53,20 @@
     <Item ItemId="0;localdebuggerenvironment@StringListProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Specifies the environment for the debugee, or variables to merge with existing environment.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[指定调试对象的环境，或要与现有环境合并的变量。]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="23" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggerenvironment@StringListProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Environment]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[环境]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="21" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;StringProperty&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -55,38 +74,56 @@
     <Item ItemId="0;localdebuggercommand@StringProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[The debug command to execute.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[要执行的调试命令。]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="7" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggercommandarguments@StringProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[The command line arguments to pass to the application.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[要传递到应用程序的命令行参数。]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="15" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggerworkingdirectory@StringProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[The application's working directory. By default, the directory containing the project file.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[应用程序的工作目录。默认情况下，为包含项目文件的目录。]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="19" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggercommand@StringProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Command]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[命令]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="5" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggercommandarguments@StringProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Command Arguments]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[命令参数]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="13" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggerworkingdirectory@StringProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Working Directory]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[工作目录]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="17" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;ValueEditor&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -94,14 +131,20 @@
     <Item ItemId="0;5a88dad82b4127d481f86820c9fcbf98" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[<Edit...>]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[<编辑...>]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="9" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;b66ab1d4354799e0066c0af0ab39211f" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[<Browse...>]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[<浏览...>]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="11" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
-<Settings Name="@SettingsPath@\default.lss" Type="Lss" /></LCX>
+</LCX>

--- a/Python/loc/lcl/CHS/VCTargets/x64/ImportAfter/Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml.lcl
+++ b/Python/loc/lcl/CHS/VCTargets/x64/ImportAfter/Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml.lcl
@@ -1,23 +1,30 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="D:\a\_work\1\b\raw\binaries\VCTargets\x64\ImportAfter\Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml" PsrId="22" SrcCul="en-US" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx" TgtCul="zh-CN">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\20\b\raw\binaries\VCTargets\Win32\ImportAfter\Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml" PsrId="22" FileType="1" SrcCul="en-US" TgtCul="zh-CN" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="Dev" />
     <Cmt Name="LcxAdmin" />
     <Cmt Name="Rccx" />
   </OwnedComments>
+  <Settings Name="@SettingsPath@\default.lss" Type="Lss" />
   <Item ItemId=";&lt;BoolProperty&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
     <Item ItemId="0;localdebuggermergeenvironment@BoolProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Merge specified environment variables with existing environment.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[将指定的环境变量与现有环境合并。]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="27" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggermergeenvironment@BoolProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Merge Environment]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[合并环境]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="25" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;Rule&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -25,14 +32,20 @@
     <Item ItemId="0;pythondebuglaunchprovider@Rule@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Python/Native debugging options]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Python/本机调试选项]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="3" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;pythondebuglaunchprovider@Rule@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Python/Native Debugging]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Python/本机调试]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="1" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;StringListProperty&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -40,14 +53,20 @@
     <Item ItemId="0;localdebuggerenvironment@StringListProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Specifies the environment for the debugee, or variables to merge with existing environment.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[指定调试对象的环境，或要与现有环境合并的变量。]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="23" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggerenvironment@StringListProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Environment]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[环境]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="21" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;StringProperty&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -55,38 +74,56 @@
     <Item ItemId="0;localdebuggercommand@StringProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[The debug command to execute.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[要执行的调试命令。]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="7" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggercommandarguments@StringProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[The command line arguments to pass to the application.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[要传递到应用程序的命令行参数。]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="15" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggerworkingdirectory@StringProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[The application's working directory. By default, the directory containing the project file.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[应用程序的工作目录。默认情况下，为包含项目文件的目录。]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="19" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggercommand@StringProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Command]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[命令]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="5" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggercommandarguments@StringProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Command Arguments]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[命令参数]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="13" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggerworkingdirectory@StringProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Working Directory]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[工作目录]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="17" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;ValueEditor&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -94,14 +131,20 @@
     <Item ItemId="0;5a88dad82b4127d481f86820c9fcbf98" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[<Edit...>]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[<编辑...>]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="9" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;b66ab1d4354799e0066c0af0ab39211f" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[<Browse...>]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[<浏览...>]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="11" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
-<Settings Name="@SettingsPath@\default.lss" Type="Lss" /></LCX>
+</LCX>

--- a/Python/loc/lcl/CHT/Snippets/Python/arg_path.snippet.lcl
+++ b/Python/loc/lcl/CHT/Snippets/Python/arg_path.snippet.lcl
@@ -1,17 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="D:\a\_work\1\b\raw\binaries\Snippets\Python\arg_path.snippet" PsrId="210" SrcCul="en-US" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx" TgtCul="zh-TW">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\21\b\raw\binaries\Snippets\Python\arg_path.snippet" PsrId="210" FileType="1" SrcCul="en-US" TgtCul="zh-TW" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="Dev" />
     <Cmt Name="LcxAdmin" />
     <Cmt Name="Rccx" />
   </OwnedComments>
+  <Settings Name="@SettingsPath@\default.lss" Type="Lss" />
   <Item ItemId=";&lt;Description&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
     <Item ItemId="0;10b5db89840923ed3d0acc5fe287c167" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Code snippet for a path argument for an argparse parser.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[argparse 剖析器的路徑引數程式碼片段。]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="3" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;Title&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -19,8 +23,11 @@
     <Item ItemId="0;1cf27f1348d9adf9704b2dff0db0d888" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[argparse path argument]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[argparse 路徑引數]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="1" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;ToolTip&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -28,26 +35,38 @@
     <Item ItemId="0;69ee1bdf53fb0aeed761c52c8d49693d" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Short argument name, typically only a single letter.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[簡短引數名稱，通常是單一字母。]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="5" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;75a55c928c79bdb03057db67af054e9e" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Long argument name, typically one or two words separated by a hyphen.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[完整引數名稱，一般是以連字號分隔的一或兩個字組。]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="7" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;e7b23931982c94194e3886cd424afb72" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Description of the argument to display when called with --help/-h.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[當使用 --help/-h 呼叫時，所要顯示的引數描述。]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="11" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;ed36fc16d953d88706f27cad66ebb5f2" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Argument variable name.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[引數變數名稱。]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="9" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
-<Settings Name="@SettingsPath@\default.lss" Type="Lss" /></LCX>
+</LCX>

--- a/Python/loc/lcl/CHT/Snippets/Python/arg_path_positional.snippet.lcl
+++ b/Python/loc/lcl/CHT/Snippets/Python/arg_path_positional.snippet.lcl
@@ -1,17 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="D:\a\_work\1\b\raw\binaries\Snippets\Python\arg_path_positional.snippet" PsrId="210" SrcCul="en-US" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx" TgtCul="zh-TW">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\21\b\raw\binaries\Snippets\Python\arg_path_positional.snippet" PsrId="210" FileType="1" SrcCul="en-US" TgtCul="zh-TW" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="Dev" />
     <Cmt Name="LcxAdmin" />
     <Cmt Name="Rccx" />
   </OwnedComments>
+  <Settings Name="@SettingsPath@\default.lss" Type="Lss" />
   <Item ItemId=";&lt;Description&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
     <Item ItemId="0;12736a644fe557377d4f44fb250f3cc0" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Code snippet for a positional path argument for an argparse parser.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[argparse 剖析器的位置路徑引數程式碼片段。]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="3" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;Title&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -19,8 +23,11 @@
     <Item ItemId="0;5cb477ab75463262edfbf537292653c8" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[argparse positional path argument]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[argparse 位置路徑引數]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="1" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;ToolTip&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -28,14 +35,20 @@
     <Item ItemId="0;35282756089c336d9b7432ac72d786f1" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Argument name. Start with a hyphen to require a switch, or omit to make it positional.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[引數名稱。使用連字號為開頭可要求參數，省略則可使其成為位置引數。]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="5" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;e7b23931982c94194e3886cd424afb72" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Description of the argument to display when called with --help/-h.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[當使用 --help/-h 呼叫時，所要顯示的引數描述。]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="7" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
-<Settings Name="@SettingsPath@\default.lss" Type="Lss" /></LCX>
+</LCX>

--- a/Python/loc/lcl/CHT/Snippets/Python/arg_str.snippet.lcl
+++ b/Python/loc/lcl/CHT/Snippets/Python/arg_str.snippet.lcl
@@ -1,17 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="D:\a\_work\1\b\raw\binaries\Snippets\Python\arg_str.snippet" PsrId="210" SrcCul="en-US" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx" TgtCul="zh-TW">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\21\b\raw\binaries\Snippets\Python\arg_str.snippet" PsrId="210" FileType="1" SrcCul="en-US" TgtCul="zh-TW" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="Dev" />
     <Cmt Name="LcxAdmin" />
     <Cmt Name="Rccx" />
   </OwnedComments>
+  <Settings Name="@SettingsPath@\default.lss" Type="Lss" />
   <Item ItemId=";&lt;Description&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
     <Item ItemId="0;5162629d4963116ba811271091fe841d" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Code snippet for a string argument for an argparse parser.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[argparse 剖析器的字串引數程式碼片段。]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="3" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;Title&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -19,8 +23,11 @@
     <Item ItemId="0;8fbb5326dfe0bf71b7361d48e1a445c4" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[argparse string argument]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[argparse 字串引數]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="1" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;ToolTip&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -28,26 +35,38 @@
     <Item ItemId="0;69ee1bdf53fb0aeed761c52c8d49693d" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Short argument name, typically only a single letter.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[簡短引數名稱，通常是單一字母。]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="5" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;75a55c928c79bdb03057db67af054e9e" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Long argument name, typically one or two words separated by a hyphen.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[完整引數名稱，一般是以連字號分隔的一或兩個字組。]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="7" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;e7b23931982c94194e3886cd424afb72" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Description of the argument to display when called with --help/-h.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[當使用 --help/-h 呼叫時，所要顯示的引數描述。]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="11" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;ed36fc16d953d88706f27cad66ebb5f2" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Argument variable name.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[引數變數名稱。]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="9" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
-<Settings Name="@SettingsPath@\default.lss" Type="Lss" /></LCX>
+</LCX>

--- a/Python/loc/lcl/CHT/Snippets/Python/arg_str_positional.snippet.lcl
+++ b/Python/loc/lcl/CHT/Snippets/Python/arg_str_positional.snippet.lcl
@@ -1,17 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="D:\a\_work\1\b\raw\binaries\Snippets\Python\arg_str_positional.snippet" PsrId="210" SrcCul="en-US" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx" TgtCul="zh-TW">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\21\b\raw\binaries\Snippets\Python\arg_str_positional.snippet" PsrId="210" FileType="1" SrcCul="en-US" TgtCul="zh-TW" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="Dev" />
     <Cmt Name="LcxAdmin" />
     <Cmt Name="Rccx" />
   </OwnedComments>
+  <Settings Name="@SettingsPath@\default.lss" Type="Lss" />
   <Item ItemId=";&lt;Description&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
     <Item ItemId="0;69def699f0c2570190c042fc792b38c5" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Code snippet for a positional string argument for an argparse parser.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[argparse 剖析器的位置字串引數程式碼片段。]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="3" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;Title&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -19,8 +23,11 @@
     <Item ItemId="0;9dbaae3dbddf131d3205155271f50641" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[argparse positional string argument]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[argparse 位置字串引數]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="1" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;ToolTip&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -28,14 +35,20 @@
     <Item ItemId="0;35282756089c336d9b7432ac72d786f1" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Argument name. Start with a hyphen to require a switch, or omit to make it positional.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[引數名稱。使用連字號為開頭可要求參數，省略則可使其成為位置引數。]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="5" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;e7b23931982c94194e3886cd424afb72" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Description of the argument to display when called with --help/-h.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[當使用 --help/-h 呼叫時，所要顯示的引數描述。]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="7" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
-<Settings Name="@SettingsPath@\default.lss" Type="Lss" /></LCX>
+</LCX>

--- a/Python/loc/lcl/CHT/Snippets/Python/arg_switch.snippet.lcl
+++ b/Python/loc/lcl/CHT/Snippets/Python/arg_switch.snippet.lcl
@@ -1,17 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="D:\a\_work\1\b\raw\binaries\Snippets\Python\arg_switch.snippet" PsrId="210" SrcCul="en-US" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx" TgtCul="zh-TW">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\21\b\raw\binaries\Snippets\Python\arg_switch.snippet" PsrId="210" FileType="1" SrcCul="en-US" TgtCul="zh-TW" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="Dev" />
     <Cmt Name="LcxAdmin" />
     <Cmt Name="Rccx" />
   </OwnedComments>
+  <Settings Name="@SettingsPath@\default.lss" Type="Lss" />
   <Item ItemId=";&lt;Description&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
     <Item ItemId="0;cdf30125985a60ac677caefc318833e8" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Code snippet for a switch argument for an argparse parser.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[argparse 剖析器的參數引數程式碼片段。]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="3" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;Title&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -19,8 +23,11 @@
     <Item ItemId="0;277d72dbe38cd017f4b02e7448bf146e" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[argparse switch argument]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[argparse 參數引數]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="1" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;ToolTip&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -28,20 +35,29 @@
     <Item ItemId="0;69ee1bdf53fb0aeed761c52c8d49693d" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Short argument name, typically only a single letter.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[簡短引數名稱，通常是單一字母。]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="5" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;75a55c928c79bdb03057db67af054e9e" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Long argument name, typically one or two words separated by a hyphen.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[完整引數名稱，一般是以連字號分隔的一或兩個字組。]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="7" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;e7b23931982c94194e3886cd424afb72" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Description of the argument to display when called with --help/-h.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[當使用 --help/-h 呼叫時，所要顯示的引數描述。]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="9" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
-<Settings Name="@SettingsPath@\default.lss" Type="Lss" /></LCX>
+</LCX>

--- a/Python/loc/lcl/CHT/Snippets/Python/argparse.snippet.lcl
+++ b/Python/loc/lcl/CHT/Snippets/Python/argparse.snippet.lcl
@@ -1,17 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="D:\a\_work\1\b\raw\binaries\Snippets\Python\argparse.snippet" PsrId="210" SrcCul="en-US" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx" TgtCul="zh-TW">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\21\b\raw\binaries\Snippets\Python\argparse.snippet" PsrId="210" FileType="1" SrcCul="en-US" TgtCul="zh-TW" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="Dev" />
     <Cmt Name="LcxAdmin" />
     <Cmt Name="Rccx" />
   </OwnedComments>
+  <Settings Name="@SettingsPath@\default.lss" Type="Lss" />
   <Item ItemId=";&lt;Description&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
     <Item ItemId="0;efc9719c9afe3a8265e2a7e511a1cdc6" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Code snippet for a function to parse arguments using argparse]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[供函數使用 argparse 剖析引數的程式碼片段]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="3" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;Title&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -19,8 +23,11 @@
     <Item ItemId="0;4365422194f5997a16d7a169524e3d10" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[argparse block]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[argparse 區塊]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="1" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;ToolTip&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -28,8 +35,11 @@
     <Item ItemId="0;62568bc5e481b7c2bf94f72978c34da4" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Short description of your script]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[指令碼的簡短描述]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="5" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
-<Settings Name="@SettingsPath@\default.lss" Type="Lss" /></LCX>
+</LCX>

--- a/Python/loc/lcl/CHT/VCTargets/Win32/ImportAfter/Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml.lcl
+++ b/Python/loc/lcl/CHT/VCTargets/Win32/ImportAfter/Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml.lcl
@@ -1,23 +1,30 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="D:\a\_work\1\b\raw\binaries\VCTargets\Win32\ImportAfter\Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml" PsrId="22" SrcCul="en-US" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx" TgtCul="zh-TW">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\20\b\raw\binaries\VCTargets\Win32\ImportAfter\Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml" PsrId="22" FileType="1" SrcCul="en-US" TgtCul="zh-TW" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="Dev" />
     <Cmt Name="LcxAdmin" />
     <Cmt Name="Rccx" />
   </OwnedComments>
+  <Settings Name="@SettingsPath@\default.lss" Type="Lss" />
   <Item ItemId=";&lt;BoolProperty&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
     <Item ItemId="0;localdebuggermergeenvironment@BoolProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Merge specified environment variables with existing environment.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[合併指定的環境變數與現有的環境。]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="27" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggermergeenvironment@BoolProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Merge Environment]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[合併環境]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="25" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;Rule&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -25,14 +32,20 @@
     <Item ItemId="0;pythondebuglaunchprovider@Rule@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Python/Native debugging options]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Python/原生偵錯選項]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="3" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;pythondebuglaunchprovider@Rule@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Python/Native Debugging]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Python/原生偵錯]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="1" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;StringListProperty&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -40,14 +53,20 @@
     <Item ItemId="0;localdebuggerenvironment@StringListProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Specifies the environment for the debugee, or variables to merge with existing environment.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[指定偵錯項目的環境，或指定要與現有環境合併的變數。]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="23" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggerenvironment@StringListProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Environment]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[環境]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="21" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;StringProperty&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -55,38 +74,56 @@
     <Item ItemId="0;localdebuggercommand@StringProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[The debug command to execute.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[要執行的偵錯命令。]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="7" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggercommandarguments@StringProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[The command line arguments to pass to the application.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[要傳遞給應用程式的命令列引數。]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="15" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggerworkingdirectory@StringProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[The application's working directory. By default, the directory containing the project file.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[應用程式的工作目錄。此目錄預設會包含專案檔。]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="19" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggercommand@StringProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Command]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[命令]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="5" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggercommandarguments@StringProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Command Arguments]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[命令引數]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="13" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggerworkingdirectory@StringProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Working Directory]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[工作目錄]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="17" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;ValueEditor&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -94,14 +131,20 @@
     <Item ItemId="0;5a88dad82b4127d481f86820c9fcbf98" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[<Edit...>]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[<編輯...>]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="9" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;b66ab1d4354799e0066c0af0ab39211f" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[<Browse...>]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[<瀏覽...>]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="11" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
-<Settings Name="@SettingsPath@\default.lss" Type="Lss" /></LCX>
+</LCX>

--- a/Python/loc/lcl/CHT/VCTargets/x64/ImportAfter/Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml.lcl
+++ b/Python/loc/lcl/CHT/VCTargets/x64/ImportAfter/Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml.lcl
@@ -1,23 +1,30 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="D:\a\_work\1\b\raw\binaries\VCTargets\x64\ImportAfter\Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml" PsrId="22" SrcCul="en-US" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx" TgtCul="zh-TW">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\20\b\raw\binaries\VCTargets\Win32\ImportAfter\Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml" PsrId="22" FileType="1" SrcCul="en-US" TgtCul="zh-TW" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="Dev" />
     <Cmt Name="LcxAdmin" />
     <Cmt Name="Rccx" />
   </OwnedComments>
+  <Settings Name="@SettingsPath@\default.lss" Type="Lss" />
   <Item ItemId=";&lt;BoolProperty&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
     <Item ItemId="0;localdebuggermergeenvironment@BoolProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Merge specified environment variables with existing environment.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[合併指定的環境變數與現有的環境。]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="27" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggermergeenvironment@BoolProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Merge Environment]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[合併環境]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="25" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;Rule&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -25,14 +32,20 @@
     <Item ItemId="0;pythondebuglaunchprovider@Rule@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Python/Native debugging options]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Python/原生偵錯選項]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="3" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;pythondebuglaunchprovider@Rule@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Python/Native Debugging]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Python/原生偵錯]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="1" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;StringListProperty&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -40,14 +53,20 @@
     <Item ItemId="0;localdebuggerenvironment@StringListProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Specifies the environment for the debugee, or variables to merge with existing environment.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[指定偵錯項目的環境，或指定要與現有環境合併的變數。]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="23" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggerenvironment@StringListProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Environment]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[環境]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="21" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;StringProperty&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -55,38 +74,56 @@
     <Item ItemId="0;localdebuggercommand@StringProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[The debug command to execute.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[要執行的偵錯命令。]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="7" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggercommandarguments@StringProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[The command line arguments to pass to the application.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[要傳遞給應用程式的命令列引數。]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="15" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggerworkingdirectory@StringProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[The application's working directory. By default, the directory containing the project file.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[應用程式的工作目錄。此目錄預設會包含專案檔。]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="19" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggercommand@StringProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Command]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[命令]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="5" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggercommandarguments@StringProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Command Arguments]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[命令引數]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="13" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggerworkingdirectory@StringProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Working Directory]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[工作目錄]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="17" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;ValueEditor&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -94,14 +131,20 @@
     <Item ItemId="0;5a88dad82b4127d481f86820c9fcbf98" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[<Edit...>]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[<編輯...>]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="9" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;b66ab1d4354799e0066c0af0ab39211f" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[<Browse...>]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[<瀏覽...>]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="11" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
-<Settings Name="@SettingsPath@\default.lss" Type="Lss" /></LCX>
+</LCX>

--- a/Python/loc/lcl/CSY/Snippets/Python/arg_path.snippet.lcl
+++ b/Python/loc/lcl/CSY/Snippets/Python/arg_path.snippet.lcl
@@ -1,17 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="D:\a\_work\1\b\raw\binaries\Snippets\Python\arg_path.snippet" PsrId="210" SrcCul="en-US" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx" TgtCul="cs-CZ">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\21\b\raw\binaries\Snippets\Python\arg_path.snippet" PsrId="210" FileType="1" SrcCul="en-US" TgtCul="cs-CZ" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="Dev" />
     <Cmt Name="LcxAdmin" />
     <Cmt Name="Rccx" />
   </OwnedComments>
+  <Settings Name="@SettingsPath@\default.lss" Type="Lss" />
   <Item ItemId=";&lt;Description&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
     <Item ItemId="0;10b5db89840923ed3d0acc5fe287c167" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Code snippet for a path argument for an argparse parser.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Fragment kódu pro argument cesty pro analyzátor argparse.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="3" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;Title&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -19,8 +23,11 @@
     <Item ItemId="0;1cf27f1348d9adf9704b2dff0db0d888" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[argparse path argument]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[argument cesty argparse]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="1" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;ToolTip&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -28,26 +35,38 @@
     <Item ItemId="0;69ee1bdf53fb0aeed761c52c8d49693d" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Short argument name, typically only a single letter.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Krátký název argumentu, obvykle pouze jedno písmeno.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="5" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;75a55c928c79bdb03057db67af054e9e" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Long argument name, typically one or two words separated by a hyphen.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Dlouhý název argumentu, obvykle jedno nebo dvě slova oddělená spojovníkem.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="7" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;e7b23931982c94194e3886cd424afb72" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Description of the argument to display when called with --help/-h.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Popis argumentu, který se má zobrazit při volání s --help/h.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="11" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;ed36fc16d953d88706f27cad66ebb5f2" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Argument variable name.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Název proměnné argumentu.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="9" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
-<Settings Name="@SettingsPath@\default.lss" Type="Lss" /></LCX>
+</LCX>

--- a/Python/loc/lcl/CSY/Snippets/Python/arg_path_positional.snippet.lcl
+++ b/Python/loc/lcl/CSY/Snippets/Python/arg_path_positional.snippet.lcl
@@ -1,17 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="D:\a\_work\1\b\raw\binaries\Snippets\Python\arg_path_positional.snippet" PsrId="210" SrcCul="en-US" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx" TgtCul="cs-CZ">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\21\b\raw\binaries\Snippets\Python\arg_path_positional.snippet" PsrId="210" FileType="1" SrcCul="en-US" TgtCul="cs-CZ" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="Dev" />
     <Cmt Name="LcxAdmin" />
     <Cmt Name="Rccx" />
   </OwnedComments>
+  <Settings Name="@SettingsPath@\default.lss" Type="Lss" />
   <Item ItemId=";&lt;Description&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
     <Item ItemId="0;12736a644fe557377d4f44fb250f3cc0" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Code snippet for a positional path argument for an argparse parser.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Fragment kódu pro poziční argument cesty pro analyzátor argparse.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="3" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;Title&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -19,8 +23,11 @@
     <Item ItemId="0;5cb477ab75463262edfbf537292653c8" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[argparse positional path argument]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[poziční argument cesty argparse]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="1" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;ToolTip&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -28,14 +35,20 @@
     <Item ItemId="0;35282756089c336d9b7432ac72d786f1" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Argument name. Start with a hyphen to require a switch, or omit to make it positional.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Název argumentu. Pokud začíná spojovníkem, je požadován přepínač, bez něj je poziční.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="5" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;e7b23931982c94194e3886cd424afb72" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Description of the argument to display when called with --help/-h.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Popis argumentu, který se má zobrazit při volání s --help/h.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="7" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
-<Settings Name="@SettingsPath@\default.lss" Type="Lss" /></LCX>
+</LCX>

--- a/Python/loc/lcl/CSY/Snippets/Python/arg_str.snippet.lcl
+++ b/Python/loc/lcl/CSY/Snippets/Python/arg_str.snippet.lcl
@@ -1,17 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="D:\a\_work\1\b\raw\binaries\Snippets\Python\arg_str.snippet" PsrId="210" SrcCul="en-US" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx" TgtCul="cs-CZ">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\21\b\raw\binaries\Snippets\Python\arg_str.snippet" PsrId="210" FileType="1" SrcCul="en-US" TgtCul="cs-CZ" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="Dev" />
     <Cmt Name="LcxAdmin" />
     <Cmt Name="Rccx" />
   </OwnedComments>
+  <Settings Name="@SettingsPath@\default.lss" Type="Lss" />
   <Item ItemId=";&lt;Description&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
     <Item ItemId="0;5162629d4963116ba811271091fe841d" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Code snippet for a string argument for an argparse parser.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Fragment kódu pro argument řetězce pro analyzátor argparse.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="3" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;Title&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -19,8 +23,11 @@
     <Item ItemId="0;8fbb5326dfe0bf71b7361d48e1a445c4" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[argparse string argument]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[argument řetězce argparse]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="1" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;ToolTip&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -28,26 +35,38 @@
     <Item ItemId="0;69ee1bdf53fb0aeed761c52c8d49693d" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Short argument name, typically only a single letter.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Krátký název argumentu, obvykle pouze jedno písmeno.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="5" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;75a55c928c79bdb03057db67af054e9e" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Long argument name, typically one or two words separated by a hyphen.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Dlouhý název argumentu, obvykle jedno nebo dvě slova oddělená spojovníkem.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="7" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;e7b23931982c94194e3886cd424afb72" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Description of the argument to display when called with --help/-h.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Popis argumentu, který se má zobrazit při volání s --help/h.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="11" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;ed36fc16d953d88706f27cad66ebb5f2" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Argument variable name.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Název proměnné argumentu.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="9" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
-<Settings Name="@SettingsPath@\default.lss" Type="Lss" /></LCX>
+</LCX>

--- a/Python/loc/lcl/CSY/Snippets/Python/arg_str_positional.snippet.lcl
+++ b/Python/loc/lcl/CSY/Snippets/Python/arg_str_positional.snippet.lcl
@@ -1,17 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="D:\a\_work\1\b\raw\binaries\Snippets\Python\arg_str_positional.snippet" PsrId="210" SrcCul="en-US" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx" TgtCul="cs-CZ">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\21\b\raw\binaries\Snippets\Python\arg_str_positional.snippet" PsrId="210" FileType="1" SrcCul="en-US" TgtCul="cs-CZ" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="Dev" />
     <Cmt Name="LcxAdmin" />
     <Cmt Name="Rccx" />
   </OwnedComments>
+  <Settings Name="@SettingsPath@\default.lss" Type="Lss" />
   <Item ItemId=";&lt;Description&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
     <Item ItemId="0;69def699f0c2570190c042fc792b38c5" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Code snippet for a positional string argument for an argparse parser.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Fragment kódu pro poziční argument řetězce pro analyzátor argparse.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="3" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;Title&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -19,8 +23,11 @@
     <Item ItemId="0;9dbaae3dbddf131d3205155271f50641" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[argparse positional string argument]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[poziční argument řetězce argparse]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="1" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;ToolTip&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -28,14 +35,20 @@
     <Item ItemId="0;35282756089c336d9b7432ac72d786f1" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Argument name. Start with a hyphen to require a switch, or omit to make it positional.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Název argumentu. Pokud začíná spojovníkem, je požadován přepínač, bez něj je poziční.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="5" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;e7b23931982c94194e3886cd424afb72" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Description of the argument to display when called with --help/-h.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Popis argumentu, který se má zobrazit při volání s --help/h.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="7" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
-<Settings Name="@SettingsPath@\default.lss" Type="Lss" /></LCX>
+</LCX>

--- a/Python/loc/lcl/CSY/Snippets/Python/arg_switch.snippet.lcl
+++ b/Python/loc/lcl/CSY/Snippets/Python/arg_switch.snippet.lcl
@@ -1,17 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="D:\a\_work\1\b\raw\binaries\Snippets\Python\arg_switch.snippet" PsrId="210" SrcCul="en-US" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx" TgtCul="cs-CZ">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\21\b\raw\binaries\Snippets\Python\arg_switch.snippet" PsrId="210" FileType="1" SrcCul="en-US" TgtCul="cs-CZ" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="Dev" />
     <Cmt Name="LcxAdmin" />
     <Cmt Name="Rccx" />
   </OwnedComments>
+  <Settings Name="@SettingsPath@\default.lss" Type="Lss" />
   <Item ItemId=";&lt;Description&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
     <Item ItemId="0;cdf30125985a60ac677caefc318833e8" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Code snippet for a switch argument for an argparse parser.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Fragment kódu pro argument přepínače pro analyzátor argparse.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="3" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;Title&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -19,8 +23,11 @@
     <Item ItemId="0;277d72dbe38cd017f4b02e7448bf146e" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[argparse switch argument]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[argument přepínače argparse]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="1" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;ToolTip&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -28,20 +35,29 @@
     <Item ItemId="0;69ee1bdf53fb0aeed761c52c8d49693d" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Short argument name, typically only a single letter.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Krátký název argumentu, obvykle pouze jedno písmeno.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="5" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;75a55c928c79bdb03057db67af054e9e" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Long argument name, typically one or two words separated by a hyphen.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Dlouhý název argumentu, obvykle jedno nebo dvě slova oddělená spojovníkem.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="7" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;e7b23931982c94194e3886cd424afb72" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Description of the argument to display when called with --help/-h.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Popis argumentu, který se má zobrazit při volání s --help/h.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="9" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
-<Settings Name="@SettingsPath@\default.lss" Type="Lss" /></LCX>
+</LCX>

--- a/Python/loc/lcl/CSY/Snippets/Python/argparse.snippet.lcl
+++ b/Python/loc/lcl/CSY/Snippets/Python/argparse.snippet.lcl
@@ -1,17 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="D:\a\_work\1\b\raw\binaries\Snippets\Python\argparse.snippet" PsrId="210" SrcCul="en-US" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx" TgtCul="cs-CZ">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\21\b\raw\binaries\Snippets\Python\argparse.snippet" PsrId="210" FileType="1" SrcCul="en-US" TgtCul="cs-CZ" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="Dev" />
     <Cmt Name="LcxAdmin" />
     <Cmt Name="Rccx" />
   </OwnedComments>
+  <Settings Name="@SettingsPath@\default.lss" Type="Lss" />
   <Item ItemId=";&lt;Description&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
     <Item ItemId="0;efc9719c9afe3a8265e2a7e511a1cdc6" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Code snippet for a function to parse arguments using argparse]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Fragment kódu pro funkci parsování argumentů pomocí argparse]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="3" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;Title&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -19,8 +23,11 @@
     <Item ItemId="0;4365422194f5997a16d7a169524e3d10" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[argparse block]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[blok argparse]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="1" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;ToolTip&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -28,8 +35,11 @@
     <Item ItemId="0;62568bc5e481b7c2bf94f72978c34da4" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Short description of your script]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Krátký popis skriptu]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="5" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
-<Settings Name="@SettingsPath@\default.lss" Type="Lss" /></LCX>
+</LCX>

--- a/Python/loc/lcl/CSY/VCTargets/Win32/ImportAfter/Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml.lcl
+++ b/Python/loc/lcl/CSY/VCTargets/Win32/ImportAfter/Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml.lcl
@@ -1,23 +1,30 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="D:\a\_work\1\b\raw\binaries\VCTargets\Win32\ImportAfter\Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml" PsrId="22" SrcCul="en-US" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx" TgtCul="cs-CZ">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\20\b\raw\binaries\VCTargets\Win32\ImportAfter\Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml" PsrId="22" FileType="1" SrcCul="en-US" TgtCul="cs-CZ" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="Dev" />
     <Cmt Name="LcxAdmin" />
     <Cmt Name="Rccx" />
   </OwnedComments>
+  <Settings Name="@SettingsPath@\default.lss" Type="Lss" />
   <Item ItemId=";&lt;BoolProperty&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
     <Item ItemId="0;localdebuggermergeenvironment@BoolProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Merge specified environment variables with existing environment.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Zadané proměnné prostředí se sloučí se stávajícím prostředím.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="27" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggermergeenvironment@BoolProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Merge Environment]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Sloučit prostředí]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="25" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;Rule&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -25,14 +32,20 @@
     <Item ItemId="0;pythondebuglaunchprovider@Rule@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Python/Native debugging options]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Python/nativní ladění – možnosti]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="3" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;pythondebuglaunchprovider@Rule@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Python/Native Debugging]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Python/nativní ladění]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="1" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;StringListProperty&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -40,14 +53,20 @@
     <Item ItemId="0;localdebuggerenvironment@StringListProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Specifies the environment for the debugee, or variables to merge with existing environment.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Určuje prostředí laděného objektu nebo proměnné, které se mají sloučit se stávajícím prostředím.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="23" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggerenvironment@StringListProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Environment]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Prostředí]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="21" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;StringProperty&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -55,38 +74,56 @@
     <Item ItemId="0;localdebuggercommand@StringProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[The debug command to execute.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Příkaz ladění, který se má provést]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="7" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggercommandarguments@StringProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[The command line arguments to pass to the application.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Argumenty příkazového řádku, které se mají předat aplikaci]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="15" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggerworkingdirectory@StringProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[The application's working directory. By default, the directory containing the project file.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Pracovní adresář aplikace. Ve výchozím nastavení se jedná o adresář obsahující soubor projektu.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="19" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggercommand@StringProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Command]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Příkaz]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="5" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggercommandarguments@StringProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Command Arguments]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Argumenty příkazu]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="13" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggerworkingdirectory@StringProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Working Directory]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Pracovní adresář]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="17" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;ValueEditor&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -94,14 +131,20 @@
     <Item ItemId="0;5a88dad82b4127d481f86820c9fcbf98" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[<Edit...>]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[<Upravit...>]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="9" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;b66ab1d4354799e0066c0af0ab39211f" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[<Browse...>]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[<Procházet...>]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="11" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
-<Settings Name="@SettingsPath@\default.lss" Type="Lss" /></LCX>
+</LCX>

--- a/Python/loc/lcl/CSY/VCTargets/x64/ImportAfter/Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml.lcl
+++ b/Python/loc/lcl/CSY/VCTargets/x64/ImportAfter/Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml.lcl
@@ -1,23 +1,30 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="D:\a\_work\1\b\raw\binaries\VCTargets\x64\ImportAfter\Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml" PsrId="22" SrcCul="en-US" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx" TgtCul="cs-CZ">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\20\b\raw\binaries\VCTargets\Win32\ImportAfter\Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml" PsrId="22" FileType="1" SrcCul="en-US" TgtCul="cs-CZ" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="Dev" />
     <Cmt Name="LcxAdmin" />
     <Cmt Name="Rccx" />
   </OwnedComments>
+  <Settings Name="@SettingsPath@\default.lss" Type="Lss" />
   <Item ItemId=";&lt;BoolProperty&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
     <Item ItemId="0;localdebuggermergeenvironment@BoolProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Merge specified environment variables with existing environment.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Zadané proměnné prostředí se sloučí se stávajícím prostředím.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="27" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggermergeenvironment@BoolProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Merge Environment]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Sloučit prostředí]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="25" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;Rule&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -25,14 +32,20 @@
     <Item ItemId="0;pythondebuglaunchprovider@Rule@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Python/Native debugging options]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Python/nativní ladění – možnosti]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="3" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;pythondebuglaunchprovider@Rule@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Python/Native Debugging]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Python/nativní ladění]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="1" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;StringListProperty&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -40,14 +53,20 @@
     <Item ItemId="0;localdebuggerenvironment@StringListProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Specifies the environment for the debugee, or variables to merge with existing environment.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Určuje prostředí laděného objektu nebo proměnné, které se mají sloučit se stávajícím prostředím.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="23" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggerenvironment@StringListProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Environment]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Prostředí]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="21" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;StringProperty&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -55,38 +74,56 @@
     <Item ItemId="0;localdebuggercommand@StringProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[The debug command to execute.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Příkaz ladění, který se má provést]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="7" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggercommandarguments@StringProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[The command line arguments to pass to the application.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Argumenty příkazového řádku, které se mají předat aplikaci]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="15" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggerworkingdirectory@StringProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[The application's working directory. By default, the directory containing the project file.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Pracovní adresář aplikace. Ve výchozím nastavení se jedná o adresář obsahující soubor projektu.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="19" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggercommand@StringProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Command]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Příkaz]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="5" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggercommandarguments@StringProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Command Arguments]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Argumenty příkazu]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="13" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggerworkingdirectory@StringProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Working Directory]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Pracovní adresář]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="17" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;ValueEditor&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -94,14 +131,20 @@
     <Item ItemId="0;5a88dad82b4127d481f86820c9fcbf98" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[<Edit...>]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[<Upravit...>]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="9" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;b66ab1d4354799e0066c0af0ab39211f" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[<Browse...>]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[<Procházet...>]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="11" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
-<Settings Name="@SettingsPath@\default.lss" Type="Lss" /></LCX>
+</LCX>

--- a/Python/loc/lcl/DEU/Snippets/Python/arg_path.snippet.lcl
+++ b/Python/loc/lcl/DEU/Snippets/Python/arg_path.snippet.lcl
@@ -1,17 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="D:\a\_work\1\b\raw\binaries\Snippets\Python\arg_path.snippet" PsrId="210" SrcCul="en-US" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx" TgtCul="de-DE">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\21\b\raw\binaries\Snippets\Python\arg_path.snippet" PsrId="210" FileType="1" SrcCul="en-US" TgtCul="de-DE" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="Dev" />
     <Cmt Name="LcxAdmin" />
     <Cmt Name="Rccx" />
   </OwnedComments>
+  <Settings Name="@SettingsPath@\default.lss" Type="Lss" />
   <Item ItemId=";&lt;Description&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
     <Item ItemId="0;10b5db89840923ed3d0acc5fe287c167" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Code snippet for a path argument for an argparse parser.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Codeschnipsel für ein Pfadargument für einen argparse-Parser.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="3" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;Title&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -19,8 +23,11 @@
     <Item ItemId="0;1cf27f1348d9adf9704b2dff0db0d888" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[argparse path argument]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[argparse-Pfadargument]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="1" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;ToolTip&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -28,26 +35,38 @@
     <Item ItemId="0;69ee1bdf53fb0aeed761c52c8d49693d" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Short argument name, typically only a single letter.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Kurzer Argumentname, in der Regel nur ein Buchstabe.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="5" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;75a55c928c79bdb03057db67af054e9e" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Long argument name, typically one or two words separated by a hyphen.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Langer Argumentname, in der Regel ein oder zwei Wörter, die durch einen Bindestrich getrennt sind.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="7" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;e7b23931982c94194e3886cd424afb72" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Description of the argument to display when called with --help/-h.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Beschreibung des Arguments, die bei Aufruf mit "--help/-h" angezeigt wird.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="11" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;ed36fc16d953d88706f27cad66ebb5f2" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Argument variable name.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Argumentvariablenname.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="9" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
-<Settings Name="@SettingsPath@\default.lss" Type="Lss" /></LCX>
+</LCX>

--- a/Python/loc/lcl/DEU/Snippets/Python/arg_path_positional.snippet.lcl
+++ b/Python/loc/lcl/DEU/Snippets/Python/arg_path_positional.snippet.lcl
@@ -1,17 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="D:\a\_work\1\b\raw\binaries\Snippets\Python\arg_path_positional.snippet" PsrId="210" SrcCul="en-US" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx" TgtCul="de-DE">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\21\b\raw\binaries\Snippets\Python\arg_path_positional.snippet" PsrId="210" FileType="1" SrcCul="en-US" TgtCul="de-DE" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="Dev" />
     <Cmt Name="LcxAdmin" />
     <Cmt Name="Rccx" />
   </OwnedComments>
+  <Settings Name="@SettingsPath@\default.lss" Type="Lss" />
   <Item ItemId=";&lt;Description&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
     <Item ItemId="0;12736a644fe557377d4f44fb250f3cc0" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Code snippet for a positional path argument for an argparse parser.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Codeschnipsel für ein Positionspfadargument für einen argparse-Parser.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="3" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;Title&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -19,8 +23,11 @@
     <Item ItemId="0;5cb477ab75463262edfbf537292653c8" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[argparse positional path argument]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[argparse-Positionspfadargument]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="1" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;ToolTip&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -28,14 +35,20 @@
     <Item ItemId="0;35282756089c336d9b7432ac72d786f1" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Argument name. Start with a hyphen to require a switch, or omit to make it positional.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Name des Arguments. Beginnen Sie mit einem Bindestrich, um eine Option anzufordern, oder lassen Sie den Bindestrich weg, um ein Positionsargument festzulegen.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="5" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;e7b23931982c94194e3886cd424afb72" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Description of the argument to display when called with --help/-h.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Beschreibung des Arguments, die bei Aufruf mit "--help/-h" angezeigt wird.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="7" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
-<Settings Name="@SettingsPath@\default.lss" Type="Lss" /></LCX>
+</LCX>

--- a/Python/loc/lcl/DEU/Snippets/Python/arg_str.snippet.lcl
+++ b/Python/loc/lcl/DEU/Snippets/Python/arg_str.snippet.lcl
@@ -1,17 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="D:\a\_work\1\b\raw\binaries\Snippets\Python\arg_str.snippet" PsrId="210" SrcCul="en-US" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx" TgtCul="de-DE">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\21\b\raw\binaries\Snippets\Python\arg_str.snippet" PsrId="210" FileType="1" SrcCul="en-US" TgtCul="de-DE" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="Dev" />
     <Cmt Name="LcxAdmin" />
     <Cmt Name="Rccx" />
   </OwnedComments>
+  <Settings Name="@SettingsPath@\default.lss" Type="Lss" />
   <Item ItemId=";&lt;Description&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
     <Item ItemId="0;5162629d4963116ba811271091fe841d" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Code snippet for a string argument for an argparse parser.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Codeschnipsel für ein Zeichenfolgenargument für einen argparse-Parser.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="3" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;Title&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -19,8 +23,11 @@
     <Item ItemId="0;8fbb5326dfe0bf71b7361d48e1a445c4" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[argparse string argument]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[argparse-Zeichenfolgenargument]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="1" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;ToolTip&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -28,26 +35,38 @@
     <Item ItemId="0;69ee1bdf53fb0aeed761c52c8d49693d" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Short argument name, typically only a single letter.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Kurzer Argumentname, in der Regel nur ein Buchstabe.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="5" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;75a55c928c79bdb03057db67af054e9e" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Long argument name, typically one or two words separated by a hyphen.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Langer Argumentname, in der Regel ein oder zwei Wörter, die durch einen Bindestrich getrennt sind.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="7" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;e7b23931982c94194e3886cd424afb72" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Description of the argument to display when called with --help/-h.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Beschreibung des Arguments, die bei Aufruf mit "--help/-h" angezeigt wird.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="11" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;ed36fc16d953d88706f27cad66ebb5f2" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Argument variable name.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Argumentvariablenname.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="9" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
-<Settings Name="@SettingsPath@\default.lss" Type="Lss" /></LCX>
+</LCX>

--- a/Python/loc/lcl/DEU/Snippets/Python/arg_str_positional.snippet.lcl
+++ b/Python/loc/lcl/DEU/Snippets/Python/arg_str_positional.snippet.lcl
@@ -1,17 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="D:\a\_work\1\b\raw\binaries\Snippets\Python\arg_str_positional.snippet" PsrId="210" SrcCul="en-US" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx" TgtCul="de-DE">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\21\b\raw\binaries\Snippets\Python\arg_str_positional.snippet" PsrId="210" FileType="1" SrcCul="en-US" TgtCul="de-DE" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="Dev" />
     <Cmt Name="LcxAdmin" />
     <Cmt Name="Rccx" />
   </OwnedComments>
+  <Settings Name="@SettingsPath@\default.lss" Type="Lss" />
   <Item ItemId=";&lt;Description&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
     <Item ItemId="0;69def699f0c2570190c042fc792b38c5" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Code snippet for a positional string argument for an argparse parser.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Codeschnipsel für ein Positionszeichenfolgenargument für einen argparse-Parser.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="3" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;Title&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -19,8 +23,11 @@
     <Item ItemId="0;9dbaae3dbddf131d3205155271f50641" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[argparse positional string argument]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[argparse-Positionszeichenfolgenargument]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="1" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;ToolTip&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -28,14 +35,20 @@
     <Item ItemId="0;35282756089c336d9b7432ac72d786f1" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Argument name. Start with a hyphen to require a switch, or omit to make it positional.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Name des Arguments. Beginnen Sie mit einem Bindestrich, um eine Option anzufordern, oder lassen Sie den Bindestrich weg, um ein Positionsargument festzulegen.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="5" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;e7b23931982c94194e3886cd424afb72" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Description of the argument to display when called with --help/-h.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Beschreibung des Arguments, die bei Aufruf mit "--help/-h" angezeigt wird.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="7" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
-<Settings Name="@SettingsPath@\default.lss" Type="Lss" /></LCX>
+</LCX>

--- a/Python/loc/lcl/DEU/Snippets/Python/arg_switch.snippet.lcl
+++ b/Python/loc/lcl/DEU/Snippets/Python/arg_switch.snippet.lcl
@@ -1,17 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="D:\a\_work\1\b\raw\binaries\Snippets\Python\arg_switch.snippet" PsrId="210" SrcCul="en-US" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx" TgtCul="de-DE">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\21\b\raw\binaries\Snippets\Python\arg_switch.snippet" PsrId="210" FileType="1" SrcCul="en-US" TgtCul="de-DE" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="Dev" />
     <Cmt Name="LcxAdmin" />
     <Cmt Name="Rccx" />
   </OwnedComments>
+  <Settings Name="@SettingsPath@\default.lss" Type="Lss" />
   <Item ItemId=";&lt;Description&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
     <Item ItemId="0;cdf30125985a60ac677caefc318833e8" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Code snippet for a switch argument for an argparse parser.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Codeschnipsel für ein Optionsargument für einen argparse-Parser.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="3" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;Title&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -19,8 +23,11 @@
     <Item ItemId="0;277d72dbe38cd017f4b02e7448bf146e" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[argparse switch argument]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[argparse-Optionsargument]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="1" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;ToolTip&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -28,20 +35,29 @@
     <Item ItemId="0;69ee1bdf53fb0aeed761c52c8d49693d" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Short argument name, typically only a single letter.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Kurzer Argumentname, in der Regel nur ein Buchstabe.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="5" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;75a55c928c79bdb03057db67af054e9e" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Long argument name, typically one or two words separated by a hyphen.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Langer Argumentname, in der Regel ein oder zwei Wörter, die durch einen Bindestrich getrennt sind.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="7" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;e7b23931982c94194e3886cd424afb72" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Description of the argument to display when called with --help/-h.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Beschreibung des Arguments, die bei Aufruf mit "--help/-h" angezeigt wird.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="9" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
-<Settings Name="@SettingsPath@\default.lss" Type="Lss" /></LCX>
+</LCX>

--- a/Python/loc/lcl/DEU/Snippets/Python/argparse.snippet.lcl
+++ b/Python/loc/lcl/DEU/Snippets/Python/argparse.snippet.lcl
@@ -1,17 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="D:\a\_work\1\b\raw\binaries\Snippets\Python\argparse.snippet" PsrId="210" SrcCul="en-US" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx" TgtCul="de-DE">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\21\b\raw\binaries\Snippets\Python\argparse.snippet" PsrId="210" FileType="1" SrcCul="en-US" TgtCul="de-DE" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="Dev" />
     <Cmt Name="LcxAdmin" />
     <Cmt Name="Rccx" />
   </OwnedComments>
+  <Settings Name="@SettingsPath@\default.lss" Type="Lss" />
   <Item ItemId=";&lt;Description&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
     <Item ItemId="0;efc9719c9afe3a8265e2a7e511a1cdc6" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Code snippet for a function to parse arguments using argparse]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Codeschnipsel für eine Funktion zum Analysieren von Argumenten mit argparse]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="3" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;Title&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -19,8 +23,11 @@
     <Item ItemId="0;4365422194f5997a16d7a169524e3d10" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[argparse block]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[argparse-Block]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="1" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;ToolTip&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -28,8 +35,11 @@
     <Item ItemId="0;62568bc5e481b7c2bf94f72978c34da4" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Short description of your script]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Kurze Beschreibung Ihres Skripts]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="5" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
-<Settings Name="@SettingsPath@\default.lss" Type="Lss" /></LCX>
+</LCX>

--- a/Python/loc/lcl/DEU/VCTargets/Win32/ImportAfter/Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml.lcl
+++ b/Python/loc/lcl/DEU/VCTargets/Win32/ImportAfter/Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml.lcl
@@ -1,23 +1,30 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="D:\a\_work\1\b\raw\binaries\VCTargets\Win32\ImportAfter\Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml" PsrId="22" SrcCul="en-US" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx" TgtCul="de-DE">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\20\b\raw\binaries\VCTargets\Win32\ImportAfter\Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml" PsrId="22" FileType="1" SrcCul="en-US" TgtCul="de-DE" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="Dev" />
     <Cmt Name="LcxAdmin" />
     <Cmt Name="Rccx" />
   </OwnedComments>
+  <Settings Name="@SettingsPath@\default.lss" Type="Lss" />
   <Item ItemId=";&lt;BoolProperty&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
     <Item ItemId="0;localdebuggermergeenvironment@BoolProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Merge specified environment variables with existing environment.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Führen Sie die Umgebungsvariablen mit der vorhandenen Umgebung zusammen.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="27" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggermergeenvironment@BoolProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Merge Environment]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Zusammenführungsumgebung]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="25" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;Rule&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -25,14 +32,20 @@
     <Item ItemId="0;pythondebuglaunchprovider@Rule@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Python/Native debugging options]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Python-/Native Debugoptionen]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="3" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;pythondebuglaunchprovider@Rule@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Python/Native Debugging]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Python-/Natives Debuggen]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="1" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;StringListProperty&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -40,14 +53,20 @@
     <Item ItemId="0;localdebuggerenvironment@StringListProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Specifies the environment for the debugee, or variables to merge with existing environment.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Gibt die Umgebung für die zu debuggende Komponente oder die Variablen an, die mit der vorhandenen Umgebung zusammengeführt werden sollen.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="23" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggerenvironment@StringListProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Environment]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Umgebung]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="21" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;StringProperty&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -55,38 +74,56 @@
     <Item ItemId="0;localdebuggercommand@StringProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[The debug command to execute.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Der auszuführende Debugbefehl.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="7" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggercommandarguments@StringProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[The command line arguments to pass to the application.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Die Befehlszeilenargumente, die an die Anwendung übergeben werden sollen.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="15" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggerworkingdirectory@StringProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[The application's working directory. By default, the directory containing the project file.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Das Arbeitsverzeichnis der Anwendung. Standardmäßig das Verzeichnis, das die Projektdatei enthält.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="19" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggercommand@StringProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Command]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Befehl]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="5" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggercommandarguments@StringProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Command Arguments]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Befehlsargumente]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="13" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggerworkingdirectory@StringProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Working Directory]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Arbeitsverzeichnis]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="17" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;ValueEditor&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -94,14 +131,20 @@
     <Item ItemId="0;5a88dad82b4127d481f86820c9fcbf98" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[<Edit...>]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[<Bearbeiten...>]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="9" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;b66ab1d4354799e0066c0af0ab39211f" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[<Browse...>]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[<Durchsuchen...>]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="11" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
-<Settings Name="@SettingsPath@\default.lss" Type="Lss" /></LCX>
+</LCX>

--- a/Python/loc/lcl/DEU/VCTargets/x64/ImportAfter/Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml.lcl
+++ b/Python/loc/lcl/DEU/VCTargets/x64/ImportAfter/Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml.lcl
@@ -1,23 +1,30 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="D:\a\_work\1\b\raw\binaries\VCTargets\x64\ImportAfter\Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml" PsrId="22" SrcCul="en-US" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx" TgtCul="de-DE">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\20\b\raw\binaries\VCTargets\Win32\ImportAfter\Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml" PsrId="22" FileType="1" SrcCul="en-US" TgtCul="de-DE" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="Dev" />
     <Cmt Name="LcxAdmin" />
     <Cmt Name="Rccx" />
   </OwnedComments>
+  <Settings Name="@SettingsPath@\default.lss" Type="Lss" />
   <Item ItemId=";&lt;BoolProperty&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
     <Item ItemId="0;localdebuggermergeenvironment@BoolProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Merge specified environment variables with existing environment.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Führen Sie die Umgebungsvariablen mit der vorhandenen Umgebung zusammen.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="27" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggermergeenvironment@BoolProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Merge Environment]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Zusammenführungsumgebung]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="25" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;Rule&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -25,14 +32,20 @@
     <Item ItemId="0;pythondebuglaunchprovider@Rule@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Python/Native debugging options]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Python-/Native Debugoptionen]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="3" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;pythondebuglaunchprovider@Rule@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Python/Native Debugging]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Python-/Natives Debuggen]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="1" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;StringListProperty&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -40,14 +53,20 @@
     <Item ItemId="0;localdebuggerenvironment@StringListProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Specifies the environment for the debugee, or variables to merge with existing environment.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Gibt die Umgebung für die zu debuggende Komponente oder die Variablen an, die mit der vorhandenen Umgebung zusammengeführt werden sollen.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="23" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggerenvironment@StringListProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Environment]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Umgebung]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="21" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;StringProperty&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -55,38 +74,56 @@
     <Item ItemId="0;localdebuggercommand@StringProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[The debug command to execute.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Der auszuführende Debugbefehl.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="7" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggercommandarguments@StringProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[The command line arguments to pass to the application.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Die Befehlszeilenargumente, die an die Anwendung übergeben werden sollen.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="15" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggerworkingdirectory@StringProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[The application's working directory. By default, the directory containing the project file.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Das Arbeitsverzeichnis der Anwendung. Standardmäßig das Verzeichnis, das die Projektdatei enthält.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="19" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggercommand@StringProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Command]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Befehl]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="5" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggercommandarguments@StringProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Command Arguments]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Befehlsargumente]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="13" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggerworkingdirectory@StringProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Working Directory]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Arbeitsverzeichnis]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="17" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;ValueEditor&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -94,14 +131,20 @@
     <Item ItemId="0;5a88dad82b4127d481f86820c9fcbf98" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[<Edit...>]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[<Bearbeiten...>]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="9" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;b66ab1d4354799e0066c0af0ab39211f" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[<Browse...>]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[<Durchsuchen...>]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="11" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
-<Settings Name="@SettingsPath@\default.lss" Type="Lss" /></LCX>
+</LCX>

--- a/Python/loc/lcl/ESN/Snippets/Python/arg_path.snippet.lcl
+++ b/Python/loc/lcl/ESN/Snippets/Python/arg_path.snippet.lcl
@@ -1,17 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="D:\a\_work\1\b\raw\binaries\Snippets\Python\arg_path.snippet" PsrId="210" SrcCul="en-US" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx" TgtCul="es-ES">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\21\b\raw\binaries\Snippets\Python\arg_path.snippet" PsrId="210" FileType="1" SrcCul="en-US" TgtCul="es-ES" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="Dev" />
     <Cmt Name="LcxAdmin" />
     <Cmt Name="Rccx" />
   </OwnedComments>
+  <Settings Name="@SettingsPath@\default.lss" Type="Lss" />
   <Item ItemId=";&lt;Description&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
     <Item ItemId="0;10b5db89840923ed3d0acc5fe287c167" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Code snippet for a path argument for an argparse parser.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Fragmento de código de un argumento de ruta de acceso para un analizador de argparse.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="3" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;Title&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -19,8 +23,11 @@
     <Item ItemId="0;1cf27f1348d9adf9704b2dff0db0d888" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[argparse path argument]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[argumento de ruta de acceso de argparse]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="1" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;ToolTip&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -28,26 +35,38 @@
     <Item ItemId="0;69ee1bdf53fb0aeed761c52c8d49693d" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Short argument name, typically only a single letter.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Nombre de argumento corto; normalmente, una sola letra.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="5" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;75a55c928c79bdb03057db67af054e9e" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Long argument name, typically one or two words separated by a hyphen.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Nombre de argumento largo; normalmente, una o dos palabras separadas por un guion.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="7" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;e7b23931982c94194e3886cd424afb72" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Description of the argument to display when called with --help/-h.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Descripción del argumento que se debe mostrar cuando se llama con el argumento --help/-h.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="11" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;ed36fc16d953d88706f27cad66ebb5f2" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Argument variable name.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Nombre de variable del argumento.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="9" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
-<Settings Name="@SettingsPath@\default.lss" Type="Lss" /></LCX>
+</LCX>

--- a/Python/loc/lcl/ESN/Snippets/Python/arg_path_positional.snippet.lcl
+++ b/Python/loc/lcl/ESN/Snippets/Python/arg_path_positional.snippet.lcl
@@ -1,17 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="D:\a\_work\1\b\raw\binaries\Snippets\Python\arg_path_positional.snippet" PsrId="210" SrcCul="en-US" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx" TgtCul="es-ES">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\21\b\raw\binaries\Snippets\Python\arg_path_positional.snippet" PsrId="210" FileType="1" SrcCul="en-US" TgtCul="es-ES" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="Dev" />
     <Cmt Name="LcxAdmin" />
     <Cmt Name="Rccx" />
   </OwnedComments>
+  <Settings Name="@SettingsPath@\default.lss" Type="Lss" />
   <Item ItemId=";&lt;Description&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
     <Item ItemId="0;12736a644fe557377d4f44fb250f3cc0" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Code snippet for a positional path argument for an argparse parser.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Fragmento de código de un argumento de ruta de acceso posicional para un analizador de argparse.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="3" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;Title&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -19,8 +23,11 @@
     <Item ItemId="0;5cb477ab75463262edfbf537292653c8" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[argparse positional path argument]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[argumento de ruta de acceso posicional de argparse]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="1" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;ToolTip&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -28,14 +35,20 @@
     <Item ItemId="0;35282756089c336d9b7432ac72d786f1" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Argument name. Start with a hyphen to require a switch, or omit to make it positional.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Nombre de argumento. Empiece con un guion para solicitar un modificador o bien no lo incluya para que sea posicional.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="5" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;e7b23931982c94194e3886cd424afb72" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Description of the argument to display when called with --help/-h.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Descripción del argumento que se debe mostrar cuando se llama con el argumento --help/-h.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="7" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
-<Settings Name="@SettingsPath@\default.lss" Type="Lss" /></LCX>
+</LCX>

--- a/Python/loc/lcl/ESN/Snippets/Python/arg_str.snippet.lcl
+++ b/Python/loc/lcl/ESN/Snippets/Python/arg_str.snippet.lcl
@@ -1,17 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="D:\a\_work\1\b\raw\binaries\Snippets\Python\arg_str.snippet" PsrId="210" SrcCul="en-US" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx" TgtCul="es-ES">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\21\b\raw\binaries\Snippets\Python\arg_str.snippet" PsrId="210" FileType="1" SrcCul="en-US" TgtCul="es-ES" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="Dev" />
     <Cmt Name="LcxAdmin" />
     <Cmt Name="Rccx" />
   </OwnedComments>
+  <Settings Name="@SettingsPath@\default.lss" Type="Lss" />
   <Item ItemId=";&lt;Description&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
     <Item ItemId="0;5162629d4963116ba811271091fe841d" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Code snippet for a string argument for an argparse parser.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Fragmento de código de un argumento de cadena para un analizador de argparse.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="3" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;Title&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -19,8 +23,11 @@
     <Item ItemId="0;8fbb5326dfe0bf71b7361d48e1a445c4" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[argparse string argument]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[argumento de cadena de argparse]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="1" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;ToolTip&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -28,26 +35,38 @@
     <Item ItemId="0;69ee1bdf53fb0aeed761c52c8d49693d" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Short argument name, typically only a single letter.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Nombre de argumento corto; normalmente, una sola letra.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="5" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;75a55c928c79bdb03057db67af054e9e" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Long argument name, typically one or two words separated by a hyphen.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Nombre de argumento largo; normalmente, una o dos palabras separadas por un guion.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="7" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;e7b23931982c94194e3886cd424afb72" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Description of the argument to display when called with --help/-h.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Descripción del argumento que se debe mostrar cuando se llama con el argumento --help/-h.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="11" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;ed36fc16d953d88706f27cad66ebb5f2" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Argument variable name.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Nombre de variable del argumento.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="9" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
-<Settings Name="@SettingsPath@\default.lss" Type="Lss" /></LCX>
+</LCX>

--- a/Python/loc/lcl/ESN/Snippets/Python/arg_str_positional.snippet.lcl
+++ b/Python/loc/lcl/ESN/Snippets/Python/arg_str_positional.snippet.lcl
@@ -1,17 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="D:\a\_work\1\b\raw\binaries\Snippets\Python\arg_str_positional.snippet" PsrId="210" SrcCul="en-US" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx" TgtCul="es-ES">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\21\b\raw\binaries\Snippets\Python\arg_str_positional.snippet" PsrId="210" FileType="1" SrcCul="en-US" TgtCul="es-ES" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="Dev" />
     <Cmt Name="LcxAdmin" />
     <Cmt Name="Rccx" />
   </OwnedComments>
+  <Settings Name="@SettingsPath@\default.lss" Type="Lss" />
   <Item ItemId=";&lt;Description&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
     <Item ItemId="0;69def699f0c2570190c042fc792b38c5" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Code snippet for a positional string argument for an argparse parser.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Fragmento de código de un argumento de cadena posicional para un analizador de argparse.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="3" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;Title&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -19,8 +23,11 @@
     <Item ItemId="0;9dbaae3dbddf131d3205155271f50641" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[argparse positional string argument]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[argumento de cadena posicional de argparse]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="1" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;ToolTip&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -28,14 +35,20 @@
     <Item ItemId="0;35282756089c336d9b7432ac72d786f1" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Argument name. Start with a hyphen to require a switch, or omit to make it positional.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Nombre de argumento. Empiece con un guion para solicitar un modificador o bien no lo incluya para que sea posicional.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="5" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;e7b23931982c94194e3886cd424afb72" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Description of the argument to display when called with --help/-h.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Descripción del argumento que se debe mostrar cuando se llama con el argumento --help/-h.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="7" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
-<Settings Name="@SettingsPath@\default.lss" Type="Lss" /></LCX>
+</LCX>

--- a/Python/loc/lcl/ESN/Snippets/Python/arg_switch.snippet.lcl
+++ b/Python/loc/lcl/ESN/Snippets/Python/arg_switch.snippet.lcl
@@ -1,17 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="D:\a\_work\1\b\raw\binaries\Snippets\Python\arg_switch.snippet" PsrId="210" SrcCul="en-US" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx" TgtCul="es-ES">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\21\b\raw\binaries\Snippets\Python\arg_switch.snippet" PsrId="210" FileType="1" SrcCul="en-US" TgtCul="es-ES" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="Dev" />
     <Cmt Name="LcxAdmin" />
     <Cmt Name="Rccx" />
   </OwnedComments>
+  <Settings Name="@SettingsPath@\default.lss" Type="Lss" />
   <Item ItemId=";&lt;Description&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
     <Item ItemId="0;cdf30125985a60ac677caefc318833e8" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Code snippet for a switch argument for an argparse parser.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Fragmento de código de un argumento de modificador para un analizador de argparse.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="3" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;Title&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -19,8 +23,11 @@
     <Item ItemId="0;277d72dbe38cd017f4b02e7448bf146e" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[argparse switch argument]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[argumento de modificador de argparse]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="1" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;ToolTip&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -28,20 +35,29 @@
     <Item ItemId="0;69ee1bdf53fb0aeed761c52c8d49693d" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Short argument name, typically only a single letter.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Nombre de argumento corto; normalmente, una sola letra.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="5" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;75a55c928c79bdb03057db67af054e9e" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Long argument name, typically one or two words separated by a hyphen.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Nombre de argumento largo; normalmente, una o dos palabras separadas por un guion.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="7" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;e7b23931982c94194e3886cd424afb72" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Description of the argument to display when called with --help/-h.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Descripción del argumento que se debe mostrar cuando se llama con el argumento --help/-h.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="9" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
-<Settings Name="@SettingsPath@\default.lss" Type="Lss" /></LCX>
+</LCX>

--- a/Python/loc/lcl/ESN/Snippets/Python/argparse.snippet.lcl
+++ b/Python/loc/lcl/ESN/Snippets/Python/argparse.snippet.lcl
@@ -1,17 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="D:\a\_work\1\b\raw\binaries\Snippets\Python\argparse.snippet" PsrId="210" SrcCul="en-US" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx" TgtCul="es-ES">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\21\b\raw\binaries\Snippets\Python\argparse.snippet" PsrId="210" FileType="1" SrcCul="en-US" TgtCul="es-ES" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="Dev" />
     <Cmt Name="LcxAdmin" />
     <Cmt Name="Rccx" />
   </OwnedComments>
+  <Settings Name="@SettingsPath@\default.lss" Type="Lss" />
   <Item ItemId=";&lt;Description&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
     <Item ItemId="0;efc9719c9afe3a8265e2a7e511a1cdc6" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Code snippet for a function to parse arguments using argparse]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Fragmento de código para que una función analice los argumentos utilizando argparse]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="3" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;Title&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -19,8 +23,11 @@
     <Item ItemId="0;4365422194f5997a16d7a169524e3d10" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[argparse block]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[bloque de argparse]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="1" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;ToolTip&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -28,8 +35,11 @@
     <Item ItemId="0;62568bc5e481b7c2bf94f72978c34da4" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Short description of your script]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Breve descripción del script]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="5" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
-<Settings Name="@SettingsPath@\default.lss" Type="Lss" /></LCX>
+</LCX>

--- a/Python/loc/lcl/ESN/VCTargets/Win32/ImportAfter/Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml.lcl
+++ b/Python/loc/lcl/ESN/VCTargets/Win32/ImportAfter/Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml.lcl
@@ -1,23 +1,30 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="D:\a\_work\1\b\raw\binaries\VCTargets\Win32\ImportAfter\Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml" PsrId="22" SrcCul="en-US" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx" TgtCul="es-ES">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\20\b\raw\binaries\VCTargets\Win32\ImportAfter\Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml" PsrId="22" FileType="1" SrcCul="en-US" TgtCul="es-ES" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="Dev" />
     <Cmt Name="LcxAdmin" />
     <Cmt Name="Rccx" />
   </OwnedComments>
+  <Settings Name="@SettingsPath@\default.lss" Type="Lss" />
   <Item ItemId=";&lt;BoolProperty&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
     <Item ItemId="0;localdebuggermergeenvironment@BoolProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Merge specified environment variables with existing environment.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Combina las variables de entorno especificadas con el entorno existente.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="27" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggermergeenvironment@BoolProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Merge Environment]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Combinar entorno]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="25" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;Rule&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -25,14 +32,20 @@
     <Item ItemId="0;pythondebuglaunchprovider@Rule@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Python/Native debugging options]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Opciones de depuración nativa/Python]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="3" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;pythondebuglaunchprovider@Rule@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Python/Native Debugging]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Depuración nativa/Python]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="1" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;StringListProperty&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -40,14 +53,20 @@
     <Item ItemId="0;localdebuggerenvironment@StringListProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Specifies the environment for the debugee, or variables to merge with existing environment.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Especifica el entorno del código que se va a depurar o las variables para combinar con el entorno existente.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="23" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggerenvironment@StringListProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Environment]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Entorno]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="21" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;StringProperty&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -55,38 +74,56 @@
     <Item ItemId="0;localdebuggercommand@StringProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[The debug command to execute.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Comando de depuración para ejecutar.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="7" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggercommandarguments@StringProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[The command line arguments to pass to the application.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Argumentos de la línea de comandos que se pasarán a la aplicación.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="15" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggerworkingdirectory@StringProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[The application's working directory. By default, the directory containing the project file.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Directorio de trabajo de la aplicación. De forma predeterminada, es el directorio que contiene el archivo de proyecto.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="19" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggercommand@StringProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Command]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Comando]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="5" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggercommandarguments@StringProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Command Arguments]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Argumentos de comandos]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="13" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggerworkingdirectory@StringProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Working Directory]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Directorio de trabajo]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="17" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;ValueEditor&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -94,14 +131,20 @@
     <Item ItemId="0;5a88dad82b4127d481f86820c9fcbf98" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[<Edit...>]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[<Editar...>]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="9" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;b66ab1d4354799e0066c0af0ab39211f" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[<Browse...>]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[<Examinar...>]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="11" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
-<Settings Name="@SettingsPath@\default.lss" Type="Lss" /></LCX>
+</LCX>

--- a/Python/loc/lcl/ESN/VCTargets/x64/ImportAfter/Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml.lcl
+++ b/Python/loc/lcl/ESN/VCTargets/x64/ImportAfter/Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml.lcl
@@ -1,23 +1,30 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="D:\a\_work\1\b\raw\binaries\VCTargets\x64\ImportAfter\Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml" PsrId="22" SrcCul="en-US" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx" TgtCul="es-ES">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\20\b\raw\binaries\VCTargets\Win32\ImportAfter\Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml" PsrId="22" FileType="1" SrcCul="en-US" TgtCul="es-ES" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="Dev" />
     <Cmt Name="LcxAdmin" />
     <Cmt Name="Rccx" />
   </OwnedComments>
+  <Settings Name="@SettingsPath@\default.lss" Type="Lss" />
   <Item ItemId=";&lt;BoolProperty&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
     <Item ItemId="0;localdebuggermergeenvironment@BoolProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Merge specified environment variables with existing environment.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Combina las variables de entorno especificadas con el entorno existente.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="27" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggermergeenvironment@BoolProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Merge Environment]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Combinar entorno]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="25" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;Rule&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -25,14 +32,20 @@
     <Item ItemId="0;pythondebuglaunchprovider@Rule@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Python/Native debugging options]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Opciones de depuración nativa/Python]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="3" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;pythondebuglaunchprovider@Rule@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Python/Native Debugging]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Depuración nativa/Python]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="1" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;StringListProperty&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -40,14 +53,20 @@
     <Item ItemId="0;localdebuggerenvironment@StringListProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Specifies the environment for the debugee, or variables to merge with existing environment.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Especifica el entorno del código que se va a depurar o las variables para combinar con el entorno existente.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="23" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggerenvironment@StringListProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Environment]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Entorno]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="21" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;StringProperty&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -55,38 +74,56 @@
     <Item ItemId="0;localdebuggercommand@StringProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[The debug command to execute.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Comando de depuración para ejecutar.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="7" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggercommandarguments@StringProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[The command line arguments to pass to the application.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Argumentos de la línea de comandos que se pasarán a la aplicación.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="15" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggerworkingdirectory@StringProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[The application's working directory. By default, the directory containing the project file.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Directorio de trabajo de la aplicación. De forma predeterminada, es el directorio que contiene el archivo de proyecto.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="19" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggercommand@StringProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Command]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Comando]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="5" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggercommandarguments@StringProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Command Arguments]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Argumentos de comandos]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="13" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggerworkingdirectory@StringProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Working Directory]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Directorio de trabajo]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="17" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;ValueEditor&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -94,14 +131,20 @@
     <Item ItemId="0;5a88dad82b4127d481f86820c9fcbf98" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[<Edit...>]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[<Editar...>]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="9" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;b66ab1d4354799e0066c0af0ab39211f" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[<Browse...>]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[<Examinar...>]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="11" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
-<Settings Name="@SettingsPath@\default.lss" Type="Lss" /></LCX>
+</LCX>

--- a/Python/loc/lcl/FRA/Snippets/Python/arg_path.snippet.lcl
+++ b/Python/loc/lcl/FRA/Snippets/Python/arg_path.snippet.lcl
@@ -1,17 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="D:\a\_work\1\b\raw\binaries\Snippets\Python\arg_path.snippet" PsrId="210" SrcCul="en-US" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx" TgtCul="fr-FR">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\21\b\raw\binaries\Snippets\Python\arg_path.snippet" PsrId="210" FileType="1" SrcCul="en-US" TgtCul="fr-FR" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="Dev" />
     <Cmt Name="LcxAdmin" />
     <Cmt Name="Rccx" />
   </OwnedComments>
+  <Settings Name="@SettingsPath@\default.lss" Type="Lss" />
   <Item ItemId=";&lt;Description&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
     <Item ItemId="0;10b5db89840923ed3d0acc5fe287c167" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Code snippet for a path argument for an argparse parser.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Extrait de code d'un argument de chemin pour un analyseur argparse.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="3" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;Title&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -19,8 +23,11 @@
     <Item ItemId="0;1cf27f1348d9adf9704b2dff0db0d888" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[argparse path argument]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[argument de chemin argparse]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="1" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;ToolTip&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -28,26 +35,38 @@
     <Item ItemId="0;69ee1bdf53fb0aeed761c52c8d49693d" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Short argument name, typically only a single letter.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Nom d'argument court, généralement une seule lettre.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="5" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;75a55c928c79bdb03057db67af054e9e" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Long argument name, typically one or two words separated by a hyphen.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Nom d'argument long, généralement un ou deux mots séparés par un trait d'union.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="7" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;e7b23931982c94194e3886cd424afb72" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Description of the argument to display when called with --help/-h.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Description de l'argument à afficher quand il est appelé avec --help/-h.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="11" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;ed36fc16d953d88706f27cad66ebb5f2" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Argument variable name.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Nom de la variable d'argument.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="9" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
-<Settings Name="@SettingsPath@\default.lss" Type="Lss" /></LCX>
+</LCX>

--- a/Python/loc/lcl/FRA/Snippets/Python/arg_path_positional.snippet.lcl
+++ b/Python/loc/lcl/FRA/Snippets/Python/arg_path_positional.snippet.lcl
@@ -1,17 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="D:\a\_work\1\b\raw\binaries\Snippets\Python\arg_path_positional.snippet" PsrId="210" SrcCul="en-US" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx" TgtCul="fr-FR">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\21\b\raw\binaries\Snippets\Python\arg_path_positional.snippet" PsrId="210" FileType="1" SrcCul="en-US" TgtCul="fr-FR" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="Dev" />
     <Cmt Name="LcxAdmin" />
     <Cmt Name="Rccx" />
   </OwnedComments>
+  <Settings Name="@SettingsPath@\default.lss" Type="Lss" />
   <Item ItemId=";&lt;Description&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
     <Item ItemId="0;12736a644fe557377d4f44fb250f3cc0" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Code snippet for a positional path argument for an argparse parser.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Extrait de code d'un argument de chemin positionnel pour un analyseur argparse.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="3" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;Title&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -19,8 +23,11 @@
     <Item ItemId="0;5cb477ab75463262edfbf537292653c8" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[argparse positional path argument]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[argument de chemin positionnel argparse]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="1" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;ToolTip&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -28,14 +35,20 @@
     <Item ItemId="0;35282756089c336d9b7432ac72d786f1" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Argument name. Start with a hyphen to require a switch, or omit to make it positional.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Nom de l'argument. Commencez avec un trait d'union pour demander un commutateur ou ne le rendez pas positionnel.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="5" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;e7b23931982c94194e3886cd424afb72" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Description of the argument to display when called with --help/-h.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Description de l'argument à afficher quand il est appelé avec --help/-h.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="7" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
-<Settings Name="@SettingsPath@\default.lss" Type="Lss" /></LCX>
+</LCX>

--- a/Python/loc/lcl/FRA/Snippets/Python/arg_str.snippet.lcl
+++ b/Python/loc/lcl/FRA/Snippets/Python/arg_str.snippet.lcl
@@ -1,17 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="D:\a\_work\1\b\raw\binaries\Snippets\Python\arg_str.snippet" PsrId="210" SrcCul="en-US" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx" TgtCul="fr-FR">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\21\b\raw\binaries\Snippets\Python\arg_str.snippet" PsrId="210" FileType="1" SrcCul="en-US" TgtCul="fr-FR" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="Dev" />
     <Cmt Name="LcxAdmin" />
     <Cmt Name="Rccx" />
   </OwnedComments>
+  <Settings Name="@SettingsPath@\default.lss" Type="Lss" />
   <Item ItemId=";&lt;Description&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
     <Item ItemId="0;5162629d4963116ba811271091fe841d" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Code snippet for a string argument for an argparse parser.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Extrait de code d'un argument de chaîne pour un analyseur argparse.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="3" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;Title&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -19,8 +23,11 @@
     <Item ItemId="0;8fbb5326dfe0bf71b7361d48e1a445c4" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[argparse string argument]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[argument de chaîne argparse]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="1" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;ToolTip&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -28,26 +35,38 @@
     <Item ItemId="0;69ee1bdf53fb0aeed761c52c8d49693d" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Short argument name, typically only a single letter.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Nom d'argument court, généralement une seule lettre.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="5" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;75a55c928c79bdb03057db67af054e9e" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Long argument name, typically one or two words separated by a hyphen.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Nom d'argument long, généralement un ou deux mots séparés par un trait d'union.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="7" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;e7b23931982c94194e3886cd424afb72" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Description of the argument to display when called with --help/-h.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Description de l'argument à afficher quand il est appelé avec --help/-h.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="11" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;ed36fc16d953d88706f27cad66ebb5f2" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Argument variable name.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Nom de la variable d'argument.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="9" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
-<Settings Name="@SettingsPath@\default.lss" Type="Lss" /></LCX>
+</LCX>

--- a/Python/loc/lcl/FRA/Snippets/Python/arg_str_positional.snippet.lcl
+++ b/Python/loc/lcl/FRA/Snippets/Python/arg_str_positional.snippet.lcl
@@ -1,17 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="D:\a\_work\1\b\raw\binaries\Snippets\Python\arg_str_positional.snippet" PsrId="210" SrcCul="en-US" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx" TgtCul="fr-FR">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\21\b\raw\binaries\Snippets\Python\arg_str_positional.snippet" PsrId="210" FileType="1" SrcCul="en-US" TgtCul="fr-FR" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="Dev" />
     <Cmt Name="LcxAdmin" />
     <Cmt Name="Rccx" />
   </OwnedComments>
+  <Settings Name="@SettingsPath@\default.lss" Type="Lss" />
   <Item ItemId=";&lt;Description&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
     <Item ItemId="0;69def699f0c2570190c042fc792b38c5" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Code snippet for a positional string argument for an argparse parser.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Extrait de code d'un argument de chaîne positionnel pour un analyseur argparse.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="3" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;Title&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -19,8 +23,11 @@
     <Item ItemId="0;9dbaae3dbddf131d3205155271f50641" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[argparse positional string argument]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[argument de chaîne positionnel argparse]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="1" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;ToolTip&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -28,14 +35,20 @@
     <Item ItemId="0;35282756089c336d9b7432ac72d786f1" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Argument name. Start with a hyphen to require a switch, or omit to make it positional.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Nom de l'argument. Commencez avec un trait d'union pour demander un commutateur ou ne le rendez pas positionnel.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="5" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;e7b23931982c94194e3886cd424afb72" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Description of the argument to display when called with --help/-h.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Description de l'argument à afficher quand il est appelé avec --help/-h.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="7" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
-<Settings Name="@SettingsPath@\default.lss" Type="Lss" /></LCX>
+</LCX>

--- a/Python/loc/lcl/FRA/Snippets/Python/arg_switch.snippet.lcl
+++ b/Python/loc/lcl/FRA/Snippets/Python/arg_switch.snippet.lcl
@@ -1,17 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="D:\a\_work\1\b\raw\binaries\Snippets\Python\arg_switch.snippet" PsrId="210" SrcCul="en-US" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx" TgtCul="fr-FR">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\21\b\raw\binaries\Snippets\Python\arg_switch.snippet" PsrId="210" FileType="1" SrcCul="en-US" TgtCul="fr-FR" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="Dev" />
     <Cmt Name="LcxAdmin" />
     <Cmt Name="Rccx" />
   </OwnedComments>
+  <Settings Name="@SettingsPath@\default.lss" Type="Lss" />
   <Item ItemId=";&lt;Description&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
     <Item ItemId="0;cdf30125985a60ac677caefc318833e8" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Code snippet for a switch argument for an argparse parser.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Extrait de code d'un argument de commutateur pour un analyseur argparse.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="3" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;Title&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -19,8 +23,11 @@
     <Item ItemId="0;277d72dbe38cd017f4b02e7448bf146e" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[argparse switch argument]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[argument de commutateur argparse]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="1" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;ToolTip&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -28,20 +35,29 @@
     <Item ItemId="0;69ee1bdf53fb0aeed761c52c8d49693d" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Short argument name, typically only a single letter.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Nom d'argument court, généralement une seule lettre.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="5" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;75a55c928c79bdb03057db67af054e9e" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Long argument name, typically one or two words separated by a hyphen.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Nom d'argument long, généralement un ou deux mots séparés par un trait d'union.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="7" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;e7b23931982c94194e3886cd424afb72" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Description of the argument to display when called with --help/-h.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Description de l'argument à afficher quand il est appelé avec --help/-h.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="9" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
-<Settings Name="@SettingsPath@\default.lss" Type="Lss" /></LCX>
+</LCX>

--- a/Python/loc/lcl/FRA/Snippets/Python/argparse.snippet.lcl
+++ b/Python/loc/lcl/FRA/Snippets/Python/argparse.snippet.lcl
@@ -1,17 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="D:\a\_work\1\b\raw\binaries\Snippets\Python\argparse.snippet" PsrId="210" SrcCul="en-US" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx" TgtCul="fr-FR">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\21\b\raw\binaries\Snippets\Python\argparse.snippet" PsrId="210" FileType="1" SrcCul="en-US" TgtCul="fr-FR" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="Dev" />
     <Cmt Name="LcxAdmin" />
     <Cmt Name="Rccx" />
   </OwnedComments>
+  <Settings Name="@SettingsPath@\default.lss" Type="Lss" />
   <Item ItemId=";&lt;Description&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
     <Item ItemId="0;efc9719c9afe3a8265e2a7e511a1cdc6" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Code snippet for a function to parse arguments using argparse]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Extrait de code d'une fonction permettant d'analyser des arguments avec argparse]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="3" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;Title&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -19,8 +23,11 @@
     <Item ItemId="0;4365422194f5997a16d7a169524e3d10" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[argparse block]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[bloc argparse]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="1" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;ToolTip&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -28,8 +35,11 @@
     <Item ItemId="0;62568bc5e481b7c2bf94f72978c34da4" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Short description of your script]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Brève description de votre script]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="5" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
-<Settings Name="@SettingsPath@\default.lss" Type="Lss" /></LCX>
+</LCX>

--- a/Python/loc/lcl/FRA/VCTargets/Win32/ImportAfter/Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml.lcl
+++ b/Python/loc/lcl/FRA/VCTargets/Win32/ImportAfter/Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml.lcl
@@ -1,23 +1,30 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="D:\a\_work\1\b\raw\binaries\VCTargets\Win32\ImportAfter\Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml" PsrId="22" SrcCul="en-US" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx" TgtCul="fr-FR">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\20\b\raw\binaries\VCTargets\Win32\ImportAfter\Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml" PsrId="22" FileType="1" SrcCul="en-US" TgtCul="fr-FR" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="Dev" />
     <Cmt Name="LcxAdmin" />
     <Cmt Name="Rccx" />
   </OwnedComments>
+  <Settings Name="@SettingsPath@\default.lss" Type="Lss" />
   <Item ItemId=";&lt;BoolProperty&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
     <Item ItemId="0;localdebuggermergeenvironment@BoolProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Merge specified environment variables with existing environment.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Fusionne les variables d'environnement spécifiées avec l'environnement existant.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="27" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggermergeenvironment@BoolProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Merge Environment]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Fusion de l'environnement]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="25" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;Rule&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -25,14 +32,20 @@
     <Item ItemId="0;pythondebuglaunchprovider@Rule@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Python/Native debugging options]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Options de débogage Python/natif]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="3" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;pythondebuglaunchprovider@Rule@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Python/Native Debugging]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Débogage Python/natif]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="1" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;StringListProperty&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -40,14 +53,20 @@
     <Item ItemId="0;localdebuggerenvironment@StringListProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Specifies the environment for the debugee, or variables to merge with existing environment.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Spécifie l'environnement du débogueur ou les variables à fusionner avec l'environnement existant.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="23" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggerenvironment@StringListProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Environment]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Environnement]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="21" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;StringProperty&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -55,38 +74,56 @@
     <Item ItemId="0;localdebuggercommand@StringProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[The debug command to execute.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Commande de débogage à exécuter.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="7" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggercommandarguments@StringProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[The command line arguments to pass to the application.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Spécifie les arguments de la ligne de commande qui doivent être passés à l'application.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="15" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggerworkingdirectory@StringProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[The application's working directory. By default, the directory containing the project file.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Spécifie le répertoire de travail de l'application. Par défaut, il s'agit du répertoire contenant le fichier projet.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="19" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggercommand@StringProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Command]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Commande]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="5" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggercommandarguments@StringProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Command Arguments]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Arguments de la commande]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="13" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggerworkingdirectory@StringProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Working Directory]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Répertoire de travail]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="17" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;ValueEditor&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -94,14 +131,20 @@
     <Item ItemId="0;5a88dad82b4127d481f86820c9fcbf98" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[<Edit...>]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[<Modifier...>]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="9" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;b66ab1d4354799e0066c0af0ab39211f" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[<Browse...>]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[<Parcourir...>]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="11" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
-<Settings Name="@SettingsPath@\default.lss" Type="Lss" /></LCX>
+</LCX>

--- a/Python/loc/lcl/FRA/VCTargets/x64/ImportAfter/Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml.lcl
+++ b/Python/loc/lcl/FRA/VCTargets/x64/ImportAfter/Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml.lcl
@@ -1,23 +1,30 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="D:\a\_work\1\b\raw\binaries\VCTargets\x64\ImportAfter\Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml" PsrId="22" SrcCul="en-US" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx" TgtCul="fr-FR">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\20\b\raw\binaries\VCTargets\Win32\ImportAfter\Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml" PsrId="22" FileType="1" SrcCul="en-US" TgtCul="fr-FR" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="Dev" />
     <Cmt Name="LcxAdmin" />
     <Cmt Name="Rccx" />
   </OwnedComments>
+  <Settings Name="@SettingsPath@\default.lss" Type="Lss" />
   <Item ItemId=";&lt;BoolProperty&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
     <Item ItemId="0;localdebuggermergeenvironment@BoolProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Merge specified environment variables with existing environment.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Fusionne les variables d'environnement spécifiées avec l'environnement existant.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="27" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggermergeenvironment@BoolProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Merge Environment]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Fusion de l'environnement]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="25" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;Rule&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -25,14 +32,20 @@
     <Item ItemId="0;pythondebuglaunchprovider@Rule@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Python/Native debugging options]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Options de débogage Python/natif]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="3" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;pythondebuglaunchprovider@Rule@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Python/Native Debugging]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Débogage Python/natif]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="1" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;StringListProperty&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -40,14 +53,20 @@
     <Item ItemId="0;localdebuggerenvironment@StringListProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Specifies the environment for the debugee, or variables to merge with existing environment.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Spécifie l'environnement du débogueur ou les variables à fusionner avec l'environnement existant.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="23" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggerenvironment@StringListProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Environment]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Environnement]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="21" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;StringProperty&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -55,38 +74,56 @@
     <Item ItemId="0;localdebuggercommand@StringProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[The debug command to execute.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Commande de débogage à exécuter.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="7" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggercommandarguments@StringProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[The command line arguments to pass to the application.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Spécifie les arguments de la ligne de commande qui doivent être passés à l'application.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="15" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggerworkingdirectory@StringProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[The application's working directory. By default, the directory containing the project file.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Spécifie le répertoire de travail de l'application. Par défaut, il s'agit du répertoire contenant le fichier projet.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="19" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggercommand@StringProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Command]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Commande]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="5" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggercommandarguments@StringProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Command Arguments]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Arguments de la commande]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="13" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggerworkingdirectory@StringProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Working Directory]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Répertoire de travail]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="17" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;ValueEditor&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -94,14 +131,20 @@
     <Item ItemId="0;5a88dad82b4127d481f86820c9fcbf98" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[<Edit...>]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[<Modifier...>]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="9" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;b66ab1d4354799e0066c0af0ab39211f" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[<Browse...>]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[<Parcourir...>]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="11" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
-<Settings Name="@SettingsPath@\default.lss" Type="Lss" /></LCX>
+</LCX>

--- a/Python/loc/lcl/ITA/Snippets/Python/arg_path.snippet.lcl
+++ b/Python/loc/lcl/ITA/Snippets/Python/arg_path.snippet.lcl
@@ -1,17 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="D:\a\_work\1\b\raw\binaries\Snippets\Python\arg_path.snippet" PsrId="210" SrcCul="en-US" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx" TgtCul="it-IT">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\21\b\raw\binaries\Snippets\Python\arg_path.snippet" PsrId="210" FileType="1" SrcCul="en-US" TgtCul="it-IT" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="Dev" />
     <Cmt Name="LcxAdmin" />
     <Cmt Name="Rccx" />
   </OwnedComments>
+  <Settings Name="@SettingsPath@\default.lss" Type="Lss" />
   <Item ItemId=";&lt;Description&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
     <Item ItemId="0;10b5db89840923ed3d0acc5fe287c167" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Code snippet for a path argument for an argparse parser.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Frammento di codice di un argomento path per un parser argparse.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="3" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;Title&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -19,8 +23,11 @@
     <Item ItemId="0;1cf27f1348d9adf9704b2dff0db0d888" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[argparse path argument]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[argomento path argparse]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="1" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;ToolTip&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -28,26 +35,38 @@
     <Item ItemId="0;69ee1bdf53fb0aeed761c52c8d49693d" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Short argument name, typically only a single letter.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Nome argomento breve, in genere una sola lettera.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="5" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;75a55c928c79bdb03057db67af054e9e" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Long argument name, typically one or two words separated by a hyphen.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Nome argomento lungo, in genere una o due parole separate da un trattino.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="7" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;e7b23931982c94194e3886cd424afb72" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Description of the argument to display when called with --help/-h.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Descrizione dell'argomento da visualizzare quando viene chiamato con --help/-h.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="11" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;ed36fc16d953d88706f27cad66ebb5f2" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Argument variable name.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Nome variabile dell'argomento.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="9" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
-<Settings Name="@SettingsPath@\default.lss" Type="Lss" /></LCX>
+</LCX>

--- a/Python/loc/lcl/ITA/Snippets/Python/arg_path_positional.snippet.lcl
+++ b/Python/loc/lcl/ITA/Snippets/Python/arg_path_positional.snippet.lcl
@@ -1,17 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="D:\a\_work\1\b\raw\binaries\Snippets\Python\arg_path_positional.snippet" PsrId="210" SrcCul="en-US" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx" TgtCul="it-IT">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\21\b\raw\binaries\Snippets\Python\arg_path_positional.snippet" PsrId="210" FileType="1" SrcCul="en-US" TgtCul="it-IT" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="Dev" />
     <Cmt Name="LcxAdmin" />
     <Cmt Name="Rccx" />
   </OwnedComments>
+  <Settings Name="@SettingsPath@\default.lss" Type="Lss" />
   <Item ItemId=";&lt;Description&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
     <Item ItemId="0;12736a644fe557377d4f44fb250f3cc0" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Code snippet for a positional path argument for an argparse parser.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Frammento di codice di un argomento path posizionale per un parser argparse.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="3" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;Title&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -19,8 +23,11 @@
     <Item ItemId="0;5cb477ab75463262edfbf537292653c8" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[argparse positional path argument]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[argomento path posizionale argparse]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="1" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;ToolTip&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -28,14 +35,20 @@
     <Item ItemId="0;35282756089c336d9b7432ac72d786f1" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Argument name. Start with a hyphen to require a switch, or omit to make it positional.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Nome dell'argomento. Iniziare con un trattino per richiedere un'opzione o ometterlo per renderlo posizionale.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="5" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;e7b23931982c94194e3886cd424afb72" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Description of the argument to display when called with --help/-h.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Descrizione dell'argomento da visualizzare quando viene chiamato con --help/-h.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="7" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
-<Settings Name="@SettingsPath@\default.lss" Type="Lss" /></LCX>
+</LCX>

--- a/Python/loc/lcl/ITA/Snippets/Python/arg_str.snippet.lcl
+++ b/Python/loc/lcl/ITA/Snippets/Python/arg_str.snippet.lcl
@@ -1,17 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="D:\a\_work\1\b\raw\binaries\Snippets\Python\arg_str.snippet" PsrId="210" SrcCul="en-US" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx" TgtCul="it-IT">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\21\b\raw\binaries\Snippets\Python\arg_str.snippet" PsrId="210" FileType="1" SrcCul="en-US" TgtCul="it-IT" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="Dev" />
     <Cmt Name="LcxAdmin" />
     <Cmt Name="Rccx" />
   </OwnedComments>
+  <Settings Name="@SettingsPath@\default.lss" Type="Lss" />
   <Item ItemId=";&lt;Description&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
     <Item ItemId="0;5162629d4963116ba811271091fe841d" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Code snippet for a string argument for an argparse parser.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Frammento di codice di un argomento string per un parser argparse.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="3" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;Title&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -19,8 +23,11 @@
     <Item ItemId="0;8fbb5326dfe0bf71b7361d48e1a445c4" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[argparse string argument]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[argomento string argparse]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="1" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;ToolTip&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -28,26 +35,38 @@
     <Item ItemId="0;69ee1bdf53fb0aeed761c52c8d49693d" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Short argument name, typically only a single letter.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Nome argomento breve, in genere una sola lettera.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="5" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;75a55c928c79bdb03057db67af054e9e" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Long argument name, typically one or two words separated by a hyphen.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Nome argomento lungo, in genere una o due parole separate da un trattino.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="7" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;e7b23931982c94194e3886cd424afb72" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Description of the argument to display when called with --help/-h.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Descrizione dell'argomento da visualizzare quando viene chiamato con --help/-h.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="11" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;ed36fc16d953d88706f27cad66ebb5f2" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Argument variable name.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Nome variabile dell'argomento.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="9" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
-<Settings Name="@SettingsPath@\default.lss" Type="Lss" /></LCX>
+</LCX>

--- a/Python/loc/lcl/ITA/Snippets/Python/arg_str_positional.snippet.lcl
+++ b/Python/loc/lcl/ITA/Snippets/Python/arg_str_positional.snippet.lcl
@@ -1,17 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="D:\a\_work\1\b\raw\binaries\Snippets\Python\arg_str_positional.snippet" PsrId="210" SrcCul="en-US" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx" TgtCul="it-IT">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\21\b\raw\binaries\Snippets\Python\arg_str_positional.snippet" PsrId="210" FileType="1" SrcCul="en-US" TgtCul="it-IT" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="Dev" />
     <Cmt Name="LcxAdmin" />
     <Cmt Name="Rccx" />
   </OwnedComments>
+  <Settings Name="@SettingsPath@\default.lss" Type="Lss" />
   <Item ItemId=";&lt;Description&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
     <Item ItemId="0;69def699f0c2570190c042fc792b38c5" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Code snippet for a positional string argument for an argparse parser.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Frammento di codice di un argomento string posizionale per un parser argparse.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="3" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;Title&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -19,8 +23,11 @@
     <Item ItemId="0;9dbaae3dbddf131d3205155271f50641" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[argparse positional string argument]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[argomento string posizionale argparse]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="1" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;ToolTip&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -28,14 +35,20 @@
     <Item ItemId="0;35282756089c336d9b7432ac72d786f1" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Argument name. Start with a hyphen to require a switch, or omit to make it positional.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Nome dell'argomento. Iniziare con un trattino per richiedere un'opzione o ometterlo per renderlo posizionale.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="5" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;e7b23931982c94194e3886cd424afb72" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Description of the argument to display when called with --help/-h.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Descrizione dell'argomento da visualizzare quando viene chiamato con --help/-h.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="7" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
-<Settings Name="@SettingsPath@\default.lss" Type="Lss" /></LCX>
+</LCX>

--- a/Python/loc/lcl/ITA/Snippets/Python/arg_switch.snippet.lcl
+++ b/Python/loc/lcl/ITA/Snippets/Python/arg_switch.snippet.lcl
@@ -1,17 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="D:\a\_work\1\b\raw\binaries\Snippets\Python\arg_switch.snippet" PsrId="210" SrcCul="en-US" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx" TgtCul="it-IT">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\21\b\raw\binaries\Snippets\Python\arg_switch.snippet" PsrId="210" FileType="1" SrcCul="en-US" TgtCul="it-IT" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="Dev" />
     <Cmt Name="LcxAdmin" />
     <Cmt Name="Rccx" />
   </OwnedComments>
+  <Settings Name="@SettingsPath@\default.lss" Type="Lss" />
   <Item ItemId=";&lt;Description&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
     <Item ItemId="0;cdf30125985a60ac677caefc318833e8" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Code snippet for a switch argument for an argparse parser.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Frammento di codice di un argomento switch per un parser argparse.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="3" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;Title&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -19,8 +23,11 @@
     <Item ItemId="0;277d72dbe38cd017f4b02e7448bf146e" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[argparse switch argument]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[argomento switch argparse]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="1" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;ToolTip&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -28,20 +35,29 @@
     <Item ItemId="0;69ee1bdf53fb0aeed761c52c8d49693d" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Short argument name, typically only a single letter.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Nome argomento breve, in genere una sola lettera.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="5" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;75a55c928c79bdb03057db67af054e9e" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Long argument name, typically one or two words separated by a hyphen.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Nome argomento lungo, in genere una o due parole separate da un trattino.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="7" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;e7b23931982c94194e3886cd424afb72" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Description of the argument to display when called with --help/-h.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Descrizione dell'argomento da visualizzare quando viene chiamato con --help/-h.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="9" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
-<Settings Name="@SettingsPath@\default.lss" Type="Lss" /></LCX>
+</LCX>

--- a/Python/loc/lcl/ITA/Snippets/Python/argparse.snippet.lcl
+++ b/Python/loc/lcl/ITA/Snippets/Python/argparse.snippet.lcl
@@ -1,17 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="D:\a\_work\1\b\raw\binaries\Snippets\Python\argparse.snippet" PsrId="210" SrcCul="en-US" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx" TgtCul="it-IT">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\21\b\raw\binaries\Snippets\Python\argparse.snippet" PsrId="210" FileType="1" SrcCul="en-US" TgtCul="it-IT" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="Dev" />
     <Cmt Name="LcxAdmin" />
     <Cmt Name="Rccx" />
   </OwnedComments>
+  <Settings Name="@SettingsPath@\default.lss" Type="Lss" />
   <Item ItemId=";&lt;Description&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
     <Item ItemId="0;efc9719c9afe3a8265e2a7e511a1cdc6" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Code snippet for a function to parse arguments using argparse]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Frammento di codice di una funzione per analizzare gli argomenti con argparse]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="3" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;Title&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -19,8 +23,11 @@
     <Item ItemId="0;4365422194f5997a16d7a169524e3d10" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[argparse block]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[blocco argparse]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="1" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;ToolTip&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -28,8 +35,11 @@
     <Item ItemId="0;62568bc5e481b7c2bf94f72978c34da4" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Short description of your script]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Breve descrizione dello script]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="5" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
-<Settings Name="@SettingsPath@\default.lss" Type="Lss" /></LCX>
+</LCX>

--- a/Python/loc/lcl/ITA/VCTargets/Win32/ImportAfter/Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml.lcl
+++ b/Python/loc/lcl/ITA/VCTargets/Win32/ImportAfter/Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml.lcl
@@ -1,23 +1,30 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="D:\a\_work\1\b\raw\binaries\VCTargets\Win32\ImportAfter\Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml" PsrId="22" SrcCul="en-US" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx" TgtCul="it-IT">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\20\b\raw\binaries\VCTargets\Win32\ImportAfter\Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml" PsrId="22" FileType="1" SrcCul="en-US" TgtCul="it-IT" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="Dev" />
     <Cmt Name="LcxAdmin" />
     <Cmt Name="Rccx" />
   </OwnedComments>
+  <Settings Name="@SettingsPath@\default.lss" Type="Lss" />
   <Item ItemId=";&lt;BoolProperty&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
     <Item ItemId="0;localdebuggermergeenvironment@BoolProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Merge specified environment variables with existing environment.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Unisce le variabili di ambiente specificate con l'ambiente esistente.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="27" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggermergeenvironment@BoolProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Merge Environment]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Unisci ambiente]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="25" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;Rule&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -25,14 +32,20 @@
     <Item ItemId="0;pythondebuglaunchprovider@Rule@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Python/Native debugging options]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Opzioni di debug Python/nativo]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="3" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;pythondebuglaunchprovider@Rule@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Python/Native Debugging]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Debug Python/nativo]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="1" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;StringListProperty&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -40,14 +53,20 @@
     <Item ItemId="0;localdebuggerenvironment@StringListProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Specifies the environment for the debugee, or variables to merge with existing environment.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Specifica l'ambiente per l'oggetto del debug o le variabili da unire con l'ambiente esistente.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="23" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggerenvironment@StringListProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Environment]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Ambiente]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="21" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;StringProperty&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -55,38 +74,56 @@
     <Item ItemId="0;localdebuggercommand@StringProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[The debug command to execute.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Comando di debug da eseguire.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="7" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggercommandarguments@StringProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[The command line arguments to pass to the application.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Argomenti della riga di comando da passare all'applicazione.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="15" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggerworkingdirectory@StringProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[The application's working directory. By default, the directory containing the project file.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Directory di lavoro dell'applicazione. Per impostazione predefinita, è la directory contenente il file di progetto.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="19" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggercommand@StringProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Command]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Comando]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="5" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggercommandarguments@StringProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Command Arguments]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Argomenti del comando]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="13" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggerworkingdirectory@StringProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Working Directory]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Directory di lavoro]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="17" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;ValueEditor&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -94,14 +131,20 @@
     <Item ItemId="0;5a88dad82b4127d481f86820c9fcbf98" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[<Edit...>]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[<Modifica...>]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="9" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;b66ab1d4354799e0066c0af0ab39211f" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[<Browse...>]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[<Sfoglia...>]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="11" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
-<Settings Name="@SettingsPath@\default.lss" Type="Lss" /></LCX>
+</LCX>

--- a/Python/loc/lcl/ITA/VCTargets/x64/ImportAfter/Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml.lcl
+++ b/Python/loc/lcl/ITA/VCTargets/x64/ImportAfter/Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml.lcl
@@ -1,23 +1,30 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="D:\a\_work\1\b\raw\binaries\VCTargets\x64\ImportAfter\Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml" PsrId="22" SrcCul="en-US" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx" TgtCul="it-IT">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\20\b\raw\binaries\VCTargets\Win32\ImportAfter\Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml" PsrId="22" FileType="1" SrcCul="en-US" TgtCul="it-IT" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="Dev" />
     <Cmt Name="LcxAdmin" />
     <Cmt Name="Rccx" />
   </OwnedComments>
+  <Settings Name="@SettingsPath@\default.lss" Type="Lss" />
   <Item ItemId=";&lt;BoolProperty&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
     <Item ItemId="0;localdebuggermergeenvironment@BoolProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Merge specified environment variables with existing environment.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Unisce le variabili di ambiente specificate con l'ambiente esistente.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="27" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggermergeenvironment@BoolProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Merge Environment]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Unisci ambiente]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="25" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;Rule&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -25,14 +32,20 @@
     <Item ItemId="0;pythondebuglaunchprovider@Rule@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Python/Native debugging options]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Opzioni di debug Python/nativo]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="3" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;pythondebuglaunchprovider@Rule@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Python/Native Debugging]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Debug Python/nativo]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="1" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;StringListProperty&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -40,14 +53,20 @@
     <Item ItemId="0;localdebuggerenvironment@StringListProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Specifies the environment for the debugee, or variables to merge with existing environment.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Specifica l'ambiente per l'oggetto del debug o le variabili da unire con l'ambiente esistente.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="23" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggerenvironment@StringListProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Environment]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Ambiente]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="21" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;StringProperty&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -55,38 +74,56 @@
     <Item ItemId="0;localdebuggercommand@StringProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[The debug command to execute.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Comando di debug da eseguire.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="7" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggercommandarguments@StringProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[The command line arguments to pass to the application.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Argomenti della riga di comando da passare all'applicazione.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="15" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggerworkingdirectory@StringProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[The application's working directory. By default, the directory containing the project file.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Directory di lavoro dell'applicazione. Per impostazione predefinita, è la directory contenente il file di progetto.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="19" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggercommand@StringProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Command]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Comando]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="5" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggercommandarguments@StringProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Command Arguments]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Argomenti del comando]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="13" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggerworkingdirectory@StringProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Working Directory]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Directory di lavoro]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="17" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;ValueEditor&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -94,14 +131,20 @@
     <Item ItemId="0;5a88dad82b4127d481f86820c9fcbf98" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[<Edit...>]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[<Modifica...>]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="9" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;b66ab1d4354799e0066c0af0ab39211f" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[<Browse...>]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[<Sfoglia...>]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="11" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
-<Settings Name="@SettingsPath@\default.lss" Type="Lss" /></LCX>
+</LCX>

--- a/Python/loc/lcl/JPN/Snippets/Python/arg_path.snippet.lcl
+++ b/Python/loc/lcl/JPN/Snippets/Python/arg_path.snippet.lcl
@@ -1,17 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="D:\a\_work\1\b\raw\binaries\Snippets\Python\arg_path.snippet" PsrId="210" SrcCul="en-US" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx" TgtCul="ja-JP">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\21\b\raw\binaries\Snippets\Python\arg_path.snippet" PsrId="210" FileType="1" SrcCul="en-US" TgtCul="ja-JP" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="Dev" />
     <Cmt Name="LcxAdmin" />
     <Cmt Name="Rccx" />
   </OwnedComments>
+  <Settings Name="@SettingsPath@\default.lss" Type="Lss" />
   <Item ItemId=";&lt;Description&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
     <Item ItemId="0;10b5db89840923ed3d0acc5fe287c167" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Code snippet for a path argument for an argparse parser.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[argparse パーサーのパス引数のコード スニペット。]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="3" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;Title&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -19,8 +23,11 @@
     <Item ItemId="0;1cf27f1348d9adf9704b2dff0db0d888" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[argparse path argument]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[argparse のパス引数]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="1" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;ToolTip&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -28,26 +35,38 @@
     <Item ItemId="0;69ee1bdf53fb0aeed761c52c8d49693d" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Short argument name, typically only a single letter.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[短い引数名。通常は 1 文字のみです。]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="5" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;75a55c928c79bdb03057db67af054e9e" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Long argument name, typically one or two words separated by a hyphen.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[長い引数名。通常、1 つの単語か、ハイフンで区切られた 2 つの単語です。]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="7" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;e7b23931982c94194e3886cd424afb72" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Description of the argument to display when called with --help/-h.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[--help/-h を指定して呼び出されたときに表示される引数の説明。]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="11" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;ed36fc16d953d88706f27cad66ebb5f2" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Argument variable name.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[引数の変数名。]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="9" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
-<Settings Name="@SettingsPath@\default.lss" Type="Lss" /></LCX>
+</LCX>

--- a/Python/loc/lcl/JPN/Snippets/Python/arg_path_positional.snippet.lcl
+++ b/Python/loc/lcl/JPN/Snippets/Python/arg_path_positional.snippet.lcl
@@ -1,17 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="D:\a\_work\1\b\raw\binaries\Snippets\Python\arg_path_positional.snippet" PsrId="210" SrcCul="en-US" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx" TgtCul="ja-JP">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\21\b\raw\binaries\Snippets\Python\arg_path_positional.snippet" PsrId="210" FileType="1" SrcCul="en-US" TgtCul="ja-JP" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="Dev" />
     <Cmt Name="LcxAdmin" />
     <Cmt Name="Rccx" />
   </OwnedComments>
+  <Settings Name="@SettingsPath@\default.lss" Type="Lss" />
   <Item ItemId=";&lt;Description&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
     <Item ItemId="0;12736a644fe557377d4f44fb250f3cc0" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Code snippet for a positional path argument for an argparse parser.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[argparse パーサーの位置指定パス引数のコード スニペット。]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="3" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;Title&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -19,8 +23,11 @@
     <Item ItemId="0;5cb477ab75463262edfbf537292653c8" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[argparse positional path argument]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[argparse の位置指定パス引数]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="1" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;ToolTip&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -28,14 +35,20 @@
     <Item ItemId="0;35282756089c336d9b7432ac72d786f1" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Argument name. Start with a hyphen to require a switch, or omit to make it positional.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[引数の名前。ハイフンで始めるとスイッチが必須になり、省略すると位置指定になります。]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="5" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;e7b23931982c94194e3886cd424afb72" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Description of the argument to display when called with --help/-h.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[--help/-h を指定して呼び出されたときに表示される引数の説明。]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="7" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
-<Settings Name="@SettingsPath@\default.lss" Type="Lss" /></LCX>
+</LCX>

--- a/Python/loc/lcl/JPN/Snippets/Python/arg_str.snippet.lcl
+++ b/Python/loc/lcl/JPN/Snippets/Python/arg_str.snippet.lcl
@@ -1,17 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="D:\a\_work\1\b\raw\binaries\Snippets\Python\arg_str.snippet" PsrId="210" SrcCul="en-US" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx" TgtCul="ja-JP">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\21\b\raw\binaries\Snippets\Python\arg_str.snippet" PsrId="210" FileType="1" SrcCul="en-US" TgtCul="ja-JP" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="Dev" />
     <Cmt Name="LcxAdmin" />
     <Cmt Name="Rccx" />
   </OwnedComments>
+  <Settings Name="@SettingsPath@\default.lss" Type="Lss" />
   <Item ItemId=";&lt;Description&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
     <Item ItemId="0;5162629d4963116ba811271091fe841d" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Code snippet for a string argument for an argparse parser.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[argparse パーサーの文字列引数のコード スニペット。]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="3" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;Title&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -19,8 +23,11 @@
     <Item ItemId="0;8fbb5326dfe0bf71b7361d48e1a445c4" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[argparse string argument]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[argparse の文字列引数]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="1" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;ToolTip&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -28,26 +35,38 @@
     <Item ItemId="0;69ee1bdf53fb0aeed761c52c8d49693d" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Short argument name, typically only a single letter.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[短い引数名。通常は 1 文字のみです。]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="5" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;75a55c928c79bdb03057db67af054e9e" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Long argument name, typically one or two words separated by a hyphen.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[長い引数名。通常、1 つの単語か、ハイフンで区切られた 2 つの単語です。]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="7" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;e7b23931982c94194e3886cd424afb72" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Description of the argument to display when called with --help/-h.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[--help/-h を指定して呼び出されたときに表示される引数の説明。]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="11" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;ed36fc16d953d88706f27cad66ebb5f2" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Argument variable name.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[引数の変数名。]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="9" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
-<Settings Name="@SettingsPath@\default.lss" Type="Lss" /></LCX>
+</LCX>

--- a/Python/loc/lcl/JPN/Snippets/Python/arg_str_positional.snippet.lcl
+++ b/Python/loc/lcl/JPN/Snippets/Python/arg_str_positional.snippet.lcl
@@ -1,17 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="D:\a\_work\1\b\raw\binaries\Snippets\Python\arg_str_positional.snippet" PsrId="210" SrcCul="en-US" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx" TgtCul="ja-JP">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\21\b\raw\binaries\Snippets\Python\arg_str_positional.snippet" PsrId="210" FileType="1" SrcCul="en-US" TgtCul="ja-JP" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="Dev" />
     <Cmt Name="LcxAdmin" />
     <Cmt Name="Rccx" />
   </OwnedComments>
+  <Settings Name="@SettingsPath@\default.lss" Type="Lss" />
   <Item ItemId=";&lt;Description&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
     <Item ItemId="0;69def699f0c2570190c042fc792b38c5" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Code snippet for a positional string argument for an argparse parser.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[argparse パーサーの位置指定文字列引数のコード スニペット。]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="3" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;Title&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -19,8 +23,11 @@
     <Item ItemId="0;9dbaae3dbddf131d3205155271f50641" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[argparse positional string argument]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[argparse の位置指定文字列引数]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="1" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;ToolTip&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -28,14 +35,20 @@
     <Item ItemId="0;35282756089c336d9b7432ac72d786f1" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Argument name. Start with a hyphen to require a switch, or omit to make it positional.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[引数の名前。ハイフンで始めるとスイッチが必須になり、省略すると位置指定になります。]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="5" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;e7b23931982c94194e3886cd424afb72" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Description of the argument to display when called with --help/-h.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[--help/-h を指定して呼び出されたときに表示される引数の説明。]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="7" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
-<Settings Name="@SettingsPath@\default.lss" Type="Lss" /></LCX>
+</LCX>

--- a/Python/loc/lcl/JPN/Snippets/Python/arg_switch.snippet.lcl
+++ b/Python/loc/lcl/JPN/Snippets/Python/arg_switch.snippet.lcl
@@ -1,17 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="D:\a\_work\1\b\raw\binaries\Snippets\Python\arg_switch.snippet" PsrId="210" SrcCul="en-US" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx" TgtCul="ja-JP">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\21\b\raw\binaries\Snippets\Python\arg_switch.snippet" PsrId="210" FileType="1" SrcCul="en-US" TgtCul="ja-JP" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="Dev" />
     <Cmt Name="LcxAdmin" />
     <Cmt Name="Rccx" />
   </OwnedComments>
+  <Settings Name="@SettingsPath@\default.lss" Type="Lss" />
   <Item ItemId=";&lt;Description&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
     <Item ItemId="0;cdf30125985a60ac677caefc318833e8" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Code snippet for a switch argument for an argparse parser.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[argparse パーサーのスイッチ引数のコード スニペット。]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="3" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;Title&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -19,8 +23,11 @@
     <Item ItemId="0;277d72dbe38cd017f4b02e7448bf146e" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[argparse switch argument]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[argparse のスイッチ引数]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="1" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;ToolTip&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -28,20 +35,29 @@
     <Item ItemId="0;69ee1bdf53fb0aeed761c52c8d49693d" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Short argument name, typically only a single letter.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[短い引数名。通常は 1 文字のみです。]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="5" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;75a55c928c79bdb03057db67af054e9e" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Long argument name, typically one or two words separated by a hyphen.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[長い引数名。通常、1 つの単語か、ハイフンで区切られた 2 つの単語です。]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="7" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;e7b23931982c94194e3886cd424afb72" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Description of the argument to display when called with --help/-h.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[--help/-h を指定して呼び出されたときに表示される引数の説明。]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="9" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
-<Settings Name="@SettingsPath@\default.lss" Type="Lss" /></LCX>
+</LCX>

--- a/Python/loc/lcl/JPN/Snippets/Python/argparse.snippet.lcl
+++ b/Python/loc/lcl/JPN/Snippets/Python/argparse.snippet.lcl
@@ -1,17 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="D:\a\_work\1\b\raw\binaries\Snippets\Python\argparse.snippet" PsrId="210" SrcCul="en-US" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx" TgtCul="ja-JP">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\21\b\raw\binaries\Snippets\Python\argparse.snippet" PsrId="210" FileType="1" SrcCul="en-US" TgtCul="ja-JP" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="Dev" />
     <Cmt Name="LcxAdmin" />
     <Cmt Name="Rccx" />
   </OwnedComments>
+  <Settings Name="@SettingsPath@\default.lss" Type="Lss" />
   <Item ItemId=";&lt;Description&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
     <Item ItemId="0;efc9719c9afe3a8265e2a7e511a1cdc6" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Code snippet for a function to parse arguments using argparse]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[argparse を使用して引数を解析する関数のコード スニペット]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="3" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;Title&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -19,8 +23,11 @@
     <Item ItemId="0;4365422194f5997a16d7a169524e3d10" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[argparse block]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[argparse ブロック]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="1" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;ToolTip&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -28,8 +35,11 @@
     <Item ItemId="0;62568bc5e481b7c2bf94f72978c34da4" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Short description of your script]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[スクリプトの短い説明]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="5" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
-<Settings Name="@SettingsPath@\default.lss" Type="Lss" /></LCX>
+</LCX>

--- a/Python/loc/lcl/JPN/VCTargets/Win32/ImportAfter/Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml.lcl
+++ b/Python/loc/lcl/JPN/VCTargets/Win32/ImportAfter/Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml.lcl
@@ -1,23 +1,30 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="D:\a\_work\1\b\raw\binaries\VCTargets\Win32\ImportAfter\Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml" PsrId="22" SrcCul="en-US" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx" TgtCul="ja-JP">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\20\b\raw\binaries\VCTargets\Win32\ImportAfter\Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml" PsrId="22" FileType="1" SrcCul="en-US" TgtCul="ja-JP" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="Dev" />
     <Cmt Name="LcxAdmin" />
     <Cmt Name="Rccx" />
   </OwnedComments>
+  <Settings Name="@SettingsPath@\default.lss" Type="Lss" />
   <Item ItemId=";&lt;BoolProperty&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
     <Item ItemId="0;localdebuggermergeenvironment@BoolProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Merge specified environment variables with existing environment.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[既存の環境に指定された環境変数をマージします。]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="27" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggermergeenvironment@BoolProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Merge Environment]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[マージ環境]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="25" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;Rule&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -25,14 +32,20 @@
     <Item ItemId="0;pythondebuglaunchprovider@Rule@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Python/Native debugging options]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Python/ネイティブ デバッグのオプション]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="3" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;pythondebuglaunchprovider@Rule@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Python/Native Debugging]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Python/ネイティブ デバッグ]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="1" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;StringListProperty&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -40,14 +53,20 @@
     <Item ItemId="0;localdebuggerenvironment@StringListProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Specifies the environment for the debugee, or variables to merge with existing environment.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[既存の環境とマージするデバッグ対象または変数の環境を指定します。]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="23" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggerenvironment@StringListProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Environment]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[環境]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="21" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;StringProperty&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -55,38 +74,56 @@
     <Item ItemId="0;localdebuggercommand@StringProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[The debug command to execute.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[実行するデバッグ コマンドです。]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="7" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggercommandarguments@StringProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[The command line arguments to pass to the application.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[アプリケーションに渡すコマンド ライン引数です。]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="15" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggerworkingdirectory@StringProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[The application's working directory. By default, the directory containing the project file.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[アプリケーションの作業ディレクトリです。既定でディレクトリにはプロジェクト ファイルを含みます。]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="19" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggercommand@StringProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Command]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[コマンド]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="5" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggercommandarguments@StringProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Command Arguments]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[コマンド引数]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="13" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggerworkingdirectory@StringProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Working Directory]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[作業ディレクトリ]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="17" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;ValueEditor&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -94,14 +131,20 @@
     <Item ItemId="0;5a88dad82b4127d481f86820c9fcbf98" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[<Edit...>]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[<編集...>]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="9" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;b66ab1d4354799e0066c0af0ab39211f" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[<Browse...>]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[<参照...>]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="11" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
-<Settings Name="@SettingsPath@\default.lss" Type="Lss" /></LCX>
+</LCX>

--- a/Python/loc/lcl/JPN/VCTargets/x64/ImportAfter/Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml.lcl
+++ b/Python/loc/lcl/JPN/VCTargets/x64/ImportAfter/Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml.lcl
@@ -1,23 +1,30 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="D:\a\_work\1\b\raw\binaries\VCTargets\x64\ImportAfter\Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml" PsrId="22" SrcCul="en-US" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx" TgtCul="ja-JP">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\20\b\raw\binaries\VCTargets\Win32\ImportAfter\Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml" PsrId="22" FileType="1" SrcCul="en-US" TgtCul="ja-JP" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="Dev" />
     <Cmt Name="LcxAdmin" />
     <Cmt Name="Rccx" />
   </OwnedComments>
+  <Settings Name="@SettingsPath@\default.lss" Type="Lss" />
   <Item ItemId=";&lt;BoolProperty&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
     <Item ItemId="0;localdebuggermergeenvironment@BoolProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Merge specified environment variables with existing environment.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[既存の環境に指定された環境変数をマージします。]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="27" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggermergeenvironment@BoolProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Merge Environment]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[マージ環境]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="25" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;Rule&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -25,14 +32,20 @@
     <Item ItemId="0;pythondebuglaunchprovider@Rule@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Python/Native debugging options]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Python/ネイティブ デバッグのオプション]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="3" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;pythondebuglaunchprovider@Rule@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Python/Native Debugging]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Python/ネイティブ デバッグ]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="1" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;StringListProperty&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -40,14 +53,20 @@
     <Item ItemId="0;localdebuggerenvironment@StringListProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Specifies the environment for the debugee, or variables to merge with existing environment.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[既存の環境とマージするデバッグ対象または変数の環境を指定します。]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="23" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggerenvironment@StringListProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Environment]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[環境]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="21" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;StringProperty&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -55,38 +74,56 @@
     <Item ItemId="0;localdebuggercommand@StringProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[The debug command to execute.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[実行するデバッグ コマンドです。]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="7" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggercommandarguments@StringProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[The command line arguments to pass to the application.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[アプリケーションに渡すコマンド ライン引数です。]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="15" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggerworkingdirectory@StringProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[The application's working directory. By default, the directory containing the project file.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[アプリケーションの作業ディレクトリです。既定でディレクトリにはプロジェクト ファイルを含みます。]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="19" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggercommand@StringProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Command]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[コマンド]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="5" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggercommandarguments@StringProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Command Arguments]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[コマンド引数]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="13" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggerworkingdirectory@StringProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Working Directory]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[作業ディレクトリ]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="17" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;ValueEditor&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -94,14 +131,20 @@
     <Item ItemId="0;5a88dad82b4127d481f86820c9fcbf98" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[<Edit...>]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[<編集...>]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="9" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;b66ab1d4354799e0066c0af0ab39211f" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[<Browse...>]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[<参照...>]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="11" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
-<Settings Name="@SettingsPath@\default.lss" Type="Lss" /></LCX>
+</LCX>

--- a/Python/loc/lcl/KOR/Snippets/Python/arg_path.snippet.lcl
+++ b/Python/loc/lcl/KOR/Snippets/Python/arg_path.snippet.lcl
@@ -1,17 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="D:\a\_work\1\b\raw\binaries\Snippets\Python\arg_path.snippet" PsrId="210" SrcCul="en-US" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx" TgtCul="ko-KR">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\21\b\raw\binaries\Snippets\Python\arg_path.snippet" PsrId="210" FileType="1" SrcCul="en-US" TgtCul="ko-KR" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="Dev" />
     <Cmt Name="LcxAdmin" />
     <Cmt Name="Rccx" />
   </OwnedComments>
+  <Settings Name="@SettingsPath@\default.lss" Type="Lss" />
   <Item ItemId=";&lt;Description&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
     <Item ItemId="0;10b5db89840923ed3d0acc5fe287c167" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Code snippet for a path argument for an argparse parser.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[argparse 파서의 경로 인수에 대한 코드 조각입니다.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="3" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;Title&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -19,8 +23,11 @@
     <Item ItemId="0;1cf27f1348d9adf9704b2dff0db0d888" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[argparse path argument]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[argparse 경로 인수]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="1" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;ToolTip&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -28,26 +35,38 @@
     <Item ItemId="0;69ee1bdf53fb0aeed761c52c8d49693d" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Short argument name, typically only a single letter.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[짧은 인수 이름으로, 일반적으로 단일 문자만 사용됩니다.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="5" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;75a55c928c79bdb03057db67af054e9e" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Long argument name, typically one or two words separated by a hyphen.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[긴 인수 이름으로, 일반적으로 하이픈으로 구분된 하나 또는 두 개의 단어입니다.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="7" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;e7b23931982c94194e3886cd424afb72" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Description of the argument to display when called with --help/-h.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[--help/-h를 사용하여 호출할 때 표시할 인수에 대한 설명입니다.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="11" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;ed36fc16d953d88706f27cad66ebb5f2" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Argument variable name.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[인수 변수 이름입니다.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="9" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
-<Settings Name="@SettingsPath@\default.lss" Type="Lss" /></LCX>
+</LCX>

--- a/Python/loc/lcl/KOR/Snippets/Python/arg_path_positional.snippet.lcl
+++ b/Python/loc/lcl/KOR/Snippets/Python/arg_path_positional.snippet.lcl
@@ -1,17 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="D:\a\_work\1\b\raw\binaries\Snippets\Python\arg_path_positional.snippet" PsrId="210" SrcCul="en-US" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx" TgtCul="ko-KR">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\21\b\raw\binaries\Snippets\Python\arg_path_positional.snippet" PsrId="210" FileType="1" SrcCul="en-US" TgtCul="ko-KR" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="Dev" />
     <Cmt Name="LcxAdmin" />
     <Cmt Name="Rccx" />
   </OwnedComments>
+  <Settings Name="@SettingsPath@\default.lss" Type="Lss" />
   <Item ItemId=";&lt;Description&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
     <Item ItemId="0;12736a644fe557377d4f44fb250f3cc0" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Code snippet for a positional path argument for an argparse parser.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[argparse 파서의 위치 경로 인수에 대한 코드 조각입니다.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="3" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;Title&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -19,8 +23,11 @@
     <Item ItemId="0;5cb477ab75463262edfbf537292653c8" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[argparse positional path argument]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[argparse 위치 경로 인수]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="1" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;ToolTip&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -28,14 +35,20 @@
     <Item ItemId="0;35282756089c336d9b7432ac72d786f1" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Argument name. Start with a hyphen to require a switch, or omit to make it positional.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[인수 이름입니다. 스위치가 필요하도록 하이픈으로 시작하거나, 생략하여 위치에 따라 달라지도록 합니다.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="5" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;e7b23931982c94194e3886cd424afb72" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Description of the argument to display when called with --help/-h.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[--help/-h를 사용하여 호출할 때 표시할 인수에 대한 설명입니다.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="7" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
-<Settings Name="@SettingsPath@\default.lss" Type="Lss" /></LCX>
+</LCX>

--- a/Python/loc/lcl/KOR/Snippets/Python/arg_str.snippet.lcl
+++ b/Python/loc/lcl/KOR/Snippets/Python/arg_str.snippet.lcl
@@ -1,17 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="D:\a\_work\1\b\raw\binaries\Snippets\Python\arg_str.snippet" PsrId="210" SrcCul="en-US" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx" TgtCul="ko-KR">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\21\b\raw\binaries\Snippets\Python\arg_str.snippet" PsrId="210" FileType="1" SrcCul="en-US" TgtCul="ko-KR" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="Dev" />
     <Cmt Name="LcxAdmin" />
     <Cmt Name="Rccx" />
   </OwnedComments>
+  <Settings Name="@SettingsPath@\default.lss" Type="Lss" />
   <Item ItemId=";&lt;Description&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
     <Item ItemId="0;5162629d4963116ba811271091fe841d" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Code snippet for a string argument for an argparse parser.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[argparse 파서의 문자열 인수에 대한 코드 조각입니다.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="3" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;Title&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -19,8 +23,11 @@
     <Item ItemId="0;8fbb5326dfe0bf71b7361d48e1a445c4" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[argparse string argument]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[argparse 문자열 인수]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="1" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;ToolTip&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -28,26 +35,38 @@
     <Item ItemId="0;69ee1bdf53fb0aeed761c52c8d49693d" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Short argument name, typically only a single letter.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[짧은 인수 이름으로, 일반적으로 단일 문자만 사용됩니다.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="5" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;75a55c928c79bdb03057db67af054e9e" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Long argument name, typically one or two words separated by a hyphen.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[긴 인수 이름으로, 일반적으로 하이픈으로 구분된 하나 또는 두 개의 단어입니다.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="7" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;e7b23931982c94194e3886cd424afb72" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Description of the argument to display when called with --help/-h.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[--help/-h를 사용하여 호출할 때 표시할 인수에 대한 설명입니다.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="11" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;ed36fc16d953d88706f27cad66ebb5f2" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Argument variable name.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[인수 변수 이름입니다.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="9" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
-<Settings Name="@SettingsPath@\default.lss" Type="Lss" /></LCX>
+</LCX>

--- a/Python/loc/lcl/KOR/Snippets/Python/arg_str_positional.snippet.lcl
+++ b/Python/loc/lcl/KOR/Snippets/Python/arg_str_positional.snippet.lcl
@@ -1,17 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="D:\a\_work\1\b\raw\binaries\Snippets\Python\arg_str_positional.snippet" PsrId="210" SrcCul="en-US" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx" TgtCul="ko-KR">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\21\b\raw\binaries\Snippets\Python\arg_str_positional.snippet" PsrId="210" FileType="1" SrcCul="en-US" TgtCul="ko-KR" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="Dev" />
     <Cmt Name="LcxAdmin" />
     <Cmt Name="Rccx" />
   </OwnedComments>
+  <Settings Name="@SettingsPath@\default.lss" Type="Lss" />
   <Item ItemId=";&lt;Description&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
     <Item ItemId="0;69def699f0c2570190c042fc792b38c5" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Code snippet for a positional string argument for an argparse parser.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[argparse 파서의 위치 문자열 인수에 대한 코드 조각입니다.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="3" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;Title&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -19,8 +23,11 @@
     <Item ItemId="0;9dbaae3dbddf131d3205155271f50641" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[argparse positional string argument]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[argparse 위치 문자열 인수]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="1" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;ToolTip&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -28,14 +35,20 @@
     <Item ItemId="0;35282756089c336d9b7432ac72d786f1" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Argument name. Start with a hyphen to require a switch, or omit to make it positional.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[인수 이름입니다. 스위치가 필요하도록 하이픈으로 시작하거나, 생략하여 위치에 따라 달라지도록 합니다.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="5" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;e7b23931982c94194e3886cd424afb72" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Description of the argument to display when called with --help/-h.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[--help/-h를 사용하여 호출할 때 표시할 인수에 대한 설명입니다.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="7" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
-<Settings Name="@SettingsPath@\default.lss" Type="Lss" /></LCX>
+</LCX>

--- a/Python/loc/lcl/KOR/Snippets/Python/arg_switch.snippet.lcl
+++ b/Python/loc/lcl/KOR/Snippets/Python/arg_switch.snippet.lcl
@@ -1,17 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="D:\a\_work\1\b\raw\binaries\Snippets\Python\arg_switch.snippet" PsrId="210" SrcCul="en-US" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx" TgtCul="ko-KR">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\21\b\raw\binaries\Snippets\Python\arg_switch.snippet" PsrId="210" FileType="1" SrcCul="en-US" TgtCul="ko-KR" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="Dev" />
     <Cmt Name="LcxAdmin" />
     <Cmt Name="Rccx" />
   </OwnedComments>
+  <Settings Name="@SettingsPath@\default.lss" Type="Lss" />
   <Item ItemId=";&lt;Description&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
     <Item ItemId="0;cdf30125985a60ac677caefc318833e8" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Code snippet for a switch argument for an argparse parser.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[argparse 파서의 스위치 인수에 대한 코드 조각입니다.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="3" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;Title&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -19,8 +23,11 @@
     <Item ItemId="0;277d72dbe38cd017f4b02e7448bf146e" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[argparse switch argument]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[argparse 스위치 인수]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="1" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;ToolTip&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -28,20 +35,29 @@
     <Item ItemId="0;69ee1bdf53fb0aeed761c52c8d49693d" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Short argument name, typically only a single letter.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[짧은 인수 이름으로, 일반적으로 단일 문자만 사용됩니다.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="5" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;75a55c928c79bdb03057db67af054e9e" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Long argument name, typically one or two words separated by a hyphen.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[긴 인수 이름으로, 일반적으로 하이픈으로 구분된 하나 또는 두 개의 단어입니다.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="7" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;e7b23931982c94194e3886cd424afb72" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Description of the argument to display when called with --help/-h.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[--help/-h를 사용하여 호출할 때 표시할 인수에 대한 설명입니다.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="9" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
-<Settings Name="@SettingsPath@\default.lss" Type="Lss" /></LCX>
+</LCX>

--- a/Python/loc/lcl/KOR/Snippets/Python/argparse.snippet.lcl
+++ b/Python/loc/lcl/KOR/Snippets/Python/argparse.snippet.lcl
@@ -1,17 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="D:\a\_work\1\b\raw\binaries\Snippets\Python\argparse.snippet" PsrId="210" SrcCul="en-US" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx" TgtCul="ko-KR">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\21\b\raw\binaries\Snippets\Python\argparse.snippet" PsrId="210" FileType="1" SrcCul="en-US" TgtCul="ko-KR" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="Dev" />
     <Cmt Name="LcxAdmin" />
     <Cmt Name="Rccx" />
   </OwnedComments>
+  <Settings Name="@SettingsPath@\default.lss" Type="Lss" />
   <Item ItemId=";&lt;Description&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
     <Item ItemId="0;efc9719c9afe3a8265e2a7e511a1cdc6" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Code snippet for a function to parse arguments using argparse]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[argparse를 사용하여 인수를 구문 분석하는 함수에 대한 코드 조각입니다.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="3" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;Title&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -19,8 +23,11 @@
     <Item ItemId="0;4365422194f5997a16d7a169524e3d10" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[argparse block]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[argparse 블록]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="1" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;ToolTip&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -28,8 +35,11 @@
     <Item ItemId="0;62568bc5e481b7c2bf94f72978c34da4" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Short description of your script]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[스크립트의 간단한 설명]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="5" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
-<Settings Name="@SettingsPath@\default.lss" Type="Lss" /></LCX>
+</LCX>

--- a/Python/loc/lcl/KOR/VCTargets/Win32/ImportAfter/Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml.lcl
+++ b/Python/loc/lcl/KOR/VCTargets/Win32/ImportAfter/Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml.lcl
@@ -1,23 +1,30 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="D:\a\_work\1\b\raw\binaries\VCTargets\Win32\ImportAfter\Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml" PsrId="22" SrcCul="en-US" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx" TgtCul="ko-KR">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\20\b\raw\binaries\VCTargets\Win32\ImportAfter\Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml" PsrId="22" FileType="1" SrcCul="en-US" TgtCul="ko-KR" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="Dev" />
     <Cmt Name="LcxAdmin" />
     <Cmt Name="Rccx" />
   </OwnedComments>
+  <Settings Name="@SettingsPath@\default.lss" Type="Lss" />
   <Item ItemId=";&lt;BoolProperty&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
     <Item ItemId="0;localdebuggermergeenvironment@BoolProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Merge specified environment variables with existing environment.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[지정한 환경 변수를 기존 환경과 병합합니다.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="27" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggermergeenvironment@BoolProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Merge Environment]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[환경 병합]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="25" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;Rule&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -25,14 +32,20 @@
     <Item ItemId="0;pythondebuglaunchprovider@Rule@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Python/Native debugging options]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Python/네이티브 디버깅 옵션]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="3" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;pythondebuglaunchprovider@Rule@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Python/Native Debugging]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Python/네이티브 디버깅]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="1" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;StringListProperty&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -40,14 +53,20 @@
     <Item ItemId="0;localdebuggerenvironment@StringListProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Specifies the environment for the debugee, or variables to merge with existing environment.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[디버거의 환경을 지정하거나 기존 환경과 병합할 변수를 지정합니다.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="23" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggerenvironment@StringListProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Environment]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[환경]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="21" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;StringProperty&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -55,38 +74,56 @@
     <Item ItemId="0;localdebuggercommand@StringProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[The debug command to execute.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[실행할 디버그 명령입니다.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="7" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggercommandarguments@StringProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[The command line arguments to pass to the application.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[애플리케이션에 전달할 명령줄 인수입니다.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="15" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggerworkingdirectory@StringProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[The application's working directory. By default, the directory containing the project file.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[애플리케이션의 작업 디렉터리입니다. 기본적으로 이 디렉터리에는 프로젝트 파일이 들어 있습니다.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="19" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggercommand@StringProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Command]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[명령]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="5" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggercommandarguments@StringProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Command Arguments]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[명령 인수]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="13" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggerworkingdirectory@StringProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Working Directory]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[작업 디렉터리]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="17" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;ValueEditor&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -94,14 +131,20 @@
     <Item ItemId="0;5a88dad82b4127d481f86820c9fcbf98" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[<Edit...>]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[<편집...>]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="9" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;b66ab1d4354799e0066c0af0ab39211f" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[<Browse...>]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[<찾아보기...>]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="11" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
-<Settings Name="@SettingsPath@\default.lss" Type="Lss" /></LCX>
+</LCX>

--- a/Python/loc/lcl/KOR/VCTargets/x64/ImportAfter/Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml.lcl
+++ b/Python/loc/lcl/KOR/VCTargets/x64/ImportAfter/Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml.lcl
@@ -1,23 +1,30 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="D:\a\_work\1\b\raw\binaries\VCTargets\x64\ImportAfter\Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml" PsrId="22" SrcCul="en-US" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx" TgtCul="ko-KR">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\20\b\raw\binaries\VCTargets\Win32\ImportAfter\Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml" PsrId="22" FileType="1" SrcCul="en-US" TgtCul="ko-KR" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="Dev" />
     <Cmt Name="LcxAdmin" />
     <Cmt Name="Rccx" />
   </OwnedComments>
+  <Settings Name="@SettingsPath@\default.lss" Type="Lss" />
   <Item ItemId=";&lt;BoolProperty&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
     <Item ItemId="0;localdebuggermergeenvironment@BoolProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Merge specified environment variables with existing environment.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[지정한 환경 변수를 기존 환경과 병합합니다.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="27" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggermergeenvironment@BoolProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Merge Environment]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[환경 병합]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="25" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;Rule&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -25,14 +32,20 @@
     <Item ItemId="0;pythondebuglaunchprovider@Rule@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Python/Native debugging options]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Python/네이티브 디버깅 옵션]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="3" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;pythondebuglaunchprovider@Rule@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Python/Native Debugging]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Python/네이티브 디버깅]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="1" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;StringListProperty&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -40,14 +53,20 @@
     <Item ItemId="0;localdebuggerenvironment@StringListProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Specifies the environment for the debugee, or variables to merge with existing environment.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[디버거의 환경을 지정하거나 기존 환경과 병합할 변수를 지정합니다.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="23" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggerenvironment@StringListProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Environment]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[환경]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="21" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;StringProperty&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -55,38 +74,56 @@
     <Item ItemId="0;localdebuggercommand@StringProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[The debug command to execute.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[실행할 디버그 명령입니다.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="7" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggercommandarguments@StringProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[The command line arguments to pass to the application.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[애플리케이션에 전달할 명령줄 인수입니다.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="15" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggerworkingdirectory@StringProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[The application's working directory. By default, the directory containing the project file.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[애플리케이션의 작업 디렉터리입니다. 기본적으로 이 디렉터리에는 프로젝트 파일이 들어 있습니다.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="19" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggercommand@StringProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Command]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[명령]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="5" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggercommandarguments@StringProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Command Arguments]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[명령 인수]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="13" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggerworkingdirectory@StringProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Working Directory]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[작업 디렉터리]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="17" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;ValueEditor&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -94,14 +131,20 @@
     <Item ItemId="0;5a88dad82b4127d481f86820c9fcbf98" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[<Edit...>]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[<편집...>]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="9" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;b66ab1d4354799e0066c0af0ab39211f" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[<Browse...>]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[<찾아보기...>]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="11" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
-<Settings Name="@SettingsPath@\default.lss" Type="Lss" /></LCX>
+</LCX>

--- a/Python/loc/lcl/PLK/Snippets/Python/arg_path.snippet.lcl
+++ b/Python/loc/lcl/PLK/Snippets/Python/arg_path.snippet.lcl
@@ -1,17 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="D:\a\_work\1\b\raw\binaries\Snippets\Python\arg_path.snippet" PsrId="210" SrcCul="en-US" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx" TgtCul="pl-PL">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\21\b\raw\binaries\Snippets\Python\arg_path.snippet" PsrId="210" FileType="1" SrcCul="en-US" TgtCul="pl-PL" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="Dev" />
     <Cmt Name="LcxAdmin" />
     <Cmt Name="Rccx" />
   </OwnedComments>
+  <Settings Name="@SettingsPath@\default.lss" Type="Lss" />
   <Item ItemId=";&lt;Description&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
     <Item ItemId="0;10b5db89840923ed3d0acc5fe287c167" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Code snippet for a path argument for an argparse parser.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Fragment kodu dla argumentu ścieżki dla analizatora modułu argparse.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="3" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;Title&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -19,8 +23,11 @@
     <Item ItemId="0;1cf27f1348d9adf9704b2dff0db0d888" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[argparse path argument]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Argument ścieżki modułu argparse]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="1" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;ToolTip&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -28,26 +35,38 @@
     <Item ItemId="0;69ee1bdf53fb0aeed761c52c8d49693d" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Short argument name, typically only a single letter.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Krótka nazwa argumentu, zazwyczaj tylko jedna litera.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="5" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;75a55c928c79bdb03057db67af054e9e" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Long argument name, typically one or two words separated by a hyphen.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Długa nazwa argumentu, zazwyczaj jedno lub dwa słowa rozdzielone łącznikiem.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="7" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;e7b23931982c94194e3886cd424afb72" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Description of the argument to display when called with --help/-h.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Opis argumentu do wyświetlenia, gdy zostanie wywołany przy użyciu polecenia --help/-h.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="11" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;ed36fc16d953d88706f27cad66ebb5f2" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Argument variable name.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Nazwa zmiennej argumentu.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="9" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
-<Settings Name="@SettingsPath@\default.lss" Type="Lss" /></LCX>
+</LCX>

--- a/Python/loc/lcl/PLK/Snippets/Python/arg_path_positional.snippet.lcl
+++ b/Python/loc/lcl/PLK/Snippets/Python/arg_path_positional.snippet.lcl
@@ -1,17 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="D:\a\_work\1\b\raw\binaries\Snippets\Python\arg_path_positional.snippet" PsrId="210" SrcCul="en-US" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx" TgtCul="pl-PL">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\21\b\raw\binaries\Snippets\Python\arg_path_positional.snippet" PsrId="210" FileType="1" SrcCul="en-US" TgtCul="pl-PL" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="Dev" />
     <Cmt Name="LcxAdmin" />
     <Cmt Name="Rccx" />
   </OwnedComments>
+  <Settings Name="@SettingsPath@\default.lss" Type="Lss" />
   <Item ItemId=";&lt;Description&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
     <Item ItemId="0;12736a644fe557377d4f44fb250f3cc0" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Code snippet for a positional path argument for an argparse parser.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Fragment kodu dla argumentu pozycyjnego ścieżki dla analizatora modułu argparse.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="3" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;Title&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -19,8 +23,11 @@
     <Item ItemId="0;5cb477ab75463262edfbf537292653c8" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[argparse positional path argument]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Argument pozycyjny ścieżki modułu argparse]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="1" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;ToolTip&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -28,14 +35,20 @@
     <Item ItemId="0;35282756089c336d9b7432ac72d786f1" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Argument name. Start with a hyphen to require a switch, or omit to make it positional.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Nazwa argumentu. Zacznij od łącznika, aby wymagać przełącznika, lub pomiń, aby argument był pozycyjny.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="5" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;e7b23931982c94194e3886cd424afb72" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Description of the argument to display when called with --help/-h.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Opis argumentu do wyświetlenia, gdy zostanie wywołany przy użyciu polecenia --help/-h.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="7" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
-<Settings Name="@SettingsPath@\default.lss" Type="Lss" /></LCX>
+</LCX>

--- a/Python/loc/lcl/PLK/Snippets/Python/arg_str.snippet.lcl
+++ b/Python/loc/lcl/PLK/Snippets/Python/arg_str.snippet.lcl
@@ -1,17 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="D:\a\_work\1\b\raw\binaries\Snippets\Python\arg_str.snippet" PsrId="210" SrcCul="en-US" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx" TgtCul="pl-PL">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\21\b\raw\binaries\Snippets\Python\arg_str.snippet" PsrId="210" FileType="1" SrcCul="en-US" TgtCul="pl-PL" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="Dev" />
     <Cmt Name="LcxAdmin" />
     <Cmt Name="Rccx" />
   </OwnedComments>
+  <Settings Name="@SettingsPath@\default.lss" Type="Lss" />
   <Item ItemId=";&lt;Description&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
     <Item ItemId="0;5162629d4963116ba811271091fe841d" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Code snippet for a string argument for an argparse parser.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Fragment kodu dla argumentu ciągu dla analizatora modułu argparse.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="3" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;Title&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -19,8 +23,11 @@
     <Item ItemId="0;8fbb5326dfe0bf71b7361d48e1a445c4" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[argparse string argument]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Argument ciągu modułu argparse]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="1" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;ToolTip&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -28,26 +35,38 @@
     <Item ItemId="0;69ee1bdf53fb0aeed761c52c8d49693d" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Short argument name, typically only a single letter.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Krótka nazwa argumentu, zazwyczaj tylko jedna litera.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="5" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;75a55c928c79bdb03057db67af054e9e" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Long argument name, typically one or two words separated by a hyphen.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Długa nazwa argumentu, zazwyczaj jedno lub dwa słowa rozdzielone łącznikiem.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="7" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;e7b23931982c94194e3886cd424afb72" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Description of the argument to display when called with --help/-h.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Opis argumentu do wyświetlenia, gdy zostanie wywołany przy użyciu polecenia --help/-h.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="11" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;ed36fc16d953d88706f27cad66ebb5f2" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Argument variable name.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Nazwa zmiennej argumentu.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="9" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
-<Settings Name="@SettingsPath@\default.lss" Type="Lss" /></LCX>
+</LCX>

--- a/Python/loc/lcl/PLK/Snippets/Python/arg_str_positional.snippet.lcl
+++ b/Python/loc/lcl/PLK/Snippets/Python/arg_str_positional.snippet.lcl
@@ -1,17 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="D:\a\_work\1\b\raw\binaries\Snippets\Python\arg_str_positional.snippet" PsrId="210" SrcCul="en-US" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx" TgtCul="pl-PL">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\21\b\raw\binaries\Snippets\Python\arg_str_positional.snippet" PsrId="210" FileType="1" SrcCul="en-US" TgtCul="pl-PL" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="Dev" />
     <Cmt Name="LcxAdmin" />
     <Cmt Name="Rccx" />
   </OwnedComments>
+  <Settings Name="@SettingsPath@\default.lss" Type="Lss" />
   <Item ItemId=";&lt;Description&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
     <Item ItemId="0;69def699f0c2570190c042fc792b38c5" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Code snippet for a positional string argument for an argparse parser.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Fragment kodu dla argumentu pozycyjnego ciągu dla analizatora modułu argparse.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="3" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;Title&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -19,8 +23,11 @@
     <Item ItemId="0;9dbaae3dbddf131d3205155271f50641" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[argparse positional string argument]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Argument pozycyjny ciągu modułu argparse]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="1" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;ToolTip&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -28,14 +35,20 @@
     <Item ItemId="0;35282756089c336d9b7432ac72d786f1" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Argument name. Start with a hyphen to require a switch, or omit to make it positional.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Nazwa argumentu. Zacznij od łącznika, aby wymagać przełącznika, lub pomiń, aby argument był pozycyjny.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="5" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;e7b23931982c94194e3886cd424afb72" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Description of the argument to display when called with --help/-h.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Opis argumentu do wyświetlenia, gdy zostanie wywołany przy użyciu polecenia --help/-h.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="7" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
-<Settings Name="@SettingsPath@\default.lss" Type="Lss" /></LCX>
+</LCX>

--- a/Python/loc/lcl/PLK/Snippets/Python/arg_switch.snippet.lcl
+++ b/Python/loc/lcl/PLK/Snippets/Python/arg_switch.snippet.lcl
@@ -1,17 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="D:\a\_work\1\b\raw\binaries\Snippets\Python\arg_switch.snippet" PsrId="210" SrcCul="en-US" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx" TgtCul="pl-PL">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\21\b\raw\binaries\Snippets\Python\arg_switch.snippet" PsrId="210" FileType="1" SrcCul="en-US" TgtCul="pl-PL" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="Dev" />
     <Cmt Name="LcxAdmin" />
     <Cmt Name="Rccx" />
   </OwnedComments>
+  <Settings Name="@SettingsPath@\default.lss" Type="Lss" />
   <Item ItemId=";&lt;Description&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
     <Item ItemId="0;cdf30125985a60ac677caefc318833e8" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Code snippet for a switch argument for an argparse parser.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Fragment kodu dla argumentu przełącznika dla analizatora modułu argparse.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="3" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;Title&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -19,8 +23,11 @@
     <Item ItemId="0;277d72dbe38cd017f4b02e7448bf146e" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[argparse switch argument]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Argument przełącznika modułu argparse]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="1" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;ToolTip&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -28,20 +35,29 @@
     <Item ItemId="0;69ee1bdf53fb0aeed761c52c8d49693d" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Short argument name, typically only a single letter.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Krótka nazwa argumentu, zazwyczaj tylko jedna litera.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="5" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;75a55c928c79bdb03057db67af054e9e" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Long argument name, typically one or two words separated by a hyphen.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Długa nazwa argumentu, zazwyczaj jedno lub dwa słowa rozdzielone łącznikiem.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="7" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;e7b23931982c94194e3886cd424afb72" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Description of the argument to display when called with --help/-h.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Opis argumentu do wyświetlenia, gdy zostanie wywołany przy użyciu polecenia --help/-h.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="9" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
-<Settings Name="@SettingsPath@\default.lss" Type="Lss" /></LCX>
+</LCX>

--- a/Python/loc/lcl/PLK/Snippets/Python/argparse.snippet.lcl
+++ b/Python/loc/lcl/PLK/Snippets/Python/argparse.snippet.lcl
@@ -1,17 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="D:\a\_work\1\b\raw\binaries\Snippets\Python\argparse.snippet" PsrId="210" SrcCul="en-US" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx" TgtCul="pl-PL">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\21\b\raw\binaries\Snippets\Python\argparse.snippet" PsrId="210" FileType="1" SrcCul="en-US" TgtCul="pl-PL" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="Dev" />
     <Cmt Name="LcxAdmin" />
     <Cmt Name="Rccx" />
   </OwnedComments>
+  <Settings Name="@SettingsPath@\default.lss" Type="Lss" />
   <Item ItemId=";&lt;Description&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
     <Item ItemId="0;efc9719c9afe3a8265e2a7e511a1cdc6" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Code snippet for a function to parse arguments using argparse]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Fragment kodu dla funkcji do analizy argumentów przy użyciu modułu argparse]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="3" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;Title&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -19,8 +23,11 @@
     <Item ItemId="0;4365422194f5997a16d7a169524e3d10" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[argparse block]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Blok modułu argparse]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="1" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;ToolTip&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -28,8 +35,11 @@
     <Item ItemId="0;62568bc5e481b7c2bf94f72978c34da4" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Short description of your script]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Krótki opis skryptu]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="5" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
-<Settings Name="@SettingsPath@\default.lss" Type="Lss" /></LCX>
+</LCX>

--- a/Python/loc/lcl/PLK/VCTargets/Win32/ImportAfter/Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml.lcl
+++ b/Python/loc/lcl/PLK/VCTargets/Win32/ImportAfter/Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml.lcl
@@ -1,23 +1,30 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="D:\a\_work\1\b\raw\binaries\VCTargets\Win32\ImportAfter\Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml" PsrId="22" SrcCul="en-US" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx" TgtCul="pl-PL">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\20\b\raw\binaries\VCTargets\Win32\ImportAfter\Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml" PsrId="22" FileType="1" SrcCul="en-US" TgtCul="pl-PL" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="Dev" />
     <Cmt Name="LcxAdmin" />
     <Cmt Name="Rccx" />
   </OwnedComments>
+  <Settings Name="@SettingsPath@\default.lss" Type="Lss" />
   <Item ItemId=";&lt;BoolProperty&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
     <Item ItemId="0;localdebuggermergeenvironment@BoolProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Merge specified environment variables with existing environment.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Scala określone zmienne środowiskowe z istniejącym środowiskiem.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="27" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggermergeenvironment@BoolProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Merge Environment]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Scal środowisko]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="25" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;Rule&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -25,14 +32,20 @@
     <Item ItemId="0;pythondebuglaunchprovider@Rule@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Python/Native debugging options]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Opcje debugowania języka Python/debugowania natywnego]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="3" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;pythondebuglaunchprovider@Rule@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Python/Native Debugging]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Debugowanie języka Python/debugowanie natywne]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="1" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;StringListProperty&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -40,14 +53,20 @@
     <Item ItemId="0;localdebuggerenvironment@StringListProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Specifies the environment for the debugee, or variables to merge with existing environment.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Określa środowisko dla obiektu debugowanego lub zmienne do scalenia z istniejącym środowiskiem.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="23" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggerenvironment@StringListProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Environment]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Środowisko]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="21" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;StringProperty&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -55,38 +74,56 @@
     <Item ItemId="0;localdebuggercommand@StringProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[The debug command to execute.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Polecenie debugowania do wykonania.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="7" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggercommandarguments@StringProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[The command line arguments to pass to the application.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Argumenty wiersza polecenia do przekazania aplikacji.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="15" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggerworkingdirectory@StringProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[The application's working directory. By default, the directory containing the project file.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Katalog roboczy aplikacji. Domyślnie — katalog zawierający plik projektu.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="19" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggercommand@StringProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Command]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Polecenie]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="5" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggercommandarguments@StringProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Command Arguments]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Argumenty polecenia]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="13" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggerworkingdirectory@StringProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Working Directory]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Katalog roboczy]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="17" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;ValueEditor&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -94,14 +131,20 @@
     <Item ItemId="0;5a88dad82b4127d481f86820c9fcbf98" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[<Edit...>]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[<Edytuj...>]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="9" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;b66ab1d4354799e0066c0af0ab39211f" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[<Browse...>]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[<Przeglądaj...>]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="11" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
-<Settings Name="@SettingsPath@\default.lss" Type="Lss" /></LCX>
+</LCX>

--- a/Python/loc/lcl/PLK/VCTargets/x64/ImportAfter/Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml.lcl
+++ b/Python/loc/lcl/PLK/VCTargets/x64/ImportAfter/Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml.lcl
@@ -1,23 +1,30 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="D:\a\_work\1\b\raw\binaries\VCTargets\x64\ImportAfter\Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml" PsrId="22" SrcCul="en-US" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx" TgtCul="pl-PL">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\20\b\raw\binaries\VCTargets\Win32\ImportAfter\Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml" PsrId="22" FileType="1" SrcCul="en-US" TgtCul="pl-PL" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="Dev" />
     <Cmt Name="LcxAdmin" />
     <Cmt Name="Rccx" />
   </OwnedComments>
+  <Settings Name="@SettingsPath@\default.lss" Type="Lss" />
   <Item ItemId=";&lt;BoolProperty&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
     <Item ItemId="0;localdebuggermergeenvironment@BoolProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Merge specified environment variables with existing environment.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Scala określone zmienne środowiskowe z istniejącym środowiskiem.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="27" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggermergeenvironment@BoolProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Merge Environment]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Scal środowisko]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="25" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;Rule&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -25,14 +32,20 @@
     <Item ItemId="0;pythondebuglaunchprovider@Rule@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Python/Native debugging options]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Opcje debugowania języka Python/debugowania natywnego]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="3" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;pythondebuglaunchprovider@Rule@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Python/Native Debugging]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Debugowanie języka Python/debugowanie natywne]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="1" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;StringListProperty&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -40,14 +53,20 @@
     <Item ItemId="0;localdebuggerenvironment@StringListProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Specifies the environment for the debugee, or variables to merge with existing environment.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Określa środowisko dla obiektu debugowanego lub zmienne do scalenia z istniejącym środowiskiem.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="23" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggerenvironment@StringListProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Environment]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Środowisko]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="21" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;StringProperty&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -55,38 +74,56 @@
     <Item ItemId="0;localdebuggercommand@StringProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[The debug command to execute.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Polecenie debugowania do wykonania.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="7" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggercommandarguments@StringProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[The command line arguments to pass to the application.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Argumenty wiersza polecenia do przekazania aplikacji.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="15" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggerworkingdirectory@StringProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[The application's working directory. By default, the directory containing the project file.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Katalog roboczy aplikacji. Domyślnie — katalog zawierający plik projektu.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="19" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggercommand@StringProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Command]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Polecenie]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="5" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggercommandarguments@StringProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Command Arguments]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Argumenty polecenia]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="13" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggerworkingdirectory@StringProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Working Directory]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Katalog roboczy]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="17" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;ValueEditor&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -94,14 +131,20 @@
     <Item ItemId="0;5a88dad82b4127d481f86820c9fcbf98" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[<Edit...>]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[<Edytuj...>]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="9" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;b66ab1d4354799e0066c0af0ab39211f" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[<Browse...>]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[<Przeglądaj...>]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="11" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
-<Settings Name="@SettingsPath@\default.lss" Type="Lss" /></LCX>
+</LCX>

--- a/Python/loc/lcl/PTB/Snippets/Python/arg_path.snippet.lcl
+++ b/Python/loc/lcl/PTB/Snippets/Python/arg_path.snippet.lcl
@@ -1,17 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="D:\a\_work\1\b\raw\binaries\Snippets\Python\arg_path.snippet" PsrId="210" SrcCul="en-US" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx" TgtCul="pt-BR">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\21\b\raw\binaries\Snippets\Python\arg_path.snippet" PsrId="210" FileType="1" SrcCul="en-US" TgtCul="pt-BR" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="Dev" />
     <Cmt Name="LcxAdmin" />
     <Cmt Name="Rccx" />
   </OwnedComments>
+  <Settings Name="@SettingsPath@\default.lss" Type="Lss" />
   <Item ItemId=";&lt;Description&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
     <Item ItemId="0;10b5db89840923ed3d0acc5fe287c167" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Code snippet for a path argument for an argparse parser.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Snippet de código para um argumento de caminho para um analisador argparse.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="3" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;Title&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -19,8 +23,11 @@
     <Item ItemId="0;1cf27f1348d9adf9704b2dff0db0d888" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[argparse path argument]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[argumento de caminho argparse]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="1" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;ToolTip&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -28,26 +35,38 @@
     <Item ItemId="0;69ee1bdf53fb0aeed761c52c8d49693d" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Short argument name, typically only a single letter.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Nome de argumento curto, normalmente apenas uma única letra.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="5" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;75a55c928c79bdb03057db67af054e9e" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Long argument name, typically one or two words separated by a hyphen.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Nome de argumento longo, normalmente uma ou duas palavras separadas por hífen.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="7" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;e7b23931982c94194e3886cd424afb72" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Description of the argument to display when called with --help/-h.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Descrição do argumento a ser exibido quando chamado com --help/-h.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="11" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;ed36fc16d953d88706f27cad66ebb5f2" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Argument variable name.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Nome da variável de argumento.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="9" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
-<Settings Name="@SettingsPath@\default.lss" Type="Lss" /></LCX>
+</LCX>

--- a/Python/loc/lcl/PTB/Snippets/Python/arg_path_positional.snippet.lcl
+++ b/Python/loc/lcl/PTB/Snippets/Python/arg_path_positional.snippet.lcl
@@ -1,17 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="D:\a\_work\1\b\raw\binaries\Snippets\Python\arg_path_positional.snippet" PsrId="210" SrcCul="en-US" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx" TgtCul="pt-BR">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\21\b\raw\binaries\Snippets\Python\arg_path_positional.snippet" PsrId="210" FileType="1" SrcCul="en-US" TgtCul="pt-BR" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="Dev" />
     <Cmt Name="LcxAdmin" />
     <Cmt Name="Rccx" />
   </OwnedComments>
+  <Settings Name="@SettingsPath@\default.lss" Type="Lss" />
   <Item ItemId=";&lt;Description&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
     <Item ItemId="0;12736a644fe557377d4f44fb250f3cc0" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Code snippet for a positional path argument for an argparse parser.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Snippet de código para um argumento de caminho posicional para um analisador argparse.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="3" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;Title&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -19,8 +23,11 @@
     <Item ItemId="0;5cb477ab75463262edfbf537292653c8" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[argparse positional path argument]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[argumento de caminho posicional argparse]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="1" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;ToolTip&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -28,14 +35,20 @@
     <Item ItemId="0;35282756089c336d9b7432ac72d786f1" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Argument name. Start with a hyphen to require a switch, or omit to make it positional.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Nome do argumento. Comece com um hífen para exigir uma opção ou omita para torná-lo posicional.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="5" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;e7b23931982c94194e3886cd424afb72" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Description of the argument to display when called with --help/-h.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Descrição do argumento a ser exibido quando chamado com --help/-h.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="7" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
-<Settings Name="@SettingsPath@\default.lss" Type="Lss" /></LCX>
+</LCX>

--- a/Python/loc/lcl/PTB/Snippets/Python/arg_str.snippet.lcl
+++ b/Python/loc/lcl/PTB/Snippets/Python/arg_str.snippet.lcl
@@ -1,17 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="D:\a\_work\1\b\raw\binaries\Snippets\Python\arg_str.snippet" PsrId="210" SrcCul="en-US" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx" TgtCul="pt-BR">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\21\b\raw\binaries\Snippets\Python\arg_str.snippet" PsrId="210" FileType="1" SrcCul="en-US" TgtCul="pt-BR" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="Dev" />
     <Cmt Name="LcxAdmin" />
     <Cmt Name="Rccx" />
   </OwnedComments>
+  <Settings Name="@SettingsPath@\default.lss" Type="Lss" />
   <Item ItemId=";&lt;Description&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
     <Item ItemId="0;5162629d4963116ba811271091fe841d" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Code snippet for a string argument for an argparse parser.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Snippet de código para um argumento de cadeia de caracteres para um analisador argparse.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="3" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;Title&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -19,8 +23,11 @@
     <Item ItemId="0;8fbb5326dfe0bf71b7361d48e1a445c4" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[argparse string argument]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[argumento de cadeia de caracteres argparse]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="1" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;ToolTip&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -28,26 +35,38 @@
     <Item ItemId="0;69ee1bdf53fb0aeed761c52c8d49693d" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Short argument name, typically only a single letter.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Nome de argumento curto, normalmente apenas uma única letra.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="5" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;75a55c928c79bdb03057db67af054e9e" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Long argument name, typically one or two words separated by a hyphen.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Nome de argumento longo, normalmente uma ou duas palavras separadas por hífen.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="7" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;e7b23931982c94194e3886cd424afb72" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Description of the argument to display when called with --help/-h.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Descrição do argumento a ser exibido quando chamado com --help/-h.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="11" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;ed36fc16d953d88706f27cad66ebb5f2" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Argument variable name.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Nome da variável de argumento.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="9" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
-<Settings Name="@SettingsPath@\default.lss" Type="Lss" /></LCX>
+</LCX>

--- a/Python/loc/lcl/PTB/Snippets/Python/arg_str_positional.snippet.lcl
+++ b/Python/loc/lcl/PTB/Snippets/Python/arg_str_positional.snippet.lcl
@@ -1,17 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="D:\a\_work\1\b\raw\binaries\Snippets\Python\arg_str_positional.snippet" PsrId="210" SrcCul="en-US" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx" TgtCul="pt-BR">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\21\b\raw\binaries\Snippets\Python\arg_str_positional.snippet" PsrId="210" FileType="1" SrcCul="en-US" TgtCul="pt-BR" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="Dev" />
     <Cmt Name="LcxAdmin" />
     <Cmt Name="Rccx" />
   </OwnedComments>
+  <Settings Name="@SettingsPath@\default.lss" Type="Lss" />
   <Item ItemId=";&lt;Description&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
     <Item ItemId="0;69def699f0c2570190c042fc792b38c5" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Code snippet for a positional string argument for an argparse parser.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Snippet de código para um argumento posicional da cadeia de caracteres para um analisador argparse.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="3" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;Title&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -19,8 +23,11 @@
     <Item ItemId="0;9dbaae3dbddf131d3205155271f50641" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[argparse positional string argument]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[argumento de posicional de cadeia de caracteres argparse]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="1" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;ToolTip&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -28,14 +35,20 @@
     <Item ItemId="0;35282756089c336d9b7432ac72d786f1" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Argument name. Start with a hyphen to require a switch, or omit to make it positional.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Nome do argumento. Comece com um hífen para exigir uma opção ou omita para torná-lo posicional.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="5" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;e7b23931982c94194e3886cd424afb72" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Description of the argument to display when called with --help/-h.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Descrição do argumento a ser exibido quando chamado com --help/-h.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="7" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
-<Settings Name="@SettingsPath@\default.lss" Type="Lss" /></LCX>
+</LCX>

--- a/Python/loc/lcl/PTB/Snippets/Python/arg_switch.snippet.lcl
+++ b/Python/loc/lcl/PTB/Snippets/Python/arg_switch.snippet.lcl
@@ -1,17 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="D:\a\_work\1\b\raw\binaries\Snippets\Python\arg_switch.snippet" PsrId="210" SrcCul="en-US" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx" TgtCul="pt-BR">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\21\b\raw\binaries\Snippets\Python\arg_switch.snippet" PsrId="210" FileType="1" SrcCul="en-US" TgtCul="pt-BR" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="Dev" />
     <Cmt Name="LcxAdmin" />
     <Cmt Name="Rccx" />
   </OwnedComments>
+  <Settings Name="@SettingsPath@\default.lss" Type="Lss" />
   <Item ItemId=";&lt;Description&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
     <Item ItemId="0;cdf30125985a60ac677caefc318833e8" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Code snippet for a switch argument for an argparse parser.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Snippet de código para um argumento de opção para um analisador argparse.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="3" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;Title&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -19,8 +23,11 @@
     <Item ItemId="0;277d72dbe38cd017f4b02e7448bf146e" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[argparse switch argument]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[argumento de opção argparse]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="1" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;ToolTip&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -28,20 +35,29 @@
     <Item ItemId="0;69ee1bdf53fb0aeed761c52c8d49693d" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Short argument name, typically only a single letter.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Nome de argumento curto, normalmente apenas uma única letra.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="5" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;75a55c928c79bdb03057db67af054e9e" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Long argument name, typically one or two words separated by a hyphen.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Nome de argumento longo, normalmente uma ou duas palavras separadas por hífen.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="7" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;e7b23931982c94194e3886cd424afb72" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Description of the argument to display when called with --help/-h.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Descrição do argumento a ser exibido quando chamado com --help/-h.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="9" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
-<Settings Name="@SettingsPath@\default.lss" Type="Lss" /></LCX>
+</LCX>

--- a/Python/loc/lcl/PTB/Snippets/Python/argparse.snippet.lcl
+++ b/Python/loc/lcl/PTB/Snippets/Python/argparse.snippet.lcl
@@ -1,17 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="D:\a\_work\1\b\raw\binaries\Snippets\Python\argparse.snippet" PsrId="210" SrcCul="en-US" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx" TgtCul="pt-BR">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\21\b\raw\binaries\Snippets\Python\argparse.snippet" PsrId="210" FileType="1" SrcCul="en-US" TgtCul="pt-BR" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="Dev" />
     <Cmt Name="LcxAdmin" />
     <Cmt Name="Rccx" />
   </OwnedComments>
+  <Settings Name="@SettingsPath@\default.lss" Type="Lss" />
   <Item ItemId=";&lt;Description&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
     <Item ItemId="0;efc9719c9afe3a8265e2a7e511a1cdc6" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Code snippet for a function to parse arguments using argparse]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Snippet de código para uma função a fim de analisar argumentos usando argparse]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="3" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;Title&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -19,8 +23,11 @@
     <Item ItemId="0;4365422194f5997a16d7a169524e3d10" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[argparse block]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[bloco argparse]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="1" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;ToolTip&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -28,8 +35,11 @@
     <Item ItemId="0;62568bc5e481b7c2bf94f72978c34da4" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Short description of your script]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Breve descrição do seu script]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="5" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
-<Settings Name="@SettingsPath@\default.lss" Type="Lss" /></LCX>
+</LCX>

--- a/Python/loc/lcl/PTB/VCTargets/Win32/ImportAfter/Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml.lcl
+++ b/Python/loc/lcl/PTB/VCTargets/Win32/ImportAfter/Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml.lcl
@@ -1,23 +1,30 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="D:\a\_work\1\b\raw\binaries\VCTargets\Win32\ImportAfter\Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml" PsrId="22" SrcCul="en-US" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx" TgtCul="pt-BR">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\20\b\raw\binaries\VCTargets\Win32\ImportAfter\Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml" PsrId="22" FileType="1" SrcCul="en-US" TgtCul="pt-BR" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="Dev" />
     <Cmt Name="LcxAdmin" />
     <Cmt Name="Rccx" />
   </OwnedComments>
+  <Settings Name="@SettingsPath@\default.lss" Type="Lss" />
   <Item ItemId=";&lt;BoolProperty&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
     <Item ItemId="0;localdebuggermergeenvironment@BoolProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Merge specified environment variables with existing environment.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Mescle variáveis de ambiente especificadas com o ambiente existente.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="27" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggermergeenvironment@BoolProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Merge Environment]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Ambiente de Mesclagem]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="25" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;Rule&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -25,14 +32,20 @@
     <Item ItemId="0;pythondebuglaunchprovider@Rule@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Python/Native debugging options]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Opções de depuração Nativa/do Python]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="3" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;pythondebuglaunchprovider@Rule@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Python/Native Debugging]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Depuração Nativa/do Python]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="1" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;StringListProperty&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -40,14 +53,20 @@
     <Item ItemId="0;localdebuggerenvironment@StringListProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Specifies the environment for the debugee, or variables to merge with existing environment.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Especifica o ambiente para o depurador ou as variáveis a serem mescladas com o ambiente existente.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="23" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggerenvironment@StringListProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Environment]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Ambiente]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="21" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;StringProperty&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -55,38 +74,56 @@
     <Item ItemId="0;localdebuggercommand@StringProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[The debug command to execute.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[O comando de depuração a ser executado.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="7" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggercommandarguments@StringProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[The command line arguments to pass to the application.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Os argumentos de linha de comando a serem passados para o aplicativo.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="15" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggerworkingdirectory@StringProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[The application's working directory. By default, the directory containing the project file.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[O diretório de trabalho do aplicativo. Por padrão, o diretório que contém o arquivo de projeto.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="19" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggercommand@StringProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Command]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Comando]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="5" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggercommandarguments@StringProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Command Arguments]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Argumentos do Comando]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="13" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggerworkingdirectory@StringProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Working Directory]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Diretório de Trabalho]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="17" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;ValueEditor&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -94,14 +131,20 @@
     <Item ItemId="0;5a88dad82b4127d481f86820c9fcbf98" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[<Edit...>]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[<Editar...>]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="9" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;b66ab1d4354799e0066c0af0ab39211f" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[<Browse...>]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[<Procurar...>]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="11" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
-<Settings Name="@SettingsPath@\default.lss" Type="Lss" /></LCX>
+</LCX>

--- a/Python/loc/lcl/PTB/VCTargets/x64/ImportAfter/Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml.lcl
+++ b/Python/loc/lcl/PTB/VCTargets/x64/ImportAfter/Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml.lcl
@@ -1,23 +1,30 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="D:\a\_work\1\b\raw\binaries\VCTargets\x64\ImportAfter\Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml" PsrId="22" SrcCul="en-US" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx" TgtCul="pt-BR">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\20\b\raw\binaries\VCTargets\Win32\ImportAfter\Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml" PsrId="22" FileType="1" SrcCul="en-US" TgtCul="pt-BR" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="Dev" />
     <Cmt Name="LcxAdmin" />
     <Cmt Name="Rccx" />
   </OwnedComments>
+  <Settings Name="@SettingsPath@\default.lss" Type="Lss" />
   <Item ItemId=";&lt;BoolProperty&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
     <Item ItemId="0;localdebuggermergeenvironment@BoolProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Merge specified environment variables with existing environment.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Mescle variáveis de ambiente especificadas com o ambiente existente.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="27" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggermergeenvironment@BoolProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Merge Environment]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Ambiente de Mesclagem]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="25" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;Rule&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -25,14 +32,20 @@
     <Item ItemId="0;pythondebuglaunchprovider@Rule@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Python/Native debugging options]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Opções de depuração Nativa/do Python]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="3" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;pythondebuglaunchprovider@Rule@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Python/Native Debugging]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Depuração Nativa/do Python]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="1" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;StringListProperty&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -40,14 +53,20 @@
     <Item ItemId="0;localdebuggerenvironment@StringListProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Specifies the environment for the debugee, or variables to merge with existing environment.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Especifica o ambiente para o depurador ou as variáveis a serem mescladas com o ambiente existente.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="23" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggerenvironment@StringListProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Environment]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Ambiente]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="21" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;StringProperty&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -55,38 +74,56 @@
     <Item ItemId="0;localdebuggercommand@StringProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[The debug command to execute.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[O comando de depuração a ser executado.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="7" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggercommandarguments@StringProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[The command line arguments to pass to the application.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Os argumentos de linha de comando a serem passados para o aplicativo.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="15" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggerworkingdirectory@StringProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[The application's working directory. By default, the directory containing the project file.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[O diretório de trabalho do aplicativo. Por padrão, o diretório que contém o arquivo de projeto.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="19" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggercommand@StringProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Command]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Comando]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="5" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggercommandarguments@StringProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Command Arguments]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Argumentos do Comando]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="13" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggerworkingdirectory@StringProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Working Directory]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Diretório de Trabalho]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="17" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;ValueEditor&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -94,14 +131,20 @@
     <Item ItemId="0;5a88dad82b4127d481f86820c9fcbf98" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[<Edit...>]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[<Editar...>]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="9" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;b66ab1d4354799e0066c0af0ab39211f" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[<Browse...>]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[<Procurar...>]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="11" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
-<Settings Name="@SettingsPath@\default.lss" Type="Lss" /></LCX>
+</LCX>

--- a/Python/loc/lcl/RUS/Snippets/Python/arg_path.snippet.lcl
+++ b/Python/loc/lcl/RUS/Snippets/Python/arg_path.snippet.lcl
@@ -1,17 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="D:\a\_work\1\b\raw\binaries\Snippets\Python\arg_path.snippet" PsrId="210" SrcCul="en-US" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx" TgtCul="ru-RU">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\21\b\raw\binaries\Snippets\Python\arg_path.snippet" PsrId="210" FileType="1" SrcCul="en-US" TgtCul="ru-RU" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="Dev" />
     <Cmt Name="LcxAdmin" />
     <Cmt Name="Rccx" />
   </OwnedComments>
+  <Settings Name="@SettingsPath@\default.lss" Type="Lss" />
   <Item ItemId=";&lt;Description&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
     <Item ItemId="0;10b5db89840923ed3d0acc5fe287c167" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Code snippet for a path argument for an argparse parser.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Фрагмент кода с аргументом пути для средства синтаксического анализа argparse.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="3" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;Title&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -19,8 +23,11 @@
     <Item ItemId="0;1cf27f1348d9adf9704b2dff0db0d888" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[argparse path argument]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Аргумент пути argparse]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="1" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;ToolTip&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -28,26 +35,38 @@
     <Item ItemId="0;69ee1bdf53fb0aeed761c52c8d49693d" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Short argument name, typically only a single letter.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Короткое имя аргумента, обычно состоит из одной буквы.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="5" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;75a55c928c79bdb03057db67af054e9e" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Long argument name, typically one or two words separated by a hyphen.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Длинное имя аргумента, обычно одно или два слова, разделенные дефисом.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="7" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;e7b23931982c94194e3886cd424afb72" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Description of the argument to display when called with --help/-h.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Описание аргумента, отображаемое при вызове --help/-h.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="11" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;ed36fc16d953d88706f27cad66ebb5f2" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Argument variable name.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Имя переменной аргумента.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="9" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
-<Settings Name="@SettingsPath@\default.lss" Type="Lss" /></LCX>
+</LCX>

--- a/Python/loc/lcl/RUS/Snippets/Python/arg_path_positional.snippet.lcl
+++ b/Python/loc/lcl/RUS/Snippets/Python/arg_path_positional.snippet.lcl
@@ -1,17 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="D:\a\_work\1\b\raw\binaries\Snippets\Python\arg_path_positional.snippet" PsrId="210" SrcCul="en-US" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx" TgtCul="ru-RU">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\21\b\raw\binaries\Snippets\Python\arg_path_positional.snippet" PsrId="210" FileType="1" SrcCul="en-US" TgtCul="ru-RU" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="Dev" />
     <Cmt Name="LcxAdmin" />
     <Cmt Name="Rccx" />
   </OwnedComments>
+  <Settings Name="@SettingsPath@\default.lss" Type="Lss" />
   <Item ItemId=";&lt;Description&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
     <Item ItemId="0;12736a644fe557377d4f44fb250f3cc0" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Code snippet for a positional path argument for an argparse parser.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Фрагмент кода с позиционным аргументом пути для средства синтаксического анализа argparse.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="3" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;Title&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -19,8 +23,11 @@
     <Item ItemId="0;5cb477ab75463262edfbf537292653c8" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[argparse positional path argument]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Позиционный аргумент пути argparse]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="1" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;ToolTip&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -28,14 +35,20 @@
     <Item ItemId="0;35282756089c336d9b7432ac72d786f1" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Argument name. Start with a hyphen to require a switch, or omit to make it positional.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Имя аргумента. Добавьте дефис в начале, если требуется параметр, или не добавляйте, чтобы сделать аргумент позиционным.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="5" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;e7b23931982c94194e3886cd424afb72" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Description of the argument to display when called with --help/-h.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Описание аргумента, отображаемое при вызове --help/-h.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="7" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
-<Settings Name="@SettingsPath@\default.lss" Type="Lss" /></LCX>
+</LCX>

--- a/Python/loc/lcl/RUS/Snippets/Python/arg_str.snippet.lcl
+++ b/Python/loc/lcl/RUS/Snippets/Python/arg_str.snippet.lcl
@@ -1,17 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="D:\a\_work\1\b\raw\binaries\Snippets\Python\arg_str.snippet" PsrId="210" SrcCul="en-US" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx" TgtCul="ru-RU">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\21\b\raw\binaries\Snippets\Python\arg_str.snippet" PsrId="210" FileType="1" SrcCul="en-US" TgtCul="ru-RU" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="Dev" />
     <Cmt Name="LcxAdmin" />
     <Cmt Name="Rccx" />
   </OwnedComments>
+  <Settings Name="@SettingsPath@\default.lss" Type="Lss" />
   <Item ItemId=";&lt;Description&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
     <Item ItemId="0;5162629d4963116ba811271091fe841d" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Code snippet for a string argument for an argparse parser.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Фрагмент кода со строковым аргументом для средства синтаксического анализа argparse.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="3" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;Title&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -19,8 +23,11 @@
     <Item ItemId="0;8fbb5326dfe0bf71b7361d48e1a445c4" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[argparse string argument]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Строковый аргумент argparse]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="1" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;ToolTip&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -28,26 +35,38 @@
     <Item ItemId="0;69ee1bdf53fb0aeed761c52c8d49693d" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Short argument name, typically only a single letter.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Короткое имя аргумента, обычно состоит из одной буквы.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="5" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;75a55c928c79bdb03057db67af054e9e" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Long argument name, typically one or two words separated by a hyphen.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Длинное имя аргумента, обычно одно или два слова, разделенные дефисом.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="7" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;e7b23931982c94194e3886cd424afb72" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Description of the argument to display when called with --help/-h.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Описание аргумента, отображаемое при вызове --help/-h.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="11" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;ed36fc16d953d88706f27cad66ebb5f2" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Argument variable name.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Имя переменной аргумента.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="9" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
-<Settings Name="@SettingsPath@\default.lss" Type="Lss" /></LCX>
+</LCX>

--- a/Python/loc/lcl/RUS/Snippets/Python/arg_str_positional.snippet.lcl
+++ b/Python/loc/lcl/RUS/Snippets/Python/arg_str_positional.snippet.lcl
@@ -1,17 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="D:\a\_work\1\b\raw\binaries\Snippets\Python\arg_str_positional.snippet" PsrId="210" SrcCul="en-US" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx" TgtCul="ru-RU">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\21\b\raw\binaries\Snippets\Python\arg_str_positional.snippet" PsrId="210" FileType="1" SrcCul="en-US" TgtCul="ru-RU" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="Dev" />
     <Cmt Name="LcxAdmin" />
     <Cmt Name="Rccx" />
   </OwnedComments>
+  <Settings Name="@SettingsPath@\default.lss" Type="Lss" />
   <Item ItemId=";&lt;Description&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
     <Item ItemId="0;69def699f0c2570190c042fc792b38c5" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Code snippet for a positional string argument for an argparse parser.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Фрагмент кода с позиционным строковым аргументом для средства синтаксического анализа argparse.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="3" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;Title&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -19,8 +23,11 @@
     <Item ItemId="0;9dbaae3dbddf131d3205155271f50641" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[argparse positional string argument]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Позиционный строковый аргумент argparse]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="1" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;ToolTip&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -28,14 +35,20 @@
     <Item ItemId="0;35282756089c336d9b7432ac72d786f1" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Argument name. Start with a hyphen to require a switch, or omit to make it positional.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Имя аргумента. Добавьте дефис в начале, если требуется параметр, или не добавляйте, чтобы сделать аргумент позиционным.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="5" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;e7b23931982c94194e3886cd424afb72" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Description of the argument to display when called with --help/-h.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Описание аргумента, отображаемое при вызове --help/-h.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="7" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
-<Settings Name="@SettingsPath@\default.lss" Type="Lss" /></LCX>
+</LCX>

--- a/Python/loc/lcl/RUS/Snippets/Python/arg_switch.snippet.lcl
+++ b/Python/loc/lcl/RUS/Snippets/Python/arg_switch.snippet.lcl
@@ -1,17 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="D:\a\_work\1\b\raw\binaries\Snippets\Python\arg_switch.snippet" PsrId="210" SrcCul="en-US" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx" TgtCul="ru-RU">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\21\b\raw\binaries\Snippets\Python\arg_switch.snippet" PsrId="210" FileType="1" SrcCul="en-US" TgtCul="ru-RU" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="Dev" />
     <Cmt Name="LcxAdmin" />
     <Cmt Name="Rccx" />
   </OwnedComments>
+  <Settings Name="@SettingsPath@\default.lss" Type="Lss" />
   <Item ItemId=";&lt;Description&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
     <Item ItemId="0;cdf30125985a60ac677caefc318833e8" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Code snippet for a switch argument for an argparse parser.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Фрагмент кода с аргументом параметра для средства синтаксического анализа argparse.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="3" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;Title&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -19,8 +23,11 @@
     <Item ItemId="0;277d72dbe38cd017f4b02e7448bf146e" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[argparse switch argument]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Аргумент параметра argparse]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="1" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;ToolTip&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -28,20 +35,29 @@
     <Item ItemId="0;69ee1bdf53fb0aeed761c52c8d49693d" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Short argument name, typically only a single letter.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Короткое имя аргумента, обычно состоит из одной буквы.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="5" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;75a55c928c79bdb03057db67af054e9e" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Long argument name, typically one or two words separated by a hyphen.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Длинное имя аргумента, обычно одно или два слова, разделенные дефисом.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="7" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;e7b23931982c94194e3886cd424afb72" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Description of the argument to display when called with --help/-h.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Описание аргумента, отображаемое при вызове --help/-h.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="9" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
-<Settings Name="@SettingsPath@\default.lss" Type="Lss" /></LCX>
+</LCX>

--- a/Python/loc/lcl/RUS/Snippets/Python/argparse.snippet.lcl
+++ b/Python/loc/lcl/RUS/Snippets/Python/argparse.snippet.lcl
@@ -1,17 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="D:\a\_work\1\b\raw\binaries\Snippets\Python\argparse.snippet" PsrId="210" SrcCul="en-US" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx" TgtCul="ru-RU">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\21\b\raw\binaries\Snippets\Python\argparse.snippet" PsrId="210" FileType="1" SrcCul="en-US" TgtCul="ru-RU" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="Dev" />
     <Cmt Name="LcxAdmin" />
     <Cmt Name="Rccx" />
   </OwnedComments>
+  <Settings Name="@SettingsPath@\default.lss" Type="Lss" />
   <Item ItemId=";&lt;Description&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
-    <Item ItemId="0;efc9719c9afe3a8265e2a7e511a1cdc6" ItemType="42;XML:Text" PsrId="210" Leaf="true">
+    <Item ItemId="0;efc9719c9afe3a8265e2a7e511a1cdc6" ItemType="42;XML:Text" PsrId="210" Leaf="True">
       <Str Cat="AppData">
         <Val><![CDATA[Code snippet for a function to parse arguments using argparse]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Фрагмент кода с функцией для синтаксического анализа аргументов с помощью argparse]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="3" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;Title&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -19,8 +23,11 @@
     <Item ItemId="0;4365422194f5997a16d7a169524e3d10" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[argparse block]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Блок argparse]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="1" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;ToolTip&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -28,8 +35,11 @@
     <Item ItemId="0;62568bc5e481b7c2bf94f72978c34da4" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Short description of your script]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Краткое описание сценария]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="5" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
-<Settings Name="@SettingsPath@\default.lss" Type="Lss" /></LCX>
+</LCX>

--- a/Python/loc/lcl/RUS/VCTargets/Win32/ImportAfter/Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml.lcl
+++ b/Python/loc/lcl/RUS/VCTargets/Win32/ImportAfter/Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml.lcl
@@ -1,23 +1,30 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="D:\a\_work\1\b\raw\binaries\VCTargets\Win32\ImportAfter\Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml" PsrId="22" SrcCul="en-US" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx" TgtCul="ru-RU">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\20\b\raw\binaries\VCTargets\Win32\ImportAfter\Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml" PsrId="22" FileType="1" SrcCul="en-US" TgtCul="ru-RU" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="Dev" />
     <Cmt Name="LcxAdmin" />
     <Cmt Name="Rccx" />
   </OwnedComments>
+  <Settings Name="@SettingsPath@\default.lss" Type="Lss" />
   <Item ItemId=";&lt;BoolProperty&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
     <Item ItemId="0;localdebuggermergeenvironment@BoolProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Merge specified environment variables with existing environment.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Объединять указанные переменные среды с существующей средой.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="27" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggermergeenvironment@BoolProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Merge Environment]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Объединение среды]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="25" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;Rule&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -25,14 +32,20 @@
     <Item ItemId="0;pythondebuglaunchprovider@Rule@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Python/Native debugging options]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Варианты отладки Python и в машинном коде]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="3" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;pythondebuglaunchprovider@Rule@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Python/Native Debugging]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Отладка Python и в машинном коде]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="1" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;StringListProperty&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -40,14 +53,20 @@
     <Item ItemId="0;localdebuggerenvironment@StringListProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Specifies the environment for the debugee, or variables to merge with existing environment.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Задает среду для отлаживаемого элемента. Также можно указать переменные, которые будут объединены с существующей средой.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="23" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggerenvironment@StringListProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Environment]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Окружение]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="21" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;StringProperty&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -55,38 +74,56 @@
     <Item ItemId="0;localdebuggercommand@StringProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[The debug command to execute.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Команда отладки для выполнения.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="7" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggercommandarguments@StringProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[The command line arguments to pass to the application.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Аргументы командной строки, которые будут переданы приложению.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="15" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggerworkingdirectory@StringProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[The application's working directory. By default, the directory containing the project file.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Рабочий каталог приложения. По умолчанию это каталог, содержащий файл проекта.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="19" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggercommand@StringProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Command]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Команда]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="5" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggercommandarguments@StringProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Command Arguments]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Аргументы команды]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="13" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggerworkingdirectory@StringProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Working Directory]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Рабочий каталог]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="17" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;ValueEditor&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -94,14 +131,20 @@
     <Item ItemId="0;5a88dad82b4127d481f86820c9fcbf98" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[<Edit...>]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[<Изменить...>]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="9" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;b66ab1d4354799e0066c0af0ab39211f" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[<Browse...>]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[<Обзор...>]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="11" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
-<Settings Name="@SettingsPath@\default.lss" Type="Lss" /></LCX>
+</LCX>

--- a/Python/loc/lcl/RUS/VCTargets/x64/ImportAfter/Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml.lcl
+++ b/Python/loc/lcl/RUS/VCTargets/x64/ImportAfter/Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml.lcl
@@ -1,23 +1,30 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="D:\a\_work\1\b\raw\binaries\VCTargets\x64\ImportAfter\Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml" PsrId="22" SrcCul="en-US" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx" TgtCul="ru-RU">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\20\b\raw\binaries\VCTargets\Win32\ImportAfter\Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml" PsrId="22" FileType="1" SrcCul="en-US" TgtCul="ru-RU" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="Dev" />
     <Cmt Name="LcxAdmin" />
     <Cmt Name="Rccx" />
   </OwnedComments>
+  <Settings Name="@SettingsPath@\default.lss" Type="Lss" />
   <Item ItemId=";&lt;BoolProperty&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
     <Item ItemId="0;localdebuggermergeenvironment@BoolProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Merge specified environment variables with existing environment.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Объединять указанные переменные среды с существующей средой.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="27" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggermergeenvironment@BoolProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Merge Environment]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Объединение среды]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="25" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;Rule&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -25,14 +32,20 @@
     <Item ItemId="0;pythondebuglaunchprovider@Rule@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Python/Native debugging options]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Варианты отладки Python и в машинном коде]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="3" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;pythondebuglaunchprovider@Rule@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Python/Native Debugging]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Отладка Python и в машинном коде]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="1" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;StringListProperty&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -40,14 +53,20 @@
     <Item ItemId="0;localdebuggerenvironment@StringListProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Specifies the environment for the debugee, or variables to merge with existing environment.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Задает среду для отлаживаемого элемента. Также можно указать переменные, которые будут объединены с существующей средой.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="23" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggerenvironment@StringListProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Environment]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Окружение]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="21" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;StringProperty&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -55,38 +74,56 @@
     <Item ItemId="0;localdebuggercommand@StringProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[The debug command to execute.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Команда отладки для выполнения.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="7" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggercommandarguments@StringProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[The command line arguments to pass to the application.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Аргументы командной строки, которые будут переданы приложению.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="15" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggerworkingdirectory@StringProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[The application's working directory. By default, the directory containing the project file.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Рабочий каталог приложения. По умолчанию это каталог, содержащий файл проекта.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="19" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggercommand@StringProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Command]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Команда]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="5" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggercommandarguments@StringProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Command Arguments]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Аргументы команды]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="13" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggerworkingdirectory@StringProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Working Directory]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Рабочий каталог]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="17" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;ValueEditor&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -94,14 +131,20 @@
     <Item ItemId="0;5a88dad82b4127d481f86820c9fcbf98" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[<Edit...>]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[<Изменить...>]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="9" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;b66ab1d4354799e0066c0af0ab39211f" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[<Browse...>]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[<Обзор...>]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="11" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
-<Settings Name="@SettingsPath@\default.lss" Type="Lss" /></LCX>
+</LCX>

--- a/Python/loc/lcl/TRK/Snippets/Python/arg_path.snippet.lcl
+++ b/Python/loc/lcl/TRK/Snippets/Python/arg_path.snippet.lcl
@@ -1,17 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="D:\a\_work\1\b\raw\binaries\Snippets\Python\arg_path.snippet" PsrId="210" SrcCul="en-US" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx" TgtCul="tr-TR">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\21\b\raw\binaries\Snippets\Python\arg_path.snippet" PsrId="210" FileType="1" SrcCul="en-US" TgtCul="tr-TR" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="Dev" />
     <Cmt Name="LcxAdmin" />
     <Cmt Name="Rccx" />
   </OwnedComments>
+  <Settings Name="@SettingsPath@\default.lss" Type="Lss" />
   <Item ItemId=";&lt;Description&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
     <Item ItemId="0;10b5db89840923ed3d0acc5fe287c167" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Code snippet for a path argument for an argparse parser.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Bir argparse ayrıştırıcısının yol bağımsız değişkeni için kod parçacığı.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="3" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;Title&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -19,8 +23,11 @@
     <Item ItemId="0;1cf27f1348d9adf9704b2dff0db0d888" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[argparse path argument]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[argparse yol bağımsız değişkeni]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="1" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;ToolTip&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -28,26 +35,38 @@
     <Item ItemId="0;69ee1bdf53fb0aeed761c52c8d49693d" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Short argument name, typically only a single letter.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Kısa bağımsız değişken adı, genellikle yalnızca tek bir harften oluşur.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="5" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;75a55c928c79bdb03057db67af054e9e" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Long argument name, typically one or two words separated by a hyphen.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Uzun bağımsız değişken adı, genellikle bir veya kısa çizgiyle ayrılmış iki sözcükten oluşur.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="7" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;e7b23931982c94194e3886cd424afb72" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Description of the argument to display when called with --help/-h.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[--help/-h ile çağrıldığında görüntülenecek bağımsız değişken açıklaması.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="11" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;ed36fc16d953d88706f27cad66ebb5f2" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Argument variable name.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Bağımsız değişken adı.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="9" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
-<Settings Name="@SettingsPath@\default.lss" Type="Lss" /></LCX>
+</LCX>

--- a/Python/loc/lcl/TRK/Snippets/Python/arg_path_positional.snippet.lcl
+++ b/Python/loc/lcl/TRK/Snippets/Python/arg_path_positional.snippet.lcl
@@ -1,17 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="D:\a\_work\1\b\raw\binaries\Snippets\Python\arg_path_positional.snippet" PsrId="210" SrcCul="en-US" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx" TgtCul="tr-TR">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\21\b\raw\binaries\Snippets\Python\arg_path_positional.snippet" PsrId="210" FileType="1" SrcCul="en-US" TgtCul="tr-TR" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="Dev" />
     <Cmt Name="LcxAdmin" />
     <Cmt Name="Rccx" />
   </OwnedComments>
+  <Settings Name="@SettingsPath@\default.lss" Type="Lss" />
   <Item ItemId=";&lt;Description&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
     <Item ItemId="0;12736a644fe557377d4f44fb250f3cc0" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Code snippet for a positional path argument for an argparse parser.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Bir argparse ayrıştırıcısının konumsal yol bağımsız değişkeni için kod parçacığı.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="3" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;Title&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -19,8 +23,11 @@
     <Item ItemId="0;5cb477ab75463262edfbf537292653c8" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[argparse positional path argument]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[argparse konumsal yol bağımsız değişkeni]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="1" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;ToolTip&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -28,14 +35,20 @@
     <Item ItemId="0;35282756089c336d9b7432ac72d786f1" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Argument name. Start with a hyphen to require a switch, or omit to make it positional.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Bağımsız değişken adı. Bir anahtarı gerektirmek için kısa çizgiyle başlayabilir veya konumsal yapmak için bunu atlayabilirsiniz.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="5" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;e7b23931982c94194e3886cd424afb72" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Description of the argument to display when called with --help/-h.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[--help/-h ile çağrıldığında görüntülenecek bağımsız değişken açıklaması.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="7" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
-<Settings Name="@SettingsPath@\default.lss" Type="Lss" /></LCX>
+</LCX>

--- a/Python/loc/lcl/TRK/Snippets/Python/arg_str.snippet.lcl
+++ b/Python/loc/lcl/TRK/Snippets/Python/arg_str.snippet.lcl
@@ -1,17 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="D:\a\_work\1\b\raw\binaries\Snippets\Python\arg_str.snippet" PsrId="210" SrcCul="en-US" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx" TgtCul="tr-TR">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\21\b\raw\binaries\Snippets\Python\arg_str.snippet" PsrId="210" FileType="1" SrcCul="en-US" TgtCul="tr-TR" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="Dev" />
     <Cmt Name="LcxAdmin" />
     <Cmt Name="Rccx" />
   </OwnedComments>
+  <Settings Name="@SettingsPath@\default.lss" Type="Lss" />
   <Item ItemId=";&lt;Description&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
     <Item ItemId="0;5162629d4963116ba811271091fe841d" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Code snippet for a string argument for an argparse parser.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Bir argparse ayrıştırıcısının dize bağımsız değişkeni için kod parçacığı.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="3" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;Title&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -19,8 +23,11 @@
     <Item ItemId="0;8fbb5326dfe0bf71b7361d48e1a445c4" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[argparse string argument]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[argparse dize bağımsız değişkeni]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="1" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;ToolTip&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -28,26 +35,38 @@
     <Item ItemId="0;69ee1bdf53fb0aeed761c52c8d49693d" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Short argument name, typically only a single letter.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Kısa bağımsız değişken adı, genellikle yalnızca tek bir harften oluşur.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="5" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;75a55c928c79bdb03057db67af054e9e" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Long argument name, typically one or two words separated by a hyphen.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Uzun bağımsız değişken adı, genellikle bir veya kısa çizgiyle ayrılmış iki sözcükten oluşur.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="7" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;e7b23931982c94194e3886cd424afb72" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Description of the argument to display when called with --help/-h.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[--help/-h ile çağrıldığında görüntülenecek bağımsız değişken açıklaması.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="11" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;ed36fc16d953d88706f27cad66ebb5f2" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Argument variable name.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Bağımsız değişken adı.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="9" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
-<Settings Name="@SettingsPath@\default.lss" Type="Lss" /></LCX>
+</LCX>

--- a/Python/loc/lcl/TRK/Snippets/Python/arg_str_positional.snippet.lcl
+++ b/Python/loc/lcl/TRK/Snippets/Python/arg_str_positional.snippet.lcl
@@ -1,17 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="D:\a\_work\1\b\raw\binaries\Snippets\Python\arg_str_positional.snippet" PsrId="210" SrcCul="en-US" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx" TgtCul="tr-TR">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\21\b\raw\binaries\Snippets\Python\arg_str_positional.snippet" PsrId="210" FileType="1" SrcCul="en-US" TgtCul="tr-TR" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="Dev" />
     <Cmt Name="LcxAdmin" />
     <Cmt Name="Rccx" />
   </OwnedComments>
+  <Settings Name="@SettingsPath@\default.lss" Type="Lss" />
   <Item ItemId=";&lt;Description&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
     <Item ItemId="0;69def699f0c2570190c042fc792b38c5" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Code snippet for a positional string argument for an argparse parser.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Bir argparse ayrıştırıcısının konumsal dize bağımsız değişkeni için kod parçacığı.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="3" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;Title&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -19,8 +23,11 @@
     <Item ItemId="0;9dbaae3dbddf131d3205155271f50641" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[argparse positional string argument]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[argparse konumsal dize bağımsız değişkeni]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="1" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;ToolTip&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -28,14 +35,20 @@
     <Item ItemId="0;35282756089c336d9b7432ac72d786f1" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Argument name. Start with a hyphen to require a switch, or omit to make it positional.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Bağımsız değişken adı. Bir anahtarı gerektirmek için kısa çizgiyle başlayabilir veya konumsal yapmak için bunu atlayabilirsiniz.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="5" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;e7b23931982c94194e3886cd424afb72" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Description of the argument to display when called with --help/-h.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[--help/-h ile çağrıldığında görüntülenecek bağımsız değişken açıklaması.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="7" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
-<Settings Name="@SettingsPath@\default.lss" Type="Lss" /></LCX>
+</LCX>

--- a/Python/loc/lcl/TRK/Snippets/Python/arg_switch.snippet.lcl
+++ b/Python/loc/lcl/TRK/Snippets/Python/arg_switch.snippet.lcl
@@ -1,17 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="D:\a\_work\1\b\raw\binaries\Snippets\Python\arg_switch.snippet" PsrId="210" SrcCul="en-US" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx" TgtCul="tr-TR">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\21\b\raw\binaries\Snippets\Python\arg_switch.snippet" PsrId="210" FileType="1" SrcCul="en-US" TgtCul="tr-TR" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="Dev" />
     <Cmt Name="LcxAdmin" />
     <Cmt Name="Rccx" />
   </OwnedComments>
+  <Settings Name="@SettingsPath@\default.lss" Type="Lss" />
   <Item ItemId=";&lt;Description&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
     <Item ItemId="0;cdf30125985a60ac677caefc318833e8" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Code snippet for a switch argument for an argparse parser.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Bir argparse ayrıştırıcısının anahtar bağımsız değişkeni için kod parçacığı.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="3" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;Title&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -19,8 +23,11 @@
     <Item ItemId="0;277d72dbe38cd017f4b02e7448bf146e" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[argparse switch argument]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[argparse anahtar değişkeni]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="1" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;ToolTip&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -28,20 +35,29 @@
     <Item ItemId="0;69ee1bdf53fb0aeed761c52c8d49693d" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Short argument name, typically only a single letter.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Kısa bağımsız değişken adı, genellikle yalnızca tek bir harften oluşur.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="5" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;75a55c928c79bdb03057db67af054e9e" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Long argument name, typically one or two words separated by a hyphen.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Uzun bağımsız değişken adı, genellikle bir veya kısa çizgiyle ayrılmış iki sözcükten oluşur.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="7" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;e7b23931982c94194e3886cd424afb72" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Description of the argument to display when called with --help/-h.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[--help/-h ile çağrıldığında görüntülenecek bağımsız değişken açıklaması.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="9" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
-<Settings Name="@SettingsPath@\default.lss" Type="Lss" /></LCX>
+</LCX>

--- a/Python/loc/lcl/TRK/Snippets/Python/argparse.snippet.lcl
+++ b/Python/loc/lcl/TRK/Snippets/Python/argparse.snippet.lcl
@@ -1,17 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="D:\a\_work\1\b\raw\binaries\Snippets\Python\argparse.snippet" PsrId="210" SrcCul="en-US" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx" TgtCul="tr-TR">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\21\b\raw\binaries\Snippets\Python\argparse.snippet" PsrId="210" FileType="1" SrcCul="en-US" TgtCul="tr-TR" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="Dev" />
     <Cmt Name="LcxAdmin" />
     <Cmt Name="Rccx" />
   </OwnedComments>
+  <Settings Name="@SettingsPath@\default.lss" Type="Lss" />
   <Item ItemId=";&lt;Description&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
     <Item ItemId="0;efc9719c9afe3a8265e2a7e511a1cdc6" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Code snippet for a function to parse arguments using argparse]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Bir işlev için argparse kullanarak bağımsız değişkenleri ayrıştırmak için kod parçacığı]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="3" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;Title&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -19,8 +23,11 @@
     <Item ItemId="0;4365422194f5997a16d7a169524e3d10" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[argparse block]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[argparse bloğu]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="1" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;ToolTip&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -28,8 +35,11 @@
     <Item ItemId="0;62568bc5e481b7c2bf94f72978c34da4" ItemType="42;XML:Text" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Short description of your script]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Betiğinizin kısa açıklaması]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="5" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
-<Settings Name="@SettingsPath@\default.lss" Type="Lss" /></LCX>
+</LCX>

--- a/Python/loc/lcl/TRK/VCTargets/Win32/ImportAfter/Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml.lcl
+++ b/Python/loc/lcl/TRK/VCTargets/Win32/ImportAfter/Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml.lcl
@@ -1,23 +1,30 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="D:\a\_work\1\b\raw\binaries\VCTargets\Win32\ImportAfter\Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml" PsrId="22" SrcCul="en-US" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx" TgtCul="tr-TR">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\20\b\raw\binaries\VCTargets\Win32\ImportAfter\Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml" PsrId="22" FileType="1" SrcCul="en-US" TgtCul="tr-TR" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="Dev" />
     <Cmt Name="LcxAdmin" />
     <Cmt Name="Rccx" />
   </OwnedComments>
+  <Settings Name="@SettingsPath@\default.lss" Type="Lss" />
   <Item ItemId=";&lt;BoolProperty&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
     <Item ItemId="0;localdebuggermergeenvironment@BoolProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Merge specified environment variables with existing environment.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Belirtilen ortam değişkenlerini varolan ortamla birleştirir.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="27" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggermergeenvironment@BoolProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Merge Environment]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Ortamı Birleştir]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="25" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;Rule&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -25,14 +32,20 @@
     <Item ItemId="0;pythondebuglaunchprovider@Rule@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Python/Native debugging options]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Python/Native hata ayıklama seçenekleri]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="3" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;pythondebuglaunchprovider@Rule@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Python/Native Debugging]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Python/Native Hata Ayıklama]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="1" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;StringListProperty&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -40,14 +53,20 @@
     <Item ItemId="0;localdebuggerenvironment@StringListProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Specifies the environment for the debugee, or variables to merge with existing environment.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Hata ayıklayıcı ortamını veya varolan ortamla birleştirilecek değişkenleri belirtir.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="23" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggerenvironment@StringListProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Environment]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Ortam]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="21" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;StringProperty&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -55,38 +74,56 @@
     <Item ItemId="0;localdebuggercommand@StringProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[The debug command to execute.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Yürütülecek hata ayıklama komutu.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="7" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggercommandarguments@StringProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[The command line arguments to pass to the application.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Uygulamaya geçirilecek bağımsız komut satırı değişkenleri.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="15" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggerworkingdirectory@StringProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[The application's working directory. By default, the directory containing the project file.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Uygulamanın çalışma dizini. Varsayılanı, proje dosyasının bulunduğu dizindir.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="19" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggercommand@StringProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Command]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Komut]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="5" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggercommandarguments@StringProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Command Arguments]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Bağımsız Komut Değişkenleri]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="13" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggerworkingdirectory@StringProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Working Directory]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Çalışma Dizini]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="17" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;ValueEditor&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -94,14 +131,20 @@
     <Item ItemId="0;5a88dad82b4127d481f86820c9fcbf98" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[<Edit...>]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[<Düzenle...>]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="9" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;b66ab1d4354799e0066c0af0ab39211f" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[<Browse...>]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[<Gözat...>]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="11" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
-<Settings Name="@SettingsPath@\default.lss" Type="Lss" /></LCX>
+</LCX>

--- a/Python/loc/lcl/TRK/VCTargets/x64/ImportAfter/Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml.lcl
+++ b/Python/loc/lcl/TRK/VCTargets/x64/ImportAfter/Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml.lcl
@@ -1,23 +1,30 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="D:\a\_work\1\b\raw\binaries\VCTargets\x64\ImportAfter\Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml" PsrId="22" SrcCul="en-US" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx" TgtCul="tr-TR">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\20\b\raw\binaries\VCTargets\Win32\ImportAfter\Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml" PsrId="22" FileType="1" SrcCul="en-US" TgtCul="tr-TR" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="Dev" />
     <Cmt Name="LcxAdmin" />
     <Cmt Name="Rccx" />
   </OwnedComments>
+  <Settings Name="@SettingsPath@\default.lss" Type="Lss" />
   <Item ItemId=";&lt;BoolProperty&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
     <Item ItemId="0;localdebuggermergeenvironment@BoolProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Merge specified environment variables with existing environment.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Belirtilen ortam değişkenlerini varolan ortamla birleştirir.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="27" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggermergeenvironment@BoolProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Merge Environment]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Ortamı Birleştir]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="25" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;Rule&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -25,14 +32,20 @@
     <Item ItemId="0;pythondebuglaunchprovider@Rule@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Python/Native debugging options]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Python/Native hata ayıklama seçenekleri]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="3" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;pythondebuglaunchprovider@Rule@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Python/Native Debugging]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Python/Native Hata Ayıklama]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="1" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;StringListProperty&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -40,14 +53,20 @@
     <Item ItemId="0;localdebuggerenvironment@StringListProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Specifies the environment for the debugee, or variables to merge with existing environment.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Hata ayıklayıcı ortamını veya varolan ortamla birleştirilecek değişkenleri belirtir.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="23" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggerenvironment@StringListProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Environment]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Ortam]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="21" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;StringProperty&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -55,38 +74,56 @@
     <Item ItemId="0;localdebuggercommand@StringProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[The debug command to execute.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Yürütülecek hata ayıklama komutu.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="7" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggercommandarguments@StringProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[The command line arguments to pass to the application.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Uygulamaya geçirilecek bağımsız komut satırı değişkenleri.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="15" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggerworkingdirectory@StringProperty@Description" ItemType="47;XML:Attr:Description" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[The application's working directory. By default, the directory containing the project file.]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Uygulamanın çalışma dizini. Varsayılanı, proje dosyasının bulunduğu dizindir.]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="19" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggercommand@StringProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Command]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Komut]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="5" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggercommandarguments@StringProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Command Arguments]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Bağımsız Komut Değişkenleri]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="13" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;localdebuggerworkingdirectory@StringProperty@DisplayName" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[Working Directory]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[Çalışma Dizini]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="17" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
   <Item ItemId=";&lt;ValueEditor&gt;" ItemType="0" PsrId="210" Leaf="false">
@@ -94,14 +131,20 @@
     <Item ItemId="0;5a88dad82b4127d481f86820c9fcbf98" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[<Edit...>]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[<Düzenle...>]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="9" />
+      <Disp Icon="Str" />
     </Item>
     <Item ItemId="0;b66ab1d4354799e0066c0af0ab39211f" ItemType="47;XML:Attr:DisplayName" PsrId="210" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[<Browse...>]]></Val>
+        <Tgt Cat="AppData" Stat="Loc" Orig="New">
+          <Val><![CDATA[<Gözat...>]]></Val>
+        </Tgt>
       </Str>
-      <Disp Icon="Str" Order="11" />
+      <Disp Icon="Str" />
     </Item>
   </Item>
-<Settings Name="@SettingsPath@\default.lss" Type="Lss" /></LCX>
+</LCX>


### PR DESCRIPTION
This is related to the lsbuild warning.
The new path for the .lcl needs a one-time manual sync.