### PR TITLE
Use the build number of the pipeline resource

### DIFF
--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -63,11 +63,11 @@ extends:
           displayName: 'Create Insertion PR'
           inputs:
             TargetBranch: $(VisualStudioBranch)
-            InsertionTopicBranch: 'dev/ptvs/insertions/$(VisualStudioBranch)-$(Build.SourceBranchName)-$(Build.BuildNumber)'
+            InsertionTopicBranch: 'dev/ptvs/insertions/$(VisualStudioBranch)-$(Build.SourceBranchName)-$(resources.pipeline.PTVS-Build.runName)'
             TeamName: PTVS
             TeamEmail: 'pyvs@microsoft.com'
-            ComponentJsonValues: 'Microsoft.PythonTools.vsman=https://vsdrop.corp.microsoft.com/file/v1/Products/DevDiv/microsoft/PTVS/$(Build.SourceBranchName)/$(Build.BuildNumber);Microsoft.PythonTools.vsman'
-            InsertionPayloadName: 'ptvs $(Build.SourceBranchName) $(Build.BuildNumber)'
+            ComponentJsonValues: 'Microsoft.PythonTools.vsman=https://vsdrop.corp.microsoft.com/file/v1/Products/DevDiv/microsoft/PTVS/$(Build.SourceBranchName)/$(resources.pipeline.PTVS-Build.runName);Microsoft.PythonTools.vsman'
+            InsertionPayloadName: 'ptvs $(Build.SourceBranchName) $(resources.pipeline.PTVS-Build.runName)'
             InsertionReviewers: 'pyvs@microsoft.com,plseng@microsoft.com,bschnurr@microsoft.com,advolker@microsoft.com,stellahuang@microsoft.com'
             InsertionBuildPolicy: 'Request Perf DDRITs'
             AutoCompletePR: true


### PR DESCRIPTION
`$(Build.BuildNumber)` returns the build number of the release pipeline. This isn't what we want.

We need the build number of the PTVS-Build pipeline resource that being consumed. To get that, we need to use `$(resources.pipeline.PTVS-Build.runName)`, where `PTVS-Build` is the ID of the pipeline resource (line 35). It does NOT have to match the actual name of the build pipeline, but in this case, it does.