### PR TITLE
Fix issue when running release pipeline manually

### DIFF
--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -42,11 +42,10 @@ resources:
 
     # Trigger this pipeline when the PTVS-Build pipeline completes.
     trigger:
-      # Only trigger on builds from main or release/* branches
+      # Only trigger on builds from main. Builds from release are manually triggered.
       branches:
         include:
         - main
-        - release/*
       # Only trigger on builds with all of the following tags
       tags:
         - Real signed

--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -30,17 +30,24 @@ resources:
     name: 1ESPipelineTemplates/1ESPipelineTemplates
     ref: refs/tags/release
   
-  # Trigger this pipeline when the PTVS-Build pipeline completes.
+  # Add the PTVS-Build pipeline as a resource
   pipelines:
   - pipeline: PTVS-Build
     source: PTVS-Build
+
+    # When run manually, only consume builds with all of the following tags
+    tags:
+      - Real signed
+      - Pylance Stable
+
+    # Trigger this pipeline when the PTVS-Build pipeline completes.
     trigger:
       # Only trigger on builds from main or release/* branches
       branches:
         include:
         - main
         - release/*
-      # Only trigger on builds that are real signed AND consume pylance stable
+      # Only trigger on builds with all of the following tags
       tags:
         - Real signed
         - Pylance Stable
@@ -56,6 +63,10 @@ extends:
       jobs:
       - job: job
         steps:
+
+        # we don't need to checkout any source code
+        - checkout: none
+
         # Insert the payload uploaded by the PTVS-Build pipeline into Visual Studio.
         # We don't need to download pipeline artifacts here, because the payload is uploaded to a drop location.
         # For more info, see https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_wiki/wikis/DevDiv.wiki/629/Automated-VS-Insertion.

--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -44,7 +44,6 @@ resources:
     trigger:
       # Only trigger on builds from main. Builds from release are manually triggered.
       branches:
-        include:
         - main
       # Only trigger on builds with all of the following tags
       tags:


### PR DESCRIPTION
There are two places that tags need to be set in a pipeline resource. The first is used when the pipeline is triggered manually or through a schedule. The second controls what tags need to be set in order for the current pipeline to be triggered by the completion of the pipeline resource.

In this case, the bug was with running the release pipeline manually.

Now, the release pipeline will look for a build pipeline with BOTH tags set. It will do this both when being run manually and when being triggered by PTVS-Build pipeline completion.