### PR TITLE
Set `enable line number` to `true` by default.

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Editor/LanguagePreferences.cs
+++ b/Python/Product/PythonTools/PythonTools/Editor/LanguagePreferences.cs
@@ -38,6 +38,8 @@ namespace Microsoft.PythonTools.Editor {
             var langPrefs = new LANGPREFERENCES[1];
             langPrefs[0].guidLang = languageGuid;
             ErrorHandler.ThrowOnFailure(_textMgr.GetUserPreferences(null, null, langPrefs, null));
+            langPrefs[0].fLineNumbers = 1;
+            ErrorHandler.ThrowOnFailure(_textMgr.SetUserPreferences(null, null, langPrefs, null));
             _preferences = langPrefs[0];
 
             var guid = typeof(IVsTextManagerEvents2).GUID;
@@ -103,6 +105,7 @@ namespace Microsoft.PythonTools.Editor {
                 _preferences.fAutoListParams = langPrefs[0].fAutoListParams;
                 _preferences.fHideAdvancedAutoListMembers = langPrefs[0].fHideAdvancedAutoListMembers;
                 _preferences.fDropdownBar = langPrefs[0].fDropdownBar;
+                _preferences.fLineNumbers = langPrefs[0].fLineNumbers;
             }
             return VSConstants.S_OK;
         }

--- a/Python/Product/PythonTools/PythonToolsPackage.cs
+++ b/Python/Product/PythonTools/PythonToolsPackage.cs
@@ -79,7 +79,7 @@ namespace Microsoft.PythonTools {
     [ProvideOptionPage(typeof(PythonDebuggingOptionsPage), "Python Tools", "Debugging", 115, 125, true)]
     [ProvideOptionPage(typeof(PythonCondaOptionsPage), "Python Tools", "Conda", 115, 132, true)]
     [Guid(CommonGuidList.guidPythonToolsPkgString)]              // our packages GUID
-    [ProvideLanguageService(typeof(PythonLanguageInfo), PythonConstants.LanguageName, 106, RequestStockColors = true, ShowSmartIndent = true, ShowCompletion = false, DefaultToInsertSpaces = true, HideAdvancedMembersByDefault = true, EnableAdvancedMembersOption = true, ShowDropDownOptions = false)]
+    [ProvideLanguageService(typeof(PythonLanguageInfo), PythonConstants.LanguageName, 106, RequestStockColors = true, EnableLineNumbers = true, ShowSmartIndent = true, ShowCompletion = false, DefaultToInsertSpaces = true, HideAdvancedMembersByDefault = true, EnableAdvancedMembersOption = true, ShowDropDownOptions = false)]
     [ProvideLanguageExtension(typeof(PythonLanguageInfo), PythonConstants.FileExtension)]
     [ProvideLanguageExtension(typeof(PythonLanguageInfo), PythonConstants.WindowsFileExtension)]
     [ProvideLanguageExtension(typeof(PythonLanguageInfo), PythonConstants.StubFileExtension)]

--- a/package.json
+++ b/package.json
@@ -2,6 +2,6 @@
     "name":  "ptvs",
     "private":  true,
     "devDependencies":  {
-                            "@pylance/pylance":  "2024.9.2"
+                            "@pylance/pylance":  "2024.10.1"
                         }
 }


### PR DESCRIPTION
Fixes https://github.com/microsoft/PTVS/issues/8023

We've received the same issue that the line numbers are not showing up multiple times, so I agree with Erik that it makes sense to set the default value to `true` for consistency with other languages like C#.