### PR TITLE
Fix for missing imports

### DIFF
--- a/Python/Product/PythonTools/PythonTools/LanguageServerClient/PythonLanguageClientCustomTarget.cs
+++ b/Python/Product/PythonTools/PythonTools/LanguageServerClient/PythonLanguageClientCustomTarget.cs
@@ -70,8 +70,8 @@ namespace Microsoft.PythonTools.LanguageServerClient {
         /// Event fired when client/registerCapability didChangeWorkspaceFolders is called
         /// Has to be internal so JsonRpc doesn't register this as a method.
         /// </summary>
-        internal event EventHandler WorkspaceFolderChangeRegistered;
-
+        internal event AsyncEventHandler WorkspaceFolderChangeRegistered;
+        
         /// <summary>
         /// Event fired when client/registerCapability didChangeWatchedFiles is called.
         /// Has to be internal so JsonRpc doesn't register this as a method.


### PR DESCRIPTION
the LSC will call ptvs "OnServerInitializedAsync" and here we trigger to update workspaces in pylance but we are converting from async to sync and back to async and not waiting.  This allows the LSC to send a document open before we update the workspaces, causing pylance to think the file belongs to the default workspace and hence missing imports.