### PR TITLE
Use the debug version of python if available

### DIFF
--- a/Examples/PythonCallingNative/PythonApplication/PythonApplication.pyproj
+++ b/Examples/PythonCallingNative/PythonApplication/PythonApplication.pyproj
@@ -11,6 +11,9 @@
     <OutputPath>.</OutputPath>
     <Name>PythonApplication</Name>
     <RootNamespace>PythonApplication</RootNamespace>
+    <InterpreterId>Global|PythonCore|3.9</InterpreterId>
+    <LaunchProvider>Standard Python launcher</LaunchProvider>
+    <EnableNativeCodeDebugging>True</EnableNativeCodeDebugging>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
     <DebugSymbols>true</DebugSymbols>
@@ -29,6 +32,9 @@
       <Project>{2b25e069-3b97-42bb-83ff-ee8dea051a6e}</Project>
       <Private>True</Private>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <InterpreterReference Include="Global|PythonCore|3.9" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\Python Tools\Microsoft.PythonTools.targets" />
   <!-- Uncomment the CoreCompile target to enable the Build command in

--- a/Python/Product/PythonTools/PythonTools/Debugger/DebugLaunchHelper.cs
+++ b/Python/Product/PythonTools/PythonTools/Debugger/DebugLaunchHelper.cs
@@ -1,4 +1,4 @@
-﻿// Python Tools for Visual Studio
+// Python Tools for Visual Studio
 // Copyright(c) Microsoft Corporation
 // All rights reserved.
 //
@@ -293,7 +293,9 @@ namespace Microsoft.PythonTools.Debugger {
             bool nativeDebug = config.GetLaunchOption(PythonConstants.EnableNativeCodeDebugging).IsTrue();
             var basePath = config.GetInterpreterPath();
 
-            // If native debug, use the debug version of python if it's available
+            // If native debug, use the debug version of python if it's available. This ensures 
+            // that mixed mode debugging works better because it can inspect non-optimized code. Optimized code
+            // can mess up frame walking and finding variables.
             if (nativeDebug) {
                 var debugPath = Path.Combine(Path.GetDirectoryName(basePath), Path.GetFileNameWithoutExtension(basePath) + "_d.exe");
                 if (File.Exists(debugPath)) {

--- a/Python/Product/PythonTools/PythonTools/Debugger/DebugLaunchHelper.cs
+++ b/Python/Product/PythonTools/PythonTools/Debugger/DebugLaunchHelper.cs
@@ -181,7 +181,7 @@ namespace Microsoft.PythonTools.Debugger {
 
             try {
                 dti.Info.dlo = DEBUG_LAUNCH_OPERATION.DLO_CreateProcess;
-                dti.Info.bstrExe = config.GetInterpreterPath();
+                dti.Info.bstrExe = GetLaunchingPython(config);
                 dti.Info.bstrCurDir = string.IsNullOrEmpty(config.WorkingDirectory) ? PathUtils.GetParent(config.ScriptName) : config.WorkingDirectory;
 
                 dti.Info.bstrRemoteMachine = null;
@@ -287,6 +287,20 @@ namespace Microsoft.PythonTools.Debugger {
             }
 
             return psi;
+        }
+
+        private static string GetLaunchingPython(LaunchConfiguration config) {
+            bool nativeDebug = config.GetLaunchOption(PythonConstants.EnableNativeCodeDebugging).IsTrue();
+            var basePath = config.GetInterpreterPath();
+
+            // If native debug, use the debug version of python if it's available
+            if (nativeDebug) {
+                var debugPath = Path.Combine(Path.GetDirectoryName(basePath), Path.GetFileNameWithoutExtension(basePath) + "_d.exe");
+                if (File.Exists(debugPath)) {
+                    basePath = debugPath;
+                }
+            }
+            return basePath;
         }
     }
 


### PR DESCRIPTION
The previous fix I made turned out to be because when using the release version of python, Concord has a hard time finding the parts of a function.

This change causes us to use the debug version of python instead when launching under mixed mode.