### PR TITLE
Support mixed mode for 3.10

### DIFF
--- a/Examples/PythonCallingNative/PythonApplication/PythonApplication.pyproj
+++ b/Examples/PythonCallingNative/PythonApplication/PythonApplication.pyproj
@@ -11,7 +11,7 @@
     <OutputPath>.</OutputPath>
     <Name>PythonApplication</Name>
     <RootNamespace>PythonApplication</RootNamespace>
-    <InterpreterId>Global|PythonCore|3.9</InterpreterId>
+    <InterpreterId>Global|PythonCore|3.10</InterpreterId>
     <LaunchProvider>Standard Python launcher</LaunchProvider>
     <EnableNativeCodeDebugging>True</EnableNativeCodeDebugging>
   </PropertyGroup>
@@ -34,6 +34,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <InterpreterReference Include="Global|PythonCore|3.10" />
     <InterpreterReference Include="Global|PythonCore|3.9" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\Python Tools\Microsoft.PythonTools.targets" />

--- a/Examples/PythonNative/PythonNative.cpp
+++ b/Examples/PythonNative/PythonNative.cpp
@@ -13,7 +13,8 @@ DWORD WINAPI runner(LPVOID lpParam)
     std::filesystem::path cwd = std::filesystem::current_path();
     std::filesystem::path startFile = cwd / "runner.py";
 
-    const char * startFileStr = startFile.string().c_str();
+    std::string str = startFile.string();
+    const char * startFileStr = str.c_str();
 
     PyObject* startObj = Py_BuildValue("s", startFileStr);
     FILE* file = _Py_fopen_obj(startObj, "rb+");

--- a/Examples/PythonNative/PythonNative.vcxproj
+++ b/Examples/PythonNative/PythonNative.vcxproj
@@ -104,14 +104,14 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>C:\Users\rchiodo\AppData\Local\Programs\Python\Python310\include;C:\Users\rchiodo\AppData\Local\Programs\Python\Python311\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(LOCALAPPDATA)\Programs\Python\Python310\include;$(LOCALAPPDATA)\Programs\Python\Python311\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <LanguageStandard_C>stdc17</LanguageStandard_C>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalLibraryDirectories>C:\Users\rchiodo\AppData\Local\Programs\Python\Python310\libs;C:\Users\rchiodo\AppData\Local\Programs\Python\Python311\libs;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(LOCALAPPDATA)\Programs\Python\Python310\libs;$(LOCALAPPDATA)\Programs\Python\Python311\libs;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -122,7 +122,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>C:\Users\rchiodo\AppData\Local\Programs\Python\Python310\include;C:\Users\rchiodo\AppData\Local\Programs\Python\Python311\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(LOCALAPPDATA)\Programs\Python\Python310\include;$(LOCALAPPDATA)\Programs\Python\Python311\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <LanguageStandard_C>stdc17</LanguageStandard_C>
     </ClCompile>
@@ -131,7 +131,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalLibraryDirectories>C:\Users\rchiodo\AppData\Local\Programs\Python\Python310\libs;C:\Users\rchiodo\AppData\Local\Programs\Python\Python311\libs;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(LOCALAPPDATA)\Programs\Python\Python310\libs;$(LOCALAPPDATA)\Programs\Python\Python311\libs;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/Examples/PythonNative/PythonNative.vcxproj
+++ b/Examples/PythonNative/PythonNative.vcxproj
@@ -104,14 +104,14 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>C:\Users\rchiodo\AppData\Local\Programs\Python\Python311\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>C:\Users\rchiodo\AppData\Local\Programs\Python\Python310\include;C:\Users\rchiodo\AppData\Local\Programs\Python\Python311\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <LanguageStandard_C>stdc17</LanguageStandard_C>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalLibraryDirectories>C:\Users\rchiodo\AppData\Local\Programs\Python\Python311\libs;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>C:\Users\rchiodo\AppData\Local\Programs\Python\Python310\libs;C:\Users\rchiodo\AppData\Local\Programs\Python\Python311\libs;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -122,7 +122,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>C:\Users\rchiodo\AppData\Local\Programs\Python\Python311\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>C:\Users\rchiodo\AppData\Local\Programs\Python\Python310\include;C:\Users\rchiodo\AppData\Local\Programs\Python\Python311\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <LanguageStandard_C>stdc17</LanguageStandard_C>
     </ClCompile>
@@ -131,7 +131,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalLibraryDirectories>C:\Users\rchiodo\AppData\Local\Programs\Python\Python311\libs;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>C:\Users\rchiodo\AppData\Local\Programs\Python\Python310\libs;C:\Users\rchiodo\AppData\Local\Programs\Python\Python311\libs;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/Python/Product/Cookiecutter/Shared/Interpreters/PythonLanguageVersion.cs
+++ b/Python/Product/Cookiecutter/Shared/Interpreters/PythonLanguageVersion.cs
@@ -39,7 +39,10 @@ namespace Microsoft.CookiecutterTools.Interpreters {
         V37 = 0x0307,
         V38 = 0x0308,
         V39 = 0x0309,
-        V310 = 0x0310
+        V310 = 0x030a,
+        V311 = 0x030b,
+        V312 = 0x030c,
+        V313 = 0x030d,
     }
 
     public static class PythonLanguageVersionExtensions {
@@ -87,6 +90,9 @@ namespace Microsoft.CookiecutterTools.Interpreters {
                         case 8: return PythonLanguageVersion.V38;
                         case 9: return PythonLanguageVersion.V39;
                         case 10: return PythonLanguageVersion.V310;
+                        case 11: return PythonLanguageVersion.V311;
+                        case 12: return PythonLanguageVersion.V312;
+                        case 13: return PythonLanguageVersion.V313;
                     }
                     break;
             }

--- a/Python/Product/Debugger.Concord/Debugger.Concord.csproj
+++ b/Python/Product/Debugger.Concord/Debugger.Concord.csproj
@@ -107,6 +107,7 @@
     <Compile Include="Proxies\DataProxy.cs" />
     <Compile Include="ExpressionEvaluator.cs" />
     <Compile Include="LocalStackWalkingComponent.cs" />
+    <Compile Include="Proxies\Structs\CFrameProxy.cs" />
     <Compile Include="Proxies\Structs\PyRuntimeState.cs" />
     <Compile Include="Proxies\Structs\PyEllipsisObject.cs" />
     <Compile Include="Proxies\Structs\PyComplexObject.cs" />

--- a/Python/Product/Debugger.Concord/Proxies/Structs/CFrameProxy.cs
+++ b/Python/Product/Debugger.Concord/Proxies/Structs/CFrameProxy.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.PythonTools.Common.Parsing;
+using Microsoft.VisualStudio.Debugger;
+
+namespace Microsoft.PythonTools.Debugger.Concord.Proxies.Structs {
+    [StructProxy(StructName = "_cframe", MinVersion = PythonLanguageVersion.V310)]
+    internal class CFrameProxy : StructProxy {
+        internal class Fields {
+            public StructField<Int32Proxy> use_tracing;
+            public StructField<PointerProxy<CFrameProxy>> previous;
+        }
+
+        private readonly Fields _fields;
+
+        public CFrameProxy(DkmProcess process, ulong address)
+            : base(process, address) {
+            InitializeStruct(this, out _fields);
+        }
+
+        public Int32Proxy use_tracing {
+            get { return GetFieldProxy(_fields.use_tracing); }
+        }
+    }
+}

--- a/Python/Product/Debugger.Concord/Proxies/Structs/CFrameProxy.cs
+++ b/Python/Product/Debugger.Concord/Proxies/Structs/CFrameProxy.cs
@@ -7,6 +7,7 @@ using Microsoft.PythonTools.Common.Parsing;
 using Microsoft.VisualStudio.Debugger;
 
 namespace Microsoft.PythonTools.Debugger.Concord.Proxies.Structs {
+    // This change was introduced here: https://github.com/python/cpython/commit/9e7b2076fb4380987ad0262c4c0ca900b06475ad#diff-c22186367cbe20233e843261998dc027ae5f1f8c0d2e778abfa454ae74cc59deR1613
     [StructProxy(StructName = "_cframe", MinVersion = PythonLanguageVersion.V310)]
     internal class CFrameProxy : StructProxy {
         internal class Fields {

--- a/Python/Product/Debugger.Concord/Proxies/Structs/PyInterpreterState.cs
+++ b/Python/Product/Debugger.Concord/Proxies/Structs/PyInterpreterState.cs
@@ -92,6 +92,7 @@ namespace Microsoft.PythonTools.Debugger.Concord.Proxies.Structs {
         public class ceval_state : StructProxy {
             private class Fields {
                 public StructField<Int32Proxy> recursion_limit;
+                [FieldProxy(MaxVersion = PythonLanguageVersion.V39)]
                 public StructField<Int32Proxy> tracing_possible;
             }
 

--- a/Python/Product/Debugger.Concord/Proxies/Structs/PyThreadState.cs
+++ b/Python/Product/Debugger.Concord/Proxies/Structs/PyThreadState.cs
@@ -25,7 +25,10 @@ namespace Microsoft.PythonTools.Debugger.Concord.Proxies.Structs {
         private class Fields {
             public StructField<PointerProxy<PyThreadState>> next;
             public StructField<PointerProxy<PyFrameObject>> frame;
+            [FieldProxy(MaxVersion = PythonLanguageVersion.V39)]
             public StructField<Int32Proxy> use_tracing;
+            [FieldProxy(MinVersion = PythonLanguageVersion.V310)]
+            public StructField<PointerProxy<CFrameProxy>> cframe;
             public StructField<PointerProxy> c_tracefunc;
             public StructField<PointerProxy<PyObject>> curexc_type;
             public StructField<PointerProxy<PyObject>> curexc_value;
@@ -61,6 +64,10 @@ namespace Microsoft.PythonTools.Debugger.Concord.Proxies.Structs {
             get { return GetFieldProxy(_fields.use_tracing); }
         }
 
+        public PointerProxy<CFrameProxy> cframe {
+            get { return GetFieldProxy(_fields.cframe); }
+        }
+
         public PointerProxy c_tracefunc {
             get { return GetFieldProxy(_fields.c_tracefunc); }
         }
@@ -93,6 +100,17 @@ namespace Microsoft.PythonTools.Debugger.Concord.Proxies.Structs {
 
         public static IEnumerable<PyThreadState> GetThreadStates(DkmProcess process) {
             return PyInterpreterState.GetInterpreterStates(process).SelectMany(interp => interp.GetThreadStates());
+        }
+
+        public void RegisterTracing(ulong traceFunc) {
+            if (_fields.use_tracing.Process != null) {
+                use_tracing.Write(1);
+            }
+            if (_fields.cframe.Process != null) {
+                var frame = cframe.Read();
+                frame.use_tracing.Write(1);
+            }
+            c_tracefunc.Write(traceFunc);
         }
 
         

--- a/Python/Product/Debugger.Concord/PythonRuntimeInfo.cs
+++ b/Python/Product/Debugger.Concord/PythonRuntimeInfo.cs
@@ -76,6 +76,9 @@ namespace Microsoft.PythonTools.Debugger.Concord {
                 case "38": return PythonLanguageVersion.V38;
                 case "39": return PythonLanguageVersion.V39;
                 case "310": return PythonLanguageVersion.V310;
+                case "311": return PythonLanguageVersion.V311;
+                case "312": return PythonLanguageVersion.V312;
+                case "313": return PythonLanguageVersion.V313;
                 default: return PythonLanguageVersion.None;
             }
         }

--- a/Python/Tests/Utilities.Python.Analysis/PythonPaths.cs
+++ b/Python/Tests/Utilities.Python.Analysis/PythonPaths.cs
@@ -46,6 +46,9 @@ namespace TestUtilities {
         public static readonly PythonVersion Python38 = GetCPythonVersion(PythonLanguageVersion.V38, InterpreterArchitecture.x86);
         public static readonly PythonVersion Python39 = GetCPythonVersion(PythonLanguageVersion.V39, InterpreterArchitecture.x86);
         public static readonly PythonVersion Python310 = GetCPythonVersion(PythonLanguageVersion.V310, InterpreterArchitecture.x86);
+        public static readonly PythonVersion Python311 = GetCPythonVersion(PythonLanguageVersion.V311, InterpreterArchitecture.x86);
+        public static readonly PythonVersion Python312 = GetCPythonVersion(PythonLanguageVersion.V312, InterpreterArchitecture.x86);
+        public static readonly PythonVersion Python313 = GetCPythonVersion(PythonLanguageVersion.V313, InterpreterArchitecture.x86);
         public static readonly PythonVersion Python27_x64 = GetCPythonVersion(PythonLanguageVersion.V27, InterpreterArchitecture.x64);
         public static readonly PythonVersion Python35_x64 = GetCPythonVersion(PythonLanguageVersion.V35, InterpreterArchitecture.x64);
         public static readonly PythonVersion Python36_x64 = GetCPythonVersion(PythonLanguageVersion.V36, InterpreterArchitecture.x64);
@@ -53,6 +56,9 @@ namespace TestUtilities {
         public static readonly PythonVersion Python38_x64 = GetCPythonVersion(PythonLanguageVersion.V38, InterpreterArchitecture.x64);
         public static readonly PythonVersion Python39_x64 = GetCPythonVersion(PythonLanguageVersion.V39, InterpreterArchitecture.x64);
         public static readonly PythonVersion Python310_x64 = GetCPythonVersion(PythonLanguageVersion.V310, InterpreterArchitecture.x64);
+        public static readonly PythonVersion Python311_x64 = GetCPythonVersion(PythonLanguageVersion.V311, InterpreterArchitecture.x64);
+        public static readonly PythonVersion Python312_x64 = GetCPythonVersion(PythonLanguageVersion.V312, InterpreterArchitecture.x64);
+        public static readonly PythonVersion Python313_x64 = GetCPythonVersion(PythonLanguageVersion.V313, InterpreterArchitecture.x64);
         public static readonly PythonVersion Anaconda27 = GetAnacondaVersion(PythonLanguageVersion.V27, InterpreterArchitecture.x86);
         public static readonly PythonVersion Anaconda27_x64 = GetAnacondaVersion(PythonLanguageVersion.V27, InterpreterArchitecture.x64);
         public static readonly PythonVersion Anaconda36 = GetAnacondaVersion(PythonLanguageVersion.V36, InterpreterArchitecture.x86);


### PR DESCRIPTION
It seems 3.10 was a lot easier than I thought it would be. 

This gets mixed mode working with 3.10. I tested a Python app calling C++ and a C++ app calling Python.