### PR TITLE
Get 3.11 to work in mixed mode

### DIFF
--- a/Examples/PythonCallingNative/PythonApplication/PythonApplication.pyproj
+++ b/Examples/PythonCallingNative/PythonApplication/PythonApplication.pyproj
@@ -11,7 +11,7 @@
     <OutputPath>.</OutputPath>
     <Name>PythonApplication</Name>
     <RootNamespace>PythonApplication</RootNamespace>
-    <InterpreterId>Global|PythonCore|3.10</InterpreterId>
+    <InterpreterId>Global|PythonCore|3.11</InterpreterId>
     <LaunchProvider>Standard Python launcher</LaunchProvider>
     <EnableNativeCodeDebugging>True</EnableNativeCodeDebugging>
   </PropertyGroup>
@@ -35,6 +35,7 @@
   </ItemGroup>
   <ItemGroup>
     <InterpreterReference Include="Global|PythonCore|3.10" />
+    <InterpreterReference Include="Global|PythonCore|3.11" />
     <InterpreterReference Include="Global|PythonCore|3.9" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\Python Tools\Microsoft.PythonTools.targets" />

--- a/Examples/PythonCallingNative/PythonApplication/PythonApplication.pyproj
+++ b/Examples/PythonCallingNative/PythonApplication/PythonApplication.pyproj
@@ -11,7 +11,7 @@
     <OutputPath>.</OutputPath>
     <Name>PythonApplication</Name>
     <RootNamespace>PythonApplication</RootNamespace>
-    <InterpreterId>Global|PythonCore|3.11</InterpreterId>
+    <InterpreterId>Global|PythonCore|3.12</InterpreterId>
     <LaunchProvider>Standard Python launcher</LaunchProvider>
     <EnableNativeCodeDebugging>True</EnableNativeCodeDebugging>
   </PropertyGroup>
@@ -36,6 +36,7 @@
   <ItemGroup>
     <InterpreterReference Include="Global|PythonCore|3.10" />
     <InterpreterReference Include="Global|PythonCore|3.11" />
+    <InterpreterReference Include="Global|PythonCore|3.12" />
     <InterpreterReference Include="Global|PythonCore|3.9" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\Python Tools\Microsoft.PythonTools.targets" />

--- a/Examples/PythonNative/PythonNative.vcxproj
+++ b/Examples/PythonNative/PythonNative.vcxproj
@@ -104,14 +104,14 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(LOCALAPPDATA)\Programs\Python\Python310\include;$(LOCALAPPDATA)\Programs\Python\Python311\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(LOCALAPPDATA)\Programs\Python\Python311\include;$(LOCALAPPDATA)\Programs\Python\Python310\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <LanguageStandard_C>stdc17</LanguageStandard_C>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalLibraryDirectories>$(LOCALAPPDATA)\Programs\Python\Python310\libs;$(LOCALAPPDATA)\Programs\Python\Python311\libs;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(LOCALAPPDATA)\Programs\Python\Python311\libs;$(LOCALAPPDATA)\Programs\Python\Python310\libs;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">

--- a/Python/Product/Debugger.Concord/Debugger.Concord.csproj
+++ b/Python/Product/Debugger.Concord/Debugger.Concord.csproj
@@ -108,6 +108,10 @@
     <Compile Include="ExpressionEvaluator.cs" />
     <Compile Include="LocalStackWalkingComponent.cs" />
     <Compile Include="Proxies\Structs\CFrameProxy.cs" />
+    <Compile Include="Proxies\Structs\PyCodeObject310.cs" />
+    <Compile Include="Proxies\Structs\PyCodeObject311.cs" />
+    <Compile Include="Proxies\Structs\PyDictObject.cs" />
+    <Compile Include="Proxies\Structs\PyDictObject311.cs" />
     <Compile Include="Proxies\Structs\PyFrameObject310.cs" />
     <Compile Include="Proxies\Structs\PyFrameObject311.cs" />
     <Compile Include="Proxies\Structs\PyFunctionObject.cs" />
@@ -144,7 +148,7 @@
     <Compile Include="Proxies\Structs\PyInterpreterState.cs" />
     <Compile Include="Proxies\StructProxy.cs" />
     <Compile Include="Proxies\Structs\PyCodeObject.cs" />
-    <Compile Include="Proxies\Structs\PyDictObject.cs" />
+    <Compile Include="Proxies\Structs\PyDictObject310.cs" />
     <Compile Include="Proxies\Structs\PyFrameObject.cs" />
     <Compile Include="Proxies\Structs\PyListObject.cs" />
     <Compile Include="Proxies\Structs\PyLongObject.cs" />

--- a/Python/Product/Debugger.Concord/Debugger.Concord.csproj
+++ b/Python/Product/Debugger.Concord/Debugger.Concord.csproj
@@ -108,6 +108,10 @@
     <Compile Include="ExpressionEvaluator.cs" />
     <Compile Include="LocalStackWalkingComponent.cs" />
     <Compile Include="Proxies\Structs\CFrameProxy.cs" />
+    <Compile Include="Proxies\Structs\PyFrameObject310.cs" />
+    <Compile Include="Proxies\Structs\PyFrameObject311.cs" />
+    <Compile Include="Proxies\Structs\PyFunctionObject.cs" />
+    <Compile Include="Proxies\Structs\PyInterpreterFrame.cs" />
     <Compile Include="Proxies\Structs\PyRuntimeState.cs" />
     <Compile Include="Proxies\Structs\PyEllipsisObject.cs" />
     <Compile Include="Proxies\Structs\PyComplexObject.cs" />
@@ -119,6 +123,7 @@
     <Compile Include="Proxies\Structs\PyBoolObject.cs" />
     <Compile Include="Proxies\Structs\PySetObject.cs" />
     <Compile Include="Proxies\Structs\PyCellObject.cs" />
+    <Compile Include="Proxies\Structs\PyThreads.cs" />
     <Compile Include="PythonRuntimeInfo.cs" />
     <Compile Include="StackFrameDataItem.cs" />
     <Compile Include="ValueStore.cs" />

--- a/Python/Product/Debugger.Concord/DebuggerOptions.cs
+++ b/Python/Product/Debugger.Concord/DebuggerOptions.cs
@@ -20,6 +20,9 @@ using Microsoft.VisualStudio.Debugger;
 namespace Microsoft.PythonTools.Debugger.Concord {
     public static class DebuggerOptions {
         // These are intentionally not implemented as auto-properties to enable easily changing them at runtime, including when stopped in native code.
+        //
+        // These show up in commands in the debugger watch window if you set the registry value:
+        // HKCU/Software/Microsoft/PythonTools/Debugger PythonDeveloper: DWORD = 1
         private static bool _showNativePythonFrames;
         private static bool _usePythonStepping;
         private static bool _showCppViewNodes;
@@ -29,7 +32,7 @@ namespace Microsoft.PythonTools.Debugger.Concord {
 
         public static bool ShowNativePythonFrames {
             get {
-                return _showNativePythonFrames; // Enable this to show native (C++) frames including our trace helper
+                return _showNativePythonFrames; // Enable this to show native (C++) frames including our trace helper and CPython code
             }
             set {
                 _showNativePythonFrames = value;
@@ -39,7 +42,7 @@ namespace Microsoft.PythonTools.Debugger.Concord {
 
         public static bool UsePythonStepping {
             get {
-                return _usePythonStepping; // Disable this to step through the TraceHelper dll in the launched VS
+                return _usePythonStepping; // Disable this to step through the TraceHelper dll (or CPython) in the launched VS
             }
             set {
                 _usePythonStepping = value;

--- a/Python/Product/Debugger.Concord/DebuggerOptions.cs
+++ b/Python/Product/Debugger.Concord/DebuggerOptions.cs
@@ -22,7 +22,7 @@ namespace Microsoft.PythonTools.Debugger.Concord {
         // These are intentionally not implemented as auto-properties to enable easily changing them at runtime, including when stopped in native code.
         //
         // These show up in commands in the debugger watch window if you set the registry value:
-        // HKCU/Software/Microsoft/PythonTools/Debugger PythonDeveloper: DWORD = 1
+        // Key: HKCU/Software/Microsoft/PythonTools/Debugger - Value: PythonDeveloper: DWORD = 1
         private static bool _showNativePythonFrames;
         private static bool _usePythonStepping;
         private static bool _showCppViewNodes;

--- a/Python/Product/Debugger.Concord/Proxies/StructProxy.cs
+++ b/Python/Product/Debugger.Concord/Proxies/StructProxy.cs
@@ -20,6 +20,7 @@ using System.Linq;
 using Microsoft.Dia;
 using Microsoft.PythonTools.Common.Parsing;
 using Microsoft.VisualStudio.Debugger;
+using Microsoft.VisualStudio.Debugger.Interop;
 
 namespace Microsoft.PythonTools.Debugger.Concord.Proxies {
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
@@ -137,11 +138,6 @@ namespace Microsoft.PythonTools.Debugger.Concord.Proxies {
 
         public override int GetHashCode() {
             return new { _process, _address }.GetHashCode();
-        }
-
-        protected TProxy GetFieldProxy<TProxy>(StructField<TProxy>? field, bool polymorphic = true)
-            where TProxy : IDataProxy {
-            return field.HasValue ? GetFieldProxy(field.Value) : default(TProxy);
         }
 
         protected TProxy GetFieldProxy<TProxy>(StructField<TProxy> field, bool polymorphic = true)

--- a/Python/Product/Debugger.Concord/Proxies/StructProxy.cs
+++ b/Python/Product/Debugger.Concord/Proxies/StructProxy.cs
@@ -20,7 +20,6 @@ using System.Linq;
 using Microsoft.Dia;
 using Microsoft.PythonTools.Common.Parsing;
 using Microsoft.VisualStudio.Debugger;
-using Microsoft.VisualStudio.Debugger.Interop;
 
 namespace Microsoft.PythonTools.Debugger.Concord.Proxies {
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]

--- a/Python/Product/Debugger.Concord/Proxies/Structs/CFrameProxy.cs
+++ b/Python/Product/Debugger.Concord/Proxies/Structs/CFrameProxy.cs
@@ -1,8 +1,19 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
 using Microsoft.PythonTools.Common.Parsing;
 using Microsoft.VisualStudio.Debugger;
 

--- a/Python/Product/Debugger.Concord/Proxies/Structs/CFrameProxy.cs
+++ b/Python/Product/Debugger.Concord/Proxies/Structs/CFrameProxy.cs
@@ -7,7 +7,6 @@ using Microsoft.PythonTools.Common.Parsing;
 using Microsoft.VisualStudio.Debugger;
 
 namespace Microsoft.PythonTools.Debugger.Concord.Proxies.Structs {
-    // This change was introduced here: https://github.com/python/cpython/commit/9e7b2076fb4380987ad0262c4c0ca900b06475ad#diff-c22186367cbe20233e843261998dc027ae5f1f8c0d2e778abfa454ae74cc59deR1613
     [StructProxy(StructName = "_cframe", MinVersion = PythonLanguageVersion.V310)]
     internal class CFrameProxy : StructProxy {
         internal class Fields {

--- a/Python/Product/Debugger.Concord/Proxies/Structs/CFrameProxy.cs
+++ b/Python/Product/Debugger.Concord/Proxies/Structs/CFrameProxy.cs
@@ -7,11 +7,14 @@ using Microsoft.PythonTools.Common.Parsing;
 using Microsoft.VisualStudio.Debugger;
 
 namespace Microsoft.PythonTools.Debugger.Concord.Proxies.Structs {
-    [StructProxy(StructName = "_cframe", MinVersion = PythonLanguageVersion.V310)]
+    [StructProxy(StructName = "_cframe", MinVersion = PythonLanguageVersion.V310, MaxVersion = PythonLanguageVersion.V310)]
+    [StructProxy(StructName = "_PyCFrame", MinVersion = PythonLanguageVersion.V311)]
     internal class CFrameProxy : StructProxy {
         internal class Fields {
             public StructField<Int32Proxy> use_tracing;
             public StructField<PointerProxy<CFrameProxy>> previous;
+            [FieldProxy(MinVersion = PythonLanguageVersion.V311)]
+            public StructField<PointerProxy<PyInterpreterFrame>> current_frame;
         }
 
         private readonly Fields _fields;
@@ -24,5 +27,7 @@ namespace Microsoft.PythonTools.Debugger.Concord.Proxies.Structs {
         public Int32Proxy use_tracing {
             get { return GetFieldProxy(_fields.use_tracing); }
         }
+
+        public PointerProxy<PyInterpreterFrame> current_frame => GetFieldProxy(_fields.current_frame);
     }
 }

--- a/Python/Product/Debugger.Concord/Proxies/Structs/PyCodeObject.cs
+++ b/Python/Product/Debugger.Concord/Proxies/Structs/PyCodeObject.cs
@@ -14,6 +14,7 @@
 // See the Apache Version 2.0 License for specific language governing
 // permissions and limitations under the License.
 
+using Microsoft.PythonTools.Common.Parsing;
 using Microsoft.VisualStudio.Debugger;
 
 namespace Microsoft.PythonTools.Debugger.Concord.Proxies.Structs {
@@ -21,8 +22,11 @@ namespace Microsoft.PythonTools.Debugger.Concord.Proxies.Structs {
         public class Fields {
             public StructField<Int32Proxy> co_nlocals;
             public StructField<PointerProxy<PyTupleObject>> co_names;
+            [FieldProxy(MaxVersion = PythonLanguageVersion.V310)]
             public StructField<PointerProxy<PyTupleObject>> co_varnames;
+            [FieldProxy(MaxVersion = PythonLanguageVersion.V310)]
             public StructField<PointerProxy<PyTupleObject>> co_freevars;
+            [FieldProxy(MaxVersion = PythonLanguageVersion.V310)]
             public StructField<PointerProxy<PyTupleObject>> co_cellvars;
             public StructField<PointerProxy<IPyBaseStringObject>> co_filename;
             public StructField<PointerProxy<IPyBaseStringObject>> co_name;

--- a/Python/Product/Debugger.Concord/Proxies/Structs/PyCodeObject.cs
+++ b/Python/Product/Debugger.Concord/Proxies/Structs/PyCodeObject.cs
@@ -18,60 +18,26 @@ using Microsoft.PythonTools.Common.Parsing;
 using Microsoft.VisualStudio.Debugger;
 
 namespace Microsoft.PythonTools.Debugger.Concord.Proxies.Structs {
-    internal class PyCodeObject : PyObject {
-        public class Fields {
-            public StructField<Int32Proxy> co_nlocals;
-            public StructField<PointerProxy<PyTupleObject>> co_names;
-            [FieldProxy(MaxVersion = PythonLanguageVersion.V310)]
-            public StructField<PointerProxy<PyTupleObject>> co_varnames;
-            [FieldProxy(MaxVersion = PythonLanguageVersion.V310)]
-            public StructField<PointerProxy<PyTupleObject>> co_freevars;
-            [FieldProxy(MaxVersion = PythonLanguageVersion.V310)]
-            public StructField<PointerProxy<PyTupleObject>> co_cellvars;
-            public StructField<PointerProxy<IPyBaseStringObject>> co_filename;
-            public StructField<PointerProxy<IPyBaseStringObject>> co_name;
-            public StructField<Int32Proxy> co_firstlineno;
-        }
-
-        private readonly Fields _fields;
-
+    internal abstract class PyCodeObject : PyObject {
         public PyCodeObject(DkmProcess process, ulong address)
             : base(process, address) {
-            InitializeStruct(this, out _fields);
-            CheckPyType<PyCodeObject>();
         }
 
-        public Int32Proxy co_nlocals {
-            get { return GetFieldProxy(_fields.co_nlocals); }
-        }
+        public abstract Int32Proxy co_nlocals { get; }
 
-        public PointerProxy<PyTupleObject> co_names {
-            get { return GetFieldProxy(_fields.co_names); }
-        }
+        public abstract PointerProxy<PyTupleObject> co_names { get; }
 
-        public PointerProxy<PyTupleObject> co_varnames {
-            get { return GetFieldProxy(_fields.co_varnames); }
-        }
+        public abstract IWritableDataProxy<PyTupleObject> co_varnames { get; }
 
-        public PointerProxy<PyTupleObject> co_freevars {
-            get { return GetFieldProxy(_fields.co_freevars); }
-        }
+        public abstract IWritableDataProxy<PyTupleObject> co_freevars { get; }
 
-        public PointerProxy<PyTupleObject> co_cellvars {
-            get { return GetFieldProxy(_fields.co_cellvars); }
-        }
+        public abstract IWritableDataProxy<PyTupleObject> co_cellvars { get; }
 
-        public PointerProxy<IPyBaseStringObject> co_filename {
-            get { return GetFieldProxy(_fields.co_filename); }
-        }
+        public abstract PointerProxy<IPyBaseStringObject> co_filename { get; }
 
-        public PointerProxy<IPyBaseStringObject> co_name {
-            get { return GetFieldProxy(_fields.co_name); }
-        }
+        public abstract PointerProxy<IPyBaseStringObject> co_name { get; }
 
-        public Int32Proxy co_firstlineno {
-            get { return GetFieldProxy(_fields.co_firstlineno); }
-        }
+        public abstract Int32Proxy co_firstlineno { get; }
 
         public override void Repr(ReprBuilder builder) {
             string name = co_name.TryRead().ToStringOrNull() ?? "???";

--- a/Python/Product/Debugger.Concord/Proxies/Structs/PyCodeObject310.cs
+++ b/Python/Product/Debugger.Concord/Proxies/Structs/PyCodeObject310.cs
@@ -1,8 +1,19 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
 using Microsoft.PythonTools.Common.Parsing;
 using Microsoft.VisualStudio.Debugger;
 

--- a/Python/Product/Debugger.Concord/Proxies/Structs/PyCodeObject310.cs
+++ b/Python/Product/Debugger.Concord/Proxies/Structs/PyCodeObject310.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.PythonTools.Common.Parsing;
+using Microsoft.VisualStudio.Debugger;
+
+namespace Microsoft.PythonTools.Debugger.Concord.Proxies.Structs {
+    [StructProxy(StructName = "PyCodeObject", MaxVersion = PythonLanguageVersion.V310)]
+    [PyType(MaxVersion = PythonLanguageVersion.V310, VariableName = "PyCode_Type")]
+    internal class PyCodeObject310 : PyCodeObject {
+        public class Fields {
+            public StructField<Int32Proxy> co_nlocals;
+            public StructField<PointerProxy<PyTupleObject>> co_names;
+            public StructField<PointerProxy<PyTupleObject>> co_varnames;
+            public StructField<PointerProxy<PyTupleObject>> co_freevars;
+            public StructField<PointerProxy<PyTupleObject>> co_cellvars;
+            public StructField<PointerProxy<IPyBaseStringObject>> co_filename;
+            public StructField<PointerProxy<IPyBaseStringObject>> co_name;
+            public StructField<Int32Proxy> co_firstlineno;
+        }
+
+        private readonly Fields _fields;
+
+        public override Int32Proxy co_nlocals => GetFieldProxy(_fields.co_nlocals);
+
+        public override PointerProxy<PyTupleObject> co_names => GetFieldProxy(_fields.co_names);
+
+        public override IWritableDataProxy<PyTupleObject> co_varnames => GetFieldProxy(_fields.co_varnames);
+
+        public override IWritableDataProxy<PyTupleObject> co_freevars => GetFieldProxy(_fields.co_freevars);
+
+        public override IWritableDataProxy<PyTupleObject> co_cellvars => GetFieldProxy(_fields.co_cellvars);
+
+        public override PointerProxy<IPyBaseStringObject> co_filename => GetFieldProxy(_fields.co_filename);
+
+        public override PointerProxy<IPyBaseStringObject> co_name => GetFieldProxy(_fields.co_name);
+
+        public override Int32Proxy co_firstlineno => GetFieldProxy(_fields.co_firstlineno);
+
+        public PyCodeObject310(DkmProcess process, ulong address)
+            : base(process, address) {
+            InitializeStruct(this, out _fields);
+            CheckPyType<PyCodeObject310>();
+        }
+
+    }
+}

--- a/Python/Product/Debugger.Concord/Proxies/Structs/PyCodeObject311.cs
+++ b/Python/Product/Debugger.Concord/Proxies/Structs/PyCodeObject311.cs
@@ -1,13 +1,24 @@
-﻿using System;
+﻿// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Microsoft.PythonTools.Common.Parsing;
-using Microsoft.PythonTools.Infrastructure;
 using Microsoft.VisualStudio.Debugger;
-using static Microsoft.PythonTools.Debugger.Concord.TraceManagerLocalHelper;
 
 namespace Microsoft.PythonTools.Debugger.Concord.Proxies.Structs {
     [StructProxy(StructName = "PyCodeObject", MinVersion = PythonLanguageVersion.V311)]

--- a/Python/Product/Debugger.Concord/Proxies/Structs/PyCodeObject311.cs
+++ b/Python/Product/Debugger.Concord/Proxies/Structs/PyCodeObject311.cs
@@ -1,0 +1,117 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.PythonTools.Common.Parsing;
+using Microsoft.PythonTools.Infrastructure;
+using Microsoft.VisualStudio.Debugger;
+using static Microsoft.PythonTools.Debugger.Concord.TraceManagerLocalHelper;
+
+namespace Microsoft.PythonTools.Debugger.Concord.Proxies.Structs {
+    [StructProxy(StructName = "PyCodeObject", MinVersion = PythonLanguageVersion.V311)]
+    [PyType(MinVersion = PythonLanguageVersion.V311, VariableName = "PyCode_Type")]
+    internal class PyCodeObject311 : PyCodeObject {
+        public class Fields {
+            public StructField<Int32Proxy> co_nlocals;
+            public StructField<PointerProxy<PyTupleObject>> co_names;
+            public StructField<PointerProxy<IPyBaseStringObject>> co_filename;
+            public StructField<PointerProxy<IPyBaseStringObject>> co_name;
+            public StructField<Int32Proxy> co_firstlineno;
+            public StructField<PointerProxy<PyTupleObject>> co_localsplusnames;
+            public StructField<PointerProxy<PyBytesObject>> co_localspluskinds;
+        }
+
+        private readonly Fields _fields;
+
+        public override Int32Proxy co_nlocals => GetFieldProxy(_fields.co_nlocals);
+
+        public override PointerProxy<PyTupleObject> co_names => GetFieldProxy(_fields.co_names);
+
+        public override IWritableDataProxy<PyTupleObject> co_varnames => GetVariableTupleProxy(VariableKind.CO_FAST_LOCAL);
+
+        public override IWritableDataProxy<PyTupleObject> co_freevars => GetVariableTupleProxy(VariableKind.CO_FAST_FREE);
+
+        public override IWritableDataProxy<PyTupleObject> co_cellvars => GetVariableTupleProxy(VariableKind.CO_FAST_CELL);
+
+        public override PointerProxy<IPyBaseStringObject> co_filename => GetFieldProxy(_fields.co_filename);
+
+        public override PointerProxy<IPyBaseStringObject> co_name => GetFieldProxy(_fields.co_name);
+
+        public override Int32Proxy co_firstlineno => GetFieldProxy(_fields.co_firstlineno);
+
+        public PyCodeObject311(DkmProcess process, ulong address)
+            : base(process, address) {
+            InitializeStruct(this, out _fields);
+            CheckPyType<PyCodeObject311>();
+        }
+
+        [Flags]
+        internal enum VariableKind {
+            CO_FAST_LOCAL = 0x20,
+            CO_FAST_CELL = 0x40,
+            CO_FAST_FREE = 0x80
+        }
+
+        private IWritableDataProxy<PyTupleObject> GetVariableTupleProxy(VariableKind kind) {
+            return new PyVariableTuplePointerProxy(Process, kind, GetFieldProxy(_fields.co_localsplusnames), GetFieldProxy(_fields.co_localspluskinds));
+        }
+
+        // In 3.11, the co_varnames, co_freevars, and co_cellvars were all removed. In order to not have to change our usage
+        // of them, this class and the PyVariableTuple were created in order to pretend to behave like the original co_varnames etc.
+        internal class PyVariableTuplePointerProxy : IWritableDataProxy<PyTupleObject> {
+            private readonly PyVariableTuple _pseudoTuple;
+            private readonly PointerProxy<PyTupleObject> _realTuple;
+            private readonly DkmProcess _process;
+
+            public PyVariableTuplePointerProxy(DkmProcess process, VariableKind kind, PointerProxy<PyTupleObject> localsplusnames, PointerProxy<PyBytesObject> localspluskinds) {
+                _pseudoTuple = new PyVariableTuple(process, kind, localsplusnames, localspluskinds);
+                _realTuple = localsplusnames;
+                _process = process;
+            }
+
+            public DkmProcess Process => _process;
+
+            public ulong Address => _realTuple.Address;
+
+            public long ObjectSize => _realTuple.ObjectSize;
+
+            public PyTupleObject Read() => _pseudoTuple;
+
+            public void Write(PyTupleObject value) => throw new NotImplementedException();
+            public void Write(object value) => throw new NotImplementedException();
+            object IValueStore.Read() => _pseudoTuple;
+        }
+
+        [PyType(Hidden = true)]
+        internal class PyVariableTuple : PyTupleObject {
+            private readonly VariableKind _kind;
+            private readonly PointerProxy<PyTupleObject> _localsplusnames;
+            private readonly PointerProxy<PyBytesObject> _localspluskinds;
+            private readonly DkmProcess _process;
+
+            public PyVariableTuple(DkmProcess process, VariableKind kind, PointerProxy<PyTupleObject> localsplusnames, PointerProxy<PyBytesObject> localspluskinds)
+                : base(process, localsplusnames.Read().Address) {
+                _kind = kind;
+                _localsplusnames = localsplusnames;
+                _localspluskinds = localspluskinds;
+                _process = process;
+            }
+
+            public override IEnumerable<PointerProxy<PyObject>> ReadElements() {
+                var localsplusnames = new List<PointerProxy<PyObject>>(_localsplusnames.Read().ReadElements());
+                var localspluskinds = _localspluskinds.Read().ToBytes();
+                Debug.Assert(localsplusnames.Count == localspluskinds.Length);
+                for (var i = 0; i < localsplusnames.Count; i++) {
+                    var name = localsplusnames[i];
+                    var kind = (VariableKind)localspluskinds[i];
+                    if ((kind & _kind) == _kind) {
+                        yield return name;
+                    }
+                }
+            }
+
+        }
+    }
+}

--- a/Python/Product/Debugger.Concord/Proxies/Structs/PyDictObject.cs
+++ b/Python/Product/Debugger.Concord/Proxies/Structs/PyDictObject.cs
@@ -1,4 +1,4 @@
-// Python Tools for Visual Studio
+﻿// Python Tools for Visual Studio
 // Copyright(c) Microsoft Corporation
 // All rights reserved.
 //
@@ -21,68 +21,12 @@ using Microsoft.VisualStudio.Debugger;
 using Microsoft.VisualStudio.Debugger.Evaluation;
 
 namespace Microsoft.PythonTools.Debugger.Concord.Proxies.Structs {
-    [StructProxy(StructName = "PyDictObject", MinVersion = PythonLanguageVersion.V39)]
-    [PyType(VariableName = "PyDict_Type", MinVersion = PythonLanguageVersion.V39)]
-    internal class PyDictObject : PyObject {
-        private class Fields {
-            public StructField<PointerProxy<PyDictKeysObject>> ma_keys;
-            public StructField<PointerProxy<ArrayProxy<PointerProxy<PyObject>>>> ma_values;
-        }
-
-        private readonly Fields _fields;
-
-        public PyDictObject(DkmProcess process, ulong address)
+    internal abstract class PyDictObject : PyObject {
+        protected PyDictObject(DkmProcess process, ulong address)
             : base(process, address) {
-            InitializeStruct(this, out _fields);
-            CheckPyType<PyDictObject>();
         }
 
-        public PointerProxy<PyDictKeysObject> ma_keys {
-            get { return GetFieldProxy(_fields.ma_keys); }
-        }
-
-        public PointerProxy<ArrayProxy<PointerProxy<PyObject>>> ma_values {
-            get { return GetFieldProxy(_fields.ma_values); }
-        }
-
-        public IEnumerable<KeyValuePair<PyObject, PointerProxy<PyObject>>> ReadElements() {
-            if (ma_keys.IsNull) {
-                yield break;
-            }
-
-            var keys = ma_keys.Read();
-            var size = keys.dk_size.Read();
-            if (size <= 0) {
-                yield break;
-            }
-
-            var n = keys.dk_nentries.Read();
-            var dk_entries = keys.dk_entries;
-            var entry = dk_entries[0];
-
-            if (!ma_values.IsNull) {
-                var values = ma_values.Read();
-                var value = values[0];
-
-                for (int i = 0; i < n; ++i) {
-                    var key = entry.me_key;
-                    if (!value.IsNull && !key.IsNull) {
-                        yield return new KeyValuePair<PyObject, PointerProxy<PyObject>>(key.Read(), value);
-                    }
-                    entry = entry.GetAdjacentProxy(1);
-                    value = value.GetAdjacentProxy(1);
-                }
-            } else {
-                for (int i = 0; i < n; ++i) {
-                    var key = entry.me_key;
-                    var value = entry.me_value;
-                    if (!key.IsNull && !value.IsNull) {
-                        yield return new KeyValuePair<PyObject, PointerProxy<PyObject>>(key.Read(), value);
-                    }
-                    entry = entry.GetAdjacentProxy(1);
-                }
-            }
-        }
+        public abstract IEnumerable<KeyValuePair<PyObject, PointerProxy<PyObject>>> ReadElements();
 
         public override void Repr(ReprBuilder builder) {
             var count = ReadElements().Count();
@@ -114,75 +58,4 @@ namespace Microsoft.PythonTools.Debugger.Concord.Proxies.Structs {
         }
     }
 
-    [StructProxy(MinVersion = PythonLanguageVersion.V39, StructName = "_dictkeysobject")]
-    internal class PyDictKeysObject : StructProxy {
-        public class Fields {
-            public StructField<SSizeTProxy> dk_size;
-            public StructField<SSizeTProxy> dk_nentries;
-            public StructField<ArrayProxy<SByteProxy>> dk_indices;
-        }
-
-        public readonly Fields _fields;
-
-        public SSizeTProxy dk_size {
-            get { return GetFieldProxy(_fields.dk_size); }
-        }
-
-        public SSizeTProxy dk_nentries {
-            get { return GetFieldProxy(_fields.dk_nentries); }
-        }
-
-        public ArrayProxy<PyDictKeyEntry> dk_entries {
-            get {
-                // dk_entries is located after dk_indices, which is
-                // variable length depending on the size of the table.
-                long size = dk_size.Read();
-                long offset = _fields.dk_indices.Offset;
-                if (size <= 0) {
-                    return default(ArrayProxy<PyDictKeyEntry>);
-                } else if (size <= 0xFF) {
-                    offset += size;
-                } else if (size <= 0xFFFF) {
-                    offset += size * 2;
-                } else if (size <= 0xFFFFFFFF) {
-                    offset += size * 4;
-                } else {
-                    offset += size * 8;
-                }
-
-                return DataProxy.Create<ArrayProxy<PyDictKeyEntry>>(
-                    Process,
-                    Address.OffsetBy(offset)
-                );
-            }
-        }
-
-        public PyDictKeysObject(DkmProcess process, ulong address)
-            : base(process, address) {
-            InitializeStruct(this, out _fields);
-        }
-    }
-
-    [StructProxy(MinVersion = PythonLanguageVersion.V39)]
-    internal class PyDictKeyEntry : StructProxy {
-        private class Fields {
-            public StructField<PointerProxy<PyObject>> me_key;
-            public StructField<PointerProxy<PyObject>> me_value;
-        }
-
-        private readonly Fields _fields;
-
-        public PyDictKeyEntry(DkmProcess process, ulong address)
-            : base(process, address) {
-            InitializeStruct(this, out _fields);
-        }
-
-        public PointerProxy<PyObject> me_key {
-            get { return GetFieldProxy(_fields.me_key); }
-        }
-
-        public PointerProxy<PyObject> me_value {
-            get { return GetFieldProxy(_fields.me_value); }
-        }
-    }
 }

--- a/Python/Product/Debugger.Concord/Proxies/Structs/PyDictObject310.cs
+++ b/Python/Product/Debugger.Concord/Proxies/Structs/PyDictObject310.cs
@@ -101,14 +101,14 @@ namespace Microsoft.PythonTools.Debugger.Concord.Proxies.Structs {
             get { return GetFieldProxy(_fields.dk_nentries); }
         }
 
-        public IEnumerable<IDictKeyEntry> dk_entries {
+        public IEnumerable<PyDictKeyEntry310> dk_entries {
             get {
                 // dk_entries is located after dk_indices, which is
                 // variable length depending on the size of the table.
                 long size = dk_size.Read();
                 long offset = _fields.dk_indices.Offset;
                 if (size <= 0) {
-                    return default(ArrayProxy<IDictKeyEntry>);
+                    return default(ArrayProxy<PyDictKeyEntry310>);
                 } else if (size <= 0xFF) {
                     offset += size;
                 } else if (size <= 0xFFFF) {
@@ -119,7 +119,7 @@ namespace Microsoft.PythonTools.Debugger.Concord.Proxies.Structs {
                     offset += size * 8;
                 }
 
-                return DataProxy.Create<ArrayProxy<PyDictKeyEntry311>>(
+                return DataProxy.Create<ArrayProxy<PyDictKeyEntry310>>(
                     Process,
                     Address.OffsetBy(offset)
                 );
@@ -132,7 +132,7 @@ namespace Microsoft.PythonTools.Debugger.Concord.Proxies.Structs {
         }
     }
 
-    [StructProxy(MinVersion = PythonLanguageVersion.V39)]
+    [StructProxy(MinVersion = PythonLanguageVersion.V39, StructName = "PyDictKeyEntry")]
     internal class PyDictKeyEntry310 : StructProxy {
         private class Fields {
             public StructField<PointerProxy<PyObject>> me_key;

--- a/Python/Product/Debugger.Concord/Proxies/Structs/PyDictObject310.cs
+++ b/Python/Product/Debugger.Concord/Proxies/Structs/PyDictObject310.cs
@@ -1,0 +1,157 @@
+// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.PythonTools.Common.Parsing;
+using Microsoft.VisualStudio.Debugger;
+using Microsoft.VisualStudio.Debugger.Evaluation;
+
+namespace Microsoft.PythonTools.Debugger.Concord.Proxies.Structs {
+    [StructProxy(StructName = "PyDictObject", MinVersion = PythonLanguageVersion.V39, MaxVersion = PythonLanguageVersion.V310 )]
+    [PyType(VariableName = "PyDict_Type", MinVersion = PythonLanguageVersion.V39, MaxVersion = PythonLanguageVersion.V310)]
+    internal class PyDictObject310 : PyDictObject {
+        private class Fields {
+            public StructField<PointerProxy<PyDictKeysObject310>> ma_keys;
+            public StructField<PointerProxy<ArrayProxy<PointerProxy<PyObject>>>> ma_values;
+        }
+
+        private readonly Fields _fields;
+
+        public PyDictObject310(DkmProcess process, ulong address)
+            : base(process, address) {
+            InitializeStruct(this, out _fields);
+            CheckPyType<PyDictObject310>();
+        }
+
+        public PointerProxy<PyDictKeysObject310> ma_keys {
+            get { return GetFieldProxy(_fields.ma_keys); }
+        }
+
+        public PointerProxy<ArrayProxy<PointerProxy<PyObject>>> ma_values {
+            get { return GetFieldProxy(_fields.ma_values); }
+        }
+
+        public override IEnumerable<KeyValuePair<PyObject, PointerProxy<PyObject>>> ReadElements() {
+            if (ma_keys.IsNull) {
+                yield break;
+            }
+
+            var keys = ma_keys.Read();
+            var size = keys.dk_size.Read();
+            if (size <= 0) {
+                yield break;
+            }
+
+            var n = keys.dk_nentries.Read();
+            var dk_entries = keys.dk_entries;
+            var entry = dk_entries.First();
+
+            if (!ma_values.IsNull) {
+                var values = ma_values.Read();
+                var value = values[0];
+
+                for (int i = 0; i < n; ++i) {
+                    var key = entry.me_key;
+                    if (!value.IsNull && !key.IsNull) {
+                        yield return new KeyValuePair<PyObject, PointerProxy<PyObject>>(key.Read(), value);
+                    }
+                    entry = entry.GetAdjacentProxy(1);
+                    value = value.GetAdjacentProxy(1);
+                }
+            } else {
+                for (int i = 0; i < n; ++i) {
+                    var key = entry.me_key;
+                    var value = entry.me_value;
+                    if (!key.IsNull && !value.IsNull) {
+                        yield return new KeyValuePair<PyObject, PointerProxy<PyObject>>(key.Read(), value);
+                    }
+                    entry = entry.GetAdjacentProxy(1);
+                }
+            }
+        }
+    }
+
+    [StructProxy(MinVersion = PythonLanguageVersion.V39, MaxVersion = PythonLanguageVersion.V310, StructName = "_dictkeysobject")]
+    internal class PyDictKeysObject310 : StructProxy {
+        public class Fields {
+            public StructField<SSizeTProxy> dk_size;
+            public StructField<SSizeTProxy> dk_nentries;
+            public StructField<ArrayProxy<SByteProxy>> dk_indices;
+        }
+
+        public readonly Fields _fields;
+
+        public SSizeTProxy dk_size => GetFieldProxy(_fields.dk_size);
+
+        public SSizeTProxy dk_nentries {
+            get { return GetFieldProxy(_fields.dk_nentries); }
+        }
+
+        public IEnumerable<IDictKeyEntry> dk_entries {
+            get {
+                // dk_entries is located after dk_indices, which is
+                // variable length depending on the size of the table.
+                long size = dk_size.Read();
+                long offset = _fields.dk_indices.Offset;
+                if (size <= 0) {
+                    return default(ArrayProxy<IDictKeyEntry>);
+                } else if (size <= 0xFF) {
+                    offset += size;
+                } else if (size <= 0xFFFF) {
+                    offset += size * 2;
+                } else if (size <= 0xFFFFFFFF) {
+                    offset += size * 4;
+                } else {
+                    offset += size * 8;
+                }
+
+                return DataProxy.Create<ArrayProxy<PyDictKeyEntry311>>(
+                    Process,
+                    Address.OffsetBy(offset)
+                );
+            }
+        }
+
+        public PyDictKeysObject310(DkmProcess process, ulong address)
+            : base(process, address) {
+            InitializeStruct(this, out _fields);
+        }
+    }
+
+    [StructProxy(MinVersion = PythonLanguageVersion.V39)]
+    internal class PyDictKeyEntry310 : StructProxy {
+        private class Fields {
+            public StructField<PointerProxy<PyObject>> me_key;
+            public StructField<PointerProxy<PyObject>> me_value;
+        }
+
+        private readonly Fields _fields;
+
+        public PyDictKeyEntry310(DkmProcess process, ulong address)
+            : base(process, address) {
+            InitializeStruct(this, out _fields);
+        }
+
+        public PointerProxy<PyObject> me_key {
+            get { return GetFieldProxy(_fields.me_key); }
+        }
+
+        public PointerProxy<PyObject> me_value {
+            get { return GetFieldProxy(_fields.me_value); }
+        }
+    }
+}

--- a/Python/Product/Debugger.Concord/Proxies/Structs/PyDictObject311.cs
+++ b/Python/Product/Debugger.Concord/Proxies/Structs/PyDictObject311.cs
@@ -157,7 +157,7 @@ namespace Microsoft.PythonTools.Debugger.Concord.Proxies.Structs {
         public PointerProxy<PyObject> me_value { get; }
     }
 
-    [StructProxy(MinVersion = PythonLanguageVersion.V311)]
+    [StructProxy(MinVersion = PythonLanguageVersion.V311, StructName ="PyDictKeyEntry")]
     internal class PyDictKeyEntry311 : StructProxy, IDictKeyEntry {
         private class Fields {
             public StructField<PointerProxy<PyObject>> me_key;

--- a/Python/Product/Debugger.Concord/Proxies/Structs/PyDictObject311.cs
+++ b/Python/Product/Debugger.Concord/Proxies/Structs/PyDictObject311.cs
@@ -1,0 +1,208 @@
+﻿// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.PythonTools.Common.Parsing;
+using Microsoft.VisualStudio.Debugger;
+using Microsoft.VisualStudio.Debugger.Evaluation;
+
+namespace Microsoft.PythonTools.Debugger.Concord.Proxies.Structs {
+    [StructProxy(StructName = "PyDictObject", MinVersion = PythonLanguageVersion.V311)]
+    [PyType(VariableName = "PyDict_Type", MinVersion = PythonLanguageVersion.V311)]
+    internal class PyDictObject311 : PyDictObject {
+        private class Fields {
+            public StructField<PointerProxy<PyDictKeysObject311>> ma_keys;
+            public StructField<PointerProxy<ArrayProxy<PointerProxy<PyObject>>>> ma_values;
+        }
+
+        private readonly Fields _fields;
+
+        public PyDictObject311(DkmProcess process, ulong address)
+            : base(process, address) {
+            InitializeStruct(this, out _fields);
+            CheckPyType<PyDictObject311>();
+        }
+
+        public PointerProxy<PyDictKeysObject311> ma_keys {
+            get { return GetFieldProxy(_fields.ma_keys); }
+        }
+
+        public PointerProxy<ArrayProxy<PointerProxy<PyObject>>> ma_values {
+            get { return GetFieldProxy(_fields.ma_values); }
+        }
+
+        public override IEnumerable<KeyValuePair<PyObject, PointerProxy<PyObject>>> ReadElements() {
+            if (ma_keys.IsNull) {
+                yield break;
+            }
+
+            var keys = ma_keys.Read();
+            var size = 1 << (int)keys.dk_log2_size.Read();
+            if (size <= 0) {
+                yield break;
+            }
+
+            var n = keys.dk_nentries.Read();
+            if (!ma_values.IsNull) {
+                var values = ma_values.Read();
+                var value = values[0];
+
+                for (int i = 0; i < n; ++i) {
+                    var entry = GetDkEntry(i);
+                    var key = entry.me_key;
+                    if (!value.IsNull && !key.IsNull) {
+                        yield return new KeyValuePair<PyObject, PointerProxy<PyObject>>(key.Read(), value);
+                    }
+                    value = value.GetAdjacentProxy(1);
+                }
+            } else {
+                for (int i = 0; i < n; ++i) {
+                    var entry = GetDkEntry(i);
+                    var key = entry.me_key;
+                    var value = entry.me_value;
+                    if (!key.IsNull && !value.IsNull) {
+                        yield return new KeyValuePair<PyObject, PointerProxy<PyObject>>(key.Read(), value);
+                    }
+                }
+            }
+        }
+
+        private IDictKeyEntry GetDkEntry(int position) {
+            var keys = ma_keys.Read();
+            if (keys.dk_kind.Read() == 0) {
+                var entries = keys.dk_general_entries;
+                return entries[position];
+            } else {
+                var entries = keys.dk_unicode_entries;
+                return entries[position];
+            }
+        }
+
+    }
+
+    [StructProxy(MinVersion = PythonLanguageVersion.V311, StructName = "_dictkeysobject")]
+    internal class PyDictKeysObject311 : StructProxy {
+        public class Fields {
+            public StructField<SSizeTProxy> dk_log2_size;
+            public StructField<SSizeTProxy> dk_log2_index_bytes;
+            public StructField<SSizeTProxy> dk_nentries;
+            public StructField<ArrayProxy<SByteProxy>> dk_indices;
+            public StructField<ByteProxy> dk_kind;
+        }
+
+        public readonly Fields _fields;
+
+        public SSizeTProxy dk_log2_size => GetFieldProxy(_fields.dk_log2_size);
+        public SSizeTProxy dk_log2_index_bytes => GetFieldProxy(_fields.dk_log2_index_bytes);
+
+        public ByteProxy dk_kind => GetFieldProxy(_fields.dk_kind);
+
+        public SSizeTProxy dk_nentries {
+            get { return GetFieldProxy(_fields.dk_nentries); }
+        }
+
+        public ArrayProxy<PyDictKeyEntry311> dk_general_entries {
+            get {
+                // dk_entries is located after dk_indices, which is
+                // variable length depending on the size of the table.
+                long log_size = dk_log2_index_bytes.Read();
+                long offset = _fields.dk_indices.Offset;
+                offset += 1 << (int)log_size;
+
+                return DataProxy.Create<ArrayProxy<PyDictKeyEntry311>>(
+                    Process,
+                    Address.OffsetBy(offset)
+                );
+            }
+        }
+
+        public ArrayProxy<PyDictUnicodeEntry> dk_unicode_entries {
+            get {
+                // dk_entries is located after dk_indices, which is
+                // variable length depending on the size of the table.
+                long log_size = dk_log2_index_bytes.Read();
+                long offset = _fields.dk_indices.Offset;
+                offset += 1 << (int)log_size;
+
+                return DataProxy.Create<ArrayProxy<PyDictUnicodeEntry>>(
+                    Process,
+                    Address.OffsetBy(offset)
+                );
+            }
+        }
+
+        public PyDictKeysObject311(DkmProcess process, ulong address)
+            : base(process, address) {
+            InitializeStruct(this, out _fields);
+        }
+    }
+
+    internal interface IDictKeyEntry : IDataProxy<IDictKeyEntry> {
+        public PointerProxy<PyObject> me_key { get; }
+
+        public PointerProxy<PyObject> me_value { get; }
+    }
+
+    [StructProxy(MinVersion = PythonLanguageVersion.V311)]
+    internal class PyDictKeyEntry311 : StructProxy, IDictKeyEntry {
+        private class Fields {
+            public StructField<PointerProxy<PyObject>> me_key;
+            public StructField<PointerProxy<PyObject>> me_value;
+        }
+
+        private readonly Fields _fields;
+
+        public PyDictKeyEntry311(DkmProcess process, ulong address)
+            : base(process, address) {
+            InitializeStruct(this, out _fields);
+        }
+
+        public PointerProxy<PyObject> me_key {
+            get { return GetFieldProxy(_fields.me_key); }
+        }
+
+        public PointerProxy<PyObject> me_value {
+            get { return GetFieldProxy(_fields.me_value); }
+        }
+
+        public IDictKeyEntry Read() => this;
+    }
+    [StructProxy(MinVersion = PythonLanguageVersion.V311)]
+    internal class PyDictUnicodeEntry : StructProxy, IDictKeyEntry {
+        private class Fields {
+            public StructField<PointerProxy<PyObject>> me_key;
+            public StructField<PointerProxy<PyObject>> me_value;
+        }
+
+        private readonly Fields _fields;
+
+        public PyDictUnicodeEntry(DkmProcess process, ulong address)
+            : base(process, address) {
+            InitializeStruct(this, out _fields);
+        }
+
+        public PointerProxy<PyObject> me_key {
+            get { return GetFieldProxy(_fields.me_key); }
+        }
+
+        public PointerProxy<PyObject> me_value {
+            get { return GetFieldProxy(_fields.me_value); }
+        }
+
+        public IDictKeyEntry Read() => this;
+    }
+}

--- a/Python/Product/Debugger.Concord/Proxies/Structs/PyFrameObject.cs
+++ b/Python/Product/Debugger.Concord/Proxies/Structs/PyFrameObject.cs
@@ -14,17 +14,10 @@
 // See the Apache Version 2.0 License for specific language governing
 // permissions and limitations under the License.
 
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
-using System.Runtime.CompilerServices;
-using Microsoft.PythonTools.Common.Core.OS;
 using Microsoft.PythonTools.Common.Parsing;
 using Microsoft.VisualStudio.Debugger;
 using Microsoft.VisualStudio.Debugger.CallStack;
-using Microsoft.VisualStudio.Debugger.Evaluation;
-using static Microsoft.VisualStudio.Threading.SingleThreadedSynchronizationContext;
 
 namespace Microsoft.PythonTools.Debugger.Concord.Proxies.Structs {
     internal abstract class PyFrameObject : PyVarObject {

--- a/Python/Product/Debugger.Concord/Proxies/Structs/PyFrameObject310.cs
+++ b/Python/Product/Debugger.Concord/Proxies/Structs/PyFrameObject310.cs
@@ -1,8 +1,19 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
 using Microsoft.VisualStudio.Debugger;
 using Microsoft.PythonTools.Common.Parsing;
 

--- a/Python/Product/Debugger.Concord/Proxies/Structs/PyFrameObject310.cs
+++ b/Python/Product/Debugger.Concord/Proxies/Structs/PyFrameObject310.cs
@@ -10,7 +10,7 @@ namespace Microsoft.PythonTools.Debugger.Concord.Proxies.Structs {
     [StructProxy(StructName = "_frame", MaxVersion = PythonLanguageVersion.V310)]
     [PyType(MaxVersion = PythonLanguageVersion.V310, VariableName = "PyFrame_Type")]
     internal class PyFrameObject310 : PyFrameObject {
-        internal class Fields310 {
+        internal class Fields {
             public StructField<PointerProxy<PyFrameObject>> f_back;
             public StructField<PointerProxy<PyCodeObject>> f_code;
             public StructField<PointerProxy<PyDictObject>> f_globals;
@@ -20,7 +20,7 @@ namespace Microsoft.PythonTools.Debugger.Concord.Proxies.Structs {
             public StructField<ArrayProxy<PointerProxy<PyObject>>> f_localsplus;
         }
 
-        private readonly Fields310 _fields;
+        private readonly Fields _fields;
 
         public override PointerProxy<PyFrameObject> f_back => GetFieldProxy(_fields.f_back);
 

--- a/Python/Product/Debugger.Concord/Proxies/Structs/PyFrameObject310.cs
+++ b/Python/Product/Debugger.Concord/Proxies/Structs/PyFrameObject310.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Debugger;
+using Microsoft.PythonTools.Common.Parsing;
+
+namespace Microsoft.PythonTools.Debugger.Concord.Proxies.Structs {
+    [StructProxy(StructName = "_frame", MaxVersion = PythonLanguageVersion.V310)]
+    [PyType(MaxVersion = PythonLanguageVersion.V310, VariableName = "PyFrame_Type")]
+    internal class PyFrameObject310 : PyFrameObject {
+        internal class Fields310 {
+            public StructField<PointerProxy<PyFrameObject>> f_back;
+            public StructField<PointerProxy<PyCodeObject>> f_code;
+            public StructField<PointerProxy<PyDictObject>> f_globals;
+            public StructField<PointerProxy<PyDictObject>> f_locals;
+            public StructField<PointerProxy<PyObject>> f_trace;
+            public StructField<Int32Proxy> f_lineno;
+            public StructField<ArrayProxy<PointerProxy<PyObject>>> f_localsplus;
+        }
+
+        private readonly Fields310 _fields;
+
+        public override PointerProxy<PyFrameObject> f_back => GetFieldProxy(_fields.f_back);
+
+        public override PointerProxy<PyCodeObject> f_code => GetFieldProxy(_fields.f_code);
+
+        public override PointerProxy<PyDictObject> f_globals => GetFieldProxy(_fields.f_globals);
+
+        public override PointerProxy<PyDictObject> f_locals => GetFieldProxy(_fields.f_locals);
+
+        public override Int32Proxy f_lineno => GetFieldProxy(_fields.f_lineno);
+
+        public override ArrayProxy<PointerProxy<PyObject>> f_localsplus => GetFieldProxy(_fields.f_localsplus);
+
+        public PyFrameObject310(DkmProcess process, ulong address)
+            : base(process, address) {
+            var pythonInfo = process.GetPythonRuntimeInfo();
+            InitializeStruct(this, out _fields);
+            CheckPyType<PyFrameObject310>();
+        }
+    }
+}

--- a/Python/Product/Debugger.Concord/Proxies/Structs/PyFrameObject311.cs
+++ b/Python/Product/Debugger.Concord/Proxies/Structs/PyFrameObject311.cs
@@ -11,7 +11,7 @@ namespace Microsoft.PythonTools.Debugger.Concord.Proxies.Structs {
     [StructProxy(StructName = "_frame", MinVersion = PythonLanguageVersion.V311)]
     [PyType(MinVersion = PythonLanguageVersion.V311, VariableName = "PyFrame_Type")]
     internal class PyFrameObject311 : PyFrameObject {
-        internal class Fields311 {
+        internal class Fields {
             public StructField<PointerProxy<PyFrameObject>> f_back;
             public StructField<PointerProxy<PyInterpreterFrame>> f_frame;
             public StructField<PointerProxy<PyObject>> f_trace;
@@ -22,7 +22,7 @@ namespace Microsoft.PythonTools.Debugger.Concord.Proxies.Structs {
             public StructField<ArrayProxy<PointerProxy<PyObject>>> _f_frame_data;
         }
 
-        private readonly Fields311 _fields;
+        private readonly Fields _fields;
 
         public PyFrameObject311(DkmProcess process, ulong address)
             : base(process, address) {

--- a/Python/Product/Debugger.Concord/Proxies/Structs/PyFrameObject311.cs
+++ b/Python/Product/Debugger.Concord/Proxies/Structs/PyFrameObject311.cs
@@ -1,11 +1,21 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
 using Microsoft.PythonTools.Common.Parsing;
 using Microsoft.VisualStudio.Debugger;
-using static Microsoft.PythonTools.Debugger.Concord.Proxies.Structs.PyFrameObject310;
 
 namespace Microsoft.PythonTools.Debugger.Concord.Proxies.Structs {
     [StructProxy(StructName = "_frame", MinVersion = PythonLanguageVersion.V311)]

--- a/Python/Product/Debugger.Concord/Proxies/Structs/PyFrameObject311.cs
+++ b/Python/Product/Debugger.Concord/Proxies/Structs/PyFrameObject311.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.PythonTools.Common.Parsing;
+using Microsoft.VisualStudio.Debugger;
+using static Microsoft.PythonTools.Debugger.Concord.Proxies.Structs.PyFrameObject310;
+
+namespace Microsoft.PythonTools.Debugger.Concord.Proxies.Structs {
+    [StructProxy(StructName = "_frame", MinVersion = PythonLanguageVersion.V311)]
+    [PyType(MinVersion = PythonLanguageVersion.V311, VariableName = "PyFrame_Type")]
+    internal class PyFrameObject311 : PyFrameObject {
+        internal class Fields311 {
+            public StructField<PointerProxy<PyFrameObject>> f_back;
+            public StructField<PointerProxy<PyInterpreterFrame>> f_frame;
+            public StructField<PointerProxy<PyObject>> f_trace;
+            public StructField<Int32Proxy> f_lineno;
+            public StructField<CharProxy> f_trace_lines;
+            public StructField<CharProxy> f_trace_opcodes;
+            public StructField<CharProxy> f_fast_as_locals;
+            public StructField<ArrayProxy<PointerProxy<PyObject>>> _f_frame_data;
+        }
+
+        private readonly Fields311 _fields;
+
+        public PyFrameObject311(DkmProcess process, ulong address)
+            : base(process, address) {
+            var pythonInfo = process.GetPythonRuntimeInfo();
+            InitializeStruct(this, out _fields);
+            CheckPyType<PyFrameObject311>();
+        }
+
+        private PointerProxy<PyInterpreterFrame> f_frame {
+            get { return GetFieldProxy(_fields.f_frame); }
+        }
+
+        private PyInterpreterFrame GetFrame() {
+            return f_frame.TryRead();
+        }
+
+        public override PointerProxy<PyFrameObject> f_back => GetFieldProxy(_fields.f_back);
+
+        public override PointerProxy<PyCodeObject> f_code => GetFrame().f_code;
+
+        public override PointerProxy<PyDictObject> f_globals => GetFrame().f_globals;
+
+        public override PointerProxy<PyDictObject> f_locals => GetFrame().f_locals;
+
+        public override Int32Proxy f_lineno => GetFieldProxy(_fields.f_lineno);
+
+        public override ArrayProxy<PointerProxy<PyObject>> f_localsplus => GetFrame().f_localsplus;
+    }
+}

--- a/Python/Product/Debugger.Concord/Proxies/Structs/PyFunctionObject.cs
+++ b/Python/Product/Debugger.Concord/Proxies/Structs/PyFunctionObject.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.PythonTools.Common.Parsing;
+using Microsoft.VisualStudio.Debugger;
+
+namespace Microsoft.PythonTools.Debugger.Concord.Proxies.Structs {
+    [StructProxy(StructName = "PyFunctionObject", MinVersion = PythonLanguageVersion.V311)]
+    internal class PyFunctionObject : PyObject {
+        internal class Fields {
+            public StructField<PointerProxy<PyObject>> func_globals;
+            public StructField<PointerProxy<PyObject>> func_builtins;
+            public StructField<PointerProxy<PyObject>> func_name;
+            public StructField<PointerProxy<PyObject>> func_qualname;
+            public StructField<PointerProxy<PyObject>> func_code;
+            public StructField<PointerProxy<PyObject>> func_defaults;
+            public StructField<PointerProxy<PyObject>> func_kwdefaults;
+            public StructField<PointerProxy<PyObject>> func_closure;
+            public StructField<PointerProxy<PyObject>> func_doc;
+            public StructField<PointerProxy<PyObject>> func_dict;
+            public StructField<PointerProxy<PyObject>> func_weakreflist;
+            public StructField<PointerProxy<PyObject>> func_module;
+            public StructField<PointerProxy<PyObject>> func_annotations;
+        }
+
+        private readonly Fields _fields;
+
+        public PyFunctionObject(DkmProcess process, ulong address)
+            : base(process, address) {
+            InitializeStruct(this, out _fields);
+            CheckPyType<PyFunctionObject>();
+        }
+    }
+}

--- a/Python/Product/Debugger.Concord/Proxies/Structs/PyFunctionObject.cs
+++ b/Python/Product/Debugger.Concord/Proxies/Structs/PyFunctionObject.cs
@@ -7,7 +7,7 @@ using Microsoft.PythonTools.Common.Parsing;
 using Microsoft.VisualStudio.Debugger;
 
 namespace Microsoft.PythonTools.Debugger.Concord.Proxies.Structs {
-    [StructProxy(StructName = "PyFunctionObject", MinVersion = PythonLanguageVersion.V311)]
+    [StructProxy(StructName = "PyFunctionObject", MinVersion = PythonLanguageVersion.V310)]
     internal class PyFunctionObject : PyObject {
         internal class Fields {
             public StructField<PointerProxy<PyObject>> func_globals;

--- a/Python/Product/Debugger.Concord/Proxies/Structs/PyFunctionObject.cs
+++ b/Python/Product/Debugger.Concord/Proxies/Structs/PyFunctionObject.cs
@@ -24,6 +24,7 @@ namespace Microsoft.PythonTools.Debugger.Concord.Proxies.Structs {
             public StructField<PointerProxy<PyObject>> func_module;
             public StructField<PointerProxy<PyObject>> func_annotations;
             public StructField<PointerProxy<UInt64Proxy>> vectorcall;
+            [FieldProxy(MinVersion = PythonLanguageVersion.V311)]
             public StructField<UInt32Proxy> func_version;
         }
 

--- a/Python/Product/Debugger.Concord/Proxies/Structs/PyFunctionObject.cs
+++ b/Python/Product/Debugger.Concord/Proxies/Structs/PyFunctionObject.cs
@@ -1,8 +1,19 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
 using Microsoft.PythonTools.Common.Parsing;
 using Microsoft.VisualStudio.Debugger;
 

--- a/Python/Product/Debugger.Concord/Proxies/Structs/PyFunctionObject.cs
+++ b/Python/Product/Debugger.Concord/Proxies/Structs/PyFunctionObject.cs
@@ -23,6 +23,8 @@ namespace Microsoft.PythonTools.Debugger.Concord.Proxies.Structs {
             public StructField<PointerProxy<PyObject>> func_weakreflist;
             public StructField<PointerProxy<PyObject>> func_module;
             public StructField<PointerProxy<PyObject>> func_annotations;
+            public StructField<PointerProxy<UInt64Proxy>> vectorcall;
+            public StructField<UInt32Proxy> func_version;
         }
 
         private readonly Fields _fields;

--- a/Python/Product/Debugger.Concord/Proxies/Structs/PyInterpreterFrame.cs
+++ b/Python/Product/Debugger.Concord/Proxies/Structs/PyInterpreterFrame.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.PythonTools.Common.Parsing;
+using Microsoft.VisualStudio.Debugger;
+
+namespace Microsoft.PythonTools.Debugger.Concord.Proxies.Structs {
+    // This was added in commit https://github.com/python/cpython/commit/ae0a2b756255629140efcbe57fc2e714f0267aa3
+    [StructProxy(StructName = "_PyInterpreterFrame", MinVersion = PythonLanguageVersion.V311)]
+    internal class PyInterpreterFrame : StructProxy {
+        internal class Fields {
+            public StructField<PointerProxy<PyFunctionObject>> f_func;
+            public StructField<PointerProxy<PyObject>> f_globals;
+            public StructField<PointerProxy<PyObject>> f_builtins;
+            public StructField<PointerProxy<PyObject>> f_locals;
+            public StructField<PointerProxy<PyCodeObject>> f_code;
+            public StructField<PointerProxy<PyFrameObject>> frame_obj;
+            public StructField<PointerProxy<PyInterpreterFrame>> previous;
+            public StructField<PointerProxy<PyObject>> prev_instr; // Not sure PyObject is the right type here
+            public StructField<Int32Proxy> stacktop;
+            public StructField<BoolProxy> is_entry;
+            public StructField<CharProxy> owner;
+            public StructField<PointerProxy<ArrayProxy<PyObject>>> localsplus;
+        }
+
+        private readonly Fields _fields;
+
+        public PyInterpreterFrame(DkmProcess process, ulong address)
+            : base(process, address) {
+            InitializeStruct(this, out _fields);
+        }
+    }
+}

--- a/Python/Product/Debugger.Concord/Proxies/Structs/PyInterpreterFrame.cs
+++ b/Python/Product/Debugger.Concord/Proxies/Structs/PyInterpreterFrame.cs
@@ -1,8 +1,19 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
 using Microsoft.PythonTools.Common.Parsing;
 using Microsoft.VisualStudio.Debugger;
 

--- a/Python/Product/Debugger.Concord/Proxies/Structs/PyInterpreterFrame.cs
+++ b/Python/Product/Debugger.Concord/Proxies/Structs/PyInterpreterFrame.cs
@@ -12,9 +12,9 @@ namespace Microsoft.PythonTools.Debugger.Concord.Proxies.Structs {
     internal class PyInterpreterFrame : StructProxy {
         internal class Fields {
             public StructField<PointerProxy<PyFunctionObject>> f_func;
-            public StructField<PointerProxy<PyObject>> f_globals;
-            public StructField<PointerProxy<PyObject>> f_builtins;
-            public StructField<PointerProxy<PyObject>> f_locals;
+            public StructField<PointerProxy<PyDictObject>> f_globals;
+            public StructField<PointerProxy<PyDictObject>> f_builtins;
+            public StructField<PointerProxy<PyDictObject>> f_locals;
             public StructField<PointerProxy<PyCodeObject>> f_code;
             public StructField<PointerProxy<PyFrameObject>> frame_obj;
             public StructField<PointerProxy<PyInterpreterFrame>> previous;
@@ -22,7 +22,7 @@ namespace Microsoft.PythonTools.Debugger.Concord.Proxies.Structs {
             public StructField<Int32Proxy> stacktop;
             public StructField<BoolProxy> is_entry;
             public StructField<CharProxy> owner;
-            public StructField<PointerProxy<ArrayProxy<PyObject>>> localsplus;
+            public StructField<ArrayProxy<PointerProxy<PyObject>>> localsplus;
         }
 
         private readonly Fields _fields;
@@ -31,5 +31,26 @@ namespace Microsoft.PythonTools.Debugger.Concord.Proxies.Structs {
             : base(process, address) {
             InitializeStruct(this, out _fields);
         }
+
+        public PointerProxy<PyCodeObject> f_code {
+            get { return GetFieldProxy(_fields.f_code); }
+        }
+
+        public PointerProxy<PyDictObject> f_globals {
+            get { return GetFieldProxy(_fields.f_globals); }
+        }
+
+        public PointerProxy<PyDictObject> f_locals {
+            get { return GetFieldProxy(_fields.f_locals); }
+        }
+
+        public ArrayProxy<PointerProxy<PyObject>> f_localsplus {
+            get { return GetFieldProxy(_fields.localsplus); }
+        }
+
+        public PointerProxy<PyFrameObject> frame_obj {
+            get { return GetFieldProxy(_fields.frame_obj); }
+        }
+
     }
 }

--- a/Python/Product/Debugger.Concord/Proxies/Structs/PyInterpreterState.cs
+++ b/Python/Product/Debugger.Concord/Proxies/Structs/PyInterpreterState.cs
@@ -15,6 +15,7 @@
 // permissions and limitations under the License.
 
 using System.Collections.Generic;
+using System.Diagnostics;
 using Microsoft.PythonTools.Common.Parsing;
 using Microsoft.VisualStudio.Debugger;
 
@@ -23,7 +24,10 @@ namespace Microsoft.PythonTools.Debugger.Concord.Proxies.Structs {
     internal class PyInterpreterState : StructProxy {
         private class Fields {
             public StructField<PointerProxy<PyInterpreterState>> next;
+            [FieldProxy(MaxVersion = PythonLanguageVersion.V310)]
             public StructField<PointerProxy<PyThreadState>> tstate_head;
+            [FieldProxy(MinVersion = PythonLanguageVersion.V311)]
+            public StructField<PyThreads> threads;
             public StructField<PointerProxy<PyDictObject>> modules;
             public StructField<PointerProxy> eval_frame;
             public StructField<ceval_state> ceval;
@@ -49,7 +53,13 @@ namespace Microsoft.PythonTools.Debugger.Concord.Proxies.Structs {
         }
 
         public PointerProxy<PyThreadState> tstate_head {
-            get { return GetFieldProxy(_fields.tstate_head); }
+            get { 
+                if (_fields.tstate_head.Process != null) {
+                    return GetFieldProxy(_fields.tstate_head);
+                }
+                var threads = GetFieldProxy(_fields.threads);
+                return threads.head;
+            }
         }
 
         public PointerProxy<PyDictObject> modules {
@@ -62,29 +72,31 @@ namespace Microsoft.PythonTools.Debugger.Concord.Proxies.Structs {
 
         public ceval_state ceval => GetFieldProxy(_fields.ceval);
 
-        private class InterpHeadHolder : DkmDataItem {
-            public readonly PointerProxy<PyInterpreterState> Proxy;
-
-            public InterpHeadHolder(DkmProcess process) {
-                var pyrtInfo = process.GetPythonRuntimeInfo();
-                Proxy = pyrtInfo.GetRuntimeState()?.interpreters.head
-                    ?? pyrtInfo.DLLs.Python.GetStaticVariable<PointerProxy<PyInterpreterState>>("interp_head");
-            }
-        }
-
-        public static PointerProxy<PyInterpreterState> interp_head(DkmProcess process) {
-            return process.GetOrCreateDataItem(() => new InterpHeadHolder(process)).Proxy;
-        }
 
         public static IEnumerable<PyInterpreterState> GetInterpreterStates(DkmProcess process) {
-            for (var interp = interp_head(process).TryRead(); interp != null; interp = interp.next.TryRead()) {
-                yield return interp;
+            var pyrtInfo = process.GetPythonRuntimeInfo();
+            var runtimeState = pyrtInfo.GetRuntimeState();
+            var interpreters = runtimeState.interpreters;
+            var head = interpreters.head.TryRead();
+            while (head != null) {
+                yield return head;
+                head = head.next.TryRead();
             }
         }
 
-        public IEnumerable<PyThreadState> GetThreadStates() {
-            for (var tstate = tstate_head.TryRead(); tstate != null; tstate = tstate.next.TryRead()) {
-                yield return tstate;
+        public IEnumerable<PyThreadState> GetThreadStates(DkmProcess process) {
+            var pyrtInfo = process.GetPythonRuntimeInfo();
+            if (pyrtInfo.LanguageVersion <= PythonLanguageVersion.V310) {
+                for (var tstate = tstate_head.TryRead(); tstate != null; tstate = tstate.next.TryRead()) {
+                    yield return tstate;
+                }
+            } else {
+                var threads = GetFieldProxy(_fields.threads);
+                var head = threads.head.TryRead();
+                while (head.Address != 0) {
+                    yield return head;
+                    head = head.next.TryRead();
+                }
             }
         }
 

--- a/Python/Product/Debugger.Concord/Proxies/Structs/PyThreads.cs
+++ b/Python/Product/Debugger.Concord/Proxies/Structs/PyThreads.cs
@@ -1,8 +1,19 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
 using Microsoft.PythonTools.Common.Parsing;
 using Microsoft.VisualStudio.Debugger;
 

--- a/Python/Product/Debugger.Concord/Proxies/Structs/PyThreads.cs
+++ b/Python/Product/Debugger.Concord/Proxies/Structs/PyThreads.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.PythonTools.Common.Parsing;
+using Microsoft.VisualStudio.Debugger;
+
+namespace Microsoft.PythonTools.Debugger.Concord.Proxies.Structs {
+    [StructProxy(StructName = "pythreads", MinVersion = PythonLanguageVersion.V311)]
+    internal class PyThreads: StructProxy {
+        internal class Fields {
+            public StructField<UInt64Proxy> next_unique_id;
+            public StructField<PointerProxy<PyThreadState>> head;
+            public StructField<Int64Proxy> count;
+            public StructField<UInt64Proxy> stacksize;
+        }
+
+        private readonly Fields _fields;
+
+        public PyThreads(DkmProcess process, ulong address)
+            : base(process, address) {
+            InitializeStruct(this, out _fields);
+        }
+
+        public PointerProxy<PyThreadState> head {
+            get { return GetFieldProxy(_fields.head); }
+        }
+    }
+}

--- a/Python/Product/Debugger.Concord/Proxies/Structs/PyTupleObject.cs
+++ b/Python/Product/Debugger.Concord/Proxies/Structs/PyTupleObject.cs
@@ -38,7 +38,7 @@ namespace Microsoft.PythonTools.Debugger.Concord.Proxies.Structs {
             get { return GetFieldProxy(_fields.ob_item); }
         }
 
-        public IEnumerable<PointerProxy<PyObject>> ReadElements() {
+        public virtual IEnumerable<PointerProxy<PyObject>> ReadElements() {
             return ob_item.Take(ob_size.Read());
         }
 

--- a/Python/Product/Debugger.Concord/TraceManagerLocalHelper.cs
+++ b/Python/Product/Debugger.Concord/TraceManagerLocalHelper.cs
@@ -62,13 +62,18 @@ namespace Microsoft.PythonTools.Debugger.Concord {
         // Layout of this struct must always remain in sync with DebuggerHelper/trace.cpp.
         [StructLayout(LayoutKind.Sequential, Pack = 8)]
         private struct PyCodeObject_FieldOffsets {
-            public readonly long co_varnames, co_filename, co_name;
+            public readonly long co_filename, co_name;
 
             public PyCodeObject_FieldOffsets(DkmProcess process) {
-                var fields = StructProxy.GetStructFields<PyCodeObject, PyCodeObject.Fields>(process);
-                co_varnames = fields.co_varnames.Offset;
-                co_filename = fields.co_filename.Offset;
-                co_name = fields.co_name.Offset;
+                if (process.GetPythonRuntimeInfo().LanguageVersion <= PythonLanguageVersion.V310) {
+                    var fields = StructProxy.GetStructFields<PyCodeObject310, PyCodeObject310.Fields>(process);
+                    co_filename = fields.co_filename.Offset;
+                    co_name = fields.co_name.Offset;
+                } else {
+                    var fields = StructProxy.GetStructFields<PyCodeObject311, PyCodeObject311.Fields>(process);
+                    co_filename = fields.co_filename.Offset;
+                    co_name = fields.co_name.Offset;
+                }
             }
         }
 
@@ -80,7 +85,7 @@ namespace Microsoft.PythonTools.Debugger.Concord {
             public PyFrameObject_FieldOffsets(DkmProcess process) {
                 // For 310, these are on the _frame struct itself.
                 if (process.GetPythonRuntimeInfo().LanguageVersion <= PythonLanguageVersion.V310) {
-                    var fields = StructProxy.GetStructFields<PyFrameObject310, PyFrameObject310.Fields310>(process);
+                    var fields = StructProxy.GetStructFields<PyFrameObject310, PyFrameObject310.Fields>(process);
                     f_back = fields.f_back.Offset;
                     f_code = fields.f_code.Offset;
                     f_globals = fields.f_globals.Offset;
@@ -91,7 +96,7 @@ namespace Microsoft.PythonTools.Debugger.Concord {
                 }
 
                 // For 311 and higher, they are on the PyInterpreterFrame struct which is pointed to by the _frame struct.
-                var _frameFields = StructProxy.GetStructFields<PyFrameObject311, PyFrameObject311.Fields311>(process);
+                var _frameFields = StructProxy.GetStructFields<PyFrameObject311, PyFrameObject311.Fields>(process);
                 var _interpreterFields = StructProxy.GetStructFields<PyInterpreterFrame, PyInterpreterFrame.Fields>(process);
                 f_frame = _frameFields.f_frame.Offset;
                 f_back = _frameFields.f_back.Offset;

--- a/Python/Product/Debugger.Concord/TraceManagerLocalHelper.cs
+++ b/Python/Product/Debugger.Concord/TraceManagerLocalHelper.cs
@@ -75,15 +75,30 @@ namespace Microsoft.PythonTools.Debugger.Concord {
         // Layout of this struct must always remain in sync with DebuggerHelper/trace.cpp.
         [StructLayout(LayoutKind.Sequential, Pack = 8)]
         private struct PyFrameObject_FieldOffsets {
-            public readonly long f_back, f_code, f_globals, f_locals, f_lineno;
+            public readonly long f_back, f_code, f_globals, f_locals, f_lineno, f_frame;
 
             public PyFrameObject_FieldOffsets(DkmProcess process) {
-                var fields = StructProxy.GetStructFields<PyFrameObject, PyFrameObject.Fields>(process);
-                f_back = fields.f_back.Offset;
-                f_code = fields.f_code.Offset;
-                f_globals = fields.f_globals.Offset;
-                f_locals = fields.f_locals.Offset;
-                f_lineno = fields.f_lineno.Offset;
+                // For 310, these are on the _frame struct itself.
+                if (process.GetPythonRuntimeInfo().LanguageVersion <= PythonLanguageVersion.V310) {
+                    var fields = StructProxy.GetStructFields<PyFrameObject310, PyFrameObject310.Fields310>(process);
+                    f_back = fields.f_back.Offset;
+                    f_code = fields.f_code.Offset;
+                    f_globals = fields.f_globals.Offset;
+                    f_locals = fields.f_locals.Offset;
+                    f_lineno = fields.f_lineno.Offset;
+                    f_frame = 0;
+                    return;
+                }
+
+                // For 311 and higher, they are on the PyInterpreterFrame struct which is pointed to by the _frame struct.
+                var _frameFields = StructProxy.GetStructFields<PyFrameObject311, PyFrameObject311.Fields311>(process);
+                var _interpreterFields = StructProxy.GetStructFields<PyInterpreterFrame, PyInterpreterFrame.Fields>(process);
+                f_frame = _frameFields.f_frame.Offset;
+                f_back = _frameFields.f_back.Offset;
+                f_code = _interpreterFields.f_code.Offset;
+                f_globals = _interpreterFields.f_globals.Offset;
+                f_locals = _interpreterFields.f_locals.Offset;
+                f_lineno = _frameFields.f_lineno.Offset;
             }
         }
 
@@ -180,6 +195,7 @@ namespace Microsoft.PythonTools.Debugger.Concord {
         private readonly PythonDllBreakpointHandlers _handlers;
         private readonly DkmNativeInstructionAddress _traceFunc;
         private readonly DkmNativeInstructionAddress _evalFrameFunc;
+        private readonly DkmNativeInstructionAddress _pyEval_FrameDefault;
         private readonly PointerProxy _defaultEvalFrameFunc;
         private readonly ByteProxy _isTracing;
 
@@ -222,6 +238,7 @@ namespace Microsoft.PythonTools.Debugger.Concord {
             _process = process;
             _pyrtInfo = process.GetPythonRuntimeInfo();
 
+            _pyEval_FrameDefault = _pyrtInfo.DLLs.Python.GetExportedFunctionAddress("_PyEval_EvalFrameDefault");
             _traceFunc = _pyrtInfo.DLLs.DebuggerHelper.GetExportedFunctionAddress("TraceFunc");
             _evalFrameFunc = 
                 _pyrtInfo.DLLs.DebuggerHelper.GetExportedFunctionAddress("EvalFrameFunc");
@@ -243,7 +260,7 @@ namespace Microsoft.PythonTools.Debugger.Concord {
                     if (_pyrtInfo.LanguageVersion >= PythonLanguageVersion.V36) {
                         RegisterJITTracing(interp);
                     }
-                    foreach (var tstate in interp.GetThreadStates()) {
+                    foreach (var tstate in interp.GetThreadStates(process)) {
                         RegisterTracing(tstate);
                     }
                 }
@@ -305,9 +322,15 @@ namespace Microsoft.PythonTools.Debugger.Concord {
             Debug.Assert(_pyrtInfo.LanguageVersion >= PythonLanguageVersion.V36);
 
             var current = istate.eval_frame.Read();
-            if (current != _evalFrameFunc.GetPointer()) {
+            var evalFrameAddr = _evalFrameFunc.GetPointer();
+
+            if (current == 0) {
+                // This means the eval_frame is set to the default. Write
+                // this as our _defaultEvalFrameFunc
+                _defaultEvalFrameFunc.Write(_pyEval_FrameDefault.GetPointer());
+            } else if (current != evalFrameAddr) {
                 _defaultEvalFrameFunc.Write(current);
-                istate.eval_frame.Write(_evalFrameFunc.GetPointer());
+                istate.eval_frame.Write(evalFrameAddr);
             }
         }
 
@@ -493,7 +516,7 @@ namespace Microsoft.PythonTools.Debugger.Concord {
                 _owner.OnPotentialRuntimeExit(thread, pProc);
             }
 
-            [StepInGate]
+            [StepInGate(MaxVersion = PythonLanguageVersion.V310)] // TODO: What's the side effect of this no longer working in 3.11? Seems step into won't work in some obscure cases.
             public void call_function(DkmThread thread, ulong frameBase, ulong vframe, bool useRegisters) {
                 var process = thread.Process;
                 var cppEval = new CppExpressionEvaluator(thread, frameBase, vframe);
@@ -508,6 +531,19 @@ namespace Microsoft.PythonTools.Debugger.Concord {
                     "*((*(PyObject***){0}) - {1} - 1)",
                     useRegisters ? "@rcx" : "pp_stack",
                     n);
+                var obj = PyObject.FromAddress(process, func);
+                ulong ml_meth = cppEval.EvaluateUInt64(
+                    "((PyObject*){0})->ob_type == &PyCFunction_Type ? ((PyCFunctionObject*){0})->m_ml->ml_meth : 0",
+                    func);
+
+                _owner.OnPotentialRuntimeExit(thread, ml_meth);
+            }
+
+            [StepInGate]
+            public void trace_call_function(DkmThread thread, ulong frameBase, ulong vframe, bool useRegisters) {
+                var process = thread.Process;
+                var cppEval = new CppExpressionEvaluator(thread, frameBase, vframe);
+                ulong func = cppEval.EvaluateUInt64(useRegisters ? "@rcx" : "func");
                 var obj = PyObject.FromAddress(process, func);
                 ulong ml_meth = cppEval.EvaluateUInt64(
                     "((PyObject*){0})->ob_type == &PyCFunction_Type ? ((PyCFunctionObject*){0})->m_ml->ml_meth : 0",

--- a/Python/Product/DebuggerHelper/trace.cpp
+++ b/Python/Product/DebuggerHelper/trace.cpp
@@ -442,10 +442,10 @@ static void TraceLine(void* frame) {
         co_filename = ReadField<void*>(f_code, fieldOffsets.PyCodeObject.co_filename);
     }
     else {
-		// We're on 3.11 or later. f_frame (PyInterpreterFrame) is off of the frame. It has
-		// the f_code object.
-		void* f_frame = ReadField<void*>(frame, fieldOffsets.PyFrameObject.f_frame);
-		void* f_code = ReadField<void*>(f_frame, fieldOffsets.PyFrameObject.f_code);
+        // We're on 3.11 or later. f_frame (PyInterpreterFrame) is off of the frame. It has
+        // the f_code object.
+        void* f_frame = ReadField<void*>(frame, fieldOffsets.PyFrameObject.f_frame);
+        void* f_code = ReadField<void*>(f_frame, fieldOffsets.PyFrameObject.f_code);
         co_filename = ReadField<void*>(f_code, fieldOffsets.PyCodeObject.co_filename);
     }
     if (co_filename == nullptr) {

--- a/Python/Product/DebuggerHelper/trace.cpp
+++ b/Python/Product/DebuggerHelper/trace.cpp
@@ -54,7 +54,7 @@ struct {
         int64_t f_back, f_code, f_globals, f_locals, f_lineno, f_frame;
     } PyFrameObject;
     struct {
-        int64_t co_varnames, co_filename, co_name;
+        int64_t co_filename, co_name;
     } PyCodeObject;
     struct {
         int64_t ob_sval;

--- a/Python/Product/DebuggerHelper/trace.cpp
+++ b/Python/Product/DebuggerHelper/trace.cpp
@@ -51,7 +51,7 @@ struct {
         int64_t ob_size;
     } PyVarObject;
     struct {
-        int64_t f_back, f_code, f_globals, f_locals, f_lineno;
+        int64_t f_back, f_code, f_globals, f_locals, f_lineno, f_frame;
     } PyFrameObject;
     struct {
         int64_t co_varnames, co_filename, co_name;
@@ -435,8 +435,19 @@ static void TraceLine(void* frame) {
         return;
     }
 
-    void* f_code = ReadField<void*>(frame, fieldOffsets.PyFrameObject.f_code);
-    void* co_filename = ReadField<void*>(f_code, fieldOffsets.PyCodeObject.co_filename);
+    void* co_filename = nullptr;
+    if (fieldOffsets.PyFrameObject.f_frame == 0) {
+        // We're on 3.10 or earlier. f_code is directly off of the frame.
+        void* f_code = ReadField<void*>(frame, fieldOffsets.PyFrameObject.f_code);
+        co_filename = ReadField<void*>(f_code, fieldOffsets.PyCodeObject.co_filename);
+    }
+    else {
+		// We're on 3.11 or later. f_frame (PyInterpreterFrame) is off of the frame. It has
+		// the f_code object.
+		void* f_frame = ReadField<void*>(frame, fieldOffsets.PyFrameObject.f_frame);
+		void* f_code = ReadField<void*>(f_frame, fieldOffsets.PyFrameObject.f_code);
+        co_filename = ReadField<void*>(f_code, fieldOffsets.PyCodeObject.co_filename);
+    }
     if (co_filename == nullptr) {
         return;
     }

--- a/Python/Product/PythonTools/PythonTools/LanguageServerClient/PythonLanguageClient.cs
+++ b/Python/Product/PythonTools/PythonTools/LanguageServerClient/PythonLanguageClient.cs
@@ -551,7 +551,8 @@ namespace Microsoft.PythonTools.LanguageServerClient {
                                 capabilities["workspace"]["configuration"] = true;
                                 
                                 var folders = GetFolders();
-                                Debug.Assert(folders.Any(), "no workspace or projects found");
+                                // Debug.Assert(folders.Any(), "no workspace or projects found");
+                                // This is allowed with say a loose file.
                                 messageParams["workspaceFolders"] = JToken.FromObject(folders.ToArray());
                                 _sentInitialWorkspaceFolders = true;
                                 _workspaceFoldersSupported = true;


### PR DESCRIPTION
This gets the two test apps we have in the [examples](https://github.com/microsoft/PTVS/tree/main/Examples) folder working with 3.11.

Breakpoints, callstacks, locals, and stepping all work. Probably need more testing around different types of variables, but that shouldn't be 3.11 specific.