### PR TITLE
Fix wrong Conda Python version being displayed in the UI

### DIFF
--- a/Python/Product/Cookiecutter/Shared/Interpreters/PythonRegistrySearch.cs
+++ b/Python/Product/Cookiecutter/Shared/Interpreters/PythonRegistrySearch.cs
@@ -166,13 +166,13 @@ namespace Microsoft.CookiecutterTools.Interpreters {
 
             var version = tagKey.GetValue("Version") as string;
             if (pythonCoreCompatibility && string.IsNullOrEmpty(version) && tag.Length >= 3) {
-                version = tag.Substring(0, 3);
+                version = (tag.Length > 3 && char.IsDigit(tag[3])) ? tag.Substring(0, 4) : tag.Substring(0, 3);
             }
 
             Version sysVersion;
             var sysVersionString = tagKey.GetValue("SysVersion") as string;
             if (pythonCoreCompatibility && string.IsNullOrEmpty(sysVersionString) && tag.Length >= 3) {
-                sysVersionString = tag.Substring(0, 3);
+                sysVersionString = (tag.Length > 3 && char.IsDigit(tag[3])) ? tag.Substring(0, 4) : tag.Substring(0, 3);
             }
             if (string.IsNullOrEmpty(sysVersionString) || !Version.TryParse(sysVersionString, out sysVersion)) {
                 sysVersion = new Version(0, 0);

--- a/Python/Product/Cookiecutter/Shared/Interpreters/PythonRegistrySearch.cs
+++ b/Python/Product/Cookiecutter/Shared/Interpreters/PythonRegistrySearch.cs
@@ -18,6 +18,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Text.RegularExpressions;
 using System.Threading;
 using Microsoft.CookiecutterTools.Infrastructure;
 using Microsoft.Win32;
@@ -164,15 +165,18 @@ namespace Microsoft.CookiecutterTools.Interpreters {
                 }
             }
 
+            // The regex captures the major and minor version as a group.
+            var match = Regex.Match(tag, @"^(\d+\.\d+)");
+
             var version = tagKey.GetValue("Version") as string;
             if (pythonCoreCompatibility && string.IsNullOrEmpty(version) && tag.Length >= 3) {
-                version = (tag.Length > 3 && char.IsDigit(tag[3])) ? tag.Substring(0, 4) : tag.Substring(0, 3);
+                version = match.Success ? match.Groups[1].Value : "";
             }
 
             Version sysVersion;
             var sysVersionString = tagKey.GetValue("SysVersion") as string;
             if (pythonCoreCompatibility && string.IsNullOrEmpty(sysVersionString) && tag.Length >= 3) {
-                sysVersionString = (tag.Length > 3 && char.IsDigit(tag[3])) ? tag.Substring(0, 4) : tag.Substring(0, 3);
+                sysVersionString = match.Success ? match.Groups[1].Value : "";
             }
             if (string.IsNullOrEmpty(sysVersionString) || !Version.TryParse(sysVersionString, out sysVersion)) {
                 sysVersion = new Version(0, 0);

--- a/Python/Product/VSInterpreters/Interpreter/PythonRegistrySearch.cs
+++ b/Python/Product/VSInterpreters/Interpreter/PythonRegistrySearch.cs
@@ -19,6 +19,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Threading;
 using Microsoft.PythonTools.Common.Parsing;
 using Microsoft.PythonTools.Infrastructure;
@@ -171,14 +172,17 @@ namespace Microsoft.PythonTools.Interpreter {
                 }
             }
 
+            // The regex captures the major and minor version as a group.
+            var match = Regex.Match(tag, @"^(\d+\.\d+)");
+
             var version = tagKey.GetValue("Version") as string;
             if (pythonCoreCompatibility && string.IsNullOrEmpty(version) && tag.Length >= 3) {
-                version = (tag.Length > 3 && char.IsDigit(tag[3])) ? tag.Substring(0, 4) : tag.Substring(0, 3);
+                version = match.Success ? match.Groups[1].Value : "";
             }
 
             var sysVersionString = tagKey.GetValue("SysVersion") as string;
             if (pythonCoreCompatibility && string.IsNullOrEmpty(sysVersionString) && tag.Length >= 3) {
-                sysVersionString = (tag.Length > 3 && char.IsDigit(tag[3])) ? tag.Substring(0, 4) : tag.Substring(0, 3);
+                sysVersionString = match.Success ? match.Groups[1].Value : "";
             }
             if (string.IsNullOrEmpty(sysVersionString) || !Version.TryParse(sysVersionString, out var sysVersion)) {
                 sysVersion = new Version(0, 0);

--- a/Python/Product/VSInterpreters/Interpreter/PythonRegistrySearch.cs
+++ b/Python/Product/VSInterpreters/Interpreter/PythonRegistrySearch.cs
@@ -173,12 +173,12 @@ namespace Microsoft.PythonTools.Interpreter {
 
             var version = tagKey.GetValue("Version") as string;
             if (pythonCoreCompatibility && string.IsNullOrEmpty(version) && tag.Length >= 3) {
-                version = tag.Substring(0, 3);
+                version = (tag.Length > 3 && char.IsDigit(tag[3])) ? tag.Substring(0, 4) : tag.Substring(0, 3);
             }
 
             var sysVersionString = tagKey.GetValue("SysVersion") as string;
             if (pythonCoreCompatibility && string.IsNullOrEmpty(sysVersionString) && tag.Length >= 3) {
-                sysVersionString = tag.Substring(0, 3);
+                sysVersionString = (tag.Length > 3 && char.IsDigit(tag[3])) ? tag.Substring(0, 4) : tag.Substring(0, 3);
             }
             if (string.IsNullOrEmpty(sysVersionString) || !Version.TryParse(sysVersionString, out var sysVersion)) {
                 sysVersion = new Version(0, 0);


### PR DESCRIPTION
Fixes https://github.com/microsoft/PTVS/issues/7923

PTVS find Python installations by checking the registry entries. The python.org python has some subkeys that PTVS uses to get the version number, while conda python does not.
![image](https://github.com/user-attachments/assets/ad817444-1a69-490a-8435-a1f4b6748a19)

Fix the issue by extracting the first 4 characters of the `tag` if python version is > 3.10, and the first 3 characters otherwise. 
