### PR TITLE
Pylance will request PTVS to listen for "**/*" under root but we dont…

### DIFF
--- a/Python/Product/PythonTools/PythonTools/LanguageServerClient/FileWatcher/Listener.cs
+++ b/Python/Product/PythonTools/PythonTools/LanguageServerClient/FileWatcher/Listener.cs
@@ -92,6 +92,9 @@ namespace Microsoft.PythonTools.LanguageServerClient.FileWatcher {
             Array.ForEach(patterns, p => AddPattern(p));
         }
 
+        public void AddExclude(FileSystemWatcher pattern) {
+            _matcher.AddExclude(pattern.GlobPattern);
+        }
         private void AddPattern(FileSystemWatcher pattern) {
             // Add to our matcher
             _matcher.AddInclude(pattern.GlobPattern);

--- a/Python/Product/PythonTools/PythonTools/LanguageServerClient/PythonLanguageClient.cs
+++ b/Python/Product/PythonTools/PythonTools/LanguageServerClient/PythonLanguageClient.cs
@@ -88,7 +88,7 @@ namespace Microsoft.PythonTools.LanguageServerClient {
         private List<IPythonLanguageClientContext> _clientContexts = new List<IPythonLanguageClientContext>();
         private PythonAnalysisOptions _analysisOptions;
         private PythonAdvancedEditorOptions _advancedEditorOptions;
-        private ITaskList _taskListService; 
+        private ITaskList _taskListService;
         private LanguageServer _server;
         private JsonRpc _rpc;
         private bool _workspaceFoldersSupported = false;
@@ -99,7 +99,7 @@ namespace Microsoft.PythonTools.LanguageServerClient {
         private static TaskCompletionSource<int> _readyTcs = new TaskCompletionSource<int>();
         private bool _loaded = false;
         private Timer _deferredSettingsChangedTimer;
-        private const int _defaultSettingsDelayMS = 2000;
+        private const int _defaultSettingsDelayMS = 5000;
 
         public PythonLanguageClient() {
             _disposables = new Common.Core.Disposables.DisposableBag(GetType().Name);
@@ -152,10 +152,10 @@ namespace Microsoft.PythonTools.LanguageServerClient {
 
             _disposables.Add(() => {
                 _clientContexts.ForEach(c => {
-                    c.InterpreterChanged -= OnSettingsChanged;
+                    c.InterpreterChanged -= OnInterpreterChanged;
                     c.SearchPathsChanged -= OnSettingsChanged;
                     c.ReanalyzeChanged -= OnReanalyzeChanged;
-                    });
+                });
                 _analysisOptions.Changed -= OnSettingsChanged;
                 _advancedEditorOptions.Changed -= OnSettingsChanged;
 
@@ -164,7 +164,7 @@ namespace Microsoft.PythonTools.LanguageServerClient {
                     taskListService.PropertyChanged -= OnSettingsChanged;
                 } catch (ServiceUnavailableException) {
                 }
-                
+
                 _clientContexts.ForEach(c => c.Dispose());
                 _clientContexts.Clear();
                 solutionEvents.Opened -= OnSolutionOpened;
@@ -215,7 +215,7 @@ namespace Microsoft.PythonTools.LanguageServerClient {
 
                 var pythonSetting = GetSettings(item.scopeUri);
 
-                if(pythonSetting == null) {
+                if (pythonSetting == null) {
                     continue;
                 }
 
@@ -256,7 +256,7 @@ namespace Microsoft.PythonTools.LanguageServerClient {
         }
 
         public Task AttachForCustomMessageAsync(JsonRpc rpc) {
-     
+
             _rpc = rpc;
 
             // This is a workaround until we have proper API from ILanguageClient for now.
@@ -269,7 +269,6 @@ namespace Microsoft.PythonTools.LanguageServerClient {
             _fileListener = null;
             _fileListener = new FileWatcher.Listener(_rpc, WorkspaceService, Site);
             _disposables.Add(_fileListener);
-
             // We also need to switch the order on handlers for all of the rpc targets. Until
             // the VSSDK gives us a way to do this, use reflection.
             try {
@@ -301,7 +300,7 @@ namespace Microsoft.PythonTools.LanguageServerClient {
             } catch {
                 // Any exceptions, just skip this part
             }
-            
+
             return Task.CompletedTask;
         }
 
@@ -309,7 +308,7 @@ namespace Microsoft.PythonTools.LanguageServerClient {
 
         public void AddClientContext(IPythonLanguageClientContext context) {
             _clientContexts.Add(context);
-            context.InterpreterChanged += OnSettingsChanged;
+            context.InterpreterChanged += OnInterpreterChanged;
             context.SearchPathsChanged += OnSettingsChanged;
             context.ReanalyzeChanged += OnReanalyzeChanged;
         }
@@ -367,16 +366,15 @@ namespace Microsoft.PythonTools.LanguageServerClient {
             await _rpc.NotifyWithParameterObjectAsync(request, parameters).ConfigureAwait(false);
         }
 
-        private LanguageServerSettings.PythonSettings GetSettings(Uri scopeUri = null)
-        {
+        private LanguageServerSettings.PythonSettings GetSettings(Uri scopeUri = null) {
             IPythonLanguageClientContext context = null;
             if (scopeUri == null) {
                 // REPL context has null RootPath
                 context = _clientContexts.Find(c => c.RootPath == null);
-                if (context == null) {                  
+                if (context == null) {
                     return null;
                 }
-            }else {
+            } else {
                 var pathFromScopeUri = CommonUtils.NormalizeDirectoryPath(scopeUri.LocalPath).ToLower().TrimStart('\\');
                 // Find the matching context for the item, but ignore interactive window where "RootPath" is null.
                 context = _clientContexts.Find(c => scopeUri != null && c.RootPath != null && PathUtils.IsSamePath(c.RootPath.ToLower(), pathFromScopeUri));
@@ -408,12 +406,9 @@ namespace Microsoft.PythonTools.LanguageServerClient {
             // get task list tokens from options
             var taskListTokens = new List<LanguageServerSettings.PythonSettings.PythonAnalysisSettings.TaskListToken>();
             var taskListService = Site.GetService<SVsTaskList, ITaskList>();
-            if (taskListService != null)
-            {
-                foreach (var commentToken in taskListService.CommentTokens)
-                {
-                    taskListTokens.Add(new LanguageServerSettings.PythonSettings.PythonAnalysisSettings.TaskListToken()
-                    {
+            if (taskListService != null) {
+                foreach (var commentToken in taskListService.CommentTokens) {
+                    taskListTokens.Add(new LanguageServerSettings.PythonSettings.PythonAnalysisSettings.TaskListToken() {
                         text = commentToken.Text,
                         priority = commentToken.Priority.ToString()
                     });
@@ -449,6 +444,21 @@ namespace Microsoft.PythonTools.LanguageServerClient {
             return settings;
 
         }
+        private void OnInterpreterChanged(object sender, EventArgs e) {
+
+            // By default Pylance will tell us to watch everything under the workspace
+            // we can exclude the interpreter directory because we already have package managers listening to them
+            this._clientContexts.ForEach(context => {
+
+                if (PathUtils.IsSubpathOf(context.RootPath, context.InterpreterConfiguration.InterpreterPath)) {
+                    var pattern = CommonUtils.GetRelativeFilePath(context.RootPath, context.InterpreterConfiguration.GetPrefixPath()) + "/**/*";
+                    var watcher = new FileSystemWatcher() { GlobPattern = pattern };
+                    this._fileListener.AddExclude(watcher);
+                }
+
+            });
+            OnSettingsChanged(sender, e);
+        }
 
         private void OnSettingsChanged(object sender, EventArgs e) {
             try {
@@ -470,7 +480,7 @@ namespace Microsoft.PythonTools.LanguageServerClient {
             } catch (ObjectDisposedException) {
             }
         }
-    
+
         private bool TryGetOpenedDocumentData(RunningDocumentInfo info, out ITextBuffer textBuffer, out string filePath) {
             textBuffer = null;
             filePath = string.Empty;
@@ -514,8 +524,16 @@ namespace Microsoft.PythonTools.LanguageServerClient {
         }
 
         private void WatchedFilesRegistered(object sender, DidChangeWatchedFilesRegistrationOptions e) {
-            // Add the file globs to our listener. It will listen to the globs
-            _fileListener?.AddPatterns(e.Watchers);
+            
+            //this._clientContexts.ForEach(context => {
+
+            //    if (PathUtils.IsSubpathOf(context.RootPath, context.InterpreterConfiguration.InterpreterPath)) {
+            //        var pattern = CommonUtils.GetRelativeFilePath(context.RootPath, context.InterpreterConfiguration.GetPrefixPath()) + "/**/*";
+            //        var watcher = new FileSystemWatcher() { GlobPattern = pattern };
+            //        this._fileListener.AddExclude(watcher);
+            //    }
+
+            //});
         }
 
         private void CreateClientContexts() {
@@ -549,7 +567,7 @@ namespace Microsoft.PythonTools.LanguageServerClient {
                                 capabilities["workspace"]["workspaceFolders"] = true;
                                 capabilities["workspace"]["didChangeWatchedFiles"]["dynamicRegistration"] = true;
                                 capabilities["workspace"]["configuration"] = true;
-                                
+
                                 var folders = GetFolders();
                                 Debug.Assert(folders.Any(), "no workspace or projects found");
                                 messageParams["workspaceFolders"] = JToken.FromObject(folders.ToArray());
@@ -569,15 +587,15 @@ namespace Microsoft.PythonTools.LanguageServerClient {
                         }
                     } else if (message.Value<string>("method") == "textDocument/codeAction") {
                         if (message.TryGetValue("params", out JToken messageParams)) {
-                            if (messageParams != null && messageParams["range"] != null 
-                                && messageParams["context"] != null 
+                            if (messageParams != null && messageParams["range"] != null
+                                && messageParams["context"] != null
                                 && messageParams["context"]["_vs_selectionRange"] != null) {
                                 var selectionRange = messageParams["context"]["_vs_selectionRange"];
                                 messageParams["range"]["start"] = selectionRange["start"];
                                 messageParams["range"]["end"] = selectionRange["end"];
                                 return Tuple.Create(MessageParser.Serialize(message), true);
                             }
-                                
+
                         }
                     }
                 } catch {
@@ -596,7 +614,7 @@ namespace Microsoft.PythonTools.LanguageServerClient {
                 return [folder];
             } else {
                 var folders = from n in this.ProjectContextProvider.ProjectNodes
-                       select new WorkspaceFolder { uri = new System.Uri(n.BaseURI.Directory), name = n.Name };
+                              select new WorkspaceFolder { uri = new System.Uri(n.BaseURI.Directory), name = n.Name };
                 return folders.ToList();
             }
         }
@@ -607,11 +625,11 @@ namespace Microsoft.PythonTools.LanguageServerClient {
                 // Send just this workspace folder. Assumption here is that the language client will be destroyed/recreated on
                 // each workspace open
                 var folders = GetFolders();
-                this._workspaceFolders= folders.ToList();
+                this._workspaceFolders = folders.ToList();
                 await InvokeDidChangeWorkspaceFoldersAsync(folders.ToArray(), new WorkspaceFolder[0]);
             }
         }
-        
+
         // Note this is called for both openFolder and openProject modes
         private void OnSolutionClosing() {
             this._clientContexts.Clear();

--- a/Python/Product/PythonTools/PythonTools/LanguageServerClient/PythonLanguageClient.cs
+++ b/Python/Product/PythonTools/PythonTools/LanguageServerClient/PythonLanguageClient.cs
@@ -446,7 +446,7 @@ namespace Microsoft.PythonTools.LanguageServerClient {
         }
         private void OnInterpreterChanged(object sender, EventArgs e) {
 
-            // By default Pylance will tell us to watch everything under the workspace
+            // By default Pylance will tell us to watch everything under the workspace with pattern "**/*"
             // we can exclude the interpreter directory because we already have package managers listening to them
             this._clientContexts.ForEach(context => {
 

--- a/Python/Product/PythonTools/PythonTools/LanguageServerClient/PythonLanguageClient.cs
+++ b/Python/Product/PythonTools/PythonTools/LanguageServerClient/PythonLanguageClient.cs
@@ -445,8 +445,6 @@ namespace Microsoft.PythonTools.LanguageServerClient {
 
         }
         private void OnInterpreterChanged(object sender, EventArgs e) {
-
-            
             UpdateInterpreterExcludes();
             OnSettingsChanged(sender, e);
         }
@@ -518,7 +516,7 @@ namespace Microsoft.PythonTools.LanguageServerClient {
             // Add the file globs to our listener. It will listen to the globs
             UpdateInterpreterExcludes();
             _fileListener?.AddPatterns(e.Watchers);
-           
+
         }
 
         // By default Pylance will tell us to watch everything under the workspace with pattern "**/*"

--- a/Python/Product/PythonTools/PythonTools/Project/PythonProjectNode.cs
+++ b/Python/Product/PythonTools/PythonTools/Project/PythonProjectNode.cs
@@ -245,6 +245,7 @@ namespace Microsoft.PythonTools.Project {
                 _activePackageManagers = null;
                 foreach (var pm in oldPms.MaybeEnumerate()) {
                     pm.InstalledFilesChanged -= PackageManager_InstalledFilesChanged;
+                    pm.DisableNotifications();
                 }
 
                 lock (_validFactories) {
@@ -255,15 +256,6 @@ namespace Microsoft.PythonTools.Project {
                         _active = null;
                     } else {
                         _active = value;
-                    }
-                }
-
-                // start listening for package changes on the active interpreter again if interpreter is outside our workspace.
-                _activePackageManagers = InterpreterOptions.GetPackageManagers(_active).ToArray();
-                if (_active != null && !PathUtils.IsSubpathOf(ProjectHome, _active.Configuration.InterpreterPath)) {
-                    foreach (var pm in _activePackageManagers) {
-                        pm.InstalledFilesChanged += PackageManager_InstalledFilesChanged;
-                        pm.EnableNotifications();
                     }
                 }
 
@@ -296,6 +288,15 @@ namespace Microsoft.PythonTools.Project {
                     ActiveInterpreterChanged?.Invoke(this, EventArgs.Empty);
                 }
                 BoldActiveEnvironment();
+
+                // start listening for package changes on the active interpreter again if interpreter is outside our workspace.
+                _activePackageManagers = InterpreterOptions.GetPackageManagers(_active).ToArray();
+                if (_active != null) {
+                    foreach (var pm in _activePackageManagers) {
+                        pm.InstalledFilesChanged += PackageManager_InstalledFilesChanged;
+                        pm.EnableNotifications();
+                    }
+                }
             }
         }
 

--- a/Python/Product/VSInterpreters/Interpreter/PythonWorkspaceContext.cs
+++ b/Python/Product/VSInterpreters/Interpreter/PythonWorkspaceContext.cs
@@ -35,7 +35,7 @@ namespace Microsoft.PythonTools.Interpreter {
         private const string TestFrameworkProperty = "TestFramework";
         private const string UnitTestRootDirectoryProperty = "UnitTestRootDirectory";
         private const string UnitTestPatternProperty = "UnitTestPattern";
-        private const int DebounceDelayMS = 10000;
+        private const int DebounceDelayMS = 500;
 
         private readonly IWorkspace _workspace;
         private readonly IPropertyEvaluatorService _propertyEvaluatorService;


### PR DESCRIPTION
… want to listen for file events in the interpreter folder. We already have conda and pip managers listening to them.

This fixes the issue of deleting an "env" folder then having PTVS quickly switching to the default env folder and tells Pylance to update its interpreter settings but the previous env folder file evnets are still being triggered and after Pylance updates its config it will keep refreshing analysis due to previous env file events.