### PR TITLE
Support for 312 mixed mode debugging

### DIFF
--- a/Python/Product/Debugger.Concord/CallStackFilter.cs
+++ b/Python/Product/Debugger.Concord/CallStackFilter.cs
@@ -93,7 +93,7 @@ namespace Microsoft.PythonTools.Debugger.Concord {
             PyCodeObject code = pythonFrame.f_code.Read();
             var loc = new SourceLocation(
                 code.co_filename.Read().ToStringOrNull(),
-                pythonFrame.f_lineno.Read(),
+                pythonFrame.ComputeLineNumber(stackContext.InspectionSession, nativeFrame),
                 code.co_name.Read().ToStringOrNull(),
                 nativeFrame.InstructionAddress as DkmNativeInstructionAddress);
 

--- a/Python/Product/Debugger.Concord/CppExpressionEvaluator.cs
+++ b/Python/Product/Debugger.Concord/CppExpressionEvaluator.cs
@@ -57,12 +57,11 @@ namespace Microsoft.PythonTools.Debugger.Concord {
                 DkmEvaluationFlags.TreatAsExpression | DkmEvaluationFlags.NoSideEffects, DkmFuncEvalFlags.None, inspectionContext.Radix, CppLanguage, null);
         }
 
-        public CppExpressionEvaluator(DkmThread thread, ulong frameBase, ulong vframe) {
+        public CppExpressionEvaluator(DkmThread thread, ulong frameBase, ulong vframe, DkmEvaluationFlags flags = DkmEvaluationFlags.TreatAsExpression | DkmEvaluationFlags.NoSideEffects) {
             _process = thread.Process;
-
             var inspectionSession = DkmInspectionSession.Create(_process, null);
             _cppInspectionContext = DkmInspectionContext.Create(inspectionSession, _process.GetNativeRuntimeInstance(), thread, Timeout,
-                DkmEvaluationFlags.TreatAsExpression | DkmEvaluationFlags.NoSideEffects, DkmFuncEvalFlags.None, 10, CppLanguage, null);
+                flags, DkmFuncEvalFlags.None, 10, CppLanguage, null);
 
             const int CV_ALLREG_VFRAME = 0x00007536;
             var vframeReg = DkmUnwoundRegister.Create(CV_ALLREG_VFRAME, new ReadOnlyCollection<byte>(BitConverter.GetBytes(vframe)));
@@ -79,8 +78,8 @@ namespace Microsoft.PythonTools.Debugger.Concord {
             return expr;
         }
 
-        public DkmEvaluationResult TryEvaluate(string expr) {
-            using (var cppExpr = DkmLanguageExpression.Create(CppLanguage, DkmEvaluationFlags.NoSideEffects, expr, null)) {
+        public DkmEvaluationResult TryEvaluate(string expr, DkmEvaluationFlags flags = DkmEvaluationFlags.NoSideEffects) {
+            using (var cppExpr = DkmLanguageExpression.Create(CppLanguage, flags, expr, null)) {
                 DkmEvaluationResult cppEvalResult = null;
                 var cppWorkList = DkmWorkList.Create(null);
                 _cppInspectionContext.EvaluateExpression(cppWorkList, cppExpr, _nativeFrame, (result) => {

--- a/Python/Product/Debugger.Concord/Debugger.Concord.csproj
+++ b/Python/Product/Debugger.Concord/Debugger.Concord.csproj
@@ -108,6 +108,7 @@
     <Compile Include="ExpressionEvaluator.cs" />
     <Compile Include="LocalStackWalkingComponent.cs" />
     <Compile Include="Proxies\Structs\CFrameProxy.cs" />
+    <Compile Include="Proxies\Structs\ImportState.cs" />
     <Compile Include="Proxies\Structs\PyCodeObject310.cs" />
     <Compile Include="Proxies\Structs\PyCodeObject311.cs" />
     <Compile Include="Proxies\Structs\PyDictObject.cs" />
@@ -128,6 +129,8 @@
     <Compile Include="Proxies\Structs\PySetObject.cs" />
     <Compile Include="Proxies\Structs\PyCellObject.cs" />
     <Compile Include="Proxies\Structs\PyThreads.cs" />
+    <Compile Include="Proxies\Structs\PyUnicodeObject311.cs" />
+    <Compile Include="Proxies\Structs\PyUnicodeObject312.cs" />
     <Compile Include="PythonRuntimeInfo.cs" />
     <Compile Include="StackFrameDataItem.cs" />
     <Compile Include="ValueStore.cs" />

--- a/Python/Product/Debugger.Concord/Proxies/StructProxy.cs
+++ b/Python/Product/Debugger.Concord/Proxies/StructProxy.cs
@@ -20,6 +20,7 @@ using System.Linq;
 using Microsoft.Dia;
 using Microsoft.PythonTools.Common.Parsing;
 using Microsoft.VisualStudio.Debugger;
+using Microsoft.VisualStudio.Debugger.Interop;
 
 namespace Microsoft.PythonTools.Debugger.Concord.Proxies {
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]

--- a/Python/Product/Debugger.Concord/Proxies/Structs/CFrameProxy.cs
+++ b/Python/Product/Debugger.Concord/Proxies/Structs/CFrameProxy.cs
@@ -22,6 +22,7 @@ namespace Microsoft.PythonTools.Debugger.Concord.Proxies.Structs {
     [StructProxy(StructName = "_PyCFrame", MinVersion = PythonLanguageVersion.V311)]
     internal class CFrameProxy : StructProxy {
         internal class Fields {
+            [FieldProxy(MaxVersion = PythonLanguageVersion.V311)]
             public StructField<Int32Proxy> use_tracing;
             public StructField<PointerProxy<CFrameProxy>> previous;
             [FieldProxy(MinVersion = PythonLanguageVersion.V311)]

--- a/Python/Product/Debugger.Concord/Proxies/Structs/ImportState.cs
+++ b/Python/Product/Debugger.Concord/Proxies/Structs/ImportState.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.PythonTools.Common.Parsing;
+using Microsoft.VisualStudio.Debugger;
+
+namespace Microsoft.PythonTools.Debugger.Concord.Proxies.Structs {
+    [StructProxy(StructName = "_import_state", MinVersion = PythonLanguageVersion.V312)]
+    internal class ImportState : StructProxy {
+        internal class Fields {
+            public StructField<PointerProxy<PyDictObject>> modules;
+        }
+
+        private readonly Fields _fields;
+
+        public ImportState(DkmProcess process, ulong address)
+            : base(process, address) {
+            InitializeStruct(this, out _fields);
+        }
+
+        public PointerProxy<PyDictObject> modules {
+            get { return GetFieldProxy(_fields.modules); }
+        }
+    }
+}

--- a/Python/Product/Debugger.Concord/Proxies/Structs/PyCodeObject311.cs
+++ b/Python/Product/Debugger.Concord/Proxies/Structs/PyCodeObject311.cs
@@ -32,6 +32,8 @@ namespace Microsoft.PythonTools.Debugger.Concord.Proxies.Structs {
             public StructField<Int32Proxy> co_firstlineno;
             public StructField<PointerProxy<PyTupleObject>> co_localsplusnames;
             public StructField<PointerProxy<PyBytesObject>> co_localspluskinds;
+            public StructField<ArrayProxy<SByteProxy>> co_code_adaptive;
+            public StructField<Int32Proxy> _co_firsttraceable;
         }
 
         private readonly Fields _fields;
@@ -51,6 +53,10 @@ namespace Microsoft.PythonTools.Debugger.Concord.Proxies.Structs {
         public override PointerProxy<IPyBaseStringObject> co_name => GetFieldProxy(_fields.co_name);
 
         public override Int32Proxy co_firstlineno => GetFieldProxy(_fields.co_firstlineno);
+
+        public ArrayProxy<SByteProxy> co_code_adaptive => GetFieldProxy(_fields.co_code_adaptive);
+
+        public Int32Proxy _co_firsttraceable => GetFieldProxy(_fields._co_firsttraceable);
 
         public PyCodeObject311(DkmProcess process, ulong address)
             : base(process, address) {

--- a/Python/Product/Debugger.Concord/Proxies/Structs/PyFrameObject.cs
+++ b/Python/Product/Debugger.Concord/Proxies/Structs/PyFrameObject.cs
@@ -18,6 +18,7 @@ using System.Linq;
 using Microsoft.PythonTools.Common.Parsing;
 using Microsoft.VisualStudio.Debugger;
 using Microsoft.VisualStudio.Debugger.CallStack;
+using Microsoft.VisualStudio.Debugger.Evaluation;
 
 namespace Microsoft.PythonTools.Debugger.Concord.Proxies.Structs {
     internal abstract class PyFrameObject : PyVarObject {
@@ -72,7 +73,7 @@ namespace Microsoft.PythonTools.Debugger.Concord.Proxies.Structs {
 
         public abstract PointerProxy<PyDictObject> f_locals { get; }
 
-        public abstract Int32Proxy f_lineno { get; }
+        public abstract int ComputeLineNumber(DkmInspectionSession inspectionSession, DkmStackWalkFrame frame);
 
         public abstract ArrayProxy<PointerProxy<PyObject>> f_localsplus { get; }
 
@@ -90,7 +91,7 @@ namespace Microsoft.PythonTools.Debugger.Concord.Proxies.Structs {
                     // This pyFrame should be the topmost frame. We need to go down the callstack
                     // based on the number of previous frames that were already found.
                     var numberBack = previousFrameCount != null ? previousFrameCount.Value : 0;
-                    while (numberBack > 0 && !pyFrame.f_back.IsNull) {
+                    while (numberBack > 0 && pyFrame.f_back.Process != null) {
                         pyFrame = pyFrame.f_back.Read();
                         numberBack--;
                     }

--- a/Python/Product/Debugger.Concord/Proxies/Structs/PyFrameObject.cs
+++ b/Python/Product/Debugger.Concord/Proxies/Structs/PyFrameObject.cs
@@ -85,7 +85,7 @@ namespace Microsoft.PythonTools.Debugger.Concord.Proxies.Structs {
                 var process = frame.Process;
                 var tid = frame.Thread.SystemPart.Id;
                 PyThreadState tstate = PyThreadState.GetThreadStates(process).FirstOrDefault(ts => ts.thread_id.Read() == tid);
-                PyFrameObject pyFrame = tstate.frame.Read();
+                PyFrameObject pyFrame = tstate.frame.TryRead();
                 if (pyFrame != null) {
                     // This pyFrame should be the topmost frame. We need to go down the callstack
                     // based on the number of previous frames that were already found.

--- a/Python/Product/Debugger.Concord/Proxies/Structs/PyFrameObject310.cs
+++ b/Python/Product/Debugger.Concord/Proxies/Structs/PyFrameObject310.cs
@@ -16,6 +16,8 @@
 
 using Microsoft.VisualStudio.Debugger;
 using Microsoft.PythonTools.Common.Parsing;
+using Microsoft.VisualStudio.Debugger.CallStack;
+using Microsoft.VisualStudio.Debugger.Evaluation;
 
 namespace Microsoft.PythonTools.Debugger.Concord.Proxies.Structs {
     [StructProxy(StructName = "_frame", MaxVersion = PythonLanguageVersion.V310)]
@@ -41,9 +43,9 @@ namespace Microsoft.PythonTools.Debugger.Concord.Proxies.Structs {
 
         public override PointerProxy<PyDictObject> f_locals => GetFieldProxy(_fields.f_locals);
 
-        public override Int32Proxy f_lineno => GetFieldProxy(_fields.f_lineno);
-
         public override ArrayProxy<PointerProxy<PyObject>> f_localsplus => GetFieldProxy(_fields.f_localsplus);
+
+        public override int ComputeLineNumber(DkmInspectionSession inspectionSession, DkmStackWalkFrame frame) => GetFieldProxy(_fields.f_lineno).Read();
 
         public PyFrameObject310(DkmProcess process, ulong address)
             : base(process, address) {

--- a/Python/Product/Debugger.Concord/Proxies/Structs/PyInterpreterFrame.cs
+++ b/Python/Product/Debugger.Concord/Proxies/Structs/PyInterpreterFrame.cs
@@ -22,17 +22,12 @@ namespace Microsoft.PythonTools.Debugger.Concord.Proxies.Structs {
     [StructProxy(StructName = "_PyInterpreterFrame", MinVersion = PythonLanguageVersion.V311)]
     internal class PyInterpreterFrame : StructProxy {
         internal class Fields {
-            public StructField<PointerProxy<PyFunctionObject>> f_func;
             public StructField<PointerProxy<PyDictObject>> f_globals;
             public StructField<PointerProxy<PyDictObject>> f_builtins;
             public StructField<PointerProxy<PyDictObject>> f_locals;
             public StructField<PointerProxy<PyCodeObject>> f_code;
             public StructField<PointerProxy<PyFrameObject>> frame_obj;
             public StructField<PointerProxy<PyInterpreterFrame>> previous;
-            public StructField<PointerProxy<PyObject>> prev_instr; // Not sure PyObject is the right type here
-            public StructField<Int32Proxy> stacktop;
-            public StructField<BoolProxy> is_entry;
-            public StructField<CharProxy> owner;
             public StructField<ArrayProxy<PointerProxy<PyObject>>> localsplus;
         }
 

--- a/Python/Product/Debugger.Concord/Proxies/Structs/PyInterpreterFrame.cs
+++ b/Python/Product/Debugger.Concord/Proxies/Structs/PyInterpreterFrame.cs
@@ -87,7 +87,11 @@ namespace Microsoft.PythonTools.Debugger.Concord.Proxies.Structs {
                 frame = frame.previous.TryRead();
             }
 
-            // Make sure this frame_obj is pointing to this frame 
+            // Make sure this frame_obj is pointing to this frame. Since the f_back 
+            // of a PyFrameObject can be null even if it exists, the PyFrameObject we find
+            // through the list of PyInterpreterFrames may not have been created. We need
+            // to make sure it points to the PyInterpreterFrame we found so that subsequent calls
+            // to get things like its f_locals will work.
             if (frame != null && !frame.frame_obj.IsNull) {
                 var obj = frame.frame_obj.Read() as PyFrameObject311;
                 obj.f_frame.Write(frame);

--- a/Python/Product/Debugger.Concord/Proxies/Structs/PyInterpreterState.cs
+++ b/Python/Product/Debugger.Concord/Proxies/Structs/PyInterpreterState.cs
@@ -31,7 +31,7 @@ namespace Microsoft.PythonTools.Debugger.Concord.Proxies.Structs {
             [FieldProxy(MaxVersion = PythonLanguageVersion.V311)]
             public StructField<PointerProxy<PyDictObject>> modules;
             [FieldProxy(MinVersion = PythonLanguageVersion.V312)]
-            public StructField<PointerProxy<ImportState>> imports;
+            public StructField<ImportState> imports;
             public StructField<PointerProxy> eval_frame;
             public StructField<ceval_state> ceval;
         }
@@ -71,7 +71,7 @@ namespace Microsoft.PythonTools.Debugger.Concord.Proxies.Structs {
                     return GetFieldProxy(_fields.modules);
                 }
                 var imports = GetFieldProxy(_fields.imports);
-                return imports.Read().modules;
+                return imports.modules;
             }
         }
 
@@ -102,7 +102,7 @@ namespace Microsoft.PythonTools.Debugger.Concord.Proxies.Structs {
             } else {
                 var threads = GetFieldProxy(_fields.threads);
                 var head = threads.head.TryRead();
-                while (head.Address != 0) {
+                while (head != null && head.Address != 0) {
                     yield return head;
                     head = head.next.TryRead();
                 }

--- a/Python/Product/Debugger.Concord/Proxies/Structs/PyInterpreterState.cs
+++ b/Python/Product/Debugger.Concord/Proxies/Structs/PyInterpreterState.cs
@@ -28,7 +28,10 @@ namespace Microsoft.PythonTools.Debugger.Concord.Proxies.Structs {
             public StructField<PointerProxy<PyThreadState>> tstate_head;
             [FieldProxy(MinVersion = PythonLanguageVersion.V311)]
             public StructField<PyThreads> threads;
+            [FieldProxy(MaxVersion = PythonLanguageVersion.V311)]
             public StructField<PointerProxy<PyDictObject>> modules;
+            [FieldProxy(MinVersion = PythonLanguageVersion.V312)]
+            public StructField<PointerProxy<ImportState>> imports;
             public StructField<PointerProxy> eval_frame;
             public StructField<ceval_state> ceval;
         }
@@ -63,7 +66,13 @@ namespace Microsoft.PythonTools.Debugger.Concord.Proxies.Structs {
         }
 
         public PointerProxy<PyDictObject> modules {
-            get { return GetFieldProxy(_fields.modules); }
+            get {
+                if (_fields.modules.Process != null) {
+                    return GetFieldProxy(_fields.modules);
+                }
+                var imports = GetFieldProxy(_fields.imports);
+                return imports.Read().modules;
+            }
         }
 
         public PointerProxy eval_frame {

--- a/Python/Product/Debugger.Concord/Proxies/Structs/PyLongObject.cs
+++ b/Python/Product/Debugger.Concord/Proxies/Structs/PyLongObject.cs
@@ -17,12 +17,16 @@
 using System;
 using System.Diagnostics;
 using System.Numerics;
+using Microsoft.PythonTools.Common.Parsing;
 using Microsoft.VisualStudio.Debugger;
 
 namespace Microsoft.PythonTools.Debugger.Concord.Proxies.Structs {
     internal class PyLongObject : PyVarObject {
         private class Fields {
+            [FieldProxy(MaxVersion = Common.Parsing.PythonLanguageVersion.V311)]
             public StructField<ByteProxy> ob_digit; // this is actually either uint16 or uint32, depending on Python bitness
+            [FieldProxy(MinVersion = PythonLanguageVersion.V312)]
+            public StructField<_PyLongValue> long_value;
         }
 
         private readonly Fields _fields;
@@ -40,6 +44,16 @@ namespace Microsoft.PythonTools.Debugger.Concord.Proxies.Structs {
         }
 
         public static PyLongObject Create(DkmProcess process, BigInteger value) {
+            // Use two different methods. PyLongObjects changed in 3.12. Instead of inheritance, we'll use an if statement so 
+            // that we don't have to change classes derived from PyLongObject.
+            if (process.GetPythonRuntimeInfo().LanguageVersion < PythonLanguageVersion.V312) {
+                return Create11(process, value);
+            } else {
+                return Create12(process, value);
+            }
+        }
+
+        private static PyLongObject Create11(DkmProcess process, BigInteger value) {
             var allocator = process.GetDataItem<PyObjectAllocator>();
             Debug.Assert(allocator != null);
 
@@ -77,12 +91,69 @@ namespace Microsoft.PythonTools.Debugger.Concord.Proxies.Structs {
 
             return result;
         }
+        
+        private static PyLongObject Create12(DkmProcess process, BigInteger value) {
+            var allocator = process.GetDataItem<PyObjectAllocator>();
+            Debug.Assert(allocator != null);
+
+            var bitsInDigit = process.Is64Bit() ? 30 : 15;
+            var bytesInDigit = process.Is64Bit() ? 4 : 2;
+
+            var absValue = BigInteger.Abs(value);
+            long numDigits = 0;
+            for (var t = absValue; t != 0;) {
+                ++numDigits;
+                t >>= bitsInDigit;
+            }
+
+            var result = allocator.Allocate<PyLongObject>(numDigits * bytesInDigit);
+
+            // Size comes from here:
+            // https://github.com/python/cpython/blob/a0866f4c81ecc057d4521e8e7a02f4e1fff175a1/Objects/longobject.c#L158
+            var fields = StructProxy.GetStructFields<_PyLongValue, _PyLongValue.Fields>(process);
+            long ob_size = numDigits * bytesInDigit + fields.ob_digit.Offset;
+            result.ob_size.Write(ob_size);
+
+            // Digits are stored in the long_value.lv_data field in 3.12
+            result.long_value.WriteTag((ulong)numDigits, value == 0, value < 0);
+
+            // Then we write the data out one digit at a time
+            if (bitsInDigit == 15) {
+                for (var digitPtr = new UInt16Proxy(process, result.ob_digit.Address); absValue != 0; digitPtr = digitPtr.GetAdjacentProxy(1)) {
+                    digitPtr.Write((ushort)(absValue % (1 << bitsInDigit)));
+                    absValue >>= bitsInDigit;
+                }
+            } else {
+                for (var digitPtr = new UInt32Proxy(process, result.ob_digit.Address); absValue != 0; digitPtr = digitPtr.GetAdjacentProxy(1)) {
+                    digitPtr.Write((uint)(absValue % (1 << bitsInDigit)));
+                    absValue >>= bitsInDigit;
+                }
+            }
+
+            return result;
+        }
 
         private ByteProxy ob_digit {
-            get { return GetFieldProxy(_fields.ob_digit); }
+            get {
+                if (_fields.ob_digit.Process != null) {
+                    return GetFieldProxy(_fields.ob_digit);
+                } else {
+                    return GetFieldProxy(_fields.long_value).ob_digit;
+                }
+            }
         }
 
         public BigInteger ToBigInteger() {
+            if (Process.GetPythonRuntimeInfo().LanguageVersion < PythonLanguageVersion.V312) {
+                return ToBigInteger11();
+            } else {
+                return ToBigInteger12();
+            }
+        }
+
+        public _PyLongValue long_value => GetFieldProxy(_fields.long_value);
+
+        private BigInteger ToBigInteger11() {
             var bitsInDigit = Process.Is64Bit() ? 30 : 15;
 
             long ob_size = this.ob_size.Read();
@@ -112,8 +183,86 @@ namespace Microsoft.PythonTools.Debugger.Concord.Proxies.Structs {
             return ob_size > 0 ? result : -result;
         }
 
+        public BigInteger ToBigInteger12() {
+            var bitsInDigit = Process.Is64Bit() ? 30 : 15;
+            var long_value = GetFieldProxy(_fields.long_value);
+            long count = long_value.digit_count;
+
+            // Read and parse digits in reverse, starting from the most significant ones.
+            var result = new BigInteger(0);
+            if (bitsInDigit == 15) {
+                var digitPtr = new UInt16Proxy(Process, ob_digit.Address).GetAdjacentProxy(count);
+                for (long i = 0; i != count; ++i) {
+                    digitPtr = digitPtr.GetAdjacentProxy(-1);
+                    result <<= bitsInDigit;
+                    result += digitPtr.Read();
+                }
+            } else {
+                var digitPtr = new UInt32Proxy(Process, ob_digit.Address).GetAdjacentProxy(count);
+                for (long i = 0; i != count; ++i) {
+                    digitPtr = digitPtr.GetAdjacentProxy(-1);
+                    result <<= bitsInDigit;
+                    result += digitPtr.Read();
+                }
+            }
+
+            return long_value.is_negative ? -result : result;
+        }
+
         public override void Repr(ReprBuilder builder) {
             builder.AppendLiteral(ToBigInteger());
         }
+
+        [StructProxy(MinVersion = PythonLanguageVersion.V312, StructName = "_PyLongValue")]
+        public class _PyLongValue : StructProxy {
+            public class Fields {
+                public StructField<UInt64Proxy> lv_tag;
+                public StructField<ByteProxy> ob_digit;
+            }
+
+            private const int SIGN_ZERO = 1;
+            private const int SIGN_NEGATIVE = 2;
+            private const int NON_SIZE_BITS = 3;
+            private const int SIGN_MASK = 3;
+
+            private readonly Fields _fields;
+
+            public _PyLongValue(DkmProcess process, ulong address)
+                : base(process, address) {
+                InitializeStruct(this, out _fields);
+            }
+
+            public ByteProxy ob_digit => GetFieldProxy(_fields.ob_digit);
+
+            public UInt64Proxy lv_tag => GetFieldProxy(_fields.lv_tag);
+
+            public void WriteTag(ulong numberDigits, bool isZero, bool isNegative) {
+                ulong lv_tag = numberDigits << NON_SIZE_BITS;
+                if (isZero) {
+                    lv_tag |= SIGN_ZERO;
+                } else if (isNegative) {
+                    lv_tag |= SIGN_NEGATIVE;
+                }
+                this.lv_tag.Write(lv_tag);
+            }
+
+            public uint digit_count {
+                get {
+                    return (uint)(lv_tag.Read() >> NON_SIZE_BITS);
+                }
+
+                set {
+                    lv_tag.Write((value << NON_SIZE_BITS) | (lv_tag.Read() & SIGN_MASK));
+                }
+            }
+
+            public bool is_negative {
+                get {
+                    return (lv_tag.Read() & SIGN_MASK) == SIGN_NEGATIVE;
+                }
+            }
+        }
     }
+
+
 }

--- a/Python/Product/Debugger.Concord/Proxies/Structs/PyRuntimeState.cs
+++ b/Python/Product/Debugger.Concord/Proxies/Structs/PyRuntimeState.cs
@@ -32,6 +32,7 @@ namespace Microsoft.PythonTools.Debugger.Concord.Proxies.Structs {
             public StructField<BoolProxy> core_initialized;
             public StructField<BoolProxy> initialized;
             public StructField<pyinterpreters> interpreters;
+            public StructField<gilstate_runtime_state> gilstate;
         }
 
         private readonly Fields _fields;
@@ -44,6 +45,7 @@ namespace Microsoft.PythonTools.Debugger.Concord.Proxies.Structs {
         public BoolProxy core_initialized => GetFieldProxy(_fields.core_initialized);
         public BoolProxy initialized => GetFieldProxy(_fields.initialized);
         public pyinterpreters interpreters => GetFieldProxy(_fields.interpreters);
+        public gilstate_runtime_state gilstate => GetFieldProxy(_fields.gilstate);
 
 
         [StructProxy(MinVersion = PythonLanguageVersion.V39, StructName = "pyinterpreters")]
@@ -62,6 +64,22 @@ namespace Microsoft.PythonTools.Debugger.Concord.Proxies.Structs {
 
             public PointerProxy<PyInterpreterState> head => GetFieldProxy(_fields.head);
             public PointerProxy<PyInterpreterState> main => GetFieldProxy(_fields.main);
+        }
+
+        [StructProxy(MinVersion = PythonLanguageVersion.V312, StructName = "_gilstate_runtime_state")]
+        public class gilstate_runtime_state : StructProxy {
+            public class Fields  {
+                public StructField<Int32Proxy> check_enabled;
+            }
+
+            private readonly Fields _fields;
+
+            public gilstate_runtime_state(DkmProcess process, ulong address)
+                : base(process, address) {
+                InitializeStruct(this, out _fields);
+            }
+
+            public Int32Proxy check_enabled => GetFieldProxy(_fields.check_enabled);
         }
 
 

--- a/Python/Product/Debugger.Concord/Proxies/Structs/PyUnicodeObject.cs
+++ b/Python/Product/Debugger.Concord/Proxies/Structs/PyUnicodeObject.cs
@@ -23,176 +23,11 @@ using Microsoft.VisualStudio.Debugger;
 using Microsoft.VisualStudio.Debugger.Evaluation;
 
 namespace Microsoft.PythonTools.Debugger.Concord.Proxies.Structs {
-    [StructProxy(MinVersion = PythonLanguageVersion.V39, StructName = "PyUnicodeObject")]
-    [PyType(MinVersion = PythonLanguageVersion.V39, VariableName = "PyUnicode_Type")]
-    internal class PyUnicodeObject : PyVarObject, IPyBaseStringObject {
-        private static readonly Encoding _latin1 = Encoding.GetEncoding("Latin1");
-
-        private enum PyUnicode_Kind {
-            PyUnicode_WCHAR_KIND = 0,
-            PyUnicode_1BYTE_KIND = 1,
-            PyUnicode_2BYTE_KIND = 2,
-            PyUnicode_4BYTE_KIND = 4
-        }
-
-        private enum Interned {
-            SSTATE_NOT_INTERNED = 0,
-            SSTATE_INTERNED_MORTAL = 1,
-            SSTATE_INTERNED_IMMORTAL = 2
-        }
-
-        private struct State {
-            private static readonly BitVector32.Section
-                internedSection = BitVector32.CreateSection(2),
-                kindSection = BitVector32.CreateSection(4, internedSection),
-                compactSection = BitVector32.CreateSection(1, kindSection),
-                asciiSection = BitVector32.CreateSection(1, compactSection),
-                readySection = BitVector32.CreateSection(1, asciiSection);
-
-            private BitVector32 _state;
-
-            private State(byte state) {
-                _state = new BitVector32(state);
-            }
-
-            public static explicit operator State(byte state) {
-                return new State(state);
-            }
-
-            public static explicit operator byte(State state) {
-                return (byte)state._state.Data;
-            }
-
-            public Interned interned {
-                get { return (Interned)_state[internedSection]; }
-                set { _state[internedSection] = (int)value; }
-            }
-
-            public PyUnicode_Kind kind {
-                get { return (PyUnicode_Kind)_state[kindSection]; }
-                set { _state[kindSection] = (int)value; }
-            }
-
-            public bool compact {
-                get { return _state[compactSection] != 0; }
-                set { _state[compactSection] = value ? 1 : 0; }
-            }
-
-            public bool ascii {
-                get { return _state[asciiSection] != 0; }
-                set { _state[asciiSection] = value ? 1 : 0; }
-            }
-
-            public bool ready {
-                get { return _state[readySection] != 0; }
-                set { _state[readySection] = value ? 1 : 0; }
-            }
-        }
-
-        public class Fields {
-            public StructField<PointerProxy> data;
-        }
-
-        private readonly Fields _fields;
-        private readonly PyASCIIObject _asciiObject;
-        private readonly PyCompactUnicodeObject _compactObject;
+    internal abstract class PyUnicodeObject : PyVarObject, IPyBaseStringObject {
+        protected static readonly Encoding _latin1 = Encoding.GetEncoding("Latin1");
 
         public PyUnicodeObject(DkmProcess process, ulong address)
             : base(process, address) {
-            InitializeStruct(this, out _fields);
-            CheckPyType<PyUnicodeObject>();
-
-            _asciiObject = new PyASCIIObject(process, address);
-            _compactObject = new PyCompactUnicodeObject(process, address);
-        }
-
-        public static PyUnicodeObject Create(DkmProcess process, string value) {
-            var allocator = process.GetDataItem<PyObjectAllocator>();
-            Debug.Assert(allocator != null);
-
-            var result = allocator.Allocate<PyUnicodeObject>(value.Length * sizeof(char));
-
-            result._asciiObject.hash.Write(-1);
-            result._asciiObject.length.Write(value.Length);
-            result._compactObject.wstr_length.Write(value.Length);
-
-            var state = new State {
-                interned = Interned.SSTATE_NOT_INTERNED,
-                kind = PyUnicode_Kind.PyUnicode_2BYTE_KIND,
-                compact = true,
-                ascii = false,
-                ready = true
-            };
-            result._asciiObject.state.Write((byte)state);
-
-            ulong dataPtr = result.Address.OffsetBy(StructProxy.SizeOf<PyCompactUnicodeObject>(process));
-            result._asciiObject.wstr.Write(dataPtr);
-            process.WriteMemory(dataPtr, Encoding.Unicode.GetBytes(value));
-
-            return result;
-        }
-        
-
-        public override string ToString() {
-            byte[] buf;
-
-            State state = (State)_asciiObject.state.Read();
-            if (state.ascii) {
-                state.kind = PyUnicode_Kind.PyUnicode_1BYTE_KIND;
-            }
-
-            if (!state.ready) {
-                ulong wstr = _asciiObject.wstr.Read();
-                if (wstr == 0) {
-                    return null;
-                }
-
-                uint wstr_length = checked((uint)_compactObject.wstr_length.Read());
-                if (wstr_length == 0) {
-                    return "";
-                }
-
-                buf = new byte[wstr_length * 2];
-                Process.ReadMemory(wstr, DkmReadMemoryFlags.None, buf);
-                return Encoding.Unicode.GetString(buf, 0, buf.Length);
-            }
-
-            int length = checked((int)_asciiObject.length.Read());
-            if (length == 0) {
-                return "";
-            }
-
-            ulong data;
-            if (!state.compact) {
-                data = GetFieldProxy(_fields.data).Read();
-            } else if (state.ascii) {
-                data = Address.OffsetBy(StructProxy.SizeOf<PyASCIIObject>(Process));
-            } else {
-                data = Address.OffsetBy(StructProxy.SizeOf<PyCompactUnicodeObject>(Process));
-            }
-            if (data == 0) {
-                return null;
-            }
-
-            buf = new byte[length * (int)state.kind];
-            Process.ReadMemory(data, DkmReadMemoryFlags.None, buf);
-            Encoding enc;
-            switch (state.kind) {
-                case PyUnicode_Kind.PyUnicode_1BYTE_KIND:
-                    enc = _latin1;
-                    break;
-                case PyUnicode_Kind.PyUnicode_2BYTE_KIND:
-                    enc = Encoding.Unicode;
-                    break;
-                case PyUnicode_Kind.PyUnicode_4BYTE_KIND:
-                    enc = Encoding.UTF32;
-                    break;
-                default:
-                    Debug.Fail("Unsupported PyUnicode_Kind " + state.kind);
-                    return null;
-            }
-
-            return enc.GetString(buf, 0, buf.Length);
         }
 
         public override void Repr(ReprBuilder builder) {
@@ -214,54 +49,15 @@ namespace Microsoft.PythonTools.Debugger.Concord.Proxies.Structs {
         public static explicit operator string(PyUnicodeObject obj) {
             return (object)obj == null ? null : obj.ToString();
         }
-    }
 
-    internal class PyASCIIObject : StructProxy {
-        public class Fields {
-            public StructField<SSizeTProxy> length;
-            public StructField<SSizeTProxy> hash;
-            public StructField<ByteProxy> state;
-            public StructField<PointerProxy> wstr;
-        }
-
-        private readonly Fields _fields;
-
-        public PyASCIIObject(DkmProcess process, ulong address)
-            : base(process, address) {
-            InitializeStruct(this, out _fields);
-        }
-
-        public SSizeTProxy length {
-            get { return GetFieldProxy(_fields.length); }
-        }
-
-        public SSizeTProxy hash {
-            get { return GetFieldProxy(_fields.hash); }
-        }
-
-        public ByteProxy state {
-            get { return GetFieldProxy(_fields.state); }
-        }
-
-        public PointerProxy wstr {
-            get { return GetFieldProxy(_fields.wstr); }
+        public static PyUnicodeObject Create(DkmProcess process, string value) {
+            if (process.GetPythonRuntimeInfo().LanguageVersion <= PythonLanguageVersion.V311) {
+                return PyUnicodeObject311.Create311(process, value);
+            } else {
+                return PyUnicodeObject312.Create312(process, value);
+            }
         }
     }
 
-    internal class PyCompactUnicodeObject : StructProxy {
-        public class Fields {
-            public StructField<SSizeTProxy> wstr_length;
-        }
 
-        private readonly Fields _fields;
-
-        public PyCompactUnicodeObject(DkmProcess process, ulong address)
-            : base(process, address) {
-            InitializeStruct(this, out _fields);
-        }
-
-        public SSizeTProxy wstr_length {
-            get { return GetFieldProxy(_fields.wstr_length); }
-        }
-    }
 }

--- a/Python/Product/Debugger.Concord/Proxies/Structs/PyUnicodeObject311.cs
+++ b/Python/Product/Debugger.Concord/Proxies/Structs/PyUnicodeObject311.cs
@@ -1,0 +1,232 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.PythonTools.Common.Parsing;
+using Microsoft.VisualStudio.Debugger;
+
+namespace Microsoft.PythonTools.Debugger.Concord.Proxies.Structs {
+    [StructProxy(MinVersion = PythonLanguageVersion.V39, MaxVersion = PythonLanguageVersion.V311, StructName = "PyUnicodeObject")]
+    [PyType(MinVersion = PythonLanguageVersion.V39, MaxVersion = PythonLanguageVersion.V311, VariableName = "PyUnicode_Type")]
+    internal class PyUnicodeObject311 : PyUnicodeObject {
+        private enum PyUnicode_Kind {
+            PyUnicode_WCHAR_KIND = 0,
+            PyUnicode_1BYTE_KIND = 1,
+            PyUnicode_2BYTE_KIND = 2,
+            PyUnicode_4BYTE_KIND = 4
+        }
+
+        private enum Interned {
+            SSTATE_NOT_INTERNED = 0,
+            SSTATE_INTERNED_MORTAL = 1,
+            SSTATE_INTERNED_IMMORTAL = 2
+        }
+
+        private struct State {
+            private static readonly BitVector32.Section
+                internedSection = BitVector32.CreateSection(2),
+                kindSection = BitVector32.CreateSection(4, internedSection),
+                compactSection = BitVector32.CreateSection(1, kindSection),
+                asciiSection = BitVector32.CreateSection(1, compactSection),
+                readySection = BitVector32.CreateSection(1, asciiSection);
+
+            private BitVector32 _state;
+
+            private State(byte state) {
+                _state = new BitVector32(state);
+            }
+
+            public static explicit operator State(byte state) {
+                return new State(state);
+            }
+
+            public static explicit operator byte(State state) {
+                return (byte)state._state.Data;
+            }
+
+            public Interned interned {
+                get { return (Interned)_state[internedSection]; }
+                set { _state[internedSection] = (int)value; }
+            }
+
+            public PyUnicode_Kind kind {
+                get { return (PyUnicode_Kind)_state[kindSection]; }
+                set { _state[kindSection] = (int)value; }
+            }
+
+            public bool compact {
+                get { return _state[compactSection] != 0; }
+                set { _state[compactSection] = value ? 1 : 0; }
+            }
+
+            public bool ascii {
+                get { return _state[asciiSection] != 0; }
+                set { _state[asciiSection] = value ? 1 : 0; }
+            }
+
+            public bool ready {
+                get { return _state[readySection] != 0; }
+                set { _state[readySection] = value ? 1 : 0; }
+            }
+        }
+
+        public class Fields {
+            public StructField<PointerProxy> data;
+        }
+
+        private readonly Fields _fields;
+        private readonly PyASCIIObject311 _asciiObject;
+        private readonly PyCompactUnicodeObject311 _compactObject;
+
+        public PyUnicodeObject311(DkmProcess process, ulong address)
+            : base(process, address) {
+            InitializeStruct(this, out _fields);
+            CheckPyType<PyUnicodeObject311>();
+
+            _asciiObject = new PyASCIIObject311(process, address);
+            _compactObject = new PyCompactUnicodeObject311(process, address);
+        }
+
+        public static PyUnicodeObject311 Create311(DkmProcess process, string value) {
+            var allocator = process.GetDataItem<PyObjectAllocator>();
+            Debug.Assert(allocator != null);
+
+            var result = allocator.Allocate<PyUnicodeObject311>(value.Length * sizeof(char));
+
+            result._asciiObject.hash.Write(-1);
+            result._asciiObject.length.Write(value.Length);
+            result._compactObject.wstr_length.Write(value.Length);
+
+            var state = new State {
+                interned = Interned.SSTATE_NOT_INTERNED,
+                kind = PyUnicode_Kind.PyUnicode_2BYTE_KIND,
+                compact = true,
+                ascii = false,
+                ready = true
+            };
+            result._asciiObject.state.Write((byte)state);
+
+            ulong dataPtr = result.Address.OffsetBy(StructProxy.SizeOf<PyCompactUnicodeObject311>(process));
+            result._asciiObject.wstr.Write(dataPtr);
+            process.WriteMemory(dataPtr, Encoding.Unicode.GetBytes(value));
+
+            return result;
+        }
+
+        public override string ToString() {
+            byte[] buf;
+
+            State state = (State)_asciiObject.state.Read();
+            if (state.ascii) {
+                state.kind = PyUnicode_Kind.PyUnicode_1BYTE_KIND;
+            }
+
+            if (!state.ready) {
+                ulong wstr = _asciiObject.wstr.Read();
+                if (wstr == 0) {
+                    return null;
+                }
+
+                uint wstr_length = checked((uint)_compactObject.wstr_length.Read());
+                if (wstr_length == 0) {
+                    return "";
+                }
+
+                buf = new byte[wstr_length * 2];
+                Process.ReadMemory(wstr, DkmReadMemoryFlags.None, buf);
+                return Encoding.Unicode.GetString(buf, 0, buf.Length);
+            }
+
+            int length = checked((int)_asciiObject.length.Read());
+            if (length == 0) {
+                return "";
+            }
+
+            ulong data;
+            if (!state.compact) {
+                data = GetFieldProxy(_fields.data).Read();
+            } else if (state.ascii) {
+                data = Address.OffsetBy(StructProxy.SizeOf<PyASCIIObject311>(Process));
+            } else {
+                data = Address.OffsetBy(StructProxy.SizeOf<PyCompactUnicodeObject311>(Process));
+            }
+            if (data == 0) {
+                return null;
+            }
+
+            buf = new byte[length * (int)state.kind];
+            Process.ReadMemory(data, DkmReadMemoryFlags.None, buf);
+            Encoding enc;
+            switch (state.kind) {
+                case PyUnicode_Kind.PyUnicode_1BYTE_KIND:
+                    enc = _latin1;
+                    break;
+                case PyUnicode_Kind.PyUnicode_2BYTE_KIND:
+                    enc = Encoding.Unicode;
+                    break;
+                case PyUnicode_Kind.PyUnicode_4BYTE_KIND:
+                    enc = Encoding.UTF32;
+                    break;
+                default:
+                    Debug.Fail("Unsupported PyUnicode_Kind " + state.kind);
+                    return null;
+            }
+
+            return enc.GetString(buf, 0, buf.Length);
+        }
+    }
+
+    [StructProxy(MaxVersion = PythonLanguageVersion.V311, StructName = "PyASCIIObject")]
+    [PyType(MinVersion = PythonLanguageVersion.V39, MaxVersion = PythonLanguageVersion.V311, VariableName = "PyASCII_Type")]
+    internal class PyASCIIObject311 : StructProxy {
+        public class Fields {
+            public StructField<SSizeTProxy> length;
+            public StructField<SSizeTProxy> hash;
+            public StructField<ByteProxy> state;
+            public StructField<PointerProxy> wstr;
+        }
+
+        private readonly Fields _fields;
+
+        public PyASCIIObject311(DkmProcess process, ulong address)
+            : base(process, address) {
+            InitializeStruct(this, out _fields);
+        }
+
+        public SSizeTProxy length {
+            get { return GetFieldProxy(_fields.length); }
+        }
+
+        public SSizeTProxy hash {
+            get { return GetFieldProxy(_fields.hash); }
+        }
+
+        public ByteProxy state {
+            get { return GetFieldProxy(_fields.state); }
+        }
+
+        public PointerProxy wstr => GetFieldProxy(_fields.wstr);
+    }
+
+    [StructProxy(MaxVersion = PythonLanguageVersion.V311, StructName = "PyCompactUnicodeObject")]
+    [PyType(MinVersion = PythonLanguageVersion.V39, MaxVersion = PythonLanguageVersion.V311, VariableName = "PyCompactUnicode_Type")]
+    internal class PyCompactUnicodeObject311 : StructProxy {
+        public class Fields {
+            public StructField<SSizeTProxy> wstr_length;
+        }
+
+        private readonly Fields _fields;
+
+        public PyCompactUnicodeObject311(DkmProcess process, ulong address)
+            : base(process, address) {
+            InitializeStruct(this, out _fields);
+        }
+
+        public SSizeTProxy wstr_length {
+            get { return GetFieldProxy(_fields.wstr_length); }
+        }
+    }
+}

--- a/Python/Product/Debugger.Concord/Proxies/Structs/PyUnicodeObject312.cs
+++ b/Python/Product/Debugger.Concord/Proxies/Structs/PyUnicodeObject312.cs
@@ -1,0 +1,219 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.PythonTools.Common.Core.OS;
+using Microsoft.PythonTools.Common.Parsing;
+using Microsoft.VisualStudio.Debugger;
+
+namespace Microsoft.PythonTools.Debugger.Concord.Proxies.Structs {
+    [StructProxy(MinVersion = PythonLanguageVersion.V312, StructName = "PyUnicodeObject")]
+    [PyType(MinVersion = PythonLanguageVersion.V312, VariableName = "PyUnicode_Type")]
+    internal class PyUnicodeObject312 : PyUnicodeObject {
+        private enum PyUnicode_Kind {
+            PyUnicode_1BYTE_KIND = 1,
+            PyUnicode_2BYTE_KIND = 2,
+            PyUnicode_4BYTE_KIND = 4
+        }
+
+        private enum Interned {
+            SSTATE_NOT_INTERNED = 0,
+            SSTATE_INTERNED_MORTAL = 1,
+            SSTATE_INTERNED_IMMORTAL = 2
+        }
+
+        private struct State {
+            private static readonly BitVector32.Section
+                internedSection = BitVector32.CreateSection(2),
+                kindSection = BitVector32.CreateSection(4, internedSection),
+                compactSection = BitVector32.CreateSection(1, kindSection),
+                asciiSection = BitVector32.CreateSection(1, compactSection),
+                readySection = BitVector32.CreateSection(1, asciiSection);
+
+            private BitVector32 _state;
+
+            private State(byte state) {
+                _state = new BitVector32(state);
+            }
+
+            public static explicit operator State(byte state) {
+                return new State(state);
+            }
+
+            public static explicit operator byte(State state) {
+                return (byte)state._state.Data;
+            }
+
+            public Interned interned {
+                get { return (Interned)_state[internedSection]; }
+                set { _state[internedSection] = (int)value; }
+            }
+
+            public PyUnicode_Kind kind {
+                get { return (PyUnicode_Kind)_state[kindSection]; }
+                set { _state[kindSection] = (int)value; }
+            }
+
+            public bool compact {
+                get { return _state[compactSection] != 0; }
+                set { _state[compactSection] = value ? 1 : 0; }
+            }
+
+            public bool ascii {
+                get { return _state[asciiSection] != 0; }
+                set { _state[asciiSection] = value ? 1 : 0; }
+            }
+
+            public bool ready {
+                get { return _state[readySection] != 0; }
+                set { _state[readySection] = value ? 1 : 0; }
+            }
+        }
+
+        public class Fields {
+            public StructField<PointerProxy> data;
+        }
+
+        private readonly Fields _fields;
+        private readonly PyASCIIObject312 _asciiObject;
+        private readonly PyCompactUnicodeObject312 _compactObject;
+
+        public PyUnicodeObject312(DkmProcess process, ulong address)
+            : base(process, address) {
+            InitializeStruct(this, out _fields);
+            CheckPyType<PyUnicodeObject312>();
+
+            _asciiObject = new PyASCIIObject312(process, address);
+            _compactObject = new PyCompactUnicodeObject312(process, address);
+        }
+
+        public static PyUnicodeObject312 Create312(DkmProcess process, string value) {
+            var allocator = process.GetDataItem<PyObjectAllocator>();
+            Debug.Assert(allocator != null);
+
+            var result = allocator.Allocate<PyUnicodeObject312>(value.Length * sizeof(char));
+
+            result._asciiObject.hash.Write(-1);
+            result._asciiObject.length.Write(value.Length);
+            result._compactObject.utf8_length.Write(value.Length);
+            var kind = value.Length != Encoding.UTF8.GetByteCount(value) ? PyUnicode_Kind.PyUnicode_2BYTE_KIND : PyUnicode_Kind.PyUnicode_1BYTE_KIND;
+
+            var state = new State {
+                interned = Interned.SSTATE_NOT_INTERNED,
+                kind = kind,
+                compact = true,
+                ascii = false,
+                ready = true
+            };
+            result._asciiObject.state.Write((byte)state);
+
+            ulong dataPtr = result.Address.OffsetBy(StructProxy.SizeOf<PyCompactUnicodeObject312>(process));
+            result._compactObject.utf8.Write(dataPtr);
+            process.WriteMemory(dataPtr, Encoding.UTF8.GetBytes(value));
+
+            return result;
+        }
+
+        public override string ToString() {
+            byte[] buf;
+
+            State state = (State)_asciiObject.state.Read();
+            if (state.ascii) {
+                state.kind = PyUnicode_Kind.PyUnicode_1BYTE_KIND;
+            }
+
+            int length = checked((int)_asciiObject.length.Read());
+            if (length == 0) {
+                return "";
+            }
+
+            ulong data;
+            if (!state.compact) {
+                data = GetFieldProxy(_fields.data).Read();
+            } else if (state.ascii) {
+                data = Address.OffsetBy(StructProxy.SizeOf<PyASCIIObject312>(Process));
+            } else {
+                data = Address.OffsetBy(StructProxy.SizeOf<PyCompactUnicodeObject312>(Process));
+            }
+            if (data == 0) {
+                return null;
+            }
+
+            buf = new byte[length * (int)state.kind];
+            Process.ReadMemory(data, DkmReadMemoryFlags.None, buf);
+            Encoding enc;
+            switch (state.kind) {
+                case PyUnicode_Kind.PyUnicode_1BYTE_KIND:
+                    enc = _latin1;
+                    break;
+                case PyUnicode_Kind.PyUnicode_2BYTE_KIND:
+                    enc = Encoding.Unicode;
+                    break;
+                case PyUnicode_Kind.PyUnicode_4BYTE_KIND:
+                    enc = Encoding.UTF32;
+                    break;
+                default:
+                    Debug.Fail("Unsupported PyUnicode_Kind " + state.kind);
+                    return null;
+            }
+
+            return enc.GetString(buf, 0, buf.Length);
+        }
+    }
+
+    [StructProxy(MinVersion = PythonLanguageVersion.V312, StructName = "PyASCIIObject")]
+    [PyType(MinVersion = PythonLanguageVersion.V312, VariableName = "PyASCII_Type")]
+    internal class PyASCIIObject312 : StructProxy {
+        public class Fields {
+            public StructField<SSizeTProxy> length;
+            public StructField<SSizeTProxy> hash;
+            public StructField<ByteProxy> state;
+        }
+
+        private readonly Fields _fields;
+
+        public PyASCIIObject312(DkmProcess process, ulong address)
+            : base(process, address) {
+            InitializeStruct(this, out _fields);
+        }
+
+        public SSizeTProxy length {
+            get { return GetFieldProxy(_fields.length); }
+        }
+
+        public SSizeTProxy hash {
+            get { return GetFieldProxy(_fields.hash); }
+        }
+
+        public ByteProxy state {
+            get { return GetFieldProxy(_fields.state); }
+        }
+    }
+
+    [StructProxy(MinVersion = PythonLanguageVersion.V312, StructName = "PyCompactUnicodeObject")]
+    [PyType(MinVersion = PythonLanguageVersion.V312, VariableName = "PyCompactUnicode_Type")]
+    internal class PyCompactUnicodeObject312 : StructProxy {
+        public class Fields {
+            public StructField<SSizeTProxy> utf8_length;
+            public StructField<PointerProxy> utf8;
+        }
+
+        private readonly Fields _fields;
+
+        public PyCompactUnicodeObject312(DkmProcess process, ulong address)
+            : base(process, address) {
+            InitializeStruct(this, out _fields);
+        }
+
+        public SSizeTProxy utf8_length {
+            get { return GetFieldProxy(_fields.utf8_length); }
+        }
+
+        public PointerProxy utf8 {
+            get { return GetFieldProxy(_fields.utf8); }
+        }
+    }
+}


### PR DESCRIPTION
This should get 3.12 mixed mode debugging working. I tested with the two mixed mode examples we have with stepping and adding some extra types as variables. 

3.12 made a rather difficult change to handle. No longer could we just WriteProcessMemory the `use_tracing` flag on the PyInterpreter. `use_tracing` was replaced with sys.monitoring. Using sys tracing required a function call now.

I first attempted to do this on startup and func eval the `PyEval_SetTraceAllThreads` function but I couldn't find the right spot to actually eval this that wouldn't throw an exception. 

So instead, the trace helper when it first sees a python eval, it injects the tracing then.

There was also a bunch of changes with other data types, like unicode objects and longs.