### PR TITLE
fix for msft python failing to detect pip packages due to pip needing…

### DIFF
--- a/Python/Product/VSInterpreters/PackageManager/PipPackageManager.cs
+++ b/Python/Product/VSInterpreters/PackageManager/PipPackageManager.cs
@@ -444,6 +444,15 @@ namespace Microsoft.PythonTools.Interpreter {
                                             .Where(p => p.IsValid)
                                             .OrderBy(p => p.Name)
                                             .ToList();
+
+
+                                        if(packages.Count() == 0 && proc.StandardErrorLines.Any()) {
+                                            Debug.WriteLine("Failed to run pip to collect packages");
+                                            foreach (var line in proc.StandardErrorLines) {
+                                                Debug.WriteLine(line);
+                                            }
+                                            packages = null;
+                                        }
                                     } catch (JsonException ex) {
                                         Debug.WriteLine("Failed to parse: {0}".FormatInvariant(ex.Message));
                                         foreach (var l in proc.StandardOutputLines) {


### PR DESCRIPTION
… to be updated.

in the StandardErrorLines it returns:

"[notice] A new release of pip is available: 23.0.1 -> 24.3.1"
"[notice] To update, run: C:\\Users\\bschnurr\\AppData\\Local\\Microsoft\\WindowsApps\\PythonSoftwareFoundation.Python.3.10_qbz5n2kfra8p0\\python.exe -m pip install --upgrade pip"

now we check for no packages found and error strings. if so we just set packages to null and it falls back to directory search to display instead.

fixes https://github.com/microsoft/PTVS/issues/6774