### PR TITLE
Make glass tests run as part of a PR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,7 @@ __pycache__/
 *.log
 *.pch
 *.tlog
-GlassTests
-DropTools
+/GlassTests
+/DropTools
 obj/
 

--- a/Build/run_glass.py
+++ b/Build/run_glass.py
@@ -17,7 +17,7 @@ def run_glass():
 
     # Verify the tests are there.
     if not os.path.exists(tests_source) or not os.path.exists(os.path.join(tests_dir, "PythonEngine.regdef")):
-        print(f"Error: Test source not found at {tests_source}. Make sure you run setup_glass.py first.")
+        print(f"Error: Test source or PythonEngine.regdef not found at {tests_source}. Make sure you run setup_glass.py first.")
         # List the directory contents to help diagnose the issue
         print(f"Contents of {tests_dir}:")
         for f in os.listdir(tests_dir):

--- a/Build/run_glass.py
+++ b/Build/run_glass.py
@@ -16,7 +16,7 @@ def run_glass():
     test_filter = f"/Tests:{sys.argv[1]}" if len(sys.argv) > 1 else "*"
 
     # Verify the tests are there.
-    if not os.path.exists(tests_source):
+    if not os.path.exists(tests_source) or not os.path.exists(os.path.join(tests_dir, "PythonEngine.regdef")):
         print(f"Error: Test source not found at {tests_source}. Make sure you run setup_glass.py first.")
         # List the directory contents to help diagnose the issue
         print(f"Contents of {tests_dir}:")

--- a/Build/run_glass.py
+++ b/Build/run_glass.py
@@ -14,6 +14,15 @@ def run_glass():
     tests_dir = os.path.join(glass_dir, "PythonTests")
     tests_source = os.path.join(tests_dir, "PythonConcord.GlassTestRoot")
     test_filter = f"/Tests:{sys.argv[1]}" if len(sys.argv) > 1 else "*"
+
+    # Verify the tests are there.
+    if not os.path.exists(tests_source):
+        print(f"Error: Test source not found at {tests_source}. Make sure you run setup_glass.py first.")
+        # List the directory contents to help diagnose the issue
+        print(f"Contents of {tests_dir}:")
+        for f in os.listdir(tests_dir):
+            print(f)
+        exit(1)    
     
     # Verify test_console exists
     if not os.path.exists(test_console):

--- a/Build/run_glass.py
+++ b/Build/run_glass.py
@@ -1,19 +1,20 @@
+import argparse
 import os
 import subprocess
 import sys
 from setup_glass import copy_ptvs_output
 
 
-def run_glass():
+def run_glass(build_output_dir: str | None, other_args: list[str]) -> None:
     # Ensure the PTVS output is copied to the GlassTests directory
-    copy_ptvs_output()
+    copy_ptvs_output(build_output_dir)
 
     # Get the test console app and test source directories
     glass_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "GlassTests"))
     test_console = os.path.join(glass_dir, "vstest.console.exe")
     tests_dir = os.path.join(glass_dir, "PythonTests")
     tests_source = os.path.join(tests_dir, "PythonConcord.GlassTestRoot")
-    test_filter = f"/Tests:{sys.argv[1]}" if len(sys.argv) > 1 else "*"
+    test_filter = f"/Tests:{other_args[0]}" if len(other_args) > 0 else "*"
 
     # Verify the tests are there.
     if not os.path.exists(tests_source) or not os.path.exists(os.path.join(tests_dir, "PythonEngine.regdef")):
@@ -45,4 +46,14 @@ def run_glass():
 
 
 if __name__ == "__main__":
-    run_glass()
+    arg_parser = argparse.ArgumentParser(description="Use Glass to run Python mixed mode debugger tests")
+    arg_parser.add_argument("--buildOutput", type=str, help="The path to the build output directory")
+    arg_parser.add_argument("--?", action='store_true', help="Show help")
+    args, unknown_args = arg_parser.parse_known_args()
+    build_output = args.buildOutput if args.buildOutput else None
+    args_dict = vars(args)
+
+    if args_dict.get("?"):
+       arg_parser.print_help()
+    else:
+        run_glass(build_output, unknown_args)

--- a/Build/setup_glass.py
+++ b/Build/setup_glass.py
@@ -178,9 +178,10 @@ def verify_listing():
 def get_build_output():
     debug_path = os.path.join(ptvs_root, "BuildOutput", "Debug17.0", "raw", "binaries")
     release_path = os.path.join(ptvs_root, "BuildOutput", "Release17.0", "raw", "binaries")
+    discover_exe = os.path.join(debug_path, "EnvironmentDiscover.exe")
 
     # Default to debug because that's the most likely scenario for a local dev box
-    if os.path.exists(debug_path):
+    if os.path.exists(discover_exe) and not auth_token:
         return debug_path
     return release_path
 

--- a/Build/setup_glass.py
+++ b/Build/setup_glass.py
@@ -145,7 +145,7 @@ def get_test_console_app():
         print(f"Error: Test console app not found at {test_console_app}")
         exit(1)
 
-def copy_ptvs_output():
+def copy_ptvs_output(debug_output: bool = False):
     # Copy the PythonTests folder into the glass directory
     print(f"Copying PythonTests from {python_tests_source_dir} to {python_tests_target_dir}")
     shutil.copytree(python_tests_source_dir, python_tests_target_dir, dirs_exist_ok=True)

--- a/Build/setup_glass.py
+++ b/Build/setup_glass.py
@@ -161,6 +161,14 @@ def copy_ptvs_output(debug_output: bool = False):
         shutil.copy(file, glass_debugger_dir)
         shutil.copy(file, glass_remote_debugger_dir)
 
+    # Verify some of the files were copied.
+    if not os.path.exists(os.path.join(glass_debugger_dir, "Microsoft.PythonTools.Core.pkgdef")) or not os.path.exists(os.path.join(glass_remote_debugger_dir, "Microsoft.PythonTools.Core.pkgdef")):
+        print(f"Error: Microsoft.PythonTools.Core.pkgdef not found in {glass_debugger_dir} or {glass_remote_debugger_dir}.")
+        print(f"Contents of {glass_debugger_dir}:")
+        for f in os.listdir(glass_debugger_dir):
+            print(f)
+        exit(1)
+
     # Whenever we copy new bits, we have to regenerate the Python.GlassTestGroup file
     generate_python_version_props()
 

--- a/Build/setup_glass.py
+++ b/Build/setup_glass.py
@@ -178,10 +178,10 @@ def verify_listing():
 def get_build_output():
     debug_path = os.path.join(ptvs_root, "BuildOutput", "Debug17.0", "raw", "binaries")
     release_path = os.path.join(ptvs_root, "BuildOutput", "Release17.0", "raw", "binaries")
-    discover_exe = os.path.join(debug_path, "EnvironmentDiscover.exe")
+    dkm_debugger_config = os.path.join(debug_path, "DkmDebugger.vsdconfig")
 
     # Default to debug because that's the most likely scenario for a local dev box
-    if os.path.exists(discover_exe) and not auth_token:
+    if os.path.exists(dkm_debugger_config):
         return debug_path
     return release_path
 

--- a/Build/setup_glass.py
+++ b/Build/setup_glass.py
@@ -151,8 +151,8 @@ def copy_ptvs_output(debug_output: bool = False):
     shutil.copytree(python_tests_source_dir, python_tests_target_dir, dirs_exist_ok=True)
 
     # Copy the output of the build into the glass debugger directory (where the debuggers are installed)
-    print(f"Copying PTVS Debugger bits to {glass_debugger_dir}")
     build_output = get_build_output()
+    print(f"Copying PTVS Debugger bits from {build_output} to {glass_debugger_dir}")
     for file in glob.glob(os.path.join(build_output, "Microsoft.Python*")):
         shutil.copy(file, glass_debugger_dir)
         shutil.copy(file, glass_remote_debugger_dir)

--- a/Build/setup_glass.py
+++ b/Build/setup_glass.py
@@ -175,7 +175,7 @@ def copy_ptvs_output(build_output_dir: str | None = None):
         exit(1)
 
     # Whenever we copy new bits, we have to regenerate the Python.GlassTestGroup file
-    generate_python_version_props()
+    generate_python_version_props(build_output_dir)
 
 def verify_listing():
     # Output the tests found to verify this all worked
@@ -230,14 +230,14 @@ def write_python_tests_group(file: str, props_to_add: list[PythonVersionProps]):
         f.write(f'</GlassTestGroup>\n')
 
 
-def generate_python_version_props():
+def generate_python_version_props(build_output_dir: str | None):
     print("Generaring Python version props files...")
     # This will generate the Python<Major><Bitness>.GlassTestProps files based
     # on where python is installed on this machine.
     props_folder = os.path.join(python_tests_target_dir, "Python")
 
     # Run the EnvironmentDiscoverer exe to find the installed versions of python.
-    discover_path = os.path.join(get_build_output(), "EnvironmentDiscover.exe")
+    discover_path = os.path.join(get_build_output(build_output_dir), "EnvironmentDiscover.exe")
     if not os.path.exists(discover_path):
         print(f"Error: EnvironmentDiscover.exe not found at {discover_path}. Make sure you build the project first.")
         exit(1)
@@ -308,7 +308,7 @@ def main(build_output_dir: str | None = None):
     get_glass()
     get_test_console_app()
     copy_ptvs_output(build_output_dir)
-    generate_python_version_props()
+    generate_python_version_props(build_output_dir)
     verify_listing()
 
 

--- a/Build/setup_glass.py
+++ b/Build/setup_glass.py
@@ -164,8 +164,8 @@ def copy_ptvs_output(debug_output: bool = False):
     # Verify some of the files were copied.
     if not os.path.exists(os.path.join(glass_debugger_dir, "Microsoft.PythonTools.Core.pkgdef")) or not os.path.exists(os.path.join(glass_remote_debugger_dir, "Microsoft.PythonTools.Core.pkgdef")):
         print(f"Error: Microsoft.PythonTools.Core.pkgdef not found in {glass_debugger_dir} or {glass_remote_debugger_dir}.")
-        print(f"Contents of {glass_debugger_dir}:")
-        for f in os.listdir(glass_debugger_dir):
+        print(f"Contents of {build_output}:")
+        for f in os.listdir(build_output):
             print(f)
         exit(1)
 

--- a/Build/templates/install_python.yml
+++ b/Build/templates/install_python.yml
@@ -37,7 +37,7 @@ steps:
       $updatedVersion = "${{ parameters.pythonVersion }}" -replace "\.\d+$", ""
       $installPath = "$(ProgramFiles)\Python $updatedVersion"
       Write-Host "##vso[task.setvariable variable=${{ parameters.outputVar }};isOutput=true]$installPath"
-      Get-ChildItem $(ProgramFiles)
-      Get-ChildItem $(ProgramFilesX86)
+      Get-ChildItem "$(ProgramFiles)"
+      Get-ChildItem "$(ProgramFilesX86)"
     displayName: 'Set INSTALLPATH for ${{ parameters.pythonVersion }}'
     

--- a/Build/templates/install_python.yml
+++ b/Build/templates/install_python.yml
@@ -27,6 +27,11 @@ steps:
 
   - pwsh: |
       $pythonInstaller = "$(Pipeline.Workspace)/python-installer/python-installer.exe"
-      Start-Process $pythonInstaller -ArgumentList '/quiet InstallAllUsers=1 PrependPath=1 Include_debug=1 Include_doc=0 Include_symbols=1' -NoNewWindow -Wait
+      Start-Process $pythonInstaller -ArgumentList '/quiet InstallAllUsers=1  Include_debug=1 Include_doc=0 Include_symbols=1' -NoNewWindow -Wait
     displayName: 'Install Python'
+
+  - pwsh: |
+      $installPath = "$(ProgramFiles)\Python ${{ parameters.pythonVersion }}"
+      Write-Host "##vso[task.setvariable variable=INSTALLPATH;isOutput=true]$installPath"
+    displayName: 'Set INSTALLPATH'
     

--- a/Build/templates/install_python.yml
+++ b/Build/templates/install_python.yml
@@ -14,7 +14,11 @@ steps:
     displayName: 'Cache Python Installer'
 
   - pwsh: |
+      $pythonInstallerDir = "$(Pipeline.Workspace)/python-installer"
       $pythonInstallerUrl = "https://www.python.org/ftp/python/${{ parameters.pythonVersion }}/python-${{ parameters.pythonVersion }}-amd64.exe"
+      if (-not (Test-Path -Path $pythonInstallerDir)) {
+        New-Item -ItemType Directory -Path $pythonInstallerDir | Out-Null
+      }
       $pythonInstaller = "$(Pipeline.Workspace)/python-installer/python-installer.exe"
       if (!(Test-Path -Path $pythonInstaller)) {
         Invoke-WebRequest -Uri $pythonInstallerUrl -OutFile $pythonInstaller

--- a/Build/templates/install_python.yml
+++ b/Build/templates/install_python.yml
@@ -34,8 +34,8 @@ steps:
     displayName: 'Install Python ${{ parameters.pythonVersion }}'
 
   - pwsh: |
-      $updatedVersion = "${{ parameters.pythonVersion }}" -replace "\.(\d+)\.\d+$", "$1"
-      $installPath = "$(ProgramFiles)\Python$updatedVersion"
+      $installVersion = "${{ parameters.pythonVersion }}" -replace '(\d+)\.(\d+)\.\d+', '$1$2'
+      $installPath = "$(ProgramFiles)\Python$installVersion"
       Write-Host "##vso[task.setvariable variable=${{ parameters.outputVar }};isOutput=true]$installPath"
     displayName: 'Set INSTALLPATH for ${{ parameters.pythonVersion }}'
     

--- a/Build/templates/install_python.yml
+++ b/Build/templates/install_python.yml
@@ -37,5 +37,8 @@ steps:
       $updatedVersion = "${{ parameters.pythonVersion }}" -replace "\.\d+$", ""
       $installPath = "$(ProgramFiles)\Python $updatedVersion"
       Write-Host "##vso[task.setvariable variable=${{ parameters.outputVar }};isOutput=true]$installPath"
+      Get-ChildItem -Path "$installPath"
+      Get-ChildItem $(ProgramFiles)
+      Get-ChildItem $(ProgramFilesX86)
     displayName: 'Set INSTALLPATH for ${{ parameters.pythonVersion }}'
     

--- a/Build/templates/install_python.yml
+++ b/Build/templates/install_python.yml
@@ -14,7 +14,7 @@ steps:
     displayName: 'Cache Python Installer'
 
   - pwsh: |
-      $pythonInstallerUrl = "https://www.python.org/ftp/python/$(parameters.pythonVersion)/python-$(parameters.pythonVersion)-amd64.exe"
+      $pythonInstallerUrl = "https://www.python.org/ftp/python/$(pythonVersion)/python-$(pythonVersion)-amd64.exe"
       $pythonInstaller = "$(Pipeline.Workspace)/python-installer/python-installer.exe"
       if (!(Test-Path -Path $pythonInstaller)) {
         Invoke-WebRequest -Uri $pythonInstallerUrl -OutFile $pythonInstaller

--- a/Build/templates/install_python.yml
+++ b/Build/templates/install_python.yml
@@ -20,7 +20,9 @@ steps:
         Invoke-WebRequest -Uri $pythonInstallerUrl -OutFile $pythonInstaller
       }
     displayName: 'Download Python Installer if not cached'
+    pwsh: true
 
   - script: |
       Start-Process $pythonInstaller -ArgumentList '/quiet InstallAllUsers=1 PrependPath=1 Include_debug=1 Include_doc=0 Include_symbols=1' -NoNewWindow -Wait
     displayName: 'Install Python'
+    pwsh: true

--- a/Build/templates/install_python.yml
+++ b/Build/templates/install_python.yml
@@ -11,7 +11,7 @@ steps:
       path: '$(Pipeline.Workspace)/python-installer'
       restoreKeys: |
         python-installer-
-    displayName: 'Cache Python Installer for $(pythonVersion)'
+    displayName: 'Cache Python Installer for ${{ parameters.pythonVersion }}'
 
   - pwsh: |
       $pythonInstallerDir = "$(Pipeline.Workspace)/python-installer"
@@ -23,16 +23,16 @@ steps:
       if (!(Test-Path -Path $pythonInstaller)) {
         Invoke-WebRequest -Uri $pythonInstallerUrl -OutFile $pythonInstaller
       }
-    displayName: 'Download Python Installer for $(pythonVersion) if not cached'
+    displayName: 'Download Python Installer for ${{ parameters.pythonVersion }} if not cached'
 
   - pwsh: |
       $pythonInstaller = "$(Pipeline.Workspace)/python-installer/python-installer.exe"
       Start-Process $pythonInstaller -ArgumentList '/quiet InstallAllUsers=1  Include_debug=1 Include_doc=0 Include_symbols=1' -NoNewWindow -Wait
-    displayName: 'Install Python $(pythonVersion)'
+    displayName: 'Install Python ${{ parameters.pythonVersion }}'
 
   - pwsh: |
       $updatedVersion = "${{ parameters.pythonVersion }}" -replace "\.\d+$", ""
       $installPath = "$(ProgramFiles)\Python $updatedVersion"
       Write-Host "##vso[task.setvariable variable=INSTALLPATH;isOutput=true]$installPath"
-    displayName: 'Set INSTALLPATH for $(pythonVersion)'
+    displayName: 'Set INSTALLPATH for ${{ parameters.pythonVersion }}'
     

--- a/Build/templates/install_python.yml
+++ b/Build/templates/install_python.yml
@@ -4,28 +4,23 @@ parameters:
     default: '3.9.7'
     displayName: 'Python Version'
 
-resources:
-  containers:
-    - container: windows-latest
-      image: mcr.microsoft.com/windows/servercore:ltsc2019
-
 steps:
-- task: Cache@2
-  inputs:
-    key: 'python-installer-$(parameters.pythonVersion)'
-    path: '$(Pipeline.Workspace)/python-installer'
-    restoreKeys: |
-      python-installer-
-  displayName: 'Cache Python Installer'
+  - task: Cache@2
+    inputs:
+      key: 'python-installer-$(parameters.pythonVersion)'
+      path: '$(Pipeline.Workspace)/python-installer'
+      restoreKeys: |
+        python-installer-
+    displayName: 'Cache Python Installer'
 
-- script: |
-    $pythonInstallerUrl = "https://www.python.org/ftp/python/$(parameters.pythonVersion)/python-$(parameters.pythonVersion)-amd64.exe"
-    $pythonInstaller = "$(Pipeline.Workspace)/python-installer/python-installer.exe"
-    if (!(Test-Path -Path $pythonInstaller)) {
-      Invoke-WebRequest -Uri $pythonInstallerUrl -OutFile $pythonInstaller
-    }
-  displayName: 'Download Python Installer if not cached'
+  - script: |
+      $pythonInstallerUrl = "https://www.python.org/ftp/python/$(parameters.pythonVersion)/python-$(parameters.pythonVersion)-amd64.exe"
+      $pythonInstaller = "$(Pipeline.Workspace)/python-installer/python-installer.exe"
+      if (!(Test-Path -Path $pythonInstaller)) {
+        Invoke-WebRequest -Uri $pythonInstallerUrl -OutFile $pythonInstaller
+      }
+    displayName: 'Download Python Installer if not cached'
 
-- script: |
-    Start-Process $pythonInstaller -ArgumentList '/quiet InstallAllUsers=1 PrependPath=1 Include_debug=1 Include_doc=0 Include_symbols=1' -NoNewWindow -Wait
-  displayName: 'Install Python'
+  - script: |
+      Start-Process $pythonInstaller -ArgumentList '/quiet InstallAllUsers=1 PrependPath=1 Include_debug=1 Include_doc=0 Include_symbols=1' -NoNewWindow -Wait
+    displayName: 'Install Python'

--- a/Build/templates/install_python.yml
+++ b/Build/templates/install_python.yml
@@ -10,7 +10,7 @@ parameters:
 steps:
   - task: Cache@2
     inputs:
-      key: 'python-installer-${{ parameters.pythonVersion }}'
+      key: 'python-installer-$(pythonVersion)'
       path: '$(Pipeline.Workspace)/python-installer'
       restoreKeys: |
         python-installer-

--- a/Build/templates/install_python.yml
+++ b/Build/templates/install_python.yml
@@ -11,7 +11,7 @@ steps:
       path: '$(Pipeline.Workspace)/python-installer'
       restoreKeys: |
         python-installer-
-    displayName: 'Cache Python Installer'
+    displayName: 'Cache Python Installer for $(pythonVersion)'
 
   - pwsh: |
       $pythonInstallerDir = "$(Pipeline.Workspace)/python-installer"
@@ -23,16 +23,16 @@ steps:
       if (!(Test-Path -Path $pythonInstaller)) {
         Invoke-WebRequest -Uri $pythonInstallerUrl -OutFile $pythonInstaller
       }
-    displayName: 'Download Python Installer if not cached'
+    displayName: 'Download Python Installer for $(pythonVersion) if not cached'
 
   - pwsh: |
       $pythonInstaller = "$(Pipeline.Workspace)/python-installer/python-installer.exe"
       Start-Process $pythonInstaller -ArgumentList '/quiet InstallAllUsers=1  Include_debug=1 Include_doc=0 Include_symbols=1' -NoNewWindow -Wait
-    displayName: 'Install Python'
+    displayName: 'Install Python $(pythonVersion)'
 
   - pwsh: |
       $updatedVersion = ${{ parameters.pythonVersion }} -replace "\.\d+$", ""
       $installPath = "$(ProgramFiles)\Python $(updatedVersion)"
       Write-Host "##vso[task.setvariable variable=INSTALLPATH;isOutput=true]$installPath"
-    displayName: 'Set INSTALLPATH'
+    displayName: 'Set INSTALLPATH for $(pythonVersion)'
     

--- a/Build/templates/install_python.yml
+++ b/Build/templates/install_python.yml
@@ -14,7 +14,7 @@ steps:
     displayName: 'Cache Python Installer'
 
   - pwsh: |
-      $pythonInstallerUrl = "https://www.python.org/ftp/python/$(pythonVersion)/python-$(pythonVersion)-amd64.exe"
+      $pythonInstallerUrl = "https://www.python.org/ftp/python/${{ parameters.pythonVersion }}/python-${{ parameters.pythonVersion }}-amd64.exe"
       $pythonInstaller = "$(Pipeline.Workspace)/python-installer/python-installer.exe"
       if (!(Test-Path -Path $pythonInstaller)) {
         Invoke-WebRequest -Uri $pythonInstallerUrl -OutFile $pythonInstaller

--- a/Build/templates/install_python.yml
+++ b/Build/templates/install_python.yml
@@ -37,7 +37,6 @@ steps:
       $updatedVersion = "${{ parameters.pythonVersion }}" -replace "\.\d+$", ""
       $installPath = "$(ProgramFiles)\Python $updatedVersion"
       Write-Host "##vso[task.setvariable variable=${{ parameters.outputVar }};isOutput=true]$installPath"
-      Get-ChildItem -Path "$installPath"
       Get-ChildItem $(ProgramFiles)
       Get-ChildItem $(ProgramFilesX86)
     displayName: 'Set INSTALLPATH for ${{ parameters.pythonVersion }}'

--- a/Build/templates/install_python.yml
+++ b/Build/templates/install_python.yml
@@ -7,7 +7,7 @@ parameters:
 steps:
   - task: Cache@2
     inputs:
-      key: 'python-installer-$(parameters.pythonVersion)'
+      key: 'python-installer-$(pythonVersion)'
       path: '$(Pipeline.Workspace)/python-installer'
       restoreKeys: |
         python-installer-

--- a/Build/templates/install_python.yml
+++ b/Build/templates/install_python.yml
@@ -31,7 +31,7 @@ steps:
     displayName: 'Install Python $(pythonVersion)'
 
   - pwsh: |
-      $updatedVersion = "${{ parameters.pythonVersion }}"" -replace "\.\d+$", ""
+      $updatedVersion = "${{ parameters.pythonVersion }}" -replace "\.\d+$", ""
       $installPath = "$(ProgramFiles)\Python $updatedVersion"
       Write-Host "##vso[task.setvariable variable=INSTALLPATH;isOutput=true]$installPath"
     displayName: 'Set INSTALLPATH for $(pythonVersion)'

--- a/Build/templates/install_python.yml
+++ b/Build/templates/install_python.yml
@@ -31,7 +31,8 @@ steps:
     displayName: 'Install Python'
 
   - pwsh: |
-      $installPath = "$(ProgramFiles)\Python ${{ parameters.pythonVersion }}"
+      $updatedVersion = ${{ parameters.pythonVersion }} -replace "\.\d+$", ""
+      $installPath = "$(ProgramFiles)\Python $(updatedVersion)"
       Write-Host "##vso[task.setvariable variable=INSTALLPATH;isOutput=true]$installPath"
     displayName: 'Set INSTALLPATH'
     

--- a/Build/templates/install_python.yml
+++ b/Build/templates/install_python.yml
@@ -35,9 +35,7 @@ steps:
 
   - pwsh: |
       $updatedVersion = "${{ parameters.pythonVersion }}" -replace "\.\d+$", ""
-      $installPath = "$(ProgramFiles)\Python $updatedVersion"
+      $installPath = "$(ProgramFiles)\Python$updatedVersion"
       Write-Host "##vso[task.setvariable variable=${{ parameters.outputVar }};isOutput=true]$installPath"
-      Get-ChildItem "$(ProgramFiles)"
-      Get-ChildItem "$(ProgramFilesX86)"
     displayName: 'Set INSTALLPATH for ${{ parameters.pythonVersion }}'
     

--- a/Build/templates/install_python.yml
+++ b/Build/templates/install_python.yml
@@ -31,8 +31,8 @@ steps:
     displayName: 'Install Python $(pythonVersion)'
 
   - pwsh: |
-      $updatedVersion = ${{ parameters.pythonVersion }} -replace "\.\d+$", ""
-      $installPath = "$(ProgramFiles)\Python $(updatedVersion)"
+      $updatedVersion = "${{ parameters.pythonVersion }}"" -replace "\.\d+$", ""
+      $installPath = "$(ProgramFiles)\Python $updatedVersion"
       Write-Host "##vso[task.setvariable variable=INSTALLPATH;isOutput=true]$installPath"
     displayName: 'Set INSTALLPATH for $(pythonVersion)'
     

--- a/Build/templates/install_python.yml
+++ b/Build/templates/install_python.yml
@@ -3,6 +3,9 @@ parameters:
     type: string
     default: '3.9.7'
     displayName: 'Python Version'
+  - name: outputVar
+    type: string
+    default: 'InstallPython'
 
 steps:
   - task: Cache@2
@@ -33,6 +36,6 @@ steps:
   - pwsh: |
       $updatedVersion = "${{ parameters.pythonVersion }}" -replace "\.\d+$", ""
       $installPath = "$(ProgramFiles)\Python $updatedVersion"
-      Write-Host "##vso[task.setvariable variable=INSTALLPATH;isOutput=true]$installPath"
+      Write-Host "##vso[task.setvariable variable=${{ parameters.outputVar }};isOutput=true]$installPath"
     displayName: 'Set INSTALLPATH for ${{ parameters.pythonVersion }}'
     

--- a/Build/templates/install_python.yml
+++ b/Build/templates/install_python.yml
@@ -1,7 +1,7 @@
 parameters:
   - name: pythonVersion
     type: string
-    default: '3.9.7'
+    default: '3.12.7'
     displayName: 'Python Version'
   - name: outputVar
     type: string
@@ -10,7 +10,7 @@ parameters:
 steps:
   - task: Cache@2
     inputs:
-      key: 'python-installer-$(pythonVersion)'
+      key: 'python-installer-${{ parameters.pythonVersion }}'
       path: '$(Pipeline.Workspace)/python-installer'
       restoreKeys: |
         python-installer-
@@ -22,14 +22,14 @@ steps:
       if (-not (Test-Path -Path $pythonInstallerDir)) {
         New-Item -ItemType Directory -Path $pythonInstallerDir | Out-Null
       }
-      $pythonInstaller = "$(Pipeline.Workspace)/python-installer/python-installer.exe"
+      $pythonInstaller = "$(Pipeline.Workspace)/python-installer/python-installer-${{ parameters.pythonVersion }}.exe"
       if (!(Test-Path -Path $pythonInstaller)) {
         Invoke-WebRequest -Uri $pythonInstallerUrl -OutFile $pythonInstaller
       }
     displayName: 'Download Python Installer for ${{ parameters.pythonVersion }} if not cached'
 
   - pwsh: |
-      $pythonInstaller = "$(Pipeline.Workspace)/python-installer/python-installer.exe"
+      $pythonInstaller = "$(Pipeline.Workspace)/python-installer/python-installer-${{ parameters.pythonVersion }}.exe"
       Start-Process $pythonInstaller -ArgumentList '/quiet InstallAllUsers=1  Include_debug=1 Include_doc=0 Include_symbols=1' -NoNewWindow -Wait
     displayName: 'Install Python ${{ parameters.pythonVersion }}'
 

--- a/Build/templates/install_python.yml
+++ b/Build/templates/install_python.yml
@@ -34,7 +34,7 @@ steps:
     displayName: 'Install Python ${{ parameters.pythonVersion }}'
 
   - pwsh: |
-      $updatedVersion = "${{ parameters.pythonVersion }}" -replace "\.\d+$", ""
+      $updatedVersion = "${{ parameters.pythonVersion }}" -replace "\.(\d+)\.\d+$", "$1"
       $installPath = "$(ProgramFiles)\Python$updatedVersion"
       Write-Host "##vso[task.setvariable variable=${{ parameters.outputVar }};isOutput=true]$installPath"
     displayName: 'Set INSTALLPATH for ${{ parameters.pythonVersion }}'

--- a/Build/templates/install_python.yml
+++ b/Build/templates/install_python.yml
@@ -13,16 +13,15 @@ steps:
         python-installer-
     displayName: 'Cache Python Installer'
 
-  - script: |
+  - pwsh: |
       $pythonInstallerUrl = "https://www.python.org/ftp/python/$(parameters.pythonVersion)/python-$(parameters.pythonVersion)-amd64.exe"
       $pythonInstaller = "$(Pipeline.Workspace)/python-installer/python-installer.exe"
       if (!(Test-Path -Path $pythonInstaller)) {
         Invoke-WebRequest -Uri $pythonInstallerUrl -OutFile $pythonInstaller
       }
     displayName: 'Download Python Installer if not cached'
-    pwsh: true
 
-  - script: |
+  - pwsh: |
       Start-Process $pythonInstaller -ArgumentList '/quiet InstallAllUsers=1 PrependPath=1 Include_debug=1 Include_doc=0 Include_symbols=1' -NoNewWindow -Wait
     displayName: 'Install Python'
-    pwsh: true
+    

--- a/Build/templates/install_python.yml
+++ b/Build/templates/install_python.yml
@@ -26,6 +26,7 @@ steps:
     displayName: 'Download Python Installer if not cached'
 
   - pwsh: |
+      $pythonInstaller = "$(Pipeline.Workspace)/python-installer/python-installer.exe"
       Start-Process $pythonInstaller -ArgumentList '/quiet InstallAllUsers=1 PrependPath=1 Include_debug=1 Include_doc=0 Include_symbols=1' -NoNewWindow -Wait
     displayName: 'Install Python'
     

--- a/Build/templates/install_python.yml
+++ b/Build/templates/install_python.yml
@@ -1,0 +1,31 @@
+parameters:
+  - name: pythonVersion
+    type: string
+    default: '3.9.7'
+    displayName: 'Python Version'
+
+resources:
+  containers:
+    - container: windows-latest
+      image: mcr.microsoft.com/windows/servercore:ltsc2019
+
+steps:
+- task: Cache@2
+  inputs:
+    key: 'python-installer-$(parameters.pythonVersion)'
+    path: '$(Pipeline.Workspace)/python-installer'
+    restoreKeys: |
+      python-installer-
+  displayName: 'Cache Python Installer'
+
+- script: |
+    $pythonInstallerUrl = "https://www.python.org/ftp/python/$(parameters.pythonVersion)/python-$(parameters.pythonVersion)-amd64.exe"
+    $pythonInstaller = "$(Pipeline.Workspace)/python-installer/python-installer.exe"
+    if (!(Test-Path -Path $pythonInstaller)) {
+      Invoke-WebRequest -Uri $pythonInstallerUrl -OutFile $pythonInstaller
+    }
+  displayName: 'Download Python Installer if not cached'
+
+- script: |
+    Start-Process $pythonInstaller -ArgumentList '/quiet InstallAllUsers=1 PrependPath=1 Include_debug=1 Include_doc=0 Include_symbols=1' -NoNewWindow -Wait
+  displayName: 'Install Python'

--- a/Build/templates/run_tests.yml
+++ b/Build/templates/run_tests.yml
@@ -6,9 +6,10 @@ steps:
       outputVar: InstallPython312
 
   # Debug helper, print all variables
-  - task: printAllVariables@1
-    displayName: 'Print all variables'
-
+  - powershell: |
+      Get-ChildItem Env:
+    displayName: 'Dump all variables'
+    
   # Build the product
   - task: MSBuild@1
     displayName: 'Build product'

--- a/Build/templates/run_tests.yml
+++ b/Build/templates/run_tests.yml
@@ -10,6 +10,10 @@ steps:
       Get-ChildItem Env:
     displayName: 'Dump all variables'
 
+- powershell: |
+    echo "##vso[task.setvariable variable=PYTHON_PATH]$env:POWERSHELL6_INSTALLPYTHON312"
+  displayName: 'Set PYTHON_PATH variable'
+
   # Build the product
   - task: MSBuild@1
     displayName: 'Build product'
@@ -45,7 +49,7 @@ steps:
       arguments: '--authTokenVariable SYSTEM_ACCESSTOKEN --buildOutput $(Build.BinariesDirectory)\raw\binaries'
       workingDirectory: $(Build.SourcesDirectory)
       failOnStderr: true
-      pythonInterpreter: $(POWERSHELL6_INSTALLPYTHON312)/python.exe
+      pythonInterpreter: $(PYTHON_PATH)
 
   # Run the glass tests
   - task: PythonScript@0
@@ -56,7 +60,7 @@ steps:
       arguments: '--buildOutput $(Build.BinariesDirectory)\raw\binaries'
       workingDirectory: $(Build.SourcesDirectory)
       failOnStderr: true
-      pythonInterpreter: $(POWERSHELL6_INSTALLPYTHON312)/python.exe
+      pythonInterpreter: $(PYTHON_PATH)
 
   # Upload the trx file as a test result
   - task: PublishTestResults@2

--- a/Build/templates/run_tests.yml
+++ b/Build/templates/run_tests.yml
@@ -16,12 +16,18 @@ steps:
   - template: ./install_python.yml
     parameters:
       pythonVersion: '3.13.0'
+  
+  # Find the environment variable for the install of 3.12
   - powershell: |
-      Get-ChildItem Env:
-    displayName: 'Dump all variables'
-  - powershell: |
-      echo "##vso[task.setvariable variable=PYTHON_INTERPRETER]$env:POWERSHELL6_INSTALLPYTHON312\python.exe"
-      Get-ChildItem "$env:POWERSHELL6_INSTALLPYTHON312"
+      $suffix = '_INSTALLPYTHON312'
+      $envVars = Get-ChildItem Env:
+
+      foreach ($envVar in $envVars) {
+        if ($envVar.Name.EndsWith($suffix)) {
+          echo "##vso[task.setvariable variable=PYTHON_INTERPRETER]$($envVar.Value)\python.exe"
+          break
+        }
+      }  
     displayName: 'Set PYTHON_INTERPRETER variable'
 
   - task: PythonScript@0

--- a/Build/templates/run_tests.yml
+++ b/Build/templates/run_tests.yml
@@ -84,8 +84,6 @@ steps:
     inputs:
       testResultsFiles: '$(Build.SourcesDirectory)/TestResults/*.trx'
       testRunTitle: 'Glass Tests'
-      testRunSystem: 'VSTest'
+      testResultsFormat: 'VSTest'
       failTaskOnFailedTests: true
       mergeTestResults: true
-      testRunAttachmentsEnabled: true
-      testRunAttachmentsDirectory: '$(Build.SourcesDirectory)/TestResults'      

--- a/Build/templates/run_tests.yml
+++ b/Build/templates/run_tests.yml
@@ -1,4 +1,9 @@
 steps:
+  # Install different python versions
+  - template: ./install_python.yml
+    parameters:
+      pythonVersion: '3.12.7'
+    displayName: 'Install Python 3.12'
 
   # Build the product
   - task: MSBuild@1
@@ -23,36 +28,6 @@ steps:
         # Note that the resoruce is specified to limit the token to Azure DevOps
         $token = az account get-access-token --query accessToken --resource 499b84ac-1321-427f-aa17-267ca6975798 -o tsv
         Write-Host "##vso[task.setvariable variable=DropToken;issecret=true]$token"      
-
-  # Install different python versions
-  #- task: UsePythonVersion@0
-  #  inputs:
-  #    versionSpec: '3.9' # string. Required. Version spec. Default: 3.x.
-      #disableDownloadFromRegistry: false # boolean. Disable downloading releases from the GitHub registry. Default: false.
-      #allowUnstable: false # boolean. Optional. Use when disableDownloadFromRegistry = false. Allow downloading unstable releases. Default: false.
-      #githubToken: # string. Optional. Use when disableDownloadFromRegistry = false. GitHub token for GitHub Actions python registry. 
-  #    addToPath: false # boolean. Add to PATH. Default: true.
-    # Advanced
-  #    architecture: 'x64' # 'x86' | 'x64'. Required. Architecture. Default: x64.
-  # - task: UsePythonVersion@0
-  #   inputs:
-  #     versionSpec: '3.10'
-  #     addToPath: false
-  #     architecture: 'x64'
-  # - task: UsePythonVersion@0
-  #   inputs:
-  #     versionSpec: '3.11'
-  #     addToPath: false
-  #     architecture: 'x64'
-  - template: install_python.yml
-    parameters:
-      pythonVersion: '3.12.7'
-    displayName: 'Install Python 3.12'
-  # - task: UsePythonVersion@0
-  #   inputs:
-  #     versionSpec: '3.13'
-  #     addToPath: false
-  #     architecture: 'x64'  
 
   # Setup the glass test folder
   - task: PythonScript@0

--- a/Build/templates/run_tests.yml
+++ b/Build/templates/run_tests.yml
@@ -63,7 +63,7 @@ steps:
     inputs:
       scriptSource: 'filePath' # 'filePath' | 'inline'. Required. Script source. Default: filePath.
       scriptPath: $(Build.SourcesDirectory)/Build/setup_glass.py
-      arguments: '--authTokenVariable SYSTEM_ACCESSTOKEN'
+      arguments: '--authTokenVariable SYSTEM_ACCESSTOKEN --buildOutput $(Build.BinariesDirectory)\raw\binaries'
       workingDirectory: $(Build.SourcesDirectory)
       failOnStderr: true
 

--- a/Build/templates/run_tests.yml
+++ b/Build/templates/run_tests.yml
@@ -86,4 +86,3 @@ steps:
       testRunTitle: 'Glass Tests'
       testResultsFormat: 'VSTest'
       failTaskOnFailedTests: true
-      mergeTestResults: true

--- a/Build/templates/run_tests.yml
+++ b/Build/templates/run_tests.yml
@@ -46,7 +46,7 @@ steps:
   #     architecture: 'x64'
   - task: UsePythonVersion@0
     inputs:
-      versionSpec: '3.12'
+      versionSpec: '3.12-debug'
       addToPath: true # This is the version we'll use to run the scripts below
       architecture: 'x64'
   # - task: UsePythonVersion@0

--- a/Build/templates/run_tests.yml
+++ b/Build/templates/run_tests.yml
@@ -74,7 +74,7 @@ steps:
       scriptSource: 'filePath' # 'filePath' | 'inline'. Required. Script source. Default: filePath.
       scriptPath: $(Build.SourcesDirectory)/Build/run_glass.py
       workingDirectory: $(Build.SourcesDirectory)
-      failOnStderr: true
+      failOnStderr: false
 
   # Upload the trx file as a test result
   - task: PublishTestResults@2

--- a/Build/templates/run_tests.yml
+++ b/Build/templates/run_tests.yml
@@ -2,9 +2,9 @@ steps:
 
   # Build the product
   - task: MSBuild@1
-    displayName: 'Build product'
+    displayName: 'Build full product'
     inputs:
-      solution: $(Build.SourcesDirectory)/Python/Product/dirs.proj
+      solution: $(Build.SourcesDirectory)/Python/dirs.proj
       msbuildVersion: $(MsBuildVersion)
       platform: $(Platform)
       configuration: $(BuildConfiguration)

--- a/Build/templates/run_tests.yml
+++ b/Build/templates/run_tests.yml
@@ -2,8 +2,20 @@ steps:
   # Install different python versions
   - template: ./install_python.yml
     parameters:
+      pythonVersion: '3.9.21'
+  - template: ./install_python.yml
+    parameters:
+      pythonVersion: '3.10.15'
+  - template: ./install_python.yml
+    parameters:
+      pythonVersion: '3.11.10'
+  - template: ./install_python.yml
+    parameters:
       pythonVersion: '3.12.7'
       outputVar: InstallPython312
+  - template: ./install_python.yml
+    parameters:
+      pythonVersion: '3.13.0'
 
   - powershell: |
       echo "##vso[task.setvariable variable=PYTHON_INTERPRETER]$env:POWERSHELL6_INSTALLPYTHON312\python.exe"

--- a/Build/templates/run_tests.yml
+++ b/Build/templates/run_tests.yml
@@ -3,7 +3,6 @@ steps:
   - template: ./install_python.yml
     parameters:
       pythonVersion: '3.12.7'
-    displayName: 'Install Python 3.12'
 
   # Build the product
   - task: MSBuild@1

--- a/Build/templates/run_tests.yml
+++ b/Build/templates/run_tests.yml
@@ -10,9 +10,24 @@ steps:
       Get-ChildItem Env:
     displayName: 'Dump all variables'
 
-- powershell: |
-    echo "##vso[task.setvariable variable=PYTHON_PATH]$env:POWERSHELL6_INSTALLPYTHON312"
-  displayName: 'Set PYTHON_PATH variable'
+  - powershell: |
+      echo "##vso[task.setvariable variable=PYTHON_PATH]$env:POWERSHELL6_INSTALLPYTHON312"
+    displayName: 'Set PYTHON_PATH variable'
+
+  - task: PythonScript@0
+    displayName: 'Test python path'
+    env:
+      SYSTEM_ACCESSTOKEN: $(DropToken)
+    inputs:
+      scriptSource: 'inline' # 'filePath' | 'inline'. Required. Script source. Default: filePath.
+      script: |
+        import sys
+        print(sys.executable)
+        print(sys.version)
+        print(sys.path)
+      workingDirectory: $(Build.SourcesDirectory)
+      failOnStderr: true
+      pythonInterpreter: $(PYTHON_PATH)
 
   # Build the product
   - task: MSBuild@1

--- a/Build/templates/run_tests.yml
+++ b/Build/templates/run_tests.yml
@@ -11,8 +11,8 @@ steps:
     displayName: 'Dump all variables'
 
   - powershell: |
-      echo "##vso[task.setvariable variable=PYTHON_PATH]$env:POWERSHELL6_INSTALLPYTHON312"
-    displayName: 'Set PYTHON_PATH variable'
+      echo "##vso[task.setvariable variable=PYTHON_INTERPRETER]$env:POWERSHELL6_INSTALLPYTHON312\python.exe"
+    displayName: 'Set PYTHON_INTERPRETER variable'
 
   - task: PythonScript@0
     displayName: 'Test python path'
@@ -27,7 +27,7 @@ steps:
         print(sys.path)
       workingDirectory: $(Build.SourcesDirectory)
       failOnStderr: true
-      pythonInterpreter: $(PYTHON_PATH)
+      pythonInterpreter: $(PYTHON_INTERPRETER)
 
   # Build the product
   - task: MSBuild@1
@@ -64,7 +64,7 @@ steps:
       arguments: '--authTokenVariable SYSTEM_ACCESSTOKEN --buildOutput $(Build.BinariesDirectory)\raw\binaries'
       workingDirectory: $(Build.SourcesDirectory)
       failOnStderr: true
-      pythonInterpreter: $(PYTHON_PATH)
+      pythonInterpreter: $(PYTHON_INTERPRETER)
 
   # Run the glass tests
   - task: PythonScript@0
@@ -75,7 +75,7 @@ steps:
       arguments: '--buildOutput $(Build.BinariesDirectory)\raw\binaries'
       workingDirectory: $(Build.SourcesDirectory)
       failOnStderr: true
-      pythonInterpreter: $(PYTHON_PATH)
+      pythonInterpreter: $(PYTHON_INTERPRETER)
 
   # Upload the trx file as a test result
   - task: PublishTestResults@2

--- a/Build/templates/run_tests.yml
+++ b/Build/templates/run_tests.yml
@@ -60,7 +60,9 @@ steps:
     inputs:
       scriptSource: 'filePath' # 'filePath' | 'inline'. Required. Script source. Default: filePath.
       scriptPath: $(Build.SourcesDirectory)/Build/setup_glass.py
-      arguments: '--authTokenVariable DropToken'
+      env:
+        SYSTEM_ACCESSTOKEN: $(DropToken)
+      arguments: '--authTokenVariable SYSTEM_ACCESSTOKEN'
       workingDirectory: $(Build.SourcesDirectory)
       failOnStderr: true
 

--- a/Build/templates/run_tests.yml
+++ b/Build/templates/run_tests.yml
@@ -57,17 +57,19 @@ steps:
 
   # Setup the glass test folder
   - task: PythonScript@0
+    displayName: 'Setup glass test folder'
+    env:
+      SYSTEM_ACCESSTOKEN: $(DropToken)
     inputs:
       scriptSource: 'filePath' # 'filePath' | 'inline'. Required. Script source. Default: filePath.
       scriptPath: $(Build.SourcesDirectory)/Build/setup_glass.py
-      env:
-        SYSTEM_ACCESSTOKEN: $(DropToken)
       arguments: '--authTokenVariable SYSTEM_ACCESSTOKEN'
       workingDirectory: $(Build.SourcesDirectory)
       failOnStderr: true
 
   # Run the glass tests
   - task: PythonScript@0
+    displayName: 'Run Glass tests'
     inputs:
       scriptSource: 'filePath' # 'filePath' | 'inline'. Required. Script source. Default: filePath.
       scriptPath: $(Build.SourcesDirectory)/Build/run_glass.py

--- a/Build/templates/run_tests.yml
+++ b/Build/templates/run_tests.yml
@@ -3,7 +3,6 @@ steps:
   - template: ./install_python.yml
     parameters:
       pythonVersion: '3.12.7'
-    name: InstallPython312
 
   # Build the product
   - task: MSBuild@1

--- a/Build/templates/run_tests.yml
+++ b/Build/templates/run_tests.yml
@@ -9,7 +9,7 @@ steps:
   - powershell: |
       Get-ChildItem Env:
     displayName: 'Dump all variables'
-    
+
   # Build the product
   - task: MSBuild@1
     displayName: 'Build product'
@@ -45,7 +45,7 @@ steps:
       arguments: '--authTokenVariable SYSTEM_ACCESSTOKEN --buildOutput $(Build.BinariesDirectory)\raw\binaries'
       workingDirectory: $(Build.SourcesDirectory)
       failOnStderr: true
-      pythonInterpreter: $(InstallPython312)/python.exe
+      pythonInterpreter: $(POWERSHELL6_INSTALLPYTHON312)/python.exe
 
   # Run the glass tests
   - task: PythonScript@0
@@ -56,7 +56,7 @@ steps:
       arguments: '--buildOutput $(Build.BinariesDirectory)\raw\binaries'
       workingDirectory: $(Build.SourcesDirectory)
       failOnStderr: true
-      pythonInterpreter: $(InstallPython312.INSTALLPATH)/python.exe
+      pythonInterpreter: $(POWERSHELL6_INSTALLPYTHON312)/python.exe
 
   # Upload the trx file as a test result
   - task: PublishTestResults@2

--- a/Build/templates/run_tests.yml
+++ b/Build/templates/run_tests.yml
@@ -7,6 +7,7 @@ steps:
 
   - powershell: |
       echo "##vso[task.setvariable variable=PYTHON_INTERPRETER]$env:POWERSHELL6_INSTALLPYTHON312\python.exe"
+      Get-ChildItem "$env:POWERSHELL6_INSTALLPYTHON312"
     displayName: 'Set PYTHON_INTERPRETER variable'
 
   - task: PythonScript@0

--- a/Build/templates/run_tests.yml
+++ b/Build/templates/run_tests.yml
@@ -1,6 +1,7 @@
 steps:
   # Install different python versions
   - template: ./install_python.yml
+    name: InstallPython312
     parameters:
       pythonVersion: '3.12.7'
 

--- a/Build/templates/run_tests.yml
+++ b/Build/templates/run_tests.yml
@@ -5,6 +5,10 @@ steps:
       pythonVersion: '3.12.7'
       outputVar: InstallPython312
 
+  # Debug helper, print all variables
+  - task: printAllVariables@1
+    displayName: 'Print all variables'
+
   # Build the product
   - task: MSBuild@1
     displayName: 'Build product'

--- a/Build/templates/run_tests.yml
+++ b/Build/templates/run_tests.yml
@@ -2,7 +2,7 @@ steps:
   # Install different python versions
   - template: ./install_python.yml
     parameters:
-      pythonVersion: '3.9.21'
+      pythonVersion: '3.9.13' # Last version with an installer
   - template: ./install_python.yml
     parameters:
       pythonVersion: '3.10.15'

--- a/Build/templates/run_tests.yml
+++ b/Build/templates/run_tests.yml
@@ -2,9 +2,9 @@ steps:
 
   # Build the product
   - task: MSBuild@1
-    displayName: 'Build full product'
+    displayName: 'Build product'
     inputs:
-      solution: $(Build.SourcesDirectory)/Python/dirs.proj
+      solution: $(Build.SourcesDirectory)/Python/Product/dirs.proj
       msbuildVersion: $(MsBuildVersion)
       platform: $(Platform)
       configuration: $(BuildConfiguration)

--- a/Build/templates/run_tests.yml
+++ b/Build/templates/run_tests.yml
@@ -5,10 +5,10 @@ steps:
       pythonVersion: '3.9.13' # Last version with an installer
   - template: ./install_python.yml
     parameters:
-      pythonVersion: '3.10.15'
+      pythonVersion: '3.10.11' # Last version with an installer
   - template: ./install_python.yml
     parameters:
-      pythonVersion: '3.11.10'
+      pythonVersion: '3.11.9' # Last version with an installer
   - template: ./install_python.yml
     parameters:
       pythonVersion: '3.12.7'

--- a/Build/templates/run_tests.yml
+++ b/Build/templates/run_tests.yml
@@ -44,11 +44,10 @@ steps:
   #     versionSpec: '3.11'
   #     addToPath: false
   #     architecture: 'x64'
-  - task: UsePythonVersion@0
-    inputs:
-      versionSpec: '3.12-debug'
-      addToPath: true # This is the version we'll use to run the scripts below
-      architecture: 'x64'
+  - template: install_python.yml
+    parameters:
+      pythonVersion: '3.12.7'
+    displayName: 'Install Python 3.12'
   # - task: UsePythonVersion@0
   #   inputs:
   #     versionSpec: '3.13'

--- a/Build/templates/run_tests.yml
+++ b/Build/templates/run_tests.yml
@@ -73,6 +73,7 @@ steps:
     inputs:
       scriptSource: 'filePath' # 'filePath' | 'inline'. Required. Script source. Default: filePath.
       scriptPath: $(Build.SourcesDirectory)/Build/run_glass.py
+      arguments: '--buildOutput $(Build.BinariesDirectory)\raw\binaries'
       workingDirectory: $(Build.SourcesDirectory)
       failOnStderr: true
 

--- a/Build/templates/run_tests.yml
+++ b/Build/templates/run_tests.yml
@@ -25,15 +25,15 @@ steps:
         Write-Host "##vso[task.setvariable variable=DropToken;issecret=true]$token"      
 
   # Install different python versions
-  - task: UsePythonVersion@0
-    inputs:
-      versionSpec: '3.9' # string. Required. Version spec. Default: 3.x.
+  #- task: UsePythonVersion@0
+  #  inputs:
+  #    versionSpec: '3.9' # string. Required. Version spec. Default: 3.x.
       #disableDownloadFromRegistry: false # boolean. Disable downloading releases from the GitHub registry. Default: false.
       #allowUnstable: false # boolean. Optional. Use when disableDownloadFromRegistry = false. Allow downloading unstable releases. Default: false.
       #githubToken: # string. Optional. Use when disableDownloadFromRegistry = false. GitHub token for GitHub Actions python registry. 
-      addToPath: false # boolean. Add to PATH. Default: true.
+  #    addToPath: false # boolean. Add to PATH. Default: true.
     # Advanced
-      architecture: 'x64' # 'x86' | 'x64'. Required. Architecture. Default: x64.
+  #    architecture: 'x64' # 'x86' | 'x64'. Required. Architecture. Default: x64.
   # - task: UsePythonVersion@0
   #   inputs:
   #     versionSpec: '3.10'

--- a/Build/templates/run_tests.yml
+++ b/Build/templates/run_tests.yml
@@ -16,7 +16,9 @@ steps:
   - template: ./install_python.yml
     parameters:
       pythonVersion: '3.13.0'
-
+  - powershell: |
+      Get-ChildItem Env:
+    displayName: 'Dump all variables'
   - powershell: |
       echo "##vso[task.setvariable variable=PYTHON_INTERPRETER]$env:POWERSHELL6_INSTALLPYTHON312\python.exe"
       Get-ChildItem "$env:POWERSHELL6_INSTALLPYTHON312"

--- a/Build/templates/run_tests.yml
+++ b/Build/templates/run_tests.yml
@@ -3,6 +3,7 @@ steps:
   - template: ./install_python.yml
     parameters:
       pythonVersion: '3.12.7'
+    name: InstallPython312
 
   # Build the product
   - task: MSBuild@1
@@ -39,6 +40,7 @@ steps:
       arguments: '--authTokenVariable SYSTEM_ACCESSTOKEN --buildOutput $(Build.BinariesDirectory)\raw\binaries'
       workingDirectory: $(Build.SourcesDirectory)
       failOnStderr: true
+      pythonInterpreter: $(InstallPython312.INSTALLPATH)/python.exe
 
   # Run the glass tests
   - task: PythonScript@0
@@ -49,6 +51,7 @@ steps:
       arguments: '--buildOutput $(Build.BinariesDirectory)\raw\binaries'
       workingDirectory: $(Build.SourcesDirectory)
       failOnStderr: true
+      pythonInterpreter: $(InstallPython312.INSTALLPATH)/python.exe
 
   # Upload the trx file as a test result
   - task: PublishTestResults@2

--- a/Build/templates/run_tests.yml
+++ b/Build/templates/run_tests.yml
@@ -1,9 +1,9 @@
 steps:
   # Install different python versions
   - template: ./install_python.yml
-    name: InstallPython312
     parameters:
       pythonVersion: '3.12.7'
+      outputVar: InstallPython312
 
   # Build the product
   - task: MSBuild@1
@@ -40,7 +40,7 @@ steps:
       arguments: '--authTokenVariable SYSTEM_ACCESSTOKEN --buildOutput $(Build.BinariesDirectory)\raw\binaries'
       workingDirectory: $(Build.SourcesDirectory)
       failOnStderr: true
-      pythonInterpreter: $(InstallPython312.INSTALLPATH)/python.exe
+      pythonInterpreter: $(InstallPython312)/python.exe
 
   # Run the glass tests
   - task: PythonScript@0

--- a/Build/templates/run_tests.yml
+++ b/Build/templates/run_tests.yml
@@ -74,10 +74,12 @@ steps:
       scriptSource: 'filePath' # 'filePath' | 'inline'. Required. Script source. Default: filePath.
       scriptPath: $(Build.SourcesDirectory)/Build/run_glass.py
       workingDirectory: $(Build.SourcesDirectory)
-      failOnStderr: false
+      failOnStderr: true
 
   # Upload the trx file as a test result
   - task: PublishTestResults@2
+    condition: always() # Always run this step, even if the previous step fails
+    displayName: 'Publish Glass test results'
     inputs:
       testResultsFiles: '$(Build.SourcesDirectory)/TestResults/*.trx'
       testRunTitle: 'Glass Tests'

--- a/Build/templates/run_tests.yml
+++ b/Build/templates/run_tests.yml
@@ -5,11 +5,6 @@ steps:
       pythonVersion: '3.12.7'
       outputVar: InstallPython312
 
-  # Debug helper, print all variables
-  - powershell: |
-      Get-ChildItem Env:
-    displayName: 'Dump all variables'
-
   - powershell: |
       echo "##vso[task.setvariable variable=PYTHON_INTERPRETER]$env:POWERSHELL6_INSTALLPYTHON312\python.exe"
     displayName: 'Set PYTHON_INTERPRETER variable'

--- a/Python/Product/EnvironmentDiscover/EnvironmentDiscover.csproj
+++ b/Python/Product/EnvironmentDiscover/EnvironmentDiscover.csproj
@@ -1,36 +1,53 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <Choose>
+    <When Condition=" '$(VisualStudioVersion)'=='15.0'  Or '$(TargetVisualStudioVersion)'=='VS150' ">
+      <PropertyGroup>
+        <MinimumVisualStudioVersion>15.0</MinimumVisualStudioVersion>
+        <FileUpgradeFlags>
+        </FileUpgradeFlags>
+        <UpgradeBackupLocation>
+        </UpgradeBackupLocation>
+        <OldToolsVersion>14.0</OldToolsVersion>
+      </PropertyGroup>
+    </When>
+    <When Condition=" '$(VisualStudioVersion)'=='16.0'  Or '$(TargetVisualStudioVersion)'=='VS160' ">
+      <PropertyGroup>
+        <MinimumVisualStudioVersion>16.0</MinimumVisualStudioVersion>
+        <FileUpgradeFlags>
+        </FileUpgradeFlags>
+        <UpgradeBackupLocation>
+        </UpgradeBackupLocation>
+        <OldToolsVersion>16.0</OldToolsVersion>
+      </PropertyGroup>
+    </When>
+    <When Condition=" '$(VisualStudioVersion)'=='17.0'  Or '$(TargetVisualStudioVersion)'=='VS170' ">
+      <PropertyGroup>
+        <MinimumVisualStudioVersion>17.0</MinimumVisualStudioVersion>
+        <FileUpgradeFlags>
+        </FileUpgradeFlags>
+        <UpgradeBackupLocation>
+        </UpgradeBackupLocation>
+        <OldToolsVersion>17.0</OldToolsVersion>
+      </PropertyGroup>
+    </When>
+  </Choose>
+  <Import Project="..\ProjectBefore.settings" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <Platform>AnyCPU</Platform>
+    <ProductVersion>8.0.30703</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectTypeGuids>{82b43b9b-a64c-4715-b499-d71e9ca2bd60};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <ProjectGuid>{97242D3F-EB8E-4BEF-A84A-966FBFD1839D}</ProjectGuid>
     <OutputType>Exe</OutputType>
     <RootNamespace>EnvironmentDiscover</RootNamespace>
     <AssemblyName>EnvironmentDiscover</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <Deterministic>true</Deterministic>
+    <SuppressCommonAssemblyVersion>true</SuppressCommonAssemblyVersion>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  <PropertyGroup Condition=" '$(Platform)' == 'AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>..\..\..\BuildOutput\Debug17.0\raw\binaries\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>..\..\..\BuildOutput\Release17.0\raw\binaries\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
@@ -44,7 +61,6 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Program.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />
@@ -55,5 +71,12 @@
       <Name>BuildTasks.Core</Name>
     </ProjectReference>
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\ProjectAfter.settings" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
 </Project>

--- a/Python/Product/EnvironmentDiscover/EnvironmentDiscover.csproj
+++ b/Python/Product/EnvironmentDiscover/EnvironmentDiscover.csproj
@@ -27,7 +27,7 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>..\..\..\BuildOutput\Debug17.0\raw\binaries\</OutputPath>
+    <OutputPath>..\..\..\BuildOutput\Release17.0\raw\binaries\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>

--- a/Python/Product/dirs.proj
+++ b/Python/Product/dirs.proj
@@ -42,6 +42,7 @@
 
     <ProjectFile Include="Core\Core.csproj" />
     <ProjectFile Include="..\Templates\Templates.csproj" />
+    <ProjectFile Include="EnvironmentDiscover\EnvironmentDiscover.csproj" />
   </ItemGroup>
 
   <Import Project="$(TargetsPath)\Common.Build.Traversal.targets" />

--- a/Python/Tests/GlassTests/PythonTests/Python/Python39.32.GlassTestProps
+++ b/Python/Tests/GlassTests/PythonTests/Python/Python39.32.GlassTestProps
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+
+<PropertyGroup xmlns="http://schemas.microsoft.com/vstudio/diagnostics/glasstestmanagement/2014">
+  <PythonExe CopyToEnvironment="true">C:\Program Files (x86)\Python39-32\python.exe</PythonExe>
+</PropertyGroup>

--- a/Python/Tests/GlassTests/PythonTests/Python/Python39.64.GlassTestProps
+++ b/Python/Tests/GlassTests/PythonTests/Python/Python39.64.GlassTestProps
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+
+<PropertyGroup xmlns="http://schemas.microsoft.com/vstudio/diagnostics/glasstestmanagement/2014">
+  <PythonExe CopyToEnvironment="true">C:\Program Files\Python39\python.exe</PythonExe>
+</PropertyGroup>

--- a/Python/Tests/GlassTests/PythonTests/PythonEngine.regdef
+++ b/Python/Tests/GlassTests/PythonTests/PythonEngine.regdef
@@ -1,0 +1,36 @@
+Windows Registry Editor Version 5.00
+
+[$RootKey$\AD7Metrics\Engine\{EC1375B7-E2CE-43E8-BF75-DC638DE1F1F9}]
+"Name"="Python"
+"CLSID"="{0DA53AFE-069E-47A3-AE34-32610A8253A3}"
+"ProgramProvider"="{FA452F5D-539E-4B55-BCC6-5DE7E342BC44}"
+"PortSupplier"="{708C1ECA-FF48-11D2-904F-00C04FA302A1}"
+"Attach"=dword:00000001
+"AddressBP"=dword:00000000
+"AutoSelectPriority"=dword:00000006
+"CallstackBP"=dword:00000001
+"ConditionalBP"=dword:00000001
+"Exceptions"=dword:00000001
+"SetNextStatement"=dword:00000001
+"RemoteDebugging"=dword:00000001
+"HitCountBP"=dword:00000000
+"JustMyCodeStepping"=dword:00000001
+"EngineClass"="Microsoft.PythonTools.Debugger.DebugEngine.AD7Engine"
+"EngineAssembly"="Microsoft.PythonTools.Debugger, Version=17.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"
+"LoadProgramProviderUnderWOW64"=dword:00000001
+"AlwaysLoadProgramProviderLocal"=dword:00000001
+"LoadUnderWOW64"=dword:00000001
+
+[$RootKey$\CLSID\{0DA53AFE-069E-47A3-AE34-32610A8253A3}]
+"Assembly"="Microsoft.PythonTools.Debugger, Version=17.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"
+"Class"="Microsoft.PythonTools.Debugger.DebugEngine.AD7Engine"
+"InprocServer32"="C:\\windows\\SYSTEM32\\MSCOREE.DLL"
+"CodeBase"="$GlassInstallDir$\\Microsoft.PythonTools.Debugger.dll"
+"ThreadingModel"="Free"
+
+[$RootKey$\CLSID\{FA452F5D-539E-4B55-BCC6-5DE7E342BC44}]
+"Assembly"="Microsoft.PythonTools.Debugger, Version=17.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"
+"Class"="Microsoft.PythonTools.Debugger.DebugEngine.AD7ProgramProvider"
+"InprocServer32"="C:\\windows\\SYSTEM32\\MSCOREE.DLL"
+"CodeBase"="$GlassInstallDir$\\Microsoft.PythonTools.Debugger.dll"
+"ThreadingModel"="Free"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -176,31 +176,31 @@ extends:
             debugpyVersion: ${{ parameters.debugpyVersion }}
         
         # Build and publish logs    
-        # TODO: Put Back - template: /Build/templates/build.yml@self
+        - template: /Build/templates/build.yml@self
 
         # Run tests on mixed mode debugger but only for PR builds
         - ${{ if notin(variables['Build.Reason'], 'PullRequest') }}:
           - template: /Build/templates/run_tests.yml@self
 
         # Non-PR steps
-        # - ${{ if notin(variables['Build.Reason'], 'PullRequest') }}:
+        - ${{ if notin(variables['Build.Reason'], 'PullRequest') }}:
 
           # Create VS bootstrapper for testing
-          # TODO: Put Back - template: Build/templates/create_vs_bootstrapper.yml@self
+          - template: Build/templates/create_vs_bootstrapper.yml@self
 
           # Upload vsts drop used by Visual Studio insertions
           # For more info, see https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/1es-pipeline-templates/features/outputs/microbuild-vsts-drop
-          # TODO: Put Back - task: 1ES.MicroBuildVstsDrop@1
-          #  displayName: 'Upload vsts drop'
-          #  inputs:
-          #    dropFolder: '$(Build.StagingDirectory)\release'
-          #    dropServiceUri: 'https://devdiv.artifacts.visualstudio.com/DefaultCollection'
-          #    vsDropServiceUri: 'https://vsdrop.corp.microsoft.com/file/v1'
-          #    accessToken: '$(System.AccessToken)'
-          #    dropRetentionDays: 183
+          - task: 1ES.MicroBuildVstsDrop@1
+            displayName: 'Upload vsts drop'
+            inputs:
+              dropFolder: '$(Build.StagingDirectory)\release'
+              dropServiceUri: 'https://devdiv.artifacts.visualstudio.com/DefaultCollection'
+              vsDropServiceUri: 'https://vsdrop.corp.microsoft.com/file/v1'
+              accessToken: '$(System.AccessToken)'
+              dropRetentionDays: 183
 
           # publish symbols
-          # - template: /Build/templates/publish_symbols.yml@self
+          - template: /Build/templates/publish_symbols.yml@self
 
         # MicroBuild cleanup
         - task: MicroBuildCleanup@1
@@ -208,5 +208,5 @@ extends:
           condition: succeededOrFailed()
 
         # Publish test data
-        # - template: /Build/templates/publish_test_data.yml@self
+        - template: /Build/templates/publish_test_data.yml@self
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -208,7 +208,7 @@ extends:
       - job: TestJob
         steps:
           # Run tests on mixed mode debugger but only for PR builds
-          - ${{ if notin(variables['Build.Reason'], 'PullRequest') }}:
+          - ${{ if in(variables['Build.Reason'], 'PullRequest') }}:
             - template: /Build/templates/run_tests.yml@self
 
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -112,7 +112,7 @@ extends:
     stages:
     - stage: stage
       jobs:
-      - job: job
+      - job: BuildJob
         # If the pipeline publishes artifacts, use `templateContext` to define the artifacts.
         # This will enable 1ES PT to run SDL analysis tools on the artifacts and then upload them.
         templateContext:
@@ -178,10 +178,6 @@ extends:
         # Build and publish logs    
         - template: /Build/templates/build.yml@self
 
-        # Run tests on mixed mode debugger but only for PR builds
-        - ${{ if notin(variables['Build.Reason'], 'PullRequest') }}:
-          - template: /Build/templates/run_tests.yml@self
-
         # Non-PR steps
         - ${{ if notin(variables['Build.Reason'], 'PullRequest') }}:
 
@@ -209,4 +205,11 @@ extends:
 
         # Publish test data
         - template: /Build/templates/publish_test_data.yml@self
+      - job: TestJob
+        steps:
+          # Run tests on mixed mode debugger but only for PR builds
+          - ${{ if notin(variables['Build.Reason'], 'PullRequest') }}:
+            - template: /Build/templates/run_tests.yml@self
+
+
 


### PR DESCRIPTION
[Previously](https://github.com/microsoft/PTVS/pull/8087) I added support for running glass tests for PTVS using some python scripts.

This PR uses those same python scripts to run the tests during a PR. 

It was a little bit tricky as it needs the 'debug' version of python (which the setup python task doesn't install), so it had to download the python installer for windows and install it with the debug bits. 

Tests then run using the glass bits from different parts of the VS drop.

