### PR TITLE
cache glass binaries

### DIFF
--- a/Build/templates/run_tests.yml
+++ b/Build/templates/run_tests.yml
@@ -55,8 +55,16 @@ steps:
       configuration: $(BuildConfiguration)
       msbuildArguments: '/p:VSTarget=$(VSTarget) /bl:$(Build.SourcesDirectory)\logs\BuildProduct.binlog'
 
+  - task: CacheBeta@2
+    displayName: 'Restore glass binaries from cache'
+    inputs:
+      key: 'glass'
+      path: '$(Build.BinariesDirectory)\raw\binaries'
+      cacheHitVar: 'CACHE_RESTORED'
+
   - task: AzureCLI@2
     displayName: 'Acquire an AAD token from a User-Assigned Managed Identity and save it as secret variable DropToken'
+    condition: and(succeeded(), eq(variables['CACHE_RESTORED'], 'false'))
     inputs:
       azureSubscription: 'PylanceSecureVsIdePublishWithManagedIdentity'
       scriptType: 'pscore'
@@ -72,6 +80,7 @@ steps:
   # Setup the glass test folder
   - task: PythonScript@0
     displayName: 'Setup glass test folder'
+    condition: and(succeeded(), eq(variables['CACHE_RESTORED'], 'false'))
     env:
       SYSTEM_ACCESSTOKEN: $(DropToken)
     inputs:
@@ -102,3 +111,10 @@ steps:
       testRunTitle: 'Glass Tests'
       testResultsFormat: 'VSTest'
       failTaskOnFailedTests: true
+
+  - task: CacheBeta@2
+    displayName: 'Cache glass binaries'
+    condition: and(succeeded(), eq(variables['CACHE_RESTORED'], 'false'))
+    inputs:
+      key: 'glass'
+      path: '$(Build.BinariesDirectory)\raw\binaries'


### PR DESCRIPTION
Instead of new pipelines. just add caching to the test runner