### PR TITLE
Archive symbols from etwtrace package

### DIFF
--- a/Build/templates/publish_symbols.yml
+++ b/Build/templates/publish_symbols.yml
@@ -31,6 +31,7 @@ steps:
       Contents: |
         **/*.pyd
       TargetFolder: '$(Build.ArtifactStagingDirectory)/symbols'
+      flattenFolders: true
 
   # Archive Symbols
   # When you insert your binaries into VS or ship them to any other client you need to archive your binaries & symbols to MSDL. 

--- a/Build/templates/publish_symbols.yml
+++ b/Build/templates/publish_symbols.yml
@@ -2,7 +2,7 @@ steps:
 
   # Copy symbols that will be published
   - task: CopyFiles@2
-    displayName: 'Prepare for symbol publishing'
+    displayName: 'Copy symbols (PTVS)'
     inputs:
       SourceFolder: '$(Build.BinariesDirectory)/raw/binaries'
       Contents: |
@@ -21,6 +21,15 @@ steps:
         PyDebugAttach*.dll
         VsPyProf*.pdb
         VsPyProf*.dll
+      TargetFolder: '$(Build.ArtifactStagingDirectory)/symbols'
+  
+  # Copy etwtrace symbols that will be published
+  - task: CopyFiles@2
+    displayName: 'Copy symbols (etwtrace)'
+    inputs:
+      SourceFolder: '$(Build.BinariesDirectory)/etwtrace'
+      Contents: |
+        **/*.pyd
       TargetFolder: '$(Build.ArtifactStagingDirectory)/symbols'
 
   # Archive Symbols

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -207,11 +207,12 @@ extends:
 
         # Publish test data
         - template: /Build/templates/publish_test_data.yml@self
-      - job: TestJob
-        steps:
-          # Run tests on mixed mode debugger but only for PR builds
-          - ${{ if in(variables['Build.Reason'], 'PullRequest') }}:
-            - template: /Build/templates/run_tests.yml@self
+      
+      # Run tests on mixed mode debugger but only for PR builds
+      - ${{ if in(variables['Build.Reason'], 'PullRequest') }}:
+        - job: Test
+          steps:
+          - template: /Build/templates/run_tests.yml@self
 
 
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -111,8 +111,10 @@ extends:
       skipBuildTagsForGitHubPullRequests: true
     stages:
     - stage: stage
+      displayName: Build
       jobs:
-      - job: BuildJob
+      - job: buildjob
+        displayName: Build
         # If the pipeline publishes artifacts, use `templateContext` to define the artifacts.
         # This will enable 1ES PT to run SDL analysis tools on the artifacts and then upload them.
         templateContext:
@@ -210,7 +212,8 @@ extends:
       
       # Run tests on mixed mode debugger but only for PR builds
       - ${{ if in(variables['Build.Reason'], 'PullRequest') }}:
-        - job: Test
+        - job: testjob
+          displayName: Test
           steps:
           - template: /Build/templates/run_tests.yml@self
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "ptvs",
-  "private": true,
-  "devDependencies": {
-    "@pylance/pylance": "2024.11.3"
-  }
+    "name":  "ptvs",
+    "private":  true,
+    "devDependencies":  {
+                            "@pylance/pylance":  "2024.12.1"
+                        }
 }


### PR DESCRIPTION
After bundling the etwtrace package into PTVS, we are getting symbol check failures when trying to insert into VS. These failures can be seen here:

https://devdiv.visualstudio.com/DevDiv/_git/VS/pullrequest/597367

If you click on the failing check and dig down into the failing step at https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=10681983&view=logs&j=275f1d19-1bd8-5591-b06b-07d489ea915a&t=f4062fa4-3467-5042-7419-c88746a3e56c, you can see that all the missing symbols are for `*.pyd` files that are part of the etwtrace package.

So these files need to be copied to the same directory as the other symbol files before symbol archiving is performed.

Symbol archiving is not performed for PR builds, so I had to run a full build to test this change. TODO: Add links to pipeline used for testing