### PR TITLE
Get rid of the `Black doesn't support the Format Selection command" error message.

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Editor/Formatting/PythonFormatter.cs
+++ b/Python/Product/PythonTools/PythonTools/Editor/Formatting/PythonFormatter.cs
@@ -59,10 +59,16 @@ namespace Microsoft.PythonTools.Editor.Formatting {
         protected abstract string[] GetToolCommandArgs(string documentFilePath, Range range, string[] extraArgs);
 
         protected virtual async Task<string> RunToolAsync(string interpreterExePath, string documentFilePath, Range range, string[] extraArgs) {
+            var args = GetToolCommandArgs(documentFilePath, range, extraArgs);
+
+            if (args == null) { 
+                return "";
+            }
+
             var output = ProcessOutput.RunHiddenAndCapture(
                 interpreterExePath,
                 System.Text.Encoding.UTF8,
-                GetToolCommandArgs(documentFilePath, range, extraArgs)
+                args
             );
 
             await output;

--- a/Python/Product/PythonTools/PythonTools/Editor/Formatting/PythonFormatterBlack.cs
+++ b/Python/Product/PythonTools/PythonTools/Editor/Formatting/PythonFormatterBlack.cs
@@ -24,7 +24,8 @@ namespace Microsoft.PythonTools.Editor.Formatting {
 
         protected override string[] GetToolCommandArgs(string documentFilePath, Range range, string[] extraArgs) {
             if (range != null) {
-                throw new PythonFormatterRangeNotSupportedException("Black does not support the Format Selection command.");
+                return null;
+                // throw new PythonFormatterRangeNotSupportedException("Black does not support the Format Selection command.");
             }
 
             return new[] { "-m", Package, "--diff", documentFilePath };


### PR DESCRIPTION
fixes https://github.com/microsoft/PTVS/issues/8155

Black is the default formatter for Python in VS, it only supports formatting a file, not a selection VS and/or GH Copilot is assuming the default formatter can always be used to format the selection.

I’ve filed an issue upstream and as a workaround, I removed the error message since it was unnecessarily appearing every time a user accepts Copilot edits. This change won’t affect the current user workflow, as the `Format Selection` command is already disabled for `Black` (see code below). Users won’t be able to manually trigger `Format Selection` with `Black`, so the error wouldn’t be shown in those cases anyway.

https://github.com/microsoft/PTVS/blob/9e5040e6f346f796a0e6d2ad492e2f45dd0d299e/Python/Product/PythonTools/PythonTools/Editor/Formatting/PythonFormatCommandHandler.cs#L88