### PR TITLE
Update Diagnostics Hub Package Guid

### DIFF
--- a/Python/Product/Profiling/Guids.cs
+++ b/Python/Product/Profiling/Guids.cs
@@ -29,6 +29,6 @@ namespace Microsoft.PythonTools.Profiling {
         public static readonly Guid VsUIHierarchyWindow_guid = new Guid("{7D960B07-7AF8-11D0-8E5E-00A0C911005A}");
         public static readonly Guid guidEditorFactory = new Guid(guidEditorFactoryString);
 
-        public static readonly Guid GuidPerfPkg = new Guid("{F4A63B2A-49AB-4b2d-AA59-A10F01026C89}");
+        public static readonly Guid GuidDiagnosticsHubPkg = new Guid("{22512d50-40bc-4dea-89b1-21d70bb4218e}");
     };
 }

--- a/Python/Product/Profiling/PythonProfilingPackage.cs
+++ b/Python/Product/Profiling/PythonProfilingPackage.cs
@@ -448,7 +448,7 @@ namespace Microsoft.PythonTools.Profiling {
 
         internal bool IsProfilingInstalled() {
             IVsShell shell = (IVsShell)GetService(typeof(IVsShell));
-            Guid perfGuid = GuidList.GuidPerfPkg;
+            Guid perfGuid = GuidList.GuidDiagnosticsHubPkg;
             int installed;
             ErrorHandler.ThrowOnFailure(
                 shell.IsPackageInstalled(ref perfGuid, out installed)

--- a/package.json
+++ b/package.json
@@ -2,6 +2,6 @@
     "name":  "ptvs",
     "private":  true,
     "devDependencies":  {
-                            "@pylance/pylance":  "2024.12.1"
+                            "@pylance/pylance":  "2025.2.1"
                         }
 }


### PR DESCRIPTION
fixes https://github.com/microsoft/PTVS/issues/8166

The diagnostics hub team just deleted all that code since nothing actually uses `perfpkg` anymore, even Python experience goes through the new profiler, so changing the GUID to be the Diagnostics Hub Package (new profiler)'s GUID.

Verified the existing profiling experience works now.

![profilerGUID](https://github.com/user-attachments/assets/067edd0a-212f-4055-99f1-8775bae71157)
