### PR TITLE
Load PythonProfilingPackage from shell

### DIFF
--- a/Python/Product/Profiling/Profiling/IPythonProfilerCommandService.cs
+++ b/Python/Product/Profiling/Profiling/IPythonProfilerCommandService.cs
@@ -14,6 +14,8 @@
 // See the Apache Version 2.0 License for specific language governing
 // permissions and limitations under the License.
 
+using System.Threading.Tasks;
+
 namespace Microsoft.PythonTools.Profiling {
 
     /// <summary>
@@ -23,6 +25,6 @@ namespace Microsoft.PythonTools.Profiling {
         /// <summary>
         /// Collects user input via a dialog and converts it into a <see cref="IPythonProfilingCommandArgs"/>.
         /// </summary>
-        IPythonProfilingCommandArgs GetCommandArgsFromUserInput();
+        Task<IPythonProfilingCommandArgs> GetCommandArgsFromUserInput();
     }
 }

--- a/Python/Product/Profiling/Profiling/UserInputDialog.cs
+++ b/Python/Product/Profiling/Profiling/UserInputDialog.cs
@@ -16,8 +16,7 @@
 
 namespace Microsoft.PythonTools.Profiling {
     internal class UserInputDialog {
-        public bool ShowDialog(ProfilingTargetView targetView) {
-            var pythonProfilingPackage = PythonProfilingPackage.Instance;
+        public bool ShowDialog(ProfilingTargetView targetView, PythonProfilingPackage pythonProfilingPackage) {
             var dialog = new LaunchProfiling(pythonProfilingPackage, targetView);
             return dialog.ShowModal() ?? false;
         }

--- a/Python/Product/Profiling/PythonProfilingPackage.cs
+++ b/Python/Product/Profiling/PythonProfilingPackage.cs
@@ -62,6 +62,7 @@ namespace Microsoft.PythonTools.Profiling {
           NameResourceID = 105,
           DefaultName = "PythonPerfSession")]
     [ProvideAutomationObject("PythonProfiling")]
+    [ProvideService(typeof(PythonProfilingPackage), IsAsyncQueryable = true)]
     internal sealed class PythonProfilingPackage : AsyncPackage {
         internal static PythonProfilingPackage Instance;
         private static ProfiledProcess _profilingProcess;   // process currently being profiled


### PR DESCRIPTION
Addresses the 3rd issue in https://github.com/microsoft/PTVS/issues/8168.

This issue is that when Diagnostics Hub calls `GetCommandArgsFromUserInput` they 're getting a `nullref` exception, specifically `PythonProfilingPackage.Instance` is null. 

This PR changes `GetcommandArgsFromUserInput` to be async and query the VS shell for the package.