### PR TITLE
Address feedback from Diagnostics Hub team

### DIFF
--- a/Python/Product/Profiling/Profiling/IPythonProfilerCommandService.cs
+++ b/Python/Product/Profiling/Profiling/IPythonProfilerCommandService.cs
@@ -14,6 +14,8 @@
 // See the Apache Version 2.0 License for specific language governing
 // permissions and limitations under the License.
 
+using System.Threading.Tasks;
+
 namespace Microsoft.PythonTools.Profiling {
 
     /// <summary>
@@ -23,6 +25,6 @@ namespace Microsoft.PythonTools.Profiling {
         /// <summary>
         /// Collects user input via a dialog and converts it into a <see cref="IPythonProfilingCommandArgs"/>.
         /// </summary>
-        IPythonProfilingCommandArgs GetCommandArgsFromUserInput();
+        Task<IPythonProfilingCommandArgs> GetCommandArgsFromUserInput();
     }
 }

--- a/Python/Product/Profiling/Profiling/UserInputDialog.cs
+++ b/Python/Product/Profiling/Profiling/UserInputDialog.cs
@@ -16,8 +16,7 @@
 
 namespace Microsoft.PythonTools.Profiling {
     internal class UserInputDialog {
-        public bool ShowDialog(ProfilingTargetView targetView) {
-            var pythonProfilingPackage = PythonProfilingPackage.Instance;
+        public bool ShowDialog(ProfilingTargetView targetView, PythonProfilingPackage pythonProfilingPackage) {
             var dialog = new LaunchProfiling(pythonProfilingPackage, targetView);
             return dialog.ShowModal() ?? false;
         }

--- a/Python/Product/Profiling/PythonProfilingPackage.cs
+++ b/Python/Product/Profiling/PythonProfilingPackage.cs
@@ -62,6 +62,7 @@ namespace Microsoft.PythonTools.Profiling {
           NameResourceID = 105,
           DefaultName = "PythonPerfSession")]
     [ProvideAutomationObject("PythonProfiling")]
+    [ProvideService(typeof(PythonProfilingPackage), IsAsyncQueryable = true)]
     internal sealed class PythonProfilingPackage : AsyncPackage {
         internal static PythonProfilingPackage Instance;
         private static ProfiledProcess _profilingProcess;   // process currently being profiled

--- a/Python/Product/Profiling/source.extension.vsixmanifest
+++ b/Python/Product/Profiling/source.extension.vsixmanifest
@@ -23,5 +23,6 @@
   <Assets>
     <Asset Type="Microsoft.VisualStudio.Package" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
     <Asset Type="Microsoft.VisualStudio.Assembly" Path="|%CurrentProject%;_GetTargetPath|" AssemblyName="|%CurrentProject%;_GetAssemblyName|" />
+    <Asset Type="Microsoft.VisualStudio.MefComponent" Path="|%CurrentProject%;_GetTargetPath|" />
   </Assets>
 </PackageManifest>


### PR DESCRIPTION
Addresses part of https://github.com/microsoft/PTVS/issues/8168

This PR:
1.  lets VS know Microsoft.PythonTools.Profiling.dll exposes a MEF component. 
2. load `PythonProfilingPackage` from VS shell to avoid package load sequence issue.

The feedback regarding package resolution will be addressed in separate PRs. This PR is focused on getting the fix into VS main so they can proceed with their work in parallel, as they have a workaround for the package resolution issue.