### PR TITLE
Fix for missing default settings at startup.

### DIFF
--- a/Python/Product/PythonTools/PythonTools/LanguageServerClient/PythonLanguageClient.cs
+++ b/Python/Product/PythonTools/PythonTools/LanguageServerClient/PythonLanguageClient.cs
@@ -367,12 +367,17 @@ namespace Microsoft.PythonTools.LanguageServerClient {
         }
 
         private LanguageServerSettings.PythonSettings GetSettings(Uri scopeUri = null) {
+            // on shutdown return null
+            if (_clientContexts.Count() == 0) {
+                return null;
+            }
             IPythonLanguageClientContext context = null;
             if (scopeUri == null) {
-                // REPL context has null RootPath
+                // REPL context has null RootPath 
                 context = _clientContexts.Find(c => c.RootPath == null);
                 if (context == null) {
-                    return null;
+                    // use first clientcontext as default
+                    context = _clientContexts.First();
                 }
             } else {
                 var pathFromScopeUri = CommonUtils.NormalizeDirectoryPath(scopeUri.LocalPath).ToLower().TrimStart('\\');

--- a/Python/Product/PythonTools/PythonTools/LanguageServerClient/PythonLanguageClient.cs
+++ b/Python/Product/PythonTools/PythonTools/LanguageServerClient/PythonLanguageClient.cs
@@ -367,7 +367,7 @@ namespace Microsoft.PythonTools.LanguageServerClient {
         }
 
         private LanguageServerSettings.PythonSettings GetSettings(Uri scopeUri = null) {
-            // on shutdown return null
+            // guard on shutdown
             if (_clientContexts.Count() == 0) {
                 return null;
             }
@@ -378,11 +378,12 @@ namespace Microsoft.PythonTools.LanguageServerClient {
                 if (context == null) {
                     // use first clientcontext as default
                     try {
-                        context = _clientContexts.First();
+                        context = _clientContexts.FirstOrDefault();
                     } catch (InvalidOperationException) {
                         // no client context
                         return null;
                     }
+                }
             } else {
                 var pathFromScopeUri = CommonUtils.NormalizeDirectoryPath(scopeUri.LocalPath).ToLower().TrimStart('\\');
                 // Find the matching context for the item, but ignore interactive window where "RootPath" is null.

--- a/Python/Product/PythonTools/PythonTools/LanguageServerClient/PythonLanguageClient.cs
+++ b/Python/Product/PythonTools/PythonTools/LanguageServerClient/PythonLanguageClient.cs
@@ -377,8 +377,12 @@ namespace Microsoft.PythonTools.LanguageServerClient {
                 context = _clientContexts.Find(c => c.RootPath == null);
                 if (context == null) {
                     // use first clientcontext as default
-                    context = _clientContexts.First();
-                }
+                    try {
+                        context = _clientContexts.First();
+                    } catch (InvalidOperationException) {
+                        // no client context
+                        return null;
+                    }
             } else {
                 var pathFromScopeUri = CommonUtils.NormalizeDirectoryPath(scopeUri.LocalPath).ToLower().TrimStart('\\');
                 // Find the matching context for the item, but ignore interactive window where "RootPath" is null.

--- a/Python/Product/PythonTools/PythonTools/LanguageServerClient/PythonLanguageClient.cs
+++ b/Python/Product/PythonTools/PythonTools/LanguageServerClient/PythonLanguageClient.cs
@@ -390,7 +390,7 @@ namespace Microsoft.PythonTools.LanguageServerClient {
                 context = _clientContexts.Find(c => scopeUri != null && c.RootPath != null && PathUtils.IsSamePath(c.RootPath.ToLower(), pathFromScopeUri));
             }
 
-            if (context == null) {
+            if (context == null || context.InterpreterConfiguration == null) {
                 Debug.WriteLine(String.Format("GetSettings() scopeUri not found: {0}", scopeUri));
                 return null;
             }


### PR DESCRIPTION
guard against no context elements on shutdown.  A context is created for the project or for each workspace or for each repl.


We need to send tasklist info when sending default settings with "workspace/didChangeConfiguration".  

alternatively we could pass in the uri into GetSettings() when "TriggerWorkspaceUpdateConfig" is called.

Fix for https://github.com/microsoft/PTVS/issues/8121