### PR TITLE
Publish nuget package to internal feed

### DIFF
--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -109,7 +109,7 @@ extends:
             outputs:
             - output: nuget
               useDotNetTask: false # The default is false to use the NuGetCommand task. Set to true to use the DotNetCoreCLI task to publish packages.
-              packagesToPush: '!$(System.ArtifactsDirectory)\pkg\*.nupkg'
+              packagesToPush: '$(System.ArtifactsDirectory)\pkg\*.nupkg'
               packageParentPath: '$(System.ArtifactsDirectory)'
               nuGetFeedType: internal
               allowPackageConflicts: true # Optional. NuGetCommand task only.

--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -9,6 +9,11 @@ parameters:
   type: string
   default: main
 
+- name: PublishNugetPackage
+  displayName: Publish Nuget Package
+  type: boolean
+  default: false
+
 # build number format 
 name: $(date:yy)$(DayOfYear)$(rev:.r)
 
@@ -19,6 +24,8 @@ pr: none
 variables: 
   - name: VisualStudioBranch
     value: ${{ parameters.VisualStudioBranch }}
+  - name: PublishNugetPackage
+    value: ${{ parameters.PublishNugetPackage }}
 
   # https://devdiv.visualstudio.com/DevDiv/_library?itemType=VariableGroups&view=VariableGroupView&variableGroupId=381&path=PTVS-Dev17
   - group: PTVS-Dev17
@@ -59,7 +66,8 @@ extends:
     stages:
     - stage: Release
       jobs:
-      - job: Release
+      - ${{eq(variables['PublishNugetPackage'], false)}}:
+        - job: Release
         steps:
 
         # we don't need to checkout any source code
@@ -88,6 +96,35 @@ extends:
             AutoCompleteMergeStrategy: Squash
             AddCommitsToPR: false
             LinkWorkItemsToPR: false
+
+      - ${{eq(variables['PublishNugetPackage'], true)}}:
+        - job: Publish
+          displayName: Publish Profiler Nuget Package
+
+          templateContext:
+              type: releaseJob
+              isProduction: true
+              inputs:
+              - input: pipelineArtifact
+                pipeline: PTVS-Build
+                artifactName: pkg
+                targetPath: $(System.ArtifactsDirectory)/pkg
+
+          steps:
+
+            # Remove the _manifest folder (sbom) from the pkg artifact, since we don't want to publish it.
+            - script: rd /s /q $(System.ArtifactsDirectory)\pkg\_manifest
+              displayName: Remove _manifest folder
+
+            # Publish the signed Nuget package to the devdiv/vs-impl feed.
+            # See https://devdiv.visualstudio.com/DevDiv/_wiki/wikis/DevDiv.wiki/6700/Building-NuGet-packages-in-the-VS-build-and-publishing-to-feeds-(taking-dependencies-on-VS)-for-VS-SDK-or-impl
+            - task: NuGetCommand@2
+              displayName: Nuget push
+              inputs:
+                command: push
+                packagesToPush: '$(System.ArtifactsDirectory)\pkg\*.nupkg;'
+                nuGetFeedType: external
+                publishFeedCredentials: VSIDE vs-impl
 
         
 

--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -122,12 +122,3 @@ extends:
           - script: rd /s /q $(System.ArtifactsDirectory)\pkg\_manifest
             displayName: Remove _manifest folder
 
-          # Publish the signed Nuget package to the devdiv/vs-impl feed.
-          # See https://devdiv.visualstudio.com/DevDiv/_wiki/wikis/DevDiv.wiki/6700/Building-NuGet-packages-in-the-VS-build-and-publishing-to-feeds-(taking-dependencies-on-VS)-for-VS-SDK-or-impl
-          - task: NuGetCommand@2
-            displayName: Nuget push
-            inputs:
-              command: push
-              packagesToPush: '$(System.ArtifactsDirectory)\pkg\*.nupkg;'
-              nuGetFeedType: external
-              publishFeedCredentials: VSIDE vs-impl

--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -66,8 +66,8 @@ extends:
     stages:
     - stage: Release
       jobs:
-      - ${{eq(variables['PublishNugetPackage'], false)}}:
-        - job: Release
+      - job: Release
+        condition: eq(variables['PublishNugetPackage'], 'false')
         steps:
 
         # we don't need to checkout any source code
@@ -79,8 +79,6 @@ extends:
           displayName: 'Add PTVS-Build tag'
 
         # Insert the payload uploaded by the PTVS-Build pipeline into Visual Studio.
-        # We don't need to download pipeline artifacts here, because the payload is uploaded to a drop location.
-        # For more info, see https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_wiki/wikis/DevDiv.wiki/629/Automated-VS-Insertion.
         - task: ms-vseng.MicroBuildShipTasks.55100717-a81d-45ea-a363-b8fe3ec375ad.MicroBuildInsertVsPayload@4
           displayName: 'Create Insertion PR'
           inputs:
@@ -97,34 +95,31 @@ extends:
             AddCommitsToPR: false
             LinkWorkItemsToPR: false
 
-      - ${{eq(variables['PublishNugetPackage'], true)}}:
-        - job: Publish
-          displayName: Publish Profiler Nuget Package
+      - job: Publish
+        displayName: Publish Profiler Nuget Package
+        condition: eq(variables['PublishNugetPackage'], 'true')
 
-          templateContext:
-              type: releaseJob
-              isProduction: true
-              inputs:
-              - input: pipelineArtifact
-                pipeline: PTVS-Build
-                artifactName: pkg
-                targetPath: $(System.ArtifactsDirectory)/pkg
+        templateContext:
+            type: releaseJob
+            isProduction: true
+            inputs:
+            - input: pipelineArtifact
+              pipeline: PTVS-Build
+              artifactName: pkg
+              targetPath: $(System.ArtifactsDirectory)/pkg
 
-          steps:
+        steps:
 
-            # Remove the _manifest folder (sbom) from the pkg artifact, since we don't want to publish it.
-            - script: rd /s /q $(System.ArtifactsDirectory)\pkg\_manifest
-              displayName: Remove _manifest folder
+          # Remove the _manifest folder (sbom) from the pkg artifact, since we don't want to publish it.
+          - script: rd /s /q $(System.ArtifactsDirectory)\pkg\_manifest
+            displayName: Remove _manifest folder
 
-            # Publish the signed Nuget package to the devdiv/vs-impl feed.
-            # See https://devdiv.visualstudio.com/DevDiv/_wiki/wikis/DevDiv.wiki/6700/Building-NuGet-packages-in-the-VS-build-and-publishing-to-feeds-(taking-dependencies-on-VS)-for-VS-SDK-or-impl
-            - task: NuGetCommand@2
-              displayName: Nuget push
-              inputs:
-                command: push
-                packagesToPush: '$(System.ArtifactsDirectory)\pkg\*.nupkg;'
-                nuGetFeedType: external
-                publishFeedCredentials: VSIDE vs-impl
-
-        
-
+          # Publish the signed Nuget package to the devdiv/vs-impl feed.
+          # See https://devdiv.visualstudio.com/DevDiv/_wiki/wikis/DevDiv.wiki/6700/Building-NuGet-packages-in-the-VS-build-and-publishing-to-feeds-(taking-dependencies-on-VS)-for-VS-SDK-or-impl
+          - task: NuGetCommand@2
+            displayName: Nuget push
+            inputs:
+              command: push
+              packagesToPush: '$(System.ArtifactsDirectory)\pkg\*.nupkg;'
+              nuGetFeedType: external
+              publishFeedCredentials: VSIDE vs-impl

--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -95,18 +95,26 @@ extends:
             AddCommitsToPR: false
             LinkWorkItemsToPR: false
 
+      # See https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/1es-pipeline-templates/features/outputs/nuget-packages?tabs=outputsyntax
       - job: Publish
         displayName: Publish Profiler Nuget Package
         condition: eq(variables['PublishNugetPackage'], 'true')
 
         templateContext:
-            type: releaseJob
-            isProduction: true
             inputs:
             - input: pipelineArtifact
               pipeline: PTVS-Build
               artifactName: pkg
               targetPath: $(System.ArtifactsDirectory)/pkg
+            outputs:
+            - output: nuget
+              useDotNetTask: false # The default is false to use the NuGetCommand task. Set to true to use the DotNetCoreCLI task to publish packages.
+              packagesToPush: '!$(System.ArtifactsDirectory)\pkg\*.nupkg'
+              packageParentPath: '$(System.ArtifactsDirectory)'
+              nuGetFeedType: internal 
+              allowPackageConflicts: true # Optional. NuGetCommand task only.
+              publishPackageMetadata: true # Optional. NuGetCommand task only.
+              publishFeedCredentials: VSIDE vs-impl
 
         steps:
 

--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -119,7 +119,7 @@ extends:
               publishVstsFeed: vs-impl
 
         steps:
-
+        
           # Remove the _manifest folder (sbom) from the pkg artifact, since we don't want to publish it.
           - script: rd /s /q $(System.ArtifactsDirectory)\pkg\_manifest
             displayName: Remove _manifest folder

--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -111,7 +111,7 @@ extends:
               useDotNetTask: false # The default is false to use the NuGetCommand task. Set to true to use the DotNetCoreCLI task to publish packages.
               packagesToPush: '!$(System.ArtifactsDirectory)\pkg\*.nupkg'
               packageParentPath: '$(System.ArtifactsDirectory)'
-              nuGetFeedType: internal 
+              nuGetFeedType: external
               allowPackageConflicts: true # Optional. NuGetCommand task only.
               publishPackageMetadata: true # Optional. NuGetCommand task only.
               publishFeedCredentials: VSIDE vs-impl

--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -111,10 +111,10 @@ extends:
               useDotNetTask: false # The default is false to use the NuGetCommand task. Set to true to use the DotNetCoreCLI task to publish packages.
               packagesToPush: '!$(System.ArtifactsDirectory)\pkg\*.nupkg'
               packageParentPath: '$(System.ArtifactsDirectory)'
-              nuGetFeedType: external
+              nuGetFeedType: internal
               allowPackageConflicts: true # Optional. NuGetCommand task only.
               publishPackageMetadata: true # Optional. NuGetCommand task only.
-              publishFeedCredentials: azure-public/vs-impl
+              publishVstsFeed: vs-impl
 
         steps:
 

--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -79,6 +79,8 @@ extends:
           displayName: 'Add PTVS-Build tag'
 
         # Insert the payload uploaded by the PTVS-Build pipeline into Visual Studio.
+        # We don't need to download pipeline artifacts here, because the payload is uploaded to a drop location.
+        # For more info, see https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_wiki/wikis/DevDiv.wiki/629/Automated-VS-Insertion.
         - task: ms-vseng.MicroBuildShipTasks.55100717-a81d-45ea-a363-b8fe3ec375ad.MicroBuildInsertVsPayload@4
           displayName: 'Create Insertion PR'
           inputs:
@@ -121,4 +123,5 @@ extends:
           # Remove the _manifest folder (sbom) from the pkg artifact, since we don't want to publish it.
           - script: rd /s /q $(System.ArtifactsDirectory)\pkg\_manifest
             displayName: Remove _manifest folder
+
 

--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -114,7 +114,7 @@ extends:
               nuGetFeedType: external
               allowPackageConflicts: true # Optional. NuGetCommand task only.
               publishPackageMetadata: true # Optional. NuGetCommand task only.
-              publishFeedCredentials: VSIDE vs-impl
+              publishFeedCredentials: azure-public/vs-impl
 
         steps:
 


### PR DESCRIPTION
Addresses https://github.com/microsoft/PTVS/issues/8177

This PR updates the release pipeline to download the NuGet package generated as a build artifact from the build pipeline and uses the 1ES command to publish it to an internal feed for the partner team to consume.

I've tested it on the feature branch, confirming that the package is successfully pushed to the feed. (See pipeline run at https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=11097600&view=results). Next after this PR gets merged, I'll test it on `main` to ensure it works as expected and still creates an insertion PR for changes merged into `main`.