### PR TITLE
Fix accessibility bug

### DIFF
--- a/Python/Product/Profiling/Profiling/LaunchProfiling.xaml
+++ b/Python/Product/Profiling/Profiling/LaunchProfiling.xaml
@@ -45,11 +45,14 @@
 
             <Label Grid.Row="0"
                    Content="{x:Static ui:Strings.LaunchProfiling_WhatToProfile}"
+                   Focusable="True"
+                   IsTabStop="True"
                    Margin="6 12 6 0"
                    FontWeight="Bold"/>
 
             <RadioButton Grid.Row="1" Margin="12 12 12 4"
                          Content="{x:Static ui:Strings.LaunchProfiling_OpenProject}"
+                         AutomationProperties.Name="{x:Static ui:Strings.LaunchProfiling_OpenProjectRadioButtonDescription}"
                          AutomationProperties.AutomationId="ProfileProject"
                          GroupName="ProjectOrStandalone"
                          IsEnabled="{Binding IsAnyAvailableProjects}"
@@ -66,6 +69,7 @@
             <RadioButton Grid.Row="3" Margin="12 12 12 4"
                          Content="{x:Static ui:Strings.LaunchProfiling_StandaloneScript}" 
                          AutomationProperties.AutomationId="ProfileScript"
+                         AutomationProperties.Name="{x:Static ui:Strings.LaunchProfiling_StandaloneScriptRadioButtonDescription}"
                          GroupName="ProjectOrStandalone"
                          IsChecked="{Binding IsStandaloneSelected}" />
             <ScrollViewer Grid.Row="4" Height="200">

--- a/Python/Product/Profiling/Strings.Designer.cs
+++ b/Python/Product/Profiling/Strings.Designer.cs
@@ -234,6 +234,24 @@ namespace Microsoft.PythonTools.Profiling {
                 return ResourceManager.GetString("LaunchProfiling_InterpreterPathBrowseButtonDescription", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Radio button 1 of 2, Open project.
+        /// </summary>
+        public static string LaunchProfiling_OpenProjectRadioButtonDescription {
+            get {
+                return ResourceManager.GetString("LaunchProfiling_OpenProjectRadioButtonDescription", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Radio button 2 of 2, Standalone script.
+        /// </summary>
+        public static string LaunchProfiling_StandaloneScriptRadioButtonDescription {
+            get {
+                return ResourceManager.GetString("LaunchProfiling_StandaloneScriptRadioButtonDescription", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to Mi_xed Mode Profiling.

--- a/Python/Product/Profiling/Strings.resx
+++ b/Python/Product/Profiling/Strings.resx
@@ -288,6 +288,12 @@ Error:
   <data name="LaunchProfiling_WorkingDirectoryBrowseButtonDescription" xml:space="preserve">
     <value>Browse folder dialog for working directory</value>
   </data>
+  <data name="LaunchProfiling_OpenProjectRadioButtonDescription" xml:space="preserve">
+    <value>Radio button 1 of 2, Open project</value>
+  </data>
+  <data name="LaunchProfiling_StandaloneScriptRadioButtonDescription" xml:space="preserve">
+    <value>Radio button 2 of 2, Standalone script</value>
+  </data>
   <data name="Reports" xml:space="preserve">
     <value>Reports</value>
     <comment>Tree view node that contains the set of profiling reports</comment>


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2430654/?view=edit

This PR addresses feedback from the accessibility team, it makes the following changes:
1. Make the screen reader read the "What would you like to profile" label out. 
2. Make the screen reader read the position of the radio buttons, so it now announces them like: “Radio button 1 of 2: Open Project.”


https://github.com/user-attachments/assets/14be8df9-d620-4eb6-8be1-a24588f9cada

