### PR TITLE
Accessibility fixes for Environments controls

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Environments/AddCondaEnvironmentControl.xaml
+++ b/Python/Product/PythonTools/PythonTools/Environments/AddCondaEnvironmentControl.xaml
@@ -176,11 +176,17 @@
                 ConverterParameter=MainGridLandscape|MainGridPortrait}">
 
                 <StackPanel>
-                    <Label
-                        x:Name="ProjectLabel"
-                        Content="{x:Static common:Strings.AddEnvironmentProjectLabel}"
-                        Target="{Binding ElementName=ProjectComboBox}"
-                        Style="{StaticResource ModernLabel}"/>
+                    <StackPanel Orientation="Horizontal">
+                        <Label
+                            x:Name="ProjectLabel"
+                            Content="{x:Static common:Strings.AddEnvironmentProjectLabel}"
+                            Target="{Binding ElementName=ProjectComboBox}"
+                            Style="{StaticResource ModernLabel}"/>
+                        <Label                                
+                            Content=" *"                  
+                            Style="{StaticResource ModernLabel}" />
+                    </StackPanel>
+
 
                     <ComboBox
                         x:Name="ProjectComboBox"
@@ -197,12 +203,17 @@
                         AutomationProperties.LabeledBy="{Binding ElementName=ProjectLabel}"
                         AutomationProperties.IsRequiredForForm="{Binding Path=Projects, Converter={x:Static wpf:Converters.NullOrEmptyIsFalse}}"
                         AutomationProperties.AutomationId="Project"/>
-
-                    <Label
-                        x:Name="EnvNameLabel"
-                        Content="{x:Static common:Strings.AddCondaEnvironmentNameLabel}"
-                        Target="{Binding ElementName=EnvNameTextBox}"
-                        Style="{StaticResource ModernLabel}"/>
+              
+                    <StackPanel Orientation="Horizontal">
+                        <Label
+                            x:Name="EnvNameLabel"
+                            Content="{x:Static common:Strings.AddCondaEnvironmentNameLabel}"
+                            Target="{Binding ElementName=EnvNameTextBox}"
+                            Style="{StaticResource ModernLabel}"/>
+                        <Label                                
+                            Content=" *"                  
+                            Style="{StaticResource ModernLabel}" />
+                    </StackPanel>
 
                     <TextBox
                         x:Name="EnvNameTextBox"

--- a/Python/Product/PythonTools/PythonTools/Environments/AddExistingEnvironmentControl.xaml
+++ b/Python/Product/PythonTools/PythonTools/Environments/AddExistingEnvironmentControl.xaml
@@ -51,11 +51,16 @@
     </UserControl.Resources>
     <ScrollViewer Grid.Column="0" Margin="0 7 0 0" VerticalScrollBarVisibility="Auto">
         <StackPanel Orientation="Vertical">
-            <Label
-                x:Name="ProjectLabel"
-                Content="{x:Static common:Strings.AddEnvironmentProjectLabel}"
-                Target="{Binding ElementName=ProjectComboBox}"
-                Style="{StaticResource ModernLabel}"/>
+            <StackPanel Orientation="Horizontal">
+                <Label
+                    x:Name="ProjectLabel"
+                    Content="{x:Static common:Strings.AddEnvironmentProjectLabel}"
+                    Target="{Binding ElementName=ProjectComboBox}"
+                    Style="{StaticResource ModernLabel}"/>
+                <Label                                
+                    Content=" *"                  
+                    Style="{StaticResource ModernLabel}" />    
+            </StackPanel>
 
             <ComboBox
                 x:Name="ProjectComboBox"
@@ -70,11 +75,16 @@
                 AutomationProperties.IsRequiredForForm="{Binding Path=Projects, Converter={x:Static wpf:Converters.NullOrEmptyIsFalse}}"
                 AutomationProperties.LabeledBy="{Binding ElementName=ProjectLabel}"/>
 
-            <Label
-                x:Name="ExistingEnvLabel"
-                Target="{Binding ElementName=InterpretersComboBox}"
-                Content="{x:Static common:Strings.AddExistingEnvironmentExistingLabel}"
-                Style="{StaticResource ModernLabel}"/>
+            <StackPanel Orientation="Horizontal">
+                <Label
+                    x:Name="ExistingEnvLabel"
+                    Target="{Binding ElementName=InterpretersComboBox}"
+                    Content="{x:Static common:Strings.AddExistingEnvironmentExistingLabel}"
+                    Style="{StaticResource ModernLabel}"/>
+                <Label                                
+                    Content=" *"                  
+                    Style="{StaticResource ModernLabel}" />     
+            </StackPanel>
 
             <ComboBox
                 x:Name="InterpretersComboBox"

--- a/Python/Product/PythonTools/PythonTools/Environments/AddVirtualEnvironmentControl.xaml
+++ b/Python/Product/PythonTools/PythonTools/Environments/AddVirtualEnvironmentControl.xaml
@@ -73,7 +73,6 @@
                     </Style>
                     <l:LandscapePortraitConverter x:Key="LandscapePortraitConverter" />
                     <l:ScreenAdjustingConverter x:Key="ScreenAdjustingConverter" />
-
                 </ResourceDictionary>
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
@@ -97,11 +96,18 @@
 
                 <StackPanel Orientation="Vertical" Focusable="False">
                     <!--Project-->
-                    <Label
-                        x:Name="ProjectLabel"
-                        Content="{x:Static common:Strings.AddEnvironmentProjectLabel}"
-                        Target="{Binding ElementName=ProjectComboBox}"
-                        Style="{StaticResource ModernLabel}"/>
+                 
+                    <StackPanel Orientation="Horizontal">
+                        <Label
+                             x:Name="ProjectLabel"
+                             Content="{x:Static common:Strings.AddEnvironmentProjectLabel}"
+                             Target="{Binding ElementName=ProjectComboBox}"
+                             Style="{StaticResource ModernLabel}"/>
+                                        <Label                                
+                         Content=" *"
+                  
+                         Style="{StaticResource ModernLabel}" />
+                    </StackPanel>
 
                     <ComboBox
                         x:Name="ProjectComboBox"
@@ -127,11 +133,16 @@
                         </Grid.ColumnDefinitions>
                         <StackPanel Grid.Column="0">
                             <!--Virtual environment name-->
-                            <Label
-                                x:Name="EnvNameLabel"
-                                Content="{x:Static common:Strings.AddVirtualEnvironmentNameLabel}"
-                                Target="{Binding ElementName=EnvNameTextBox}"
-                                Style="{StaticResource ModernLabel}"/>
+                            <StackPanel Orientation="Horizontal">
+                                <Label
+                                    x:Name="EnvNameLabel"
+                                    Content="{x:Static common:Strings.AddVirtualEnvironmentNameLabel}"
+                                    Target="{Binding ElementName=EnvNameTextBox}"
+                                    Style="{StaticResource ModernLabel}"/>
+                                <Label                                
+                                    Content=" *"
+                                    Style="{StaticResource ModernLabel}" />
+                            </StackPanel>
 
                             <TextBox
                                 x:Name="EnvNameTextBox"
@@ -148,11 +159,17 @@
                                 AutomationProperties.LabeledBy="{Binding ElementName=EnvNameLabel}">
                             </TextBox>
                             <!--Base interpreter-->
-                            <Label
-                                x:Name="BaseInterpreterLabel"
-                                Content="{x:Static common:Strings.AddVirtualEnvironmentBaseInterpreterLabel}"
-                                Target="{Binding ElementName=BaseInterpreterComboBox}"
-                                Style="{StaticResource ModernLabel}"/>
+                            
+                            <StackPanel Orientation="Horizontal">
+                                <Label
+                                     x:Name="BaseInterpreterLabel"
+                                     Content="{x:Static common:Strings.AddVirtualEnvironmentBaseInterpreterLabel}"
+                                     Target="{Binding ElementName=BaseInterpreterComboBox}"
+                                     Style="{StaticResource ModernLabel}"/>
+                                <Label                                
+                                    Content=" *"
+                                    Style="{StaticResource ModernLabel}" />
+                            </StackPanel>
 
                             <ComboBox
                                 x:Name="BaseInterpreterComboBox"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -253,13 +253,13 @@ extends:
         - template: /Build/templates/publish_test_data.yml@self
 
         # Run tests on mixed mode debugger but only for PR builds
-      - ${{ if or(eq(variables['Build.Reason'], 'PullRequest'), eq(variables['SkipGlassCache'], true)) }}:
-        - job: test
-          displayName: Test
-          steps:
-          - template: /Build/templates/run_tests.yml@self
-            parameters:
-              skipGlassCache: ${{ parameters.skipGlassCache }}
+      # - ${{ if or(eq(variables['Build.Reason'], 'PullRequest'), eq(variables['SkipGlassCache'], true)) }}:
+      #   - job: test
+      #     displayName: Test
+      #     steps:
+      #     - template: /Build/templates/run_tests.yml@self
+      #       parameters:
+      #         skipGlassCache: ${{ parameters.skipGlassCache }}
 
 
 


### PR DESCRIPTION
Reason:
Visual indicator (*) is not provided for the programmatically defined required field "Project Combobox" in the Add Environment dialog: A11y_Accessibility Testing for Python in VS_ Create a Virtual Environment_Devtools

fixes #2432913