### PR TITLE
update debugProjectUI tests from 3.7 to 3.9 to work with latest debugpy.

### DIFF
--- a/Common/Tests/Utilities.UI/UI/VisualStudioApp.cs
+++ b/Common/Tests/Utilities.UI/UI/VisualStudioApp.cs
@@ -642,15 +642,20 @@ namespace TestUtilities.UI {
 
             bool closed = false;
             try {
+
+                string title = dlg.Text;
+                
                 // Look for the Edit control inside the dialog
                 var editControl = dlg.Element.FindFirst(
                     TreeScope.Descendants,
                     new PropertyCondition(AutomationElement.ControlTypeProperty, ControlType.Edit)
                 );
-                
-                Assert.IsNotNull(editControl, "Failed to find Edit control in dialog");
 
-                string title = editControl.Current.Name;
+                if (editControl != null)
+                {
+                    title = editControl.Current.Name;
+                }
+                    
                 if (assertIfNoDialog) {
                     AssertUtil.Contains(title, text);
                 } else if (!text.All(title.Contains)) {

--- a/Python/Tests/DebuggerUITests/DebugProjectUITests.cs
+++ b/Python/Tests/DebuggerUITests/DebugProjectUITests.cs
@@ -541,7 +541,7 @@ namespace DebuggerUITests {
             var pyService = app.ServiceProvider.GetUIThread().Invoke(() => app.ServiceProvider.GetPythonToolsService());
             using (SelectDefaultInterpreter(app, interpreter))
             using (new PythonOptionsSetter(app.Dte, useLegacyDebugger: !useVsCodeDebugger)) {
-                string exceptionDescription = useVsCodeDebugger ? "" : "Exception";
+                string exceptionDescription = useVsCodeDebugger ? "exception: no description" : "Exception";
                 ExceptionTest(app, "SimpleException.py", exceptionDescription, "Exception", 3);
             }
         }
@@ -762,6 +762,7 @@ namespace DebuggerUITests {
 
                 app.Dte.ItemOperations.OpenFile(scriptFilePath);
                 app.Dte.Debugger.Breakpoints.Add(File: scriptFilePath, Line: 1);
+                Thread.Sleep(1000);
                 app.Dte.ExecuteCommand("Python.StartWithDebugging");
                 WaitForMode(app, dbgDebugMode.dbgBreakMode);
                 Assert.AreEqual(dbgDebugMode.dbgBreakMode, app.Dte.Debugger.CurrentMode);

--- a/Python/Tests/DebuggerUITests/DebugProjectUITests.cs
+++ b/Python/Tests/DebuggerUITests/DebugProjectUITests.cs
@@ -761,8 +761,7 @@ namespace DebuggerUITests {
                 OpenDebuggerProject(app);
 
                 app.Dte.ItemOperations.OpenFile(scriptFilePath);
-                app.Dte.Debugger.Breakpoints.Add(File: scriptFilePath, Line: 1);
-                Thread.Sleep(1000);
+                app.Dte.Debugger.Breakpoints.Add(File: scriptFilePath, Line: 1);                
                 app.Dte.ExecuteCommand("Python.StartWithDebugging");
                 WaitForMode(app, dbgDebugMode.dbgBreakMode);
                 Assert.AreEqual(dbgDebugMode.dbgBreakMode, app.Dte.Debugger.CurrentMode);

--- a/Python/Tests/DebuggerUITestsRunner/DebugProjectUITests.cs
+++ b/Python/Tests/DebuggerUITestsRunner/DebugProjectUITests.cs
@@ -271,6 +271,6 @@ namespace DebuggerUITestsRunner {
 
     [TestClass]
     public class DebugProjectUITestsDebugPy37 : DebugProjectUITestsDebugPy {
-        protected override string Interpreter => "Python37|Python37_x64";
+        protected override string Interpreter => "Python39|Python39_x64";
     }
 }


### PR DESCRIPTION
edit previous change to only look at editControls in dialogs as a fallback. Update expected default exception string