### PR TITLE
Add cookiecutter support for Python 3.13

### DIFF
--- a/Python/Product/Cookiecutter/Model/CookiecutterClient.cs
+++ b/Python/Product/Cookiecutter/Model/CookiecutterClient.cs
@@ -202,7 +202,7 @@ namespace Microsoft.CookiecutterTools.Model {
             _redirector.WriteLine(Strings.InstallingCookiecutterInstallPackages.FormatUI(_envFolderPath));
             var output = ProcessOutput.Run(
                 _envInterpreterPath,
-                new[] { "-m", "pip", "install", "cookiecutter<1.5" },
+                new[] { "-m", "pip", "install", "cookiecutter>=2.5.0", "future" },
                 null,
                 null,
                 false,


### PR DESCRIPTION
fixes https://github.com/microsoft/PTVS/issues/8245

The error shows that the cookiecutter package installed in the virtual environment has a regex pattern that's incompatible with Python 3.13.  Cookiecutter uses regular expressions internally to parse and validate template URLs/paths. Python 3.13 introduced stricter regex parsing rules, and the installed cookiecutter package is likely an older version that haven't been updated for Python 3.13 compatibility. Verified that it fixed the issue.

When playing with cookiecutter, I was also able to repro an issue that's been reported by multiple users before: 
```
[External Code]
Microsoft.VisualStudioTools.UIThreadExtensions.GetUIThread(System.IServiceProvider)
Microsoft.PythonTools.Environments.UserSpecifiedCondaLocator.CondaExecutablePath.get()
Microsoft.PythonTools.Interpreter.CondaLocatorProvider.FindLocator.AnonymousMethod__2_1(System.Lazy<Microsoft.PythonTools.Interpreter.ICondaLocator, Microsoft.PythonTools.Interpreter.ICondaLocatorMetadata>)
[External Code]
Microsoft.PythonTools.Interpreter.CondaLocatorProvider.FindLocator()
Microsoft.PythonTools.Interpreter.CondaEnvironmentFactoryProvider.GetCondaExecutablePath()
Microsoft.PythonTools.Interpreter.CondaEnvironmentFactoryProvider.FindCondaEnvironments()
Microsoft.PythonTools.Interpreter.CondaEnvironmentFactoryProvider.ForceDiscoverInterpreterFactories()
Microsoft.PythonTools.Interpreter.CondaEnvironmentFactoryProvider.DiscoverInterpreterFactories()
Microsoft.PythonTools.Interpreter.CondaEnvironmentFactoryProvider.EnsureInitialized()
Microsoft.PythonTools.Interpreter.CondaEnvironmentFactoryProvider.GetInterpreterConfigurations()
Microsoft.PythonTools.Interpreter.InterpreterRegistryService.GetConfigurations()
Microsoft.PythonTools.Interpreter.InterpreterRegistryService.Configurations.get()
Microsoft.CookiecutterTools.Model.CookiecutterClientProvider.FindCompatibleInterpreter(System.IServiceProvider)
Microsoft.CookiecutterTools.Model.CookiecutterClientProvider.IsCompatiblePythonAvailable(System.IServiceProvider)
Microsoft.CookiecutterTools.CookiecutterToolWindow.InitializeContent()
[External Code]
```
I think the root cause is that `GetUIThread()` is being called from a background thread during interpreter discovery, but it requires access to the UI thread which may not be available in this context.

I tried removing the `GetUIThread()` call from the getter because I was thinking reading a string property doesn't require UI thread, but it's causing exceptions since VS services seem to require UI thread access. Will keep looking into the issue.



