### PR TITLE
Fix a waston crash

### DIFF
--- a/Python/Product/PythonTools/PythonTools/LanguageServerClient/PythonLanguageClient.cs
+++ b/Python/Product/PythonTools/PythonTools/LanguageServerClient/PythonLanguageClient.cs
@@ -392,7 +392,7 @@ namespace Microsoft.PythonTools.LanguageServerClient {
                 ?? _analysisOptions.ExtraPaths;
 
             // Add search paths to extraPaths for pylance to look through
-            var searchPaths = context.SearchPaths.ToArray();
+            var searchPaths = context.SearchPaths?.ToArray() ?? Array.Empty<string>();
             extraPaths = extraPaths == null ? searchPaths : extraPaths.Concat(searchPaths).ToArray();
 
             var stubPath = UserSettings.GetStringSetting(


### PR DESCRIPTION
fixes https://dev.azure.com/devdiv/DevDiv/_workitems/edit/2411245/?view=edit

Looking at the call stack, there's a crash caused by `System.Linq.Enumerable.ToArray` being called in the `GetSettings` method. The `context.SearchPaths` is likely to return null instead of an empty array in some cases, and calling `.ToArray()` on a null object throws a `NullReferenceException`.

The fix ensures that if `searchPaths` is null, we use an empty array instead.
