### PR TITLE
Update the keyboard shortcuts for opening interactive window

### DIFF
--- a/Python/Product/PythonTools/PythonTools.vsct
+++ b/Python/Product/PythonTools/PythonTools.vsct
@@ -1168,7 +1168,7 @@ permissions and limitations under the License.
     <KeyBinding guid="guidPythonToolsCmdSet" id="cmdidSendToRepl" key1="E" mod1="Control" key2="E" mod2="Control" editor="guidVSStd97"/>
     <KeyBinding guid="guidPythonToolsCmdSet" id="cmdidSendToRepl" key1="VK_RETURN" mod1="Control" editor="guidTextMateEditor"/>
     <KeyBinding guid="guidPythonToolsCmdSet" id="cmdidFillParagraph" key1="E" mod1="Control" key2="P" mod2="Control" editor="guidVSStd97"/>
-    <KeyBinding guid="guidPythonToolsCmdSet" id="cmdidReplWindow" key1="I" mod1="Alt" editor="guidVSStd97"/>
+    <KeyBinding guid="guidPythonToolsCmdSet" id="cmdidReplWindow" key1="K" mod1="Control" key2="I" editor="guidVSStd97"/>
     <KeyBinding guid="guidPythonToolsCmdSet" id="cmdidInterpreterList" key1="K" mod1="Control" key2="VK_OEM_3" editor="guidVSStd97"/>
     <KeyBinding guid="guidPythonToolsCmdSet" id="cmdidInterpreterList" key1="K" mod1="Control" key2="VK_OEM_3" mod2="Control" editor="guidVSStd97"/>
     <KeyBinding guid="guidPythonToolsCmdSet" id="cmdidRemoveImports" key1="K" mod1="Control" key2="J" mod2="Control" editor="guidVSStd97"/>


### PR DESCRIPTION
fixes https://dev.azure.com/devdiv/DevDiv/_workitems/edit/2135867/?view=edit

The VS version control team said our keyboard shortcut for opening interactive window is in conflict with their commit command. I have changed to shortcut to `Ctrl+K, I` to resolve the conflicts, I chose this shortcut because it also follows the conventions of the rest of the Python specific commands on this list.