### PR TITLE
Add support for Python Toolbox (.pyt) files in PTVS

### DIFF
--- a/Python/Product/PythonTools/PythonConstants.cs
+++ b/Python/Product/PythonTools/PythonConstants.cs
@@ -38,7 +38,7 @@ namespace Microsoft.PythonTools {
         internal const string FileExtension = ".py";
         internal const string WindowsFileExtension = ".pyw";
         internal const string StubFileExtension = ".pyi";
-        internal const string toolboxExtension = ".pyt";
+        internal const string ArcGISToolboxExtension = ".pyt";
         internal const string SourceFileExtensions = ".py;.pyw;.pyi";
         internal static readonly string[] SourceFileExtensionsArray = SourceFileExtensions.Split(';');
 

--- a/Python/Product/PythonTools/PythonConstants.cs
+++ b/Python/Product/PythonTools/PythonConstants.cs
@@ -38,6 +38,7 @@ namespace Microsoft.PythonTools {
         internal const string FileExtension = ".py";
         internal const string WindowsFileExtension = ".pyw";
         internal const string StubFileExtension = ".pyi";
+        internal const string toolboxExtension = ".pyt";
         internal const string SourceFileExtensions = ".py;.pyw;.pyi";
         internal static readonly string[] SourceFileExtensionsArray = SourceFileExtensions.Split(';');
 

--- a/Python/Product/PythonTools/PythonToolsPackage.cs
+++ b/Python/Product/PythonTools/PythonToolsPackage.cs
@@ -83,7 +83,7 @@ namespace Microsoft.PythonTools {
     [ProvideLanguageExtension(typeof(PythonLanguageInfo), PythonConstants.FileExtension)]
     [ProvideLanguageExtension(typeof(PythonLanguageInfo), PythonConstants.WindowsFileExtension)]
     [ProvideLanguageExtension(typeof(PythonLanguageInfo), PythonConstants.StubFileExtension)]
-    [ProvideLanguageExtension(typeof(PythonLanguageInfo), PythonConstants.toolboxExtension)]
+    [ProvideLanguageExtension(typeof(PythonLanguageInfo), PythonConstants.ArcGISToolboxExtension)]
     [ProvideDebugEngine(AD7Engine.DebugEngineName, typeof(AD7ProgramProvider), typeof(AD7Engine), AD7Engine.DebugEngineId, hitCountBp: true)]
     [ProvideDebugAdapter("Python", DebugAdapterLauncher.VSCodeDebugEngineId, DebugAdapterLauncher.DebugAdapterLauncherCLSID, CustomDebugAdapterProtocolExtension.CustomProtocolExtensionCLSID, "Python", "{DA3C7D59-F9E4-4697-BEE7-3A0703AF6BFF}", typeof(DebugAdapterLauncher), typeof(CustomDebugAdapterProtocolExtension))]
     [ProvideDebugLanguage("Python", "{DA3C7D59-F9E4-4697-BEE7-3A0703AF6BFF}", PythonExpressionEvaluatorGuid, AD7Engine.DebugEngineId)]

--- a/Python/Product/PythonTools/PythonToolsPackage.cs
+++ b/Python/Product/PythonTools/PythonToolsPackage.cs
@@ -83,6 +83,7 @@ namespace Microsoft.PythonTools {
     [ProvideLanguageExtension(typeof(PythonLanguageInfo), PythonConstants.FileExtension)]
     [ProvideLanguageExtension(typeof(PythonLanguageInfo), PythonConstants.WindowsFileExtension)]
     [ProvideLanguageExtension(typeof(PythonLanguageInfo), PythonConstants.StubFileExtension)]
+    [ProvideLanguageExtension(typeof(PythonLanguageInfo), PythonConstants.toolboxExtension)]
     [ProvideDebugEngine(AD7Engine.DebugEngineName, typeof(AD7ProgramProvider), typeof(AD7Engine), AD7Engine.DebugEngineId, hitCountBp: true)]
     [ProvideDebugAdapter("Python", DebugAdapterLauncher.VSCodeDebugEngineId, DebugAdapterLauncher.DebugAdapterLauncherCLSID, CustomDebugAdapterProtocolExtension.CustomProtocolExtensionCLSID, "Python", "{DA3C7D59-F9E4-4697-BEE7-3A0703AF6BFF}", typeof(DebugAdapterLauncher), typeof(CustomDebugAdapterProtocolExtension))]
     [ProvideDebugLanguage("Python", "{DA3C7D59-F9E4-4697-BEE7-3A0703AF6BFF}", PythonExpressionEvaluatorGuid, AD7Engine.DebugEngineId)]


### PR DESCRIPTION
Addresses https://github.com/microsoft/PTVS/issues/8271

Support for .pyt files has been requested by multiple users in the PTVS repo over the years. This PR adds support for Python Toolbox (.pyt) files in PTVS. These files are used by ArcGIS software for creating custom geoprocessing tools.

.pyt files are 100% Python syntax, so with this change, users will get syntax highlighting, intellisense, code navigation.