### PR TITLE
fix for repl warnings 

### DIFF
--- a/Python/Product/PythonTools/ptvsd/repl/__init__.py
+++ b/Python/Product/PythonTools/ptvsd/repl/__init__.py
@@ -74,7 +74,7 @@ except NameError:
     # BaseException not defined until Python 2.5
     BaseException = Exception
 
-DEBUG = os.environ.get('DEBUG_REPL') or os.environ.get('_PTVS_DEBUG_REPL')
+DEBUG = True # os.environ.get('DEBUG_REPL') or os.environ.get('_PTVS_DEBUG_REPL')
 
 __all__ = ['ReplBackend', 'BasicReplBackend', 'BACKEND']
 

--- a/Python/Product/PythonTools/ptvsd/repl/__init__.py
+++ b/Python/Product/PythonTools/ptvsd/repl/__init__.py
@@ -74,7 +74,7 @@ except NameError:
     # BaseException not defined until Python 2.5
     BaseException = Exception
 
-DEBUG = True # os.environ.get('DEBUG_REPL') or os.environ.get('_PTVS_DEBUG_REPL')
+DEBUG = os.environ.get('DEBUG_REPL') or os.environ.get('_PTVS_DEBUG_REPL')
 
 __all__ = ['ReplBackend', 'BasicReplBackend', 'BACKEND']
 

--- a/Python/Product/PythonTools/ptvsd/util.py
+++ b/Python/Product/PythonTools/ptvsd/util.py
@@ -516,14 +516,14 @@ class SafeRepr(object):
         d1 = {}
         d1_key = 'a' * self.maxstring_inner * 2
         d1[d1_key] = d1_key
-        re_test(d1, "{'a+\.\.\.a+': 'a+\.\.\.a+'}")
+        re_test(d1, r"{'a+\.\.\.a+': 'a+\.\.\.a+'}")
         d2 = {d1_key : d1}
-        re_test(d2, "{'a+\.\.\.a+': {'a+\.\.\.a+': 'a+\.\.\.a+'}}")
+        re_test(d2, r"{'a+\.\.\.a+': {'a+\.\.\.a+': 'a+\.\.\.a+'}}")
         d3 = {d1_key : d2}
         if len(self.maxcollection) == 2:
-            re_test(d3, "{'a+\.\.\.a+': {'a+\.\.\.a+': {\.\.\.}}}")
+            re_test(d3, r"{'a+\.\.\.a+': {'a+\.\.\.a+': {\.\.\.}}}")
         else:
-            re_test(d3, "{'a+\.\.\.a+': {'a+\.\.\.a+': {'a+\.\.\.a+': 'a+\.\.\.a+'}}}")
+            re_test(d3, r"{'a+\.\.\.a+': {'a+\.\.\.a+': {'a+\.\.\.a+': 'a+\.\.\.a+'}}}")
 
         # Ensure empty dicts work
         test({}, '{}')


### PR DESCRIPTION
now using raw string

example.
c:\users\bschnurr\appdata\local\microsoft\visualstudio\17.0_0f44cb13exp\extensions\microsoft corporation\python\17.0.0\ptvsd\util.py:519: SyntaxWarning: invalid escape sequence '.' re_test(d1, "{'a+...a+': 'a+...a+'}") c:\users\bschnurr\appdata\local\microsoft\visualstudio\17.0_0f44cb13exp\extensions\microsoft corporation\python\17.0.0\ptvsd\util.py:521: SyntaxWarning: invalid escape sequence '.' re_test(d2, "{'a+...a+': {'a+...a+': 'a+...a+'}}") c:\users\bschnurr\appdata\local\microsoft\visualstudio\17.0_0f44cb13exp\extensions\microsoft corporation\python\17.0.0\ptvsd\util.py:524: SyntaxWarning: invalid escape sequence '.' re_test(d3, "{'a+...a+': {'a+...a+': {...}}}") c:\users\bschnurr\appdata\local\microsoft\visualstudio\17.0_0f44cb13exp\extensions\microsoft corporation\python\17.0.0\ptvsd\util.py:526: SyntaxWarning: invalid escape sequence '.' re_test(d3, "{'a+...a+': {'a+...a+': {'a+...a+': 'a+...a+'}}}")