### PR TITLE
Increase build pipeline timeout

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -44,6 +44,9 @@ parameters:
 # build number format 
 name: $(date:yy)$(DayOfYear)$(rev:.r)
 
+# Set pipeline timeout to 2 hours (120 minutes)
+timeoutInMinutes: 120
+
 # Trigger ci builds for commits into master and any release branches
 # Ignore changes to other yml files, since they are for different pipelines
 trigger:


### PR DESCRIPTION
I was trying to test the PME work, but noticed that recently our CI builds timeouts more often during busy hours. This is because more steps are run for CI builds and compliance and security checks introduced by 1ES template is also taking lots of time.