### PR TITLE
Update VS Bootstrapper Configuration

### DIFF
--- a/Build/templates/create_vs_bootstrapper.yml
+++ b/Build/templates/create_vs_bootstrapper.yml
@@ -7,7 +7,7 @@ steps:
     displayName: 'Build Bootstrapper'
     inputs:
       channelName: 'IntPreview'
-      vsMajorVersion: '17'
+      vsMajorVersion: '18'
       bootstrapperCoreFeedSource: 'https://devdiv.pkgs.visualstudio.com/_packaging/Setup/nuget/v3/index.json'
       bootstrapperCoreDependenciesFeedSource: 'https://devdiv.pkgs.visualstudio.com/_packaging/Setup-Dependencies/nuget/v3/index.json'
       nugetOrgPublicFeedSource: 'https://api.nuget.org/v3/index.json'


### PR DESCRIPTION
The build pipeline currently generates a Dev17 Visual Studio installer with the latest PTVS changes for testing purposes. This needs to be updated for Dev18.

Part of https://github.com/microsoft/PTVS/issues/8201