### PR TITLE
Fix issue with test explorer

### DIFF
--- a/Python/Product/VSCommon/Infrastructure/VisualStudioApp.cs
+++ b/Python/Product/VSCommon/Infrastructure/VisualStudioApp.cs
@@ -20,6 +20,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.ComTypes;
+using System.Windows.Forms;
 using EnvDTE;
 using Process = System.Diagnostics.Process;
 
@@ -85,8 +86,11 @@ namespace Microsoft.PythonTools.Infrastructure {
             }
 
             // Temporary fix. we should revert back to AssemblyVersionInfo.VSVersion once pipeline support dev18 toolchain
-            string progIdDev17 = string.Format("!{0}.DTE.{1}:{2}", prefix, 17.0, processId);
-            string progIdDev18 = string.Format("!{0}.DTE.{1}:{2}", prefix, 18.0, processId);
+            MessageBox.Show("Hello: " + Process.GetCurrentProcess().Id);
+            string progIdDev17 = string.Format("!{0}.DTE.{1}:{2}", prefix, "17.0", processId);
+            string progIdDev18 = string.Format("!{0}.DTE.{1}:{2}", prefix, "18.0", processId);
+
+            string test11 = AssemblyVersionInfo.VSVersion;
             object runningObject = null;
 
             IBindCtx bindCtx = null;
@@ -102,7 +106,7 @@ namespace Microsoft.PythonTools.Infrastructure {
                 while (enumMonikers.Next(1, moniker, IntPtr.Zero) == 0) {
                     IMoniker runningObjectMoniker = moniker[0];
 
-                    string name = null;
+                    string name = test11;
 
                     try {
                         if (runningObjectMoniker != null) {

--- a/Python/Product/VSCommon/Infrastructure/VisualStudioApp.cs
+++ b/Python/Product/VSCommon/Infrastructure/VisualStudioApp.cs
@@ -20,7 +20,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.ComTypes;
-using System.Windows.Forms;
 using EnvDTE;
 using Process = System.Diagnostics.Process;
 

--- a/Python/Product/VSCommon/Infrastructure/VisualStudioApp.cs
+++ b/Python/Product/VSCommon/Infrastructure/VisualStudioApp.cs
@@ -84,7 +84,9 @@ namespace Microsoft.PythonTools.Infrastructure {
                 prefix = "VisualStudio";
             }
 
-            string progId = string.Format("!{0}.DTE.{1}:{2}", prefix, AssemblyVersionInfo.VSVersion, processId);
+            // Temporary fix. we should revert back to AssemblyVersionInfo.VSVersion once pipeline support dev18 toolchain
+            string progIdDev17 = string.Format("!{0}.DTE.{1}:{2}", prefix, 17.0, processId);
+            string progIdDev18 = string.Format("!{0}.DTE.{1}:{2}", prefix, 18.0, processId);
             object runningObject = null;
 
             IBindCtx bindCtx = null;
@@ -110,7 +112,7 @@ namespace Microsoft.PythonTools.Infrastructure {
                         // Do nothing, there is something in the ROT that we do not have access to.
                     }
 
-                    if (!string.IsNullOrEmpty(name) && string.Equals(name, progId, StringComparison.Ordinal)) {
+                    if (!string.IsNullOrEmpty(name) && (string.Equals(name, progIdDev17, StringComparison.Ordinal) || string.Equals(name, progIdDev18, StringComparison.Ordinal))) {
                         rot.GetObject(runningObjectMoniker, out runningObject);
                         break;
                     }

--- a/Python/Product/VSCommon/Infrastructure/VisualStudioApp.cs
+++ b/Python/Product/VSCommon/Infrastructure/VisualStudioApp.cs
@@ -86,11 +86,9 @@ namespace Microsoft.PythonTools.Infrastructure {
             }
 
             // Temporary fix. we should revert back to AssemblyVersionInfo.VSVersion once pipeline support dev18 toolchain
-            MessageBox.Show("Hello: " + Process.GetCurrentProcess().Id);
             string progIdDev17 = string.Format("!{0}.DTE.{1}:{2}", prefix, "17.0", processId);
             string progIdDev18 = string.Format("!{0}.DTE.{1}:{2}", prefix, "18.0", processId);
 
-            string test11 = AssemblyVersionInfo.VSVersion;
             object runningObject = null;
 
             IBindCtx bindCtx = null;
@@ -106,7 +104,7 @@ namespace Microsoft.PythonTools.Infrastructure {
                 while (enumMonikers.Next(1, moniker, IntPtr.Zero) == 0) {
                     IMoniker runningObjectMoniker = moniker[0];
 
-                    string name = test11;
+                    string name = null;
 
                     try {
                         if (runningObjectMoniker != null) {


### PR DESCRIPTION
Fixes https://github.com/microsoft/PTVS/issues/8277

The error message:
System.InvalidOperationException: Could not find VS DTE object for process 6620
   at Microsoft.PythonTools.Infrastructure.VisualStudioProxy.GetDTE()
   at Microsoft.PythonTools.TestAdapter.Services.ExecutorService.DetachFromSillyManagedProcess(VisualStudioProxy app, PythonDebugMode debugMode)
   at Microsoft.PythonTools.TestAdapter.UnittestTestExecutor.TestRunner.Run()
Connected to socket

is caused by build pipeline now only supports building ptvs in dev17 environment, but the process is running in dev18. Fixing it by supporting both versions, but we should revert back once pipeline tool supports dev18.