### PR TITLE
Fix the issue where the option "Python/Native Debugging" is missing

### DIFF
--- a/Python/Product/VCDebugLauncher/VCDebugLauncher.csproj
+++ b/Python/Product/VCDebugLauncher/VCDebugLauncher.csproj
@@ -156,27 +156,53 @@
       <VSIXSubPath>.</VSIXSubPath>
     </Content>
     <Content Include="VCTargets\Win32\ImportAfter\Microsoft.PythonTools.Debugger.VCDebugLauncher.targets">
-      <VSIXSubPath>Microsoft\VC\$(VCTargetVersion)\Platforms\Win32\ImportAfter</VSIXSubPath>
+      <VSIXSubPath>Microsoft\VC\v170\Platforms\Win32\ImportAfter</VSIXSubPath>
       <InstallRoot>MSBuild</InstallRoot>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <IncludeInVSIX>true</IncludeInVSIX>
       <SubType>Designer</SubType>
     </Content>
     <Content Include="VCTargets\Win32\ImportBefore\Microsoft.PythonTools.Debugger.VCDebugLauncher.props">
-      <VSIXSubPath>Microsoft\VC\$(VCTargetVersion)\Platforms\Win32\ImportBefore</VSIXSubPath>
+      <VSIXSubPath>Microsoft\VC\v170\Platforms\Win32\ImportBefore</VSIXSubPath>
       <InstallRoot>MSBuild</InstallRoot>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
     <Content Include="VCTargets\x64\ImportAfter\Microsoft.PythonTools.Debugger.VCDebugLauncher.targets">
-      <VSIXSubPath>Microsoft\VC\$(VCTargetVersion)\Platforms\x64\ImportAfter</VSIXSubPath>
+      <VSIXSubPath>Microsoft\VC\v170\Platforms\x64\ImportAfter</VSIXSubPath>
       <InstallRoot>MSBuild</InstallRoot>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <IncludeInVSIX>true</IncludeInVSIX>
       <SubType>Designer</SubType>
     </Content>
     <Content Include="VCTargets\x64\ImportBefore\Microsoft.PythonTools.Debugger.VCDebugLauncher.props">
-      <VSIXSubPath>Microsoft\VC\$(VCTargetVersion)\Platforms\x64\ImportBefore</VSIXSubPath>
+      <VSIXSubPath>Microsoft\VC\v170\Platforms\x64\ImportBefore</VSIXSubPath>
+      <InstallRoot>MSBuild</InstallRoot>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <IncludeInVSIX>true</IncludeInVSIX>
+    </Content>
+    <Content Include="VCTargets\Win32\ImportAfter\Microsoft.PythonTools.Debugger.VCDebugLauncher.targets">
+      <VSIXSubPath>Microsoft\VC\v180\Platforms\Win32\ImportAfter</VSIXSubPath>
+      <InstallRoot>MSBuild</InstallRoot>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <IncludeInVSIX>true</IncludeInVSIX>
+      <SubType>Designer</SubType>
+    </Content>
+    <Content Include="VCTargets\Win32\ImportBefore\Microsoft.PythonTools.Debugger.VCDebugLauncher.props">
+      <VSIXSubPath>Microsoft\VC\v180\Platforms\Win32\ImportBefore</VSIXSubPath>
+      <InstallRoot>MSBuild</InstallRoot>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <IncludeInVSIX>true</IncludeInVSIX>
+    </Content>
+    <Content Include="VCTargets\x64\ImportAfter\Microsoft.PythonTools.Debugger.VCDebugLauncher.targets">
+      <VSIXSubPath>Microsoft\VC\v180\Platforms\x64\ImportAfter</VSIXSubPath>
+      <InstallRoot>MSBuild</InstallRoot>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <IncludeInVSIX>true</IncludeInVSIX>
+      <SubType>Designer</SubType>
+    </Content>
+    <Content Include="VCTargets\x64\ImportBefore\Microsoft.PythonTools.Debugger.VCDebugLauncher.props">
+      <VSIXSubPath>Microsoft\VC\v180\Platforms\x64\ImportBefore</VSIXSubPath>
       <InstallRoot>MSBuild</InstallRoot>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <IncludeInVSIX>true</IncludeInVSIX>
@@ -213,13 +239,25 @@
   </ItemGroup>
   <ItemGroup>
     <XamlPropertyRule Include="VCTargets\Win32\ImportAfter\Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml">
-      <VSIXSubPath>Microsoft\VC\$(VCTargetVersion)\Platforms\Win32\ImportAfter</VSIXSubPath>
+      <VSIXSubPath>Microsoft\VC\v170\Platforms\Win32\ImportAfter</VSIXSubPath>
       <InstallRoot>MSBuild</InstallRoot>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <IncludeInVSIX>true</IncludeInVSIX>
     </XamlPropertyRule>
     <Content Include="VCTargets\x64\ImportAfter\Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml">
-      <VSIXSubPath>Microsoft\VC\$(VCTargetVersion)\Platforms\x64\ImportAfter</VSIXSubPath>
+      <VSIXSubPath>Microsoft\VC\v170\Platforms\x64\ImportAfter</VSIXSubPath>
+      <InstallRoot>MSBuild</InstallRoot>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <IncludeInVSIX>true</IncludeInVSIX>
+    </Content>
+    <XamlPropertyRule Include="VCTargets\Win32\ImportAfter\Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml">
+      <VSIXSubPath>Microsoft\VC\v180\Platforms\Win32\ImportAfter</VSIXSubPath>
+      <InstallRoot>MSBuild</InstallRoot>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <IncludeInVSIX>true</IncludeInVSIX>
+    </XamlPropertyRule>
+    <Content Include="VCTargets\x64\ImportAfter\Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml">
+      <VSIXSubPath>Microsoft\VC\v180\Platforms\x64\ImportAfter</VSIXSubPath>
       <InstallRoot>MSBuild</InstallRoot>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <IncludeInVSIX>true</IncludeInVSIX>
@@ -251,12 +289,22 @@
         <IncludeInVSIX>true</IncludeInVSIX>
       </LocContent>
       <LocContent Include="$(LocOutputPath)%(VSLanguages.Identity)\VCTargets\Win32\ImportAfter\Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml">
-        <VSIXSubPath>Microsoft\VC\$(VCTargetVersion)\Platforms\Win32\ImportAfter\%(VSLanguages.LCID)</VSIXSubPath>
+        <VSIXSubPath>Microsoft\VC\v170\Platforms\Win32\ImportAfter\%(VSLanguages.LCID)</VSIXSubPath>
         <InstallRoot>MSBuild</InstallRoot>
         <IncludeInVSIX>true</IncludeInVSIX>
       </LocContent>
       <LocContent Include="$(LocOutputPath)%(VSLanguages.Identity)\VCTargets\x64\ImportAfter\Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml">
-        <VSIXSubPath>Microsoft\VC\$(VCTargetVersion)\Platforms\x64\ImportAfter\%(VSLanguages.LCID)</VSIXSubPath>
+        <VSIXSubPath>Microsoft\VC\v170\Platforms\x64\ImportAfter\%(VSLanguages.LCID)</VSIXSubPath>
+        <InstallRoot>MSBuild</InstallRoot>
+        <IncludeInVSIX>true</IncludeInVSIX>
+      </LocContent>
+      <LocContent Include="$(LocOutputPath)%(VSLanguages.Identity)\VCTargets\Win32\ImportAfter\Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml">
+        <VSIXSubPath>Microsoft\VC\v180\Platforms\Win32\ImportAfter\%(VSLanguages.LCID)</VSIXSubPath>
+        <InstallRoot>MSBuild</InstallRoot>
+        <IncludeInVSIX>true</IncludeInVSIX>
+      </LocContent>
+      <LocContent Include="$(LocOutputPath)%(VSLanguages.Identity)\VCTargets\x64\ImportAfter\Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml">
+        <VSIXSubPath>Microsoft\VC\v180\Platforms\x64\ImportAfter\%(VSLanguages.LCID)</VSIXSubPath>
         <InstallRoot>MSBuild</InstallRoot>
         <IncludeInVSIX>true</IncludeInVSIX>
       </LocContent>

--- a/Python/Product/VCDebugLauncher/VCDebugLauncher.csproj
+++ b/Python/Product/VCDebugLauncher/VCDebugLauncher.csproj
@@ -239,18 +239,6 @@
   </ItemGroup>
   <ItemGroup>
     <XamlPropertyRule Include="VCTargets\Win32\ImportAfter\Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml">
-      <VSIXSubPath>Microsoft\VC\v170\Platforms\Win32\ImportAfter</VSIXSubPath>
-      <InstallRoot>MSBuild</InstallRoot>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <IncludeInVSIX>true</IncludeInVSIX>
-    </XamlPropertyRule>
-    <Content Include="VCTargets\x64\ImportAfter\Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml">
-      <VSIXSubPath>Microsoft\VC\v170\Platforms\x64\ImportAfter</VSIXSubPath>
-      <InstallRoot>MSBuild</InstallRoot>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <IncludeInVSIX>true</IncludeInVSIX>
-    </Content>
-    <XamlPropertyRule Include="VCTargets\Win32\ImportAfter\Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml">
       <VSIXSubPath>Microsoft\VC\v180\Platforms\Win32\ImportAfter</VSIXSubPath>
       <InstallRoot>MSBuild</InstallRoot>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -258,6 +246,18 @@
     </XamlPropertyRule>
     <Content Include="VCTargets\x64\ImportAfter\Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml">
       <VSIXSubPath>Microsoft\VC\v180\Platforms\x64\ImportAfter</VSIXSubPath>
+      <InstallRoot>MSBuild</InstallRoot>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <IncludeInVSIX>true</IncludeInVSIX>
+    </Content>
+    <Content Include="VCTargets\Win32\ImportAfter\Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml">
+      <VSIXSubPath>Microsoft\VC\v170\Platforms\Win32\ImportAfter</VSIXSubPath>
+      <InstallRoot>MSBuild</InstallRoot>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <IncludeInVSIX>true</IncludeInVSIX>
+    </Content>
+    <Content Include="VCTargets\x64\ImportAfter\Microsoft.PythonTools.Debugger.VCDebugLauncher.xaml">
+      <VSIXSubPath>Microsoft\VC\v170\Platforms\x64\ImportAfter</VSIXSubPath>
       <InstallRoot>MSBuild</InstallRoot>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <IncludeInVSIX>true</IncludeInVSIX>

--- a/package.json
+++ b/package.json
@@ -2,6 +2,6 @@
     "name":  "ptvs",
     "private":  true,
     "devDependencies":  {
-                            "@pylance/pylance":  "2025.8.1"
+                            "@pylance/pylance":  "2025.8.2"
                         }
 }


### PR DESCRIPTION
fixes https://github.com/microsoft/PTVS/issues/8290.

It's caused by the same reason: PTVS is built in dev17 environment but run in dev18 environment.  Before msbuild@1 supports dev18 build environment, hardcode the path for now. See https://github.com/microsoft/PTVS/issues/8201#issue-2936315398