### PR TITLE
Fix text/enabled state of new project/file commands

### DIFF
--- a/Python/Product/Cookiecutter/Cookiecutter.vsct
+++ b/Python/Product/Cookiecutter/Cookiecutter.vsct
@@ -104,11 +104,13 @@
         <Parent guid="guidCookiecutterCmdSet" id="CookiecutterMenu"/>
         <Icon guid="guidCookiecutterImages" id="NewCookiecutter"/>
         <CommandFlag>IconIsMoniker</CommandFlag>
+        <CommandFlag>TextMenuUseButton</CommandFlag>
         <Strings>
-          <ButtonText>From &amp;Cookiecutter...</ButtonText>
-          <ToolTipText>Creates files using a Cookiecutter template.</ToolTipText>
-          <CanonicalName>Create From</CanonicalName>
-          <LocCanonicalName>Create From</LocCanonicalName>
+          <ButtonText>New From &amp;Cookiecutter...</ButtonText>
+          <MenuText>From &amp;Cookiecutter...</MenuText>
+          <ToolTipText>New project or file using a Cookiecutter template.</ToolTipText>
+          <CanonicalName>.File.NewFromCookiecutter</CanonicalName>
+          <LocCanonicalName>.File.NewFromCookiecutter</LocCanonicalName>
         </Strings>
       </Button>
 

--- a/Python/Product/Cookiecutter/CookiecutterPackage.cs
+++ b/Python/Product/Cookiecutter/CookiecutterPackage.cs
@@ -153,7 +153,7 @@ namespace Microsoft.CookiecutterTools {
                          commands[0].cmdf = KnownUIContexts.NotBuildingAndNotDebuggingContext.IsActive
                             ? (uint)(OLECMDF.OLECMDF_ENABLED | OLECMDF.OLECMDF_SUPPORTED)
                             : (uint)(OLECMDF.OLECMDF_SUPPORTED);
-    
+                        break;
                     case PackageIds.cmdidAddFromCookiecutter:
                         commands[0].cmdf = KnownUIContexts.NotBuildingAndNotDebuggingContext.IsActive &&
                                            _projectSystem.GetSelectedFolderProjectLocation() != null

--- a/Python/Product/Cookiecutter/CookiecutterPackage.cs
+++ b/Python/Product/Cookiecutter/CookiecutterPackage.cs
@@ -148,8 +148,14 @@ namespace Microsoft.CookiecutterTools {
         int IOleCommandTarget.QueryStatus(ref Guid commandGroup, uint commandsCount, OLECMD[] commands, IntPtr pCmdText) {
             if (commandGroup == PackageGuids.guidCookiecutterCmdSet && commandsCount == 1) {
                 switch (commands[0].cmdID) {
+                    case PackageIds.cmdidNewProjectFromTemplate:
+                    case PackageIds.cmdidCreateFromCookiecutter:
+                         commands[0].cmdf = KnownUIContexts.NotBuildingAndNotDebuggingContext.IsActive
+                            ? (uint)(OLECMDF.OLECMDF_ENABLED | OLECMDF.OLECMDF_SUPPORTED)
+                            : (uint)(OLECMDF.OLECMDF_SUPPORTED);
+    
                     case PackageIds.cmdidAddFromCookiecutter:
-                        commands[0].cmdf = DTE.Debugger.CurrentMode == EnvDTE.dbgDebugMode.dbgDesignMode &&
+                        commands[0].cmdf = KnownUIContexts.NotBuildingAndNotDebuggingContext.IsActive &&
                                            _projectSystem.GetSelectedFolderProjectLocation() != null
                             ? (uint)(OLECMDF.OLECMDF_ENABLED | OLECMDF.OLECMDF_SUPPORTED)
                             : (uint)(OLECMDF.OLECMDF_INVISIBLE | OLECMDF.OLECMDF_SUPPORTED);


### PR DESCRIPTION
This change does two things:

1) Visual Studio 2026 has a new drop down with the same contents as File -> New. However, in this mode, the commands text should include "New". This changes the text to follow the same pattern as the other New commands, where Button text is used for the drop down, and MenuText used for File -> New. Also fixed the canonical name which was wrong.

You can see that "Repository..." and "From Cookiecutton..." are both missing the prefix "New". This change fixes Cookiecutter.

<img width="281" height="156" alt="image" src="https://github.com/user-attachments/assets/bbdcbc1b-b694-4525-8625-1077cf0dc105" />

2) Fixed the enabled state of these commands, these commands, similar to their equivalent, should be disabled when building and/or debugging.

