### PR TITLE
fix some tests that were looking for threadign package 17.0.0.0 but n…

### DIFF
--- a/Python/Tests/Core/App.config
+++ b/Python/Tests/Core/App.config
@@ -8,7 +8,7 @@
             </dependentAssembly>
             <dependentAssembly>
                 <assemblyIdentity name="Microsoft.VisualStudio.Threading" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-                <bindingRedirect oldVersion="15.0.0.0-17.0.0.0" newVersion="17.0.0.0"/>
+                <bindingRedirect oldVersion="15.0.0.0-17.0.0.0" newVersion="17.15.0.0"/>
             </dependentAssembly>
         </assemblyBinding>
     </runtime>

--- a/Python/Tests/Core/WorkspaceTestHelper.cs
+++ b/Python/Tests/Core/WorkspaceTestHelper.cs
@@ -90,7 +90,8 @@ namespace PythonToolsTests {
             }
 
             public IEnumerable<IPackageManager> GetPackageManagers(IPythonInterpreterFactory factory) {
-                throw new NotImplementedException();
+                // Tests do not exercise package management; return empty to satisfy initialization.
+                return Enumerable.Empty<IPackageManager>();
             }
 
             public bool IsConfigurable(string id) {


### PR DESCRIPTION
…ow its 17.15.0.0

changed the mock GetPackageManagers to return empty list instead of exception