### PR TITLE
fix missing django commands for locally built ptvs and tests

### DIFF
--- a/Python/Product/BuildTasks/TestTargets/Microsoft.PythonTools.Django.targets
+++ b/Python/Product/BuildTasks/TestTargets/Microsoft.PythonTools.Django.targets
@@ -20,12 +20,7 @@ permissions and limitations under the License.
   <PropertyGroup>
     <!-- Enable logging for publish/preview -->
     <EnablePackageProcessLoggingAndAssert>true</EnablePackageProcessLoggingAndAssert>
-    <!-- Allow override; fallback to current VS install root -->
-    <_VSVer Condition="'$(VisualStudioVersion)' == ''">18.0</_VSVer>
-    <PythonToolsTargetsDir Condition="'$(PythonToolsTargetsDir)' == ''">$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v$(_VSVer)\Python Tools</PythonToolsTargetsDir>
   </PropertyGroup>
 
-  <!-- Only import if an updated Django targets file actually exists -->
-  <Import Project="$(PythonToolsTargetsDir)\Microsoft.PythonTools.Django.Core.targets"
-          Condition="Exists('$(PythonToolsTargetsDir)\Microsoft.PythonTools.Django.Core.targets')" />
+  <Import Project="$(_PythonToolsPath)\..\..\Python - Django\$(VisualStudioVersion).0\Microsoft.PythonTools.Django.targets" />
 </Project>

--- a/package.json
+++ b/package.json
@@ -2,6 +2,6 @@
     "name":  "ptvs",
     "private":  true,
     "devDependencies":  {
-                            "@pylance/pylance":  "2025.8.3"
+                            "@pylance/pylance":  "2025.9.1"
                         }
 }


### PR DESCRIPTION
- Use  $(VisualStudioVersion) to make it dynamic update pylance

<img width="660" height="809" alt="image" src="https://github.com/user-attachments/assets/0f79ccbf-a5ef-4e68-b100-b54408df9b94" />
