### PR TITLE
- this test broke when containers changed from source files to direct…

### DIFF
--- a/Python/Tests/TestAdapterTests/ProjectInfoTests.cs
+++ b/Python/Tests/TestAdapterTests/ProjectInfoTests.cs
@@ -16,10 +16,9 @@
 
 using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
+using System.IO; // added for temp directory/file creation
 using Microsoft.PythonTools.Projects;
 using Microsoft.PythonTools.TestAdapter;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -32,7 +31,7 @@ namespace TestAdapterTests {
         /// <summary>
         /// Recreate collection was modified while iterating exception
         /// System.InvalidOperationException: Collection was modified; enumeration operation may not execute.
-        /// Test shouldn't throw
+        /// Test shouldn't throw. Verifies concurrent clear/build does not break enumeration and containers are added.
         /// </summary>
         /// <returns></returns>
         [TestMethod, Priority(0)]
@@ -42,36 +41,39 @@ namespace TestAdapterTests {
             var projectName = "dummyName";
             PythonProject dummyProject = new MockPythonProject("dummyHome", projectName);
 
-            //Simulate rebuid workspace
+            // Simulate rebuild workspace
             projectMap[projectName] = new ProjectInfo(dummyProject);
 
+            // Create a root temp directory so AddTestContainer will succeed (it requires Directory.Exists(path))
+            string tempRoot = Path.Combine(Path.GetTempPath(), "PTVS_ProjectInfoTests_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(tempRoot);
+
             var rebuildTasks = Enumerable.Range(1, 10)
-                .Select(i => Task.Run(async
-                    () => {
-                        projectMap.Clear();
-                        var info = new ProjectInfo(dummyProject);
-                        projectMap[projectName] = info;
-                        foreach (int j in Enumerable.Range(1, 1000)) {
-                            info.AddTestContainer(dummyDiscoverer, j.ToString() + ".py");
-                        }
-                        
-                        await Task.Delay(100);
+                .Select(i => Task.Run(async () => {
+                    projectMap.Clear();
+                    var info = new ProjectInfo(dummyProject);
+                    projectMap[projectName] = info;
+                    foreach (int j in Enumerable.Range(1, 1000)) {
+                        // Use directory paths instead of fake .py files so Directory.Exists(path) returns true
+                        var dirPath = Path.Combine(tempRoot, j.ToString());
+                        Directory.CreateDirectory(dirPath);
+                        info.AddTestContainer(dummyDiscoverer, dirPath);
                     }
-                )
+                    await Task.Delay(100);
+                })
             );
 
-            //Simulate Get TestContainers
+            // Simulate Get TestContainers concurrently
             var iterateTasks = Enumerable.Range(1, 100)
-                .Select(i => Task.Run(async
-                    () => {
-                        var items = projectMap.Values.SelectMany(p => p.GetAllContainers()).ToList();
-                        await Task.Delay(10);
-                    }
-                )
+                .Select(i => Task.Run(async () => {
+                    var items = projectMap.Values.SelectMany(p => p.GetAllContainers()).ToList();
+                    await Task.Delay(10);
+                })
             );
 
             await Task.WhenAll(rebuildTasks.Concat(iterateTasks));
 
+            // Verify last built project has all containers
             Assert.AreEqual(1000, projectMap[projectName].GetAllContainers().Count());
         }
     }


### PR DESCRIPTION
…ories.