### PR TITLE
Fix a watson bug

### DIFF
--- a/Python/Product/PythonTools/PythonTools/LanguageServerClient/LanguageServer.cs
+++ b/Python/Product/PythonTools/PythonTools/LanguageServerClient/LanguageServer.cs
@@ -62,6 +62,9 @@ namespace Microsoft.PythonTools.LanguageServerClient {
                 return null;
             }
 
+            // Switch to a background thread before starting the process
+            await TaskScheduler.Default;
+
             var serverFolderPath = Path.GetDirectoryName(serverFilePath);
 
             var info = new ProcessStartInfo {


### PR DESCRIPTION
fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1909676

A Watson report indicates a UI hang in Visual Studio. The UI thread becomes unresponsive for a significant duration during the initialization of the Python Language Server. The PR switches to a background thread to perform the heavy work of starting the process.