### PR TITLE
Fixing PythonNative example for python3.14 Avoid deprecated _Py_fopen…

### DIFF
--- a/Examples/PythonNative/PythonNative.cpp
+++ b/Examples/PythonNative/PythonNative.cpp
@@ -17,7 +17,8 @@ DWORD WINAPI runner(LPVOID lpParam)
     const char * startFileStr = str.c_str();
 
     PyObject* startObj = Py_BuildValue("s", startFileStr);
-    FILE* file = _Py_fopen_obj(startObj, "rb+");
+    // Avoid deprecated _Py_fopen_obj (Python 3.14+). Use standard fopen with the path string.
+    FILE* file = fopen(startFileStr, "rb+");
     if (file != NULL) {
         PyRun_SimpleFileEx(file, startFileStr, 1);
     }
@@ -89,7 +90,14 @@ int main()
 
 
     // Wait for the thread to exit
-    WaitForSingleObject(runnerThread, -1);
+    if (runnerThread != NULL)
+    {
+        WaitForSingleObject(runnerThread, INFINITE);
+    }
+    else
+    {
+        std::cout << "Error: runnerThread handle is NULL." << std::endl;
+    }
 
     CloseHandle(pipe);
 }

--- a/Examples/PythonNative/PythonNative.vcxproj
+++ b/Examples/PythonNative/PythonNative.vcxproj
@@ -104,14 +104,14 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(LOCALAPPDATA)\Programs\Python\Python313\include;$(LOCALAPPDATA)\Programs\Python\Python312\include;$(LOCALAPPDATA)\Programs\Python\Python311\include;$(LOCALAPPDATA)\Programs\Python\Python310\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(LOCALAPPDATA)\Programs\Python\Python314\include;$(LOCALAPPDATA)\Programs\Python\Python313\include;$(LOCALAPPDATA)\Programs\Python\Python312\include;$(LOCALAPPDATA)\Programs\Python\Python311\include;$(LOCALAPPDATA)\Programs\Python\Python310\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <LanguageStandard_C>stdc17</LanguageStandard_C>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalLibraryDirectories>$(LOCALAPPDATA)\Programs\Python\Python313\libs;$(LOCALAPPDATA)\Programs\Python\Python312\libs;$(LOCALAPPDATA)\Programs\Python\Python311\libs;$(LOCALAPPDATA)\Programs\Python\Python310\libs;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(LOCALAPPDATA)\Programs\Python\Python314\libs;$(LOCALAPPDATA)\Programs\Python\Python313\libs;$(LOCALAPPDATA)\Programs\Python\Python312\libs;$(LOCALAPPDATA)\Programs\Python\Python311\libs;$(LOCALAPPDATA)\Programs\Python\Python310\libs;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">

--- a/Examples/README.txt
+++ b/Examples/README.txt
@@ -1,0 +1,27 @@
+﻿
+--- 
+For Python Native debugging example error python311_d.dll not found
+
+## Quick fix (recommended): put the DLL on the exe’s PATH for Debug|x64
+
+Use the VS UI (simpler than editing XML):
+
+1. Right-click the **PythonNative** project → **Properties**.
+
+2. Top left: **Configuration** = `Debug`, **Platform** = `x64`.
+
+3. Go to **Configuration Properties → Debugging**.
+
+4. In **Environment**, set: to your python311_d.dll location
+
+   ```text
+   PATH=C:\Users\bschnurr\AppData\Local\Programs\Python\Python313;%PATH%
+   ```
+
+5. Make sure **Debugger to launch** is whatever you’re using (`Python/Native Debugging` or `Local Windows Debugger`).
+
+6. Apply, OK, rebuild, F5.
+
+Now when VS starts `PythonNative.exe`, its PATH includes the folder where `python313_d.dll` lives, so the loader should find it and that specific error should go away.
+
+-


### PR DESCRIPTION
…_obj (Python 3.14+). Use standard fopen with the path string.