### PR TITLE
Handle inaccessible files gracefully

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Project/ConfigureTestFrameworkInfoBar.cs
+++ b/Python/Product/PythonTools/PythonTools/Project/ConfigureTestFrameworkInfoBar.cs
@@ -344,7 +344,12 @@ namespace Microsoft.PythonTools.Project {
         }
 
         protected override bool PythonTestFileFound(Predicate<string> fileFilter) {
-            return WorkspaceContext.EnumerateUserFiles(fileFilter).Any();
+            try {
+                return WorkspaceContext.EnumerateUserFiles(fileFilter).Any();
+            } catch (IOException) {
+                // Handle inaccessible directories gracefully
+                return false;
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/microsoft/PTVS/issues/8346

Fixes a crash that occurs when the test framework info bar attempts to detect Python test files in a workspace that contains directories that cannot be accessed (for example due to permissions) gracefully.