### PR TITLE
Fix BinSkim BA2027, BA2007, and BA6002 compliance errors

### DIFF
--- a/Build/18.0/packages.config
+++ b/Build/18.0/packages.config
@@ -7,6 +7,11 @@
 <!-- packages from private sources. See nuget.config for more info -->
   <package id="Microsoft.Internal.VisualStudio.Shell.Framework" version = "17.10.40177" /> <!-- 18.0.41550-preview.2 -->
 
+<!-- SourceLink packages for BinSkim BA2027 compliance -->
+  <package id="Microsoft.SourceLink.GitHub" version="1.1.1" />
+  <package id="Microsoft.Build.Tasks.Git" version="1.1.1" />
+  <package id="Microsoft.SourceLink.Common" version="1.1.1" />
+
 <!-- Microsoft's packages -->
   <package id="StreamJsonRpc" version="2.23.41-alpha" />
   <package id="Microsoft.VisualStudioEng.MicroBuild.Core" version = "1.0.0" />

--- a/Build/Common.Build.settings
+++ b/Build/Common.Build.settings
@@ -92,6 +92,7 @@
   <Import Project="$(TargetsPath)\Common.Build.Cpp.settings" Condition="'$(MSBuildProjectExtension)' == '.vcxproj'" />
   <Import Project="$(PackagesPath)Microsoft.VSSDK.BuildTools\build\Microsoft.VSSDK.BuildTools.props" Condition="Exists('$(PackagesPath)Microsoft.VSSDK.BuildTools')" />
   <Import Project="$(TargetsPath)\MicroBuild.props" />
+  <Import Project="$(TargetsPath)\SourceLink.props" />
 
   <!-- Check for the VSSDK Build Tools arbitrarily to see whether we should run the script. -->
   <Target Name="_EnsureDependenciesInstalled" BeforeTargets="PrepareForBuild" Condition="!Exists('$(PackagesPath)Microsoft.VSSDK.BuildTools')">

--- a/Build/Common.Build.targets
+++ b/Build/Common.Build.targets
@@ -3,6 +3,7 @@
   <Import Project="$(TargetsPath)\Common.Build.VSSDK.targets" Condition="$(UseVSSDK) or $(UseVSSDKTemplateOnly)" />
   <Import Project="$(TargetsPath)\Common.Build.Cpp.targets" Condition="'$(Language)' == 'C++'" />
   <Import Project="$(TargetsPath)\MicroBuild.targets" />
+  <Import Project="$(TargetsPath)\SourceLink.targets" />
 
   <ItemGroup>
     <CodeAnalysisDictionary Include="$(BuildRoot)\Build\CustomDictionary.xml" />

--- a/Build/PreBuild.ps1
+++ b/Build/PreBuild.ps1
@@ -92,7 +92,10 @@ $need_symlink = @(
     "Microsoft.VSSDK.BuildTools",
     "Microsoft.VSSDK.Debugger.VSDConfigTool",
     "Newtonsoft.Json",
-    $microBuildCorePackageName
+    $microBuildCorePackageName,
+    "Microsoft.SourceLink.GitHub",
+    "Microsoft.SourceLink.Common",
+    "Microsoft.Build.Tasks.Git"
 )
 
 $buildroot = $MyInvocation.MyCommand.Definition | Split-Path -Parent | Split-Path -Parent

--- a/Build/SourceLink.props
+++ b/Build/SourceLink.props
@@ -1,0 +1,10 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Condition="'$(MSBuildProjectExtension)' == '.csproj' or '$(MSBuildProjectExtension)' == '.tmp_proj'">
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+  </PropertyGroup>
+  <Import Project="$(PackagesPath)Microsoft.Build.Tasks.Git\buildTransitive\Microsoft.Build.Tasks.Git.props" Condition="'$(MSBuildProjectExtension)' != '.vcxproj' and Exists('$(PackagesPath)Microsoft.Build.Tasks.Git\buildTransitive\Microsoft.Build.Tasks.Git.props')" />
+  <Import Project="$(PackagesPath)Microsoft.Build.Tasks.Git\build\Microsoft.Build.Tasks.Git.props" Condition="'$(MSBuildProjectExtension)' != '.vcxproj' and !Exists('$(PackagesPath)Microsoft.Build.Tasks.Git\buildTransitive\Microsoft.Build.Tasks.Git.props') and Exists('$(PackagesPath)Microsoft.Build.Tasks.Git\build\Microsoft.Build.Tasks.Git.props')" />
+  <Import Project="$(PackagesPath)Microsoft.SourceLink.Common\build\Microsoft.SourceLink.Common.props" Condition="'$(MSBuildProjectExtension)' != '.vcxproj' and Exists('$(PackagesPath)Microsoft.SourceLink.Common\build\Microsoft.SourceLink.Common.props')" />
+  <Import Project="$(PackagesPath)Microsoft.SourceLink.GitHub\build\Microsoft.SourceLink.GitHub.props" Condition="'$(MSBuildProjectExtension)' != '.vcxproj' and Exists('$(PackagesPath)Microsoft.SourceLink.GitHub\build\Microsoft.SourceLink.GitHub.props')" />
+</Project>

--- a/Build/SourceLink.targets
+++ b/Build/SourceLink.targets
@@ -1,0 +1,6 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(PackagesPath)Microsoft.Build.Tasks.Git\buildTransitive\Microsoft.Build.Tasks.Git.targets" Condition="'$(MSBuildProjectExtension)' != '.vcxproj' and Exists('$(PackagesPath)Microsoft.Build.Tasks.Git\buildTransitive\Microsoft.Build.Tasks.Git.targets')" />
+  <Import Project="$(PackagesPath)Microsoft.Build.Tasks.Git\build\Microsoft.Build.Tasks.Git.targets" Condition="'$(MSBuildProjectExtension)' != '.vcxproj' and !Exists('$(PackagesPath)Microsoft.Build.Tasks.Git\buildTransitive\Microsoft.Build.Tasks.Git.targets') and Exists('$(PackagesPath)Microsoft.Build.Tasks.Git\build\Microsoft.Build.Tasks.Git.targets')" />
+  <Import Project="$(PackagesPath)Microsoft.SourceLink.Common\build\Microsoft.SourceLink.Common.targets" Condition="'$(MSBuildProjectExtension)' != '.vcxproj' and Exists('$(PackagesPath)Microsoft.SourceLink.Common\build\Microsoft.SourceLink.Common.targets')" />
+  <Import Project="$(PackagesPath)Microsoft.SourceLink.GitHub\build\Microsoft.SourceLink.GitHub.targets" Condition="'$(MSBuildProjectExtension)' != '.vcxproj' and Exists('$(PackagesPath)Microsoft.SourceLink.GitHub\build\Microsoft.SourceLink.GitHub.targets')" />
+</Project>

--- a/Python/Product/DebuggerHelper/DebuggerHelper.vcxproj
+++ b/Python/Product/DebuggerHelper/DebuggerHelper.vcxproj
@@ -95,9 +95,13 @@
     <RunCodeAnalysis>true</RunCodeAnalysis>
   </PropertyGroup>
   <ItemDefinitionGroup>
+    <ClCompile>
+      <StringPooling>true</StringPooling>
+    </ClCompile>
     <Link>
       <GenerateDebugInformation>DebugFull</GenerateDebugInformation>
       <FullProgramDatabaseFile>true</FullProgramDatabaseFile>
+      <IgnoreSpecificDefaultLibraries>odbccp32.lib;%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">

--- a/Python/Product/DebuggerHelper/DebuggerHelperX86.vcxproj
+++ b/Python/Product/DebuggerHelper/DebuggerHelperX86.vcxproj
@@ -95,9 +95,13 @@
     <RunCodeAnalysis>true</RunCodeAnalysis>
   </PropertyGroup>
   <ItemDefinitionGroup>
+    <ClCompile>
+      <StringPooling>true</StringPooling>
+    </ClCompile>
     <Link>
       <GenerateDebugInformation>DebugFull</GenerateDebugInformation>
       <FullProgramDatabaseFile>true</FullProgramDatabaseFile>
+      <IgnoreSpecificDefaultLibraries>odbccp32.lib;%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">


### PR DESCRIPTION
BA2027 (EnableSourceLink): Add Microsoft.SourceLink.GitHub 1.1.1 and dependencies to enable SourceLink for C# projects. Added SourceLink NuGet packages to packages.config, created SourceLink.props/targets build files, and registered symlinks in PreBuild.ps1.

BA2007 (EnableCriticalCompilerWarnings): Exclude odbccp32.lib from DebuggerHelper linking. This system library contains objects compiled with /wd4146 which conflicts with required warning policies. This is a known MSVC SDK issue (DevCom #11014457).

BA6002 (EliminateDuplicateStrings): Enable string pooling in both DebuggerHelper vcxproj files.