### PR TITLE
Sign Django and Web template JS/TTF files with 3PartyScriptsSHA2

### DIFF
--- a/Python/Setup/signlayout.proj
+++ b/Python/Setup/signlayout.proj
@@ -96,6 +96,26 @@
     </ItemGroup>
   </Target>
 
+  <Target Name="_StageTemplateFiles" BeforeTargets="_AddTemplateFiles">
+    <ItemGroup>
+      <!-- Glob from Python\Templates\ so RecursiveDir preserves Django\ and Web\ subdirectory structure -->
+      <_TemplateSourceFiles Include="$(BuildRoot)\Python\Templates\**\*.js;$(BuildRoot)\Python\Templates\**\*.ttf" />
+    </ItemGroup>
+    <Copy SourceFiles="@(_TemplateSourceFiles)"
+          DestinationFiles="@(_TemplateSourceFiles->'$(BinariesOutputPath)templates\%(RecursiveDir)%(Filename)%(Extension)')" />
+  </Target>
+  <Target Name="_AddTemplateFiles" BeforeTargets="_PreserveUnsigned;ListFiles">
+    <ItemGroup>
+      <TemplateFilesToSign Include="$(BinariesOutputPath)templates\**\*.js;$(BinariesOutputPath)templates\**\*.ttf" />
+      <FilesToSign Include="@(TemplateFilesToSign)">
+        <Authenticode>3PartyScriptsSHA2</Authenticode>
+        <StrongName></StrongName>
+        <SignedPath>$(BinariesOutputPath)templates\%(RecursiveDir)%(Filename)%(Extension)</SignedPath>
+        <UnsignedPath>$(UnsignedOutputPath)templates\%(RecursiveDir)%(Filename)%(Extension)</UnsignedPath>
+      </FilesToSign>
+    </ItemGroup>
+  </Target>
+
   <Target Name="_PreserveUnsigned" Inputs="%(FilesToSign.FullPath)" Outputs="%(FilesToSign.UnsignedPath)" BeforeTargets="SignFiles">
     <Copy SourceFiles="%(FilesToSign.FullPath)" DestinationFiles="%(FilesToSign.UnsignedPath)" />
   </Target>
@@ -127,9 +147,18 @@
     </ItemGroup>
   </Target>
 
+  <Target Name="_CopySignedTemplateFiles">
+    <ItemGroup>
+      <_SignedTemplateFiles Include="$(BinariesOutputPath)templates\**\*.js;$(BinariesOutputPath)templates\**\*.ttf" />
+    </ItemGroup>
+    <Copy SourceFiles="@(_SignedTemplateFiles)"
+          DestinationFiles="@(_SignedTemplateFiles->'$(BuildRoot)\Python\Templates\%(RecursiveDir)%(Filename)%(Extension)')"
+          OverwriteReadOnlyFiles="true" />
+  </Target>
+
 
   <Target Name="_UpdateLayoutWithSignedBinaries"
-          DependsOnTargets="_GetBinariesInLayout;_GetJsFilesInLayout"
+          DependsOnTargets="_GetBinariesInLayout;_GetJsFilesInLayout;_CopySignedTemplateFiles"
           AfterTargets="SignFiles">
     <Copy SourceFiles="%(_BinariesToCopy.FullPath)" DestinationFiles="%(_BinariesToCopy.TargetPath)" />
   </Target>


### PR DESCRIPTION
## Summary

The VS signing scan flags unsigned files in two PTVS template payloads:
- `mspythontoolsdjangotemplatesvsix170260206neutral`: 15 files (14 JS + 1 TTF)
- `mspythontoolswebtemplatesvsix170260206neutral`: 45 files (42 JS + 3 TTF)

All are 3rd-party OSS files (jQuery 1.10.2, Bootstrap 3.x, Modernizr 2.6.2, Respond.js, Glyphicons) in the StarterDjangoProject and Bottle/Flask web project templates.

## Root Cause

`Python/Setup/signlayout.proj` signs Pylance JS via `_AddPylanceFiles` but does not cover the Django or Web template directories. The swixprojs source from `Python/Templates/Django/` and `Python/Templates/Web/` respectively, so these files flow into the VSIXes unsigned.

## Fix

Add 3 MSBuild targets to `signlayout.proj`:

1. **`_StageTemplateFiles`** - globs JS/TTF from `Python/Templates/` (preserving Django/Web subdirectory structure) and copies to a signing staging area
2. **`_AddTemplateFiles`** - registers them for MicroBuild signing with `3PartyScriptsSHA2` certificate
3. **`_CopySignedTemplateFiles`** - copies signed files back to the source tree for SWIX packaging

## Verification

After merge + insertion, both payloads should show 0 unsigned files in the VS signing scan (60 files resolved total).

## Related

- AzDO bug [2949498](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2949498) (Django templates - 15 files)
- AzDO bug [2951790](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2951790) (Web templates - 45 files)