### PR TITLE
Skip zero-byte files in template signing to fix installer build break

### DIFF
--- a/Python/Setup/signlayout.proj
+++ b/Python/Setup/signlayout.proj
@@ -107,6 +107,11 @@
   <Target Name="_AddTemplateFiles" BeforeTargets="_PreserveUnsigned;ListFiles">
     <ItemGroup>
       <TemplateFilesToSign Include="$(BinariesOutputPath)templates\**\*.js;$(BinariesOutputPath)templates\**\*.ttf" />
+      <!-- Drop zero-byte files (e.g. the empty 'Add New Item -> JavaScript' template placeholder).
+           signtool cannot map a 0-byte file (CreateFileMapping fails with ERROR_FILE_INVALID 0x3EE),
+           which would otherwise break the signing step. -->
+      <TemplateFilesToSign Remove="@(TemplateFilesToSign)"
+                           Condition="'$([System.IO.File]::ReadAllText(%(TemplateFilesToSign.FullPath)))' == ''" />
       <FilesToSign Include="@(TemplateFilesToSign)">
         <Authenticode>3PartyScriptsSHA2</Authenticode>
         <StrongName></StrongName>


### PR DESCRIPTION
## Summary

Fixes the `Build installer` pipeline failure introduced by #8485 ("Sign Django and Web template JS and TTF files with 3PartyScriptsSHA2").

## Root cause

`signlayout.proj` (`_AddTemplateFiles`) globs **every** `*.js` / `*.ttf` under `Python/Templates/` for Authenticode signing. That glob picks up the 0-byte placeholder file `Python/Templates/Web/ItemTemplates/Python/JavaScript/JavaScript.js`, which is the payload for the VS "Add New Item → JavaScript file" item template (intentionally empty — VS copies it into the user's project on demand). SignTool cannot map a 0-byte file, so signing fails.

## Fix

Filter zero-byte entries out of `TemplateFilesToSign` before they reach `FilesToSign`
