### PR TITLE
fix mypy issue

### DIFF
--- a/Python/Product/BuildTasks/Microsoft.PythonTools.targets
+++ b/Python/Product/BuildTasks/Microsoft.PythonTools.targets
@@ -203,9 +203,13 @@ permissions and limitations under the License.
   <Target Name="PythonRunMypyCommand"
           Label="resource:Microsoft.PythonTools.Common;Microsoft.PythonTools.Common.Strings;RunMypyLabel"
           Returns="@(Commands)">
+    <!-- Disable mypy's incremental cache so that "Run Mypy"
+         always reflects the current source files and configuration; otherwise mypy
+         may reuse cached per-module results after mypy.ini is added or removed,
+         causing the Error List to show stale results. -->
     <CreatePythonCommandItem Target="mypy"
                              TargetType="module"
-                             Arguments="--show-column-numbers @(Compile, ' ')"
+                             Arguments="--no-incremental --show-column-numbers @(Compile, ' ')"
                              WorkingDirectory="$(QualifiedProjectHome)"
                              ExecuteIn="output"
                              RequiredPackages="mypy"


### PR DESCRIPTION
fixes https://github.com/microsoft/PTVS/issues/8348

Pass --no-incremental to mypy in the PythonRunMypyCommand MSBuild target in Python/Product/BuildTasks/Microsoft.PythonTools.targets. "Run Mypy" is an explicit, user-initiated command (not a continuous background analyzer), so always producing a correct result is preferable to caching for speed.