### PR TITLE
Fix #2946811: update DDE application name to `VisualStudio.18.0` so Explorer double-click opens `.py` files on VS 2026

### DIFF
--- a/Build/Common.Build.Core.settings
+++ b/Build/Common.Build.Core.settings
@@ -126,7 +126,7 @@
   <PropertyGroup>
     <PackagePreprocessorDefinitions>
       <!-- VsDdeApplication is defined incorrectly in Microsoft.Wix4.Swix.Tools.targets so we hard code it until they fix it -->
-      VsDdeApplication17=VisualStudio.17.0
+      VsDdeApplication18=VisualStudio.18.0
     </PackagePreprocessorDefinitions>
   </PropertyGroup>
 

--- a/Python/Setup/swix/Packages/file_associations.swr
+++ b/Python/Setup/swix/Packages/file_associations.swr
@@ -28,7 +28,7 @@ vs.progIds
         DefaultIconPath="[InstallDir]\Common7\Extensions\Microsoft\Python\Core\PythonFile.ico"
         DefaultIconPosition=0
         Dde=true
-        DdeApplication=$(VsDdeApplication17)
+        DdeApplication=$(VsDdeApplication18)
         DdeTopic=system
     
     vs.progId


### PR DESCRIPTION
**Issue:** [#2946811](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2946811) — Double-clicking a `.py` file in Windows Explorer opens a blank "Continue without code" page on Visual Studio 2026 18.5 (regression from VS 2022 17.14.29 where it worked).

**Context**

PTVS registers `.py`, `.pyw`, and `.pyproj` with Windows via a SWIX manifest baked into the `Microsoft.PythonTools.Core` VSIX. The ProgID for `.py` (`VisualStudio.py.[InstanceId]`) tells Windows Explorer to launch `devenv.exe /dde "%1"` and then deliver the filename through a DDE conversation with a named application target.

The DDE application name is supplied at build time via the `VsDdeApplication17` MSBuild preprocessor variable defined in `Build/Common.Build.Core.settings`. The comment next to the definition notes it has to be hard-coded because `Microsoft.Wix4.Swix.Tools.targets` defines it incorrectly.

**Issue**

The preprocessor variable was hard-coded to `VisualStudio.17.0`, which is the DDE application name `devenv.exe` registers when it runs as Visual Studio 2022 (major version 17). When VS 2026 (major version 18) ships, the running `devenv.exe` registers itself with Windows as `VisualStudio.18.0`. The DDE conversation Windows tries to initiate against `VisualStudio.17.0` never finds a peer, Windows times out, and the `/dde "%1"` filename argument is dropped. `devenv` then starts cold without a file and lands on the "Continue without code" start page.

This matches every detail of the customer's report: Explorer double-click is broken (it uses DDE), drag-and-drop still works (it doesn't), "Open with…" still works (it doesn't), VS 2022 still works (it matches the hard-coded name), VS 2026 doesn't.

**Fix**

Rename the preprocessor variable to `VsDdeApplication18` and set its value to `VisualStudio.18.0` so the file-association ProgID written into the Windows Registry matches the DDE application name the VS 2026 `devenv.exe` actually announces. The SWR reference in `file_associations.swr` is updated to the new variable name so the substitution still resolves.

Files changed:
- `Build/Common.Build.Core.settings`
- `Python/Setup/swix/Packages/file_associations.swr`