### PR TITLE
Fix Watson #1229982: Catch PathTooLongException in PipPackageManager event handlers

### DIFF
--- a/Python/Product/VSInterpreters/PackageManager/PipPackageManager.cs
+++ b/Python/Product/VSInterpreters/PackageManager/PipPackageManager.cs
@@ -756,44 +756,39 @@ namespace Microsoft.PythonTools.Interpreter {
             // RenamedEventArgs lazily builds and normalizes the full paths on demand,
             // and on .NET Framework that normalization enforces MAX_PATH (260) and
             // can throw PathTooLongException - even just reading the properties.
-            // Watch sites use IncludeSubdirectories under site-packages so deeply
-            // vendored packages routinely exceed 260 chars.
-            string fullPath, oldFullPath;
+            // The Directory.Exists / ModulePath.IsPythonFile checks below call into
+            // the same Win32 path APIs and can throw for the same reason, so wrap
+            // the whole inspection. Watch sites use IncludeSubdirectories under
+            // site-packages so deeply vendored packages routinely exceed 260 chars.
             try {
-                fullPath = e.FullPath;
-                oldFullPath = e.OldFullPath;
-            } catch (PathTooLongException) {
-                return;
-            }
-
-            if (Directory.Exists(fullPath) ||
-                ModulePath.IsPythonFile(fullPath, false, true, false) ||
-                ModulePath.IsPythonFile(oldFullPath, false, true, false)) {
-                try {
-                    _refreshIsCurrentTrigger.Change(1000, Timeout.Infinite);
-                } catch (ObjectDisposedException) {
+                if (Directory.Exists(e.FullPath) ||
+                    ModulePath.IsPythonFile(e.FullPath, false, true, false) ||
+                    ModulePath.IsPythonFile(e.OldFullPath, false, true, false)) {
+                    try {
+                        _refreshIsCurrentTrigger.Change(1000, Timeout.Infinite);
+                    } catch (ObjectDisposedException) {
+                    }
                 }
+            } catch (PathTooLongException) {
             }
         }
 
         private void OnChanged(object sender, FileSystemEventArgs e) {
             // FileSystemEventArgs lazily normalizes FullPath and can throw
-            // PathTooLongException on .NET Framework MAX_PATH overflow.
-            string fullPath;
+            // PathTooLongException on .NET Framework MAX_PATH overflow. The
+            // Directory.Exists / IsPythonFile / GetFileOrDirectoryName calls below
+            // hit the same path-normalization code, so wrap the whole inspection.
             try {
-                fullPath = e.FullPath;
-            } catch (PathTooLongException) {
-                return;
-            }
-
-            if ((Directory.Exists(fullPath) && 
-                !PathUtils.GetFileOrDirectoryName(fullPath).Equals("__pycache__", StringComparison.OrdinalIgnoreCase)) ||
-                ModulePath.IsPythonFile(fullPath, false, true, false)
-            ) {
-                try {
-                    _refreshIsCurrentTrigger.Change(1000, Timeout.Infinite);
-                } catch (ObjectDisposedException) {
+                if ((Directory.Exists(e.FullPath) &&
+                    !PathUtils.GetFileOrDirectoryName(e.FullPath).Equals("__pycache__", StringComparison.OrdinalIgnoreCase)) ||
+                    ModulePath.IsPythonFile(e.FullPath, false, true, false)
+                ) {
+                    try {
+                        _refreshIsCurrentTrigger.Change(1000, Timeout.Infinite);
+                    } catch (ObjectDisposedException) {
+                    }
                 }
+            } catch (PathTooLongException) {
             }
         }
     }

--- a/Python/Product/VSInterpreters/PackageManager/PipPackageManager.cs
+++ b/Python/Product/VSInterpreters/PackageManager/PipPackageManager.cs
@@ -753,9 +753,22 @@ namespace Microsoft.PythonTools.Interpreter {
         }
 
         private void OnRenamed(object sender, RenamedEventArgs e) {
-            if (Directory.Exists(e.FullPath) ||
-                ModulePath.IsPythonFile(e.FullPath, false, true, false) ||
-                ModulePath.IsPythonFile(e.OldFullPath, false, true, false)) {
+            // RenamedEventArgs lazily builds and normalizes the full paths on demand,
+            // and on .NET Framework that normalization enforces MAX_PATH (260) and
+            // can throw PathTooLongException - even just reading the properties.
+            // Watch sites use IncludeSubdirectories under site-packages so deeply
+            // vendored packages routinely exceed 260 chars.
+            string fullPath, oldFullPath;
+            try {
+                fullPath = e.FullPath;
+                oldFullPath = e.OldFullPath;
+            } catch (PathTooLongException) {
+                return;
+            }
+
+            if (Directory.Exists(fullPath) ||
+                ModulePath.IsPythonFile(fullPath, false, true, false) ||
+                ModulePath.IsPythonFile(oldFullPath, false, true, false)) {
                 try {
                     _refreshIsCurrentTrigger.Change(1000, Timeout.Infinite);
                 } catch (ObjectDisposedException) {
@@ -764,9 +777,18 @@ namespace Microsoft.PythonTools.Interpreter {
         }
 
         private void OnChanged(object sender, FileSystemEventArgs e) {
-            if ((Directory.Exists(e.FullPath) && 
-                !PathUtils.GetFileOrDirectoryName(e.FullPath).Equals("__pycache__", StringComparison.OrdinalIgnoreCase)) ||
-                ModulePath.IsPythonFile(e.FullPath, false, true, false)
+            // FileSystemEventArgs lazily normalizes FullPath and can throw
+            // PathTooLongException on .NET Framework MAX_PATH overflow.
+            string fullPath;
+            try {
+                fullPath = e.FullPath;
+            } catch (PathTooLongException) {
+                return;
+            }
+
+            if ((Directory.Exists(fullPath) && 
+                !PathUtils.GetFileOrDirectoryName(fullPath).Equals("__pycache__", StringComparison.OrdinalIgnoreCase)) ||
+                ModulePath.IsPythonFile(fullPath, false, true, false)
             ) {
                 try {
                     _refreshIsCurrentTrigger.Change(1000, Timeout.Infinite);


### PR DESCRIPTION
## Issue

[Watson #1229982](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1229982) — `CLR_EXCEPTION_System.IO.PathTooLongException` in `PipPackageManager.OnRenamed` (**18 hits**, build 18.4).

### Problem
The pip package watcher is registered on every `site-packages` directory with `IncludeSubdirectories = true`. `RenamedEventArgs.FullPath` / `OldFullPath` (and `FileSystemEventArgs.FullPath`) lazily build and normalize the path on demand. On .NET Framework that normalization enforces `MAX_PATH` (260) — so even the simple **property accessor** throws `PathTooLongException` for any deeply-nested vendored dependency, before our actual logic runs.

## Fix
Read `e.FullPath` / `e.OldFullPath` once into locals inside `try { … } catch (PathTooLongException) { return; }` at the top of `OnRenamed` and `OnChanged`. The downstream logic uses the local copies, so the property accessors are invoked at most once per event.

**Files changed**
- `Python/Product/VSInterpreters/PackageManager/PipPackageManager.cs`
