### PR TITLE
Fix Watson #1345469: Use ProcessStartInfo.Environment to tolerate case-insensitive duplicate env vars

### DIFF
--- a/Common/Product/SharedProject/ProcessOutput.cs
+++ b/Common/Product/SharedProject/ProcessOutput.cs
@@ -206,8 +206,11 @@ namespace Microsoft.VisualStudioTools.Infrastructure {
             psi.StandardOutputEncoding = outputEncoding ?? psi.StandardOutputEncoding;
             psi.StandardErrorEncoding = errorEncoding ?? outputEncoding ?? psi.StandardErrorEncoding;
             if (env != null) {
+                // Use psi.Environment instead of psi.EnvironmentVariables to
+                // tolerate case-insensitive duplicate keys in the inherited
+                // parent environment block.
                 foreach (var kv in env) {
-                    psi.EnvironmentVariables[kv.Key] = kv.Value;
+                    psi.Environment[kv.Key] = kv.Value;
                 }
             }
 

--- a/Python/Product/Common/Infrastructure/ProcessOutput.cs
+++ b/Python/Product/Common/Infrastructure/ProcessOutput.cs
@@ -264,8 +264,13 @@ namespace Microsoft.PythonTools.Infrastructure {
             psi.StandardOutputEncoding = outputEncoding ?? psi.StandardOutputEncoding;
             psi.StandardErrorEncoding = errorEncoding ?? outputEncoding ?? psi.StandardErrorEncoding;
             if (env != null) {
+                // Use psi.Environment (Dictionary<string,string> with OrdinalIgnoreCase)
+                // instead of psi.EnvironmentVariables (StringDictionary backed by
+                // a Hashtable that throws ArgumentException when the inherited
+                // parent environment contains case-insensitive duplicate keys
+                // such as PATH/Path or TMP/Tmp).
                 foreach (var kv in env) {
-                    psi.EnvironmentVariables[kv.Key] = kv.Value;
+                    psi.Environment[kv.Key] = kv.Value;
                 }
             }
 

--- a/Python/Product/Cookiecutter/Shared/Infrastructure/ProcessOutput.cs
+++ b/Python/Product/Cookiecutter/Shared/Infrastructure/ProcessOutput.cs
@@ -260,8 +260,11 @@ namespace Microsoft.CookiecutterTools.Infrastructure {
             psi.StandardOutputEncoding = outputEncoding ?? psi.StandardOutputEncoding;
             psi.StandardErrorEncoding = errorEncoding ?? outputEncoding ?? psi.StandardErrorEncoding;
             if (env != null) {
+                // Use psi.Environment instead of psi.EnvironmentVariables to
+                // tolerate case-insensitive duplicate keys in the inherited
+                // parent environment block.
                 foreach (var kv in env) {
-                    psi.EnvironmentVariables[kv.Key] = kv.Value;
+                    psi.Environment[kv.Key] = kv.Value;
                 }
             }
 


### PR DESCRIPTION
## Issue

[Watson #1345469](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1345469) — `CLR_EXCEPTION_System.ArgumentException` from `ProcessStartInfo.get_EnvironmentVariables` (**80 hits**, builds 16.11.32106.194 – 16.11.36602.28).

### Problem
`ProcessStartInfo.EnvironmentVariables` is a `StringDictionary` backed by a `Hashtable`. If the parent process (`devenv.exe`) ends up with two environment variables whose names differ only in casing (e.g. `Path` / `PATH`, `TEMP` / `Temp` — commonly caused by Conda activation scripts or third-party installers), the lazy build of that dictionary throws `ArgumentException: "Item has already been added"`. This is a long-standing .NET Framework defect ([dotnet/runtime#26331](https://github.com/dotnet/runtime/issues/26331)).

## Fix
Switch the env-merge loop from `psi.EnvironmentVariables[k] = v` to `psi.Environment[k] = v`. `ProcessStartInfo.Environment` (added in .NET 4.6) is an `IDictionary<string,string>` with `OrdinalIgnoreCase` semantics on Windows that tolerates duplicates by overwriting. The child process still sees the same effective environment.

Applied at all three copies of `ProcessOutput.cs`:

**Files changed**
- `Common/Product/SharedProject/ProcessOutput.cs`
- `Python/Product/Common/Infrastructure/ProcessOutput.cs`
- `Python/Product/Cookiecutter/Shared/Infrastructure/ProcessOutput.cs`
