### PR TITLE
Fix Watson #1446269: Marshal ReanalyzeProject_Notify to UI thread

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Project/PythonProjectNode.cs
+++ b/Python/Product/PythonTools/PythonTools/Project/PythonProjectNode.cs
@@ -1249,12 +1249,19 @@ namespace Microsoft.PythonTools.Project {
             if (IsClosed) {
                 return;
             }
+            // Snap Site to a local: the timer can fire during teardown after
+            // Close() nulls Site but before IsClosed flips, or during a
+            // partially-initialized project, which would NRE the call below.
+            var site = Site;
+            if (site == null) {
+                return;
+            }
             // Subscribers mutate the project hierarchy, which VS's
             // SolutionItemCacheInvalidator now asserts must run on the UI
             // thread (VS 17.14+ tightened threading). Marshal the event raise
             // back to the UI thread to avoid RPC_E_WRONG_THREAD.
             try {
-                Site.GetUIThread().InvokeAsync(() => {
+                site.GetUIThread().InvokeAsync(() => {
                     if (IsClosed) {
                         return;
                     }

--- a/Python/Product/PythonTools/PythonTools/Project/PythonProjectNode.cs
+++ b/Python/Product/PythonTools/PythonTools/Project/PythonProjectNode.cs
@@ -1249,7 +1249,20 @@ namespace Microsoft.PythonTools.Project {
             if (IsClosed) {
                 return;
             }
-            ReanalyzeProject_Notify?.Invoke(this, EventArgs.Empty);
+            // Subscribers mutate the project hierarchy, which VS's
+            // SolutionItemCacheInvalidator now asserts must run on the UI
+            // thread (VS 17.14+ tightened threading). Marshal the event raise
+            // back to the UI thread to avoid RPC_E_WRONG_THREAD.
+            try {
+                Site.GetUIThread().InvokeAsync(() => {
+                    if (IsClosed) {
+                        return;
+                    }
+                    ReanalyzeProject_Notify?.Invoke(this, EventArgs.Empty);
+                }).DoNotWait();
+            } catch (ObjectDisposedException) {
+                // Site disposed during shutdown - safe to drop the notification.
+            }
         }
 
         protected override string AssemblyReferenceTargetMoniker {


### PR DESCRIPTION
## Issue

[Watson #1446269](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1446269) — `CLR_EXCEPTION_System.Runtime.InteropServices.COMException_8001010e` (`RPC_E_WRONG_THREAD`) in `SolutionItemCacheInvalidator.OnItemDeleted` (**36 hits**, build 17.14.37216.2 — new in VS 17.14).

### Problem
`OnReanalyzeProject_Notify` is a `System.Threading.Timer` callback that runs on the thread pool. It raises `ReanalyzeProject_Notify`, whose subscriber (`PythonLanguageClientContextProject`) ultimately mutates the project hierarchy. VS 17.14 tightened threading on `SolutionItemCacheInvalidator` so any non-UI-thread hierarchy mutation now throws `RPC_E_WRONG_THREAD`.

## Fix
Wrap the `ReanalyzeProject_Notify?.Invoke(...)` raise in `Site.GetUIThread().InvokeAsync(...).DoNotWait()` so the notification fires on the UI thread. The queued lambda re-checks `IsClosed` to handle close-during-dispatch races. `ObjectDisposedException` from `Site.GetUIThread()` (site torn down during shutdown) is caught.

The pattern matches existing call sites: `CommonProjectNode.cs:951`, `ProjectNode.cs:2021`, `InterpretersNode.cs:146`. The only subscriber is a simple pass-through, so there is no ordering dependency that would be broken by async dispatch.

**Files changed**
- `Python/Product/PythonTools/PythonTools/Project/PythonProjectNode.cs`
