### PR TITLE
Fix Watson #1459718: Tolerate Win32Exception when launching missing interpreter

### DIFF
--- a/Python/Product/Common/Core/OS/ProcessServices.cs
+++ b/Python/Product/Common/Core/OS/ProcessServices.cs
@@ -15,6 +15,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -24,13 +25,29 @@ using System.Threading.Tasks;
 namespace Microsoft.PythonTools.Common.Core.OS {
     public sealed class ProcessServices : IProcessServices {
         public IProcess Start(ProcessStartInfo psi) {
-            var process = Process.Start(psi);
-            return process != null ? new PlatformProcess(this, process) : null;
+            try {
+                var process = Process.Start(psi);
+                return process != null ? new PlatformProcess(this, process) : null;
+            } catch (Win32Exception) {
+                // Interpreter executable is missing/renamed/access-denied. Returning null
+                // lets callers treat the environment as unavailable rather than crashing
+                // VS via an unhandled exception on the dispatcher.
+                return null;
+            } catch (InvalidOperationException) {
+                // ProcessStartInfo state invalid (e.g. FileName not set).
+                return null;
+            }
         }
 
         public IProcess Start(string path) {
-            var process = Process.Start(path);
-            return process != null ? new PlatformProcess(this, process) : null;
+            try {
+                var process = Process.Start(path);
+                return process != null ? new PlatformProcess(this, process) : null;
+            } catch (Win32Exception) {
+                return null;
+            } catch (InvalidOperationException) {
+                return null;
+            }
         }
 
         public void Kill(IProcess process) => Kill(process.Id);
@@ -40,6 +57,11 @@ namespace Microsoft.PythonTools.Common.Core.OS {
         public async Task<string> ExecuteAndCaptureOutputAsync(ProcessStartInfo startInfo, CancellationToken cancellationToken = default) {
             var output = string.Empty;
             using (var process = Start(startInfo)) {
+                // Start now returns null when the executable is missing instead of
+                // throwing Win32Exception. Treat null as "no output".
+                if (process == null) {
+                    return output;
+                }
 
                 if (startInfo.RedirectStandardError && process is PlatformProcess p) {
                     p.Process.ErrorDataReceived += (s, e) => { };


### PR DESCRIPTION
## Issue

[Watson #1459718](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1459718) — `CLR_EXCEPTION_System.ComponentModel.Win32Exception` in `ProcessServices.Start` (**8 hits**, build 17.2.32929.388).

### Problem
When the user selects an environment in the **Python Environments** window (Watson stack shows the WPF `MoveCurrentToPosition` trigger), PTVS launches the interpreter to gather configuration. If the executable has been deleted or renamed (very common stale registration after uninstalling Python without scrubbing the registry), `Process.Start` throws `Win32Exception` (`ERROR_FILE_NOT_FOUND` / `ERROR_DIRECTORY`). The exception propagates through async lambdas and the WPF Dispatcher → crashes VS.

## Fix
- Wrap both `Start(ProcessStartInfo)` and `Start(string)` in `try { … } catch (Win32Exception) { return null; } catch (InvalidOperationException) { return null; }`. Returning `null` matches the pre-existing "process couldn't start" contract callers already handle.
- Update `ExecuteAndCaptureOutputAsync` to early-return `string.Empty` when `Start` returns `null` (treats a missing interpreter as "no output" instead of NRE'ing on the using-block).

**Files changed**
- `Python/Product/Common/Core/OS/ProcessServices.cs`
