### PR TITLE
Fix Watson #1488201: Surface cookiecutter install failures without crashing VS

### DIFF
--- a/Python/Product/Cookiecutter/Model/CookiecutterClient.cs
+++ b/Python/Product/Cookiecutter/Model/CookiecutterClient.cs
@@ -65,15 +65,13 @@ namespace Microsoft.CookiecutterTools.Model {
         }
 
         public async Task CreateCookiecutterEnv() {
-
-            // Create a virtual environment using the global interpreter
-            try {
-                await CreateVenvWithoutPipThenInstallPip();
-            } catch (ProcessException ex) {
-                // critical exception is needed for EnsureCookiecutterIsInstalledAsync() to fail properly
-                var errMsg = Strings.InstallingCookiecutterCreateEnvFailed.FormatUI(_expectedEnvFolderPath);
-                throw new CriticalException(errMsg, ex);
-            }
+            // Failures from the underlying install steps now surface as
+            // InvalidOperationException via WaitForCookiecutterInstallOutput
+            // EnsureCookiecutterIsInstalledAsync's outer
+            // catch handles any non-critical Exception, so we no longer need
+            // to re-wrap ProcessException as a CriticalException (which used
+            // to escape the outer catch and crash VS).
+            await CreateVenvWithoutPipThenInstallPip();
         }
 
         // Checks if the specified path has been redirected by python
@@ -164,7 +162,7 @@ namespace Microsoft.CookiecutterTools.Model {
                 false,
                 _redirector
             );
-            await WaitForOutput(_interpreter.InterpreterExecutablePath, output);
+            await WaitForCookiecutterInstallOutput(_interpreter.InterpreterExecutablePath, output);
 
             // If we get here, the environment was created successfully.
             // Check for redirection again, overwriting the existing value if there is
@@ -181,7 +179,7 @@ namespace Microsoft.CookiecutterTools.Model {
                 false,
                 _redirector
             );
-            await WaitForOutput(_interpreter.InterpreterExecutablePath, output);
+            await WaitForCookiecutterInstallOutput(_interpreter.InterpreterExecutablePath, output);
         }
 
         private void RemoveExistingVenv(string envPath) {
@@ -209,7 +207,7 @@ namespace Microsoft.CookiecutterTools.Model {
                 _redirector
             );
 
-            await WaitForOutput(_envInterpreterPath, output);
+            await WaitForCookiecutterInstallOutput(_envInterpreterPath, output);
         }
 
         public async Task<TemplateContext> LoadUnrenderedContextAsync(string localTemplateFolder, string userConfigFilePath) {
@@ -693,6 +691,23 @@ namespace Microsoft.CookiecutterTools.Model {
                 }
 
                 return r;
+            }
+        }
+
+        // Helper used by the cookiecutter venv/pip install paths to convert a
+        // non-zero subprocess exit into a typed, user-visible failure instead
+        // of letting the raw ProcessException tear down VS.
+        private async Task<ProcessOutputResult> WaitForCookiecutterInstallOutput(string interpreterPath, ProcessOutput output) {
+            try {
+                return await WaitForOutput(interpreterPath, output);
+            } catch (ProcessException ex) {
+                _redirector.WriteErrorLine(Strings.CookiecutterInstallFailed.FormatUI(ex.Result.ExitCode));
+                if (ex.Result.StandardErrorLines != null) {
+                    foreach (var line in ex.Result.StandardErrorLines) {
+                        _redirector.WriteErrorLine(line);
+                    }
+                }
+                throw new InvalidOperationException(Strings.CookiecutterInstallFailed.FormatUI(ex.Result.ExitCode), ex);
             }
         }
 

--- a/Python/Product/Cookiecutter/Strings.Designer.cs
+++ b/Python/Product/Cookiecutter/Strings.Designer.cs
@@ -416,6 +416,15 @@ namespace Microsoft.CookiecutterTools {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to ----- Failed to install cookiecutter (exit code {0}). See output above for details. -----.
+        /// </summary>
+        public static string CookiecutterInstallFailed {
+            get {
+                return ResourceManager.GetString("CookiecutterInstallFailed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to ----- Installing cookiecutter -----.
         /// </summary>
         public static string InstallingCookiecutterStarted {

--- a/Python/Product/Cookiecutter/Strings.resx
+++ b/Python/Product/Cookiecutter/Strings.resx
@@ -196,6 +196,10 @@ Please delete the installed template and try again.</value>
     <value>Installing packages into virtual environment at '{0}'</value>
     <comment>{0} is a folder path</comment>
   </data>
+  <data name="CookiecutterInstallFailed" xml:space="preserve">
+    <value>----- Failed to install cookiecutter (exit code {0}). See output above for details. -----</value>
+    <comment>{0} is a numeric process exit code</comment>
+  </data>
   <data name="CloningTemplateStarted" xml:space="preserve">
     <value>----- Cloning template '{0}' -----</value>
     <comment>{0} is a template name</comment>


### PR DESCRIPTION
## Issue

[Watson #1488201](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1488201) — `CLR_EXCEPTION_Microsoft.CookiecutterTools.Model.ProcessException` from `CookiecutterClient.WaitForOutput` (**12 hits**, builds 17.11.35219.272 – 18.3.11520.95).

### Problem
The cookiecutter feature creates a side venv, installs pip, then `pip install cookiecutter`. If any of those subprocesses fail (no network, corporate proxy blocking PyPI, corrupt interpreter), the subprocess exits non-zero, `WaitForOutput` throws `ProcessException`, and the exception escapes the WPF Dispatcher → crashes VS.

The original code in `CreateCookiecutterEnv` wrapped only the first install step in `try { … } throw new CriticalException(...)`. The outer handler in `CookiecutterViewModel.EnsureCookiecutterIsInstalledAsync` uses `catch (Exception ex) when (!ex.IsCriticalException())` — so the wrapped `CriticalException` **propagated uncaught** anyway, and the other two install paths (`pip install pip`, `pip install cookiecutter`) had no guard at all.

## Fix
- Add helper `WaitForCookiecutterInstallOutput(...)` that wraps `WaitForOutput`, catches `ProcessException`, writes a formatted error + stderr lines to `_redirector`, and re-throws as `InvalidOperationException`. `InvalidOperationException` is non-critical, so the outer handler catches it cleanly → sets status to `Failed`, returns `false`, fires telemetry.
- Route all three install-path `WaitForOutput` calls through the new helper.
- Remove the old `throw new CriticalException(...)` wrap in `CreateCookiecutterEnv` (the comment claiming it was "needed for EnsureCookiecutterIsInstalledAsync to fail properly" was incorrect — it actually crashed VS).
- Add localized string `CookiecutterInstallFailed` for the formatted error message.

**Files changed**
- `Python/Product/Cookiecutter/Model/CookiecutterClient.cs`
- `Python/Product/Cookiecutter/Strings.resx`
- `Python/Product/Cookiecutter/Strings.Designer.cs`
