### PR TITLE
Fix Watson #1641198: Do not throw when CloseSolutionElement fails during teardown

### DIFF
--- a/Common/Product/SharedProject/HierarchyNode.cs
+++ b/Common/Product/SharedProject/HierarchyNode.cs
@@ -1087,7 +1087,15 @@ namespace Microsoft.VisualStudioTools.Project {
                     // Is this one of our documents?
                     if (Utilities.IsSameComObject(srpOurHier, srpHier) && itemid == node.ID) {
                         IVsSolution soln = GetService(typeof(SVsSolution)) as IVsSolution;
-                        ErrorHandler.ThrowOnFailure(soln.CloseSolutionElement(saveOptions, srpOurHier, cookie[0]));
+                        // CloseSolutionElement may legitimately fail when VS is
+                        // already tearing down (e.g. solution close in progress),
+                        // so don't throw - we still need to release ppunkDocData
+                        // and continue enumerating.
+                        if (soln != null) {
+                            var hr = soln.CloseSolutionElement(saveOptions, srpOurHier, cookie[0]);
+                            Debug.Assert(ErrorHandler.Succeeded(hr) || hr == VSConstants.E_FAIL || hr == VSConstants.E_UNEXPECTED,
+                                "CloseSolutionElement returned unexpected hr 0x" + hr.ToString("X8"));
+                        }
                     }
                     if (ppunkDocData != IntPtr.Zero)
                         Marshal.Release(ppunkDocData);

--- a/Common/Product/SharedProject/HierarchyNode.cs
+++ b/Common/Product/SharedProject/HierarchyNode.cs
@@ -1091,6 +1091,7 @@ namespace Microsoft.VisualStudioTools.Project {
                         // already tearing down (e.g. solution close in progress),
                         // so don't throw - we still need to release ppunkDocData
                         // and continue enumerating.
+                        Debug.Assert(soln != null, "SVsSolution unavailable during CloseDocumentWindow");
                         if (soln != null) {
                             var hr = soln.CloseSolutionElement(saveOptions, srpOurHier, cookie[0]);
                             Debug.Assert(ErrorHandler.Succeeded(hr) || hr == VSConstants.E_FAIL || hr == VSConstants.E_UNEXPECTED,


### PR DESCRIPTION
## Issue

[Watson #1641198](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1641198) — `CLR_EXCEPTION_System.Runtime.InteropServices.COMException_80004005` (`E_FAIL`) in `HierarchyNode.CloseDocumentWindow` (**100 hits**, builds 17.9 – 18.6, still occurring).

### Problem
`CloseDocumentWindow` calls `ErrorHandler.ThrowOnFailure(soln.CloseSolutionElement(...))`. When VS is already tearing down the solution and has beaten PTVS to closing the editor frame, `CloseSolutionElement` returns `E_FAIL`. The throw skips the `Marshal.Release(ppunkDocData)` cleanup further down the loop body → COM ref leak + VS crash.

## Fix
Replace `ThrowOnFailure(...)` with `var hr = soln.CloseSolutionElement(...); Debug.Assert(...)` and add a `soln != null` guard. Failure HRs are now ignored in release builds; `E_FAIL` / `E_UNEXPECTED` are tolerated, unexpected HRs `Debug.Assert` in dev builds. The `Marshal.Release` runs cleanly and the loop continues to enumerate remaining documents.

**Files changed**
- `Common/Product/SharedProject/HierarchyNode.cs`
