### PR TITLE
Fix Watson #1812702: Catch broken-pipe IOException in StreamIntercepter

### DIFF
--- a/Python/Product/PythonTools/PythonTools/LanguageServerClient/StreamHacking/StreamIntercepter.cs
+++ b/Python/Product/PythonTools/PythonTools/LanguageServerClient/StreamHacking/StreamIntercepter.cs
@@ -69,21 +69,29 @@ namespace Microsoft.PythonTools.LanguageServerClient.StreamHacking {
         public override long Seek(long offset, SeekOrigin origin) => baseStream.Seek(offset, origin);
         public override void SetLength(long value) => baseStream.SetLength(value);
         public override void Write(byte[] buffer, int offset, int count) {
+            // Compute the handler result outside the try so that exceptions from
+            // writeHandler (which is application logic, not pipe I/O) propagate
+            // normally and never silently null out the handler.
+            StreamData payload;
+            bool keepHandler;
+            if (writeHandler != null) {
+                var writeHandlerResult = writeHandler.Invoke(new StreamData { bytes = buffer, offset = offset, count = count });
+                payload = writeHandlerResult.Item1;
+                keepHandler = writeHandlerResult.Item2;
+            } else {
+                payload = new StreamData { bytes = buffer, offset = offset, count = count };
+                keepHandler = true;
+            }
             try {
-                if (writeHandler != null) {
-                    var writeHandlerResult = writeHandler.Invoke(new StreamData { bytes = buffer, offset = offset, count = count });
-                    baseStream.Write(writeHandlerResult.Item1.bytes, writeHandlerResult.Item1.offset, writeHandlerResult.Item1.count);
-                    if (!writeHandlerResult.Item2) {
-                        writeHandler = null;
-                    }
-                } else {
-                    baseStream.Write(buffer, offset, count);
-                }
+                baseStream.Write(payload.bytes, payload.offset, payload.count);
             } catch (IOException) {
                 // Pipe to Pylance is broken (e.g. Pylance crashed - ERROR_BROKEN_PIPE 0x8007006d).
                 // Swallow so StreamJsonRpc can detect the disconnect via its own machinery
                 // rather than throwing on a long async chain that escapes to the dispatcher.
             } catch (ObjectDisposedException) {
+            }
+            if (writeHandler != null && !keepHandler) {
+                writeHandler = null;
             }
         }
     }

--- a/Python/Product/PythonTools/PythonTools/LanguageServerClient/StreamHacking/StreamIntercepter.cs
+++ b/Python/Product/PythonTools/PythonTools/LanguageServerClient/StreamHacking/StreamIntercepter.cs
@@ -42,9 +42,26 @@ namespace Microsoft.PythonTools.LanguageServerClient.StreamHacking {
 
         public override long Position { get => baseStream.Position; set => baseStream.Position = value; }
 
-        public override void Flush() => baseStream.Flush();
+        public override void Flush() {
+            try {
+                baseStream.Flush();
+            } catch (IOException) {
+                // Pipe to Pylance is broken (e.g. Pylance crashed).
+                // Swallow so StreamJsonRpc can detect the disconnect via its own machinery.
+            } catch (ObjectDisposedException) {
+            }
+        }
         public override int Read(byte[] buffer, int offset, int count) {
-            var result = baseStream.Read(buffer, offset, count);
+            int result;
+            try {
+                result = baseStream.Read(buffer, offset, count);
+            } catch (IOException) {
+                // Pipe to Pylance is broken. Returning 0 signals EOF to StreamJsonRpc
+                // which will cleanly raise Disconnected.
+                return 0;
+            } catch (ObjectDisposedException) {
+                return 0;
+            }
             var args = new StreamData { bytes = buffer, offset = offset, count = result };
             readHandler.Invoke(args);
             return result;
@@ -52,16 +69,22 @@ namespace Microsoft.PythonTools.LanguageServerClient.StreamHacking {
         public override long Seek(long offset, SeekOrigin origin) => baseStream.Seek(offset, origin);
         public override void SetLength(long value) => baseStream.SetLength(value);
         public override void Write(byte[] buffer, int offset, int count) {
-            if (writeHandler != null) {
-                var writeHandlerResult = writeHandler.Invoke(new StreamData { bytes = buffer, offset = offset, count = count });
-                baseStream.Write(writeHandlerResult.Item1.bytes, writeHandlerResult.Item1.offset, writeHandlerResult.Item1.count);
-                if (!writeHandlerResult.Item2) {
-                    writeHandler = null;
+            try {
+                if (writeHandler != null) {
+                    var writeHandlerResult = writeHandler.Invoke(new StreamData { bytes = buffer, offset = offset, count = count });
+                    baseStream.Write(writeHandlerResult.Item1.bytes, writeHandlerResult.Item1.offset, writeHandlerResult.Item1.count);
+                    if (!writeHandlerResult.Item2) {
+                        writeHandler = null;
+                    }
+                } else {
+                    baseStream.Write(buffer, offset, count);
                 }
-            } else {
-                baseStream.Write(buffer, offset, count);
+            } catch (IOException) {
+                // Pipe to Pylance is broken (e.g. Pylance crashed - ERROR_BROKEN_PIPE 0x8007006d).
+                // Swallow so StreamJsonRpc can detect the disconnect via its own machinery
+                // rather than throwing on a long async chain that escapes to the dispatcher.
+            } catch (ObjectDisposedException) {
             }
-
         }
     }
 }


### PR DESCRIPTION
## Issue

[Watson #1812702](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1812702) — `crash64: CLR_EXCEPTION_System.IO.IOException_8007006d` (`ERROR_BROKEN_PIPE`) in `StreamIntercepter.Write` (**10 hits**, builds 17.4.33213.308 – 17.5.33627.172).

### Problem
`StreamIntercepter` wraps Pylance's stdin / stdout so PTVS can massage the LSP `initialize` message. When Pylance exits or crashes, the next `Write` / `Read` / `Flush` on the pipe throws `IOException("Pipe is broken")`. StreamJsonRpc *does* eventually convert it to a `Disconnected` event, but the throw bubbles synchronously through 30+ frames of awaiter continuations until it escapes to a thread without a handler — categorized as `crash64` because the unhandled exception surfaced natively.

## Fix
Wrap `Flush()`, `Read(...)`, and `Write(...)` in `try { … } catch (IOException) { } catch (ObjectDisposedException) { }`:
- `Read` returns `0` on failure — StreamJsonRpc treats `0` as EOF and cleanly raises `Disconnected`.
- `Flush` and `Write` simply swallow; StreamJsonRpc detects the disconnect on the next read.

**Files changed**
- `Python/Product/PythonTools/PythonTools/LanguageServerClient/StreamHacking/StreamIntercepter.cs`
