### PR TITLE
Fix Watson #2325087: Tolerate ConnectionLostException in InvokeWithParametersAsync

### DIFF
--- a/Python/Product/PythonTools/PythonTools/LanguageServerClient/PythonLanguageClient.cs
+++ b/Python/Product/PythonTools/PythonTools/LanguageServerClient/PythonLanguageClient.cs
@@ -358,13 +358,38 @@ namespace Microsoft.PythonTools.LanguageServerClient {
         private async Task<R> InvokeWithParametersAsync<R>(string request, object parameters, CancellationToken t) where R : class {
             await _readyTcs.Task.ConfigureAwait(false);
 
-            return await _rpc.InvokeWithParameterObjectAsync<R>(request, parameters, t).ConfigureAwait(false);
+            var rpc = _rpc;
+            if (rpc == null) {
+                return null;
+            }
+
+            try {
+                return await rpc.InvokeWithParameterObjectAsync<R>(request, parameters, t).ConfigureAwait(false);
+            } catch (ConnectionLostException) {
+                // Pylance crashed mid-request. Returning null - editor LSP integration
+                // tolerates null (no completions / no references shown) rather than
+                // tearing down VS via the dispatcher.
+                return null;
+            } catch (ObjectDisposedException) {
+                // JsonRpc was disposed mid-request - same shutdown semantic.
+                return null;
+            }
         }
 
         private async Task NotifyWithParametersAsync(string request, object parameters) {
             await _readyTcs.Task.ConfigureAwait(false);
 
-            await _rpc.NotifyWithParameterObjectAsync(request, parameters).ConfigureAwait(false);
+            var rpc = _rpc;
+            if (rpc == null) {
+                return;
+            }
+
+            try {
+                await rpc.NotifyWithParameterObjectAsync(request, parameters).ConfigureAwait(false);
+            } catch (ConnectionLostException) {
+                // Pylance crashed mid-notify - silently drop; the notification is fire-and-forget.
+            } catch (ObjectDisposedException) {
+            }
         }
 
         private LanguageServerSettings.PythonSettings GetSettings(Uri scopeUri = null) {

--- a/Python/Product/PythonTools/PythonTools/LanguageServerClient/PythonLanguageClient.cs
+++ b/Python/Product/PythonTools/PythonTools/LanguageServerClient/PythonLanguageClient.cs
@@ -322,12 +322,12 @@ namespace Microsoft.PythonTools.LanguageServerClient {
 
         public Task InvokeDidChangeConfigurationAsync(LSP.DidChangeConfigurationParams request) {
 
-            return _rpc.NotifyWithParameterObjectAsync("workspace/didChangeConfiguration", request);
+            return NotifyWithParametersAsync("workspace/didChangeConfiguration", request);
         }
 
-        public async Task InvokeDidChangeWorkspaceFoldersAsync(WorkspaceFolder[] added, WorkspaceFolder[] removed) {
+        public Task InvokeDidChangeWorkspaceFoldersAsync(WorkspaceFolder[] added, WorkspaceFolder[] removed) {
 
-            await _rpc.NotifyWithParameterObjectAsync("workspace/didChangeWorkspaceFolders",
+            return NotifyWithParametersAsync("workspace/didChangeWorkspaceFolders",
                 new DidChangeWorkspaceFoldersParams {
                     changeEvent = new WorkspaceFoldersChangeEvent {
                         added = added,
@@ -508,7 +508,7 @@ namespace Microsoft.PythonTools.LanguageServerClient {
                     createEvent.Uri = new Uri(CommonUtils.GetParent(context.InterpreterConfiguration.InterpreterPath));
                     var didChangeParams = new DidChangeWatchedFilesParams();
                     didChangeParams.Changes = new FileEvent[] { createEvent };
-                    _rpc.NotifyWithParameterObjectAsync(Methods.WorkspaceDidChangeWatchedFiles.Name, didChangeParams);
+                    NotifyWithParametersAsync(Methods.WorkspaceDidChangeWatchedFiles.Name, didChangeParams).DoNotWait();
                 });
                
                 


### PR DESCRIPTION
## Issue

[Watson #2325087](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2325087) — `CLR_EXCEPTION_StreamJsonRpc.ConnectionLostException` in `PythonLanguageClient.InvokeWithParametersAsync` (**10 hits**, builds 17.12.35527.113 – 17.12.35707.178).

### Problem
Editor-initiated LSP requests (completion, hover, go-to-definition, references, command execution) all funnel through `InvokeWithParametersAsync` / `NotifyWithParametersAsync`. Neither method had any exception handling. When Pylance crashes mid-request, `_rpc.InvokeWithParameterObjectAsync` throws `ConnectionLostException`, which propagates up through the editor's WPF-dispatched completion / hover provider → crashes VS.

## Fix
- Snapshot `_rpc` into a local; return `null` early if it is already nulled.
- Wrap the `await rpc.InvokeWithParameterObjectAsync<R>(...)` call in `try { … } catch (ConnectionLostException) { return null; } catch (ObjectDisposedException) { return null; }`. The editor LSP integration tolerates a `null` result (it just shows no completions / references) instead of crashing.
- Apply the same shape to `NotifyWithParametersAsync` (no return value — fire-and-forget notifications are dropped).

**Files changed**
- `Python/Product/PythonTools/PythonTools/LanguageServerClient/PythonLanguageClient.cs`
