### PR TITLE
Fix Watson #2455159: Guard PythonLanguageClient timer/GetSettings against post-dispose NRE

### DIFF
--- a/Python/Product/PythonTools/PythonTools/LanguageServerClient/PythonLanguageClient.cs
+++ b/Python/Product/PythonTools/PythonTools/LanguageServerClient/PythonLanguageClient.cs
@@ -100,6 +100,10 @@ namespace Microsoft.PythonTools.LanguageServerClient {
         private static TaskCompletionSource<int> _readyTcs = new TaskCompletionSource<int>();
         private bool _loaded = false;
         private Timer _deferredSettingsChangedTimer;
+        // Set by the dispose action before any other cleanup; consulted by the
+        // deferred timer callback, TriggerWorkspaceUpdateConfig and GetSettings so
+        // a timer tick scheduled before disposal cannot dereference cleared state.
+        private volatile bool _disposed;
         private const int _defaultSettingsDelayMS = 5000;
 
         public PythonLanguageClient() {
@@ -136,7 +140,19 @@ namespace Microsoft.PythonTools.LanguageServerClient {
             await JoinableTaskContext.Factory.SwitchToMainThreadAsync();
             CreateClientContexts();
 
-            _deferredSettingsChangedTimer = new Timer(state => TriggerWorkspaceUpdateConfig(), state: null, Timeout.Infinite, Timeout.Infinite);
+            _deferredSettingsChangedTimer = new Timer(state => {
+                // Guard the callback body: a tick scheduled before disposal can fire
+                // after the language client has been torn down.
+                if (_disposed) {
+                    return;
+                }
+                try {
+                    TriggerWorkspaceUpdateConfig();
+                } catch (NullReferenceException) {
+                    // Field was nulled or service disappeared during teardown.
+                } catch (ObjectDisposedException) {
+                }
+            }, state: null, Timeout.Infinite, Timeout.Infinite);
             _analysisOptions = Site.GetPythonToolsService().AnalysisOptions;
             _advancedEditorOptions = Site.GetPythonToolsService().AdvancedEditorOptions;
             _analysisOptions.Changed += OnSettingsChanged;
@@ -152,6 +168,14 @@ namespace Microsoft.PythonTools.LanguageServerClient {
             WorkspaceService.OnActiveWorkspaceChanged += OnWorkspaceOpening;
 
             _disposables.Add(() => {
+                // Mark disposed and stop the timer FIRST so any in-flight tick bails
+                // out and no new ticks are scheduled while we tear down fields.
+                _disposed = true;
+                try {
+                    _deferredSettingsChangedTimer.Change(Timeout.Infinite, Timeout.Infinite);
+                } catch (ObjectDisposedException) {
+                }
+
                 _clientContexts.ForEach(c => {
                     c.InterpreterChanged -= OnInterpreterChanged;
                     c.SearchPathsChanged -= OnSettingsChanged;
@@ -243,6 +267,10 @@ namespace Microsoft.PythonTools.LanguageServerClient {
         }
 
         private Task TriggerWorkspaceUpdateConfig() {
+            // Bail if the client is being torn down.
+            if (_disposed || _rpc == null) {
+                return Task.CompletedTask;
+            }
             Debug.WriteLine("Settings Changed");
             return InvokeDidChangeConfigurationAsync(new LSP.DidChangeConfigurationParams() {
                 // Pylance will ask us for per workspace configuration settings. We can send
@@ -368,8 +396,9 @@ namespace Microsoft.PythonTools.LanguageServerClient {
         }
 
         private LanguageServerSettings.PythonSettings GetSettings(Uri scopeUri = null) {
-            // guard on shutdown
-            if (_clientContexts.Count() == 0) {
+            // guard on shutdown - either we're being disposed or essential state
+            // hasn't been wired up yet.
+            if (_disposed || _analysisOptions == null || _advancedEditorOptions == null || _clientContexts.Count() == 0) {
                 return null;
             }
             IPythonLanguageClientContext context = null;


### PR DESCRIPTION
## Issue

[Watson #2455159](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2455159) — `CLR_EXCEPTION_System.NullReferenceException` in `PythonLanguageClient.GetSettings` (**174 hits**, builds 17.13.35913.81 – 17.14.37111.16).

### Problem
The `_deferredSettingsChangedTimer` fires `TriggerWorkspaceUpdateConfig` → `GetSettings()` 5 s after a settings change. If the language client is disposed before the tick fires (solution / project closed), the callback runs against fields (`_analysisOptions`, `Site`, etc.) that have been nulled / disposed → `NullReferenceException` on the timer-queue thread.

The async `Dispose` path nulled fields **without** first cancelling the timer.

## Fix
- Add `private volatile bool _disposed;` field.
- In the `_disposables` cleanup action: set `_disposed = true` **first**, then stop the timer (`Change(Timeout.Infinite, Timeout.Infinite)`) before any field nulling. Existing `timer.Dispose()` at the end is unchanged.
- Wrap the timer callback body in `if (_disposed) return; try { TriggerWorkspaceUpdateConfig(); } catch (NullReferenceException) { } catch (ObjectDisposedException) { }` so any tick that slips through during teardown bails out cleanly.
- Add early-return `if (_disposed || _rpc == null) return Task.CompletedTask;` in `TriggerWorkspaceUpdateConfig`.
- Tighten the `GetSettings` shutdown guard from `if (_clientContexts.Count() == 0)` to also bail on `_disposed`, `_analysisOptions == null`, `_advancedEditorOptions == null`.

**Files changed**
- `Python/Product/PythonTools/PythonTools/LanguageServerClient/PythonLanguageClient.cs`
