### PR TITLE
Fix Watson cluster B (#1490074, #2014172, #2017229): Race in FileWatcher.Listener.OnFileChanged

### DIFF
--- a/Python/Product/PythonTools/PythonTools/LanguageServerClient/FileWatcher/Listener.cs
+++ b/Python/Product/PythonTools/PythonTools/LanguageServerClient/FileWatcher/Listener.cs
@@ -117,8 +117,12 @@ namespace Microsoft.PythonTools.LanguageServerClient.FileWatcher {
         }
         private async Task OnFileChanged(object sender, System.IO.FileSystemEventArgs e) {
 
+            // Snapshot _rpc into a local. The field is nulled by _rpc_Disconnected
+            // (or by Dispose) and can race with this thread-pool handler.
+            var rpc = _rpc;
+
             // Skip directory change events
-            if (e.IsDirectoryChanged() || _rpc == null) {
+            if (e.IsDirectoryChanged() || rpc == null) {
                 return;
             }
 
@@ -169,8 +173,13 @@ namespace Microsoft.PythonTools.LanguageServerClient.FileWatcher {
                 }
 
                 if (didChangeParams.Changes.Any()) {
-             
-                    await _rpc.NotifyWithParameterObjectAsync(Methods.WorkspaceDidChangeWatchedFiles.Name, didChangeParams);
+                    try {
+                        await rpc.NotifyWithParameterObjectAsync(Methods.WorkspaceDidChangeWatchedFiles.Name, didChangeParams);
+                    } catch (ObjectDisposedException) {
+                        // The JsonRpc was disposed by its owner before Disconnected reached us.
+                    } catch (ConnectionLostException) {
+                        // Pylance crashed or its pipe closed mid-notify.
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Issues

Three Watsons, one root cause (**269 hits combined**):

- [Watson #2017229](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2017229) — `NullReferenceException` (228 hits, 17.9 – 17.10)
- [Watson #2014172](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2014172) — `StreamJsonRpc.ConnectionLostException` (36 hits, 17.10 – 17.12)
- [Watson #1490074](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1490074) — `ObjectDisposedException` (5 hits, 17.1)

### Problem
`FileWatcher.Listener.OnFileChanged` performs a check-then-use on `_rpc` without locking: it null-checks `_rpc` at the top, then computes file-matching params, then `await _rpc.NotifyWithParameterObjectAsync(...)`. Between the early check and the await, three things can happen:

1. `_rpc_Disconnected` runs and sets `_rpc = null` → `NullReferenceException` (#2017229)
2. The JsonRpc instance is disposed by its owner before `Disconnected` reaches us → `ObjectDisposedException` from `Microsoft.Verify.NotDisposed` (#1490074)
3. Pylance crashes mid-call → pipe closes → `ConnectionLostException` (#2014172)

## Fix
- Snapshot `var rpc = _rpc;` at the top of `OnFileChanged`. Use `rpc` for both the early null-check and the later notify, eliminating the read-twice race.
- Wrap the `await rpc.NotifyWithParameterObjectAsync(...)` in `try { … } catch (ObjectDisposedException) { } catch (ConnectionLostException) { }`.

One ~6-line change addresses all three Watsons in this cluster.

**Files changed**
- `Python/Product/PythonTools/PythonTools/LanguageServerClient/FileWatcher/Listener.cs`
