### PR TITLE
Fix Watson cluster D (#1497512, #1487204, #1363565): Silence LSP teardown exceptions in DoNotWait

### DIFF
--- a/Python/Product/Common/Infrastructure/TaskExtensions.cs
+++ b/Python/Product/Common/Infrastructure/TaskExtensions.cs
@@ -55,6 +55,25 @@ namespace Microsoft.PythonTools.Infrastructure {
             return false;
         }
 
+        // Only silence when every inner exception is a silenced type, so a real
+        // bug riding alongside a teardown exception (e.g. from Task.WhenAll) still
+        // surfaces.
+        private static bool ShouldSilence(AggregateException ae) {
+            if (ae == null) {
+                return false;
+            }
+            var flat = ae.Flatten().InnerExceptions;
+            if (flat.Count == 0) {
+                return false;
+            }
+            for (int i = 0; i < flat.Count; i++) {
+                if (!IsSilencedException(flat[i])) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
         /// <summary>
         /// Suppresses warnings about unawaited tasks and rethrows task exceptions back to the callers synchronization context if it is possible
         /// </summary>
@@ -82,20 +101,22 @@ namespace Microsoft.PythonTools.Infrastructure {
         private static void ReThrowTaskException(object state) {
             var task = (Task)state;
             if (task.IsFaulted && task.Exception != null) {
-                var exception = task.Exception.InnerException;
-                if (IsSilencedException(exception)) {
+                if (ShouldSilence(task.Exception)) {
+                    Debug.WriteLine("DoNotWait: silencing teardown exception: " + task.Exception.GetType().Name + " / " + task.Exception.InnerException?.GetType().Name);
                     return;
                 }
+                var exception = task.Exception.InnerException;
                 ExceptionDispatchInfo.Capture(exception).Throw();
             }
         }
 
         private static void DoNotWaitThreadContinuation(Task task) {
             if (task.IsFaulted && task.Exception != null) {
-                var exception = task.Exception.InnerException;
-                if (IsSilencedException(exception)) {
+                if (ShouldSilence(task.Exception)) {
+                    Debug.WriteLine("DoNotWait: silencing teardown exception: " + task.Exception.GetType().Name + " / " + task.Exception.InnerException?.GetType().Name);
                     return;
                 }
+                var exception = task.Exception.InnerException;
                 ThreadPool.QueueUserWorkItem(s => ((ExceptionDispatchInfo)s).Throw(), ExceptionDispatchInfo.Capture(exception));
             }
         }

--- a/Python/Product/Common/Infrastructure/TaskExtensions.cs
+++ b/Python/Product/Common/Infrastructure/TaskExtensions.cs
@@ -26,6 +26,36 @@ using System.Threading.Tasks;
 namespace Microsoft.PythonTools.Infrastructure {
     static class TaskExtensions {
         /// <summary>
+        /// Exception types that are silenced by <see cref="DoNotWait"/> when they
+        /// surface from a fire-and-forget task. These are expected during teardown
+        /// of the LSP / Pylance pipeline (process exit, JsonRpc disposal, pipe death)
+        /// and must not crash VS by being rethrown on the original synchronization
+        /// context.
+        /// </summary>
+        /// <remarks>
+        /// <see cref="OperationCanceledException"/> is silenced implicitly because a
+        /// canceled async task transitions to <see cref="TaskStatus.Canceled"/> with
+        /// a null <see cref="Task.Exception"/>, which the IsFaulted check below skips.
+        /// </remarks>
+        private static readonly Type[] _silencedExceptionTypes = new[] {
+            typeof(ObjectDisposedException),
+            typeof(StreamJsonRpc.ConnectionLostException),
+        };
+
+        private static bool IsSilencedException(Exception ex) {
+            if (ex == null) {
+                return false;
+            }
+            var type = ex.GetType();
+            for (int i = 0; i < _silencedExceptionTypes.Length; i++) {
+                if (_silencedExceptionTypes[i].IsAssignableFrom(type)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        /// <summary>
         /// Suppresses warnings about unawaited tasks and rethrows task exceptions back to the callers synchronization context if it is possible
         /// </summary>
         /// <remarks>
@@ -53,6 +83,9 @@ namespace Microsoft.PythonTools.Infrastructure {
             var task = (Task)state;
             if (task.IsFaulted && task.Exception != null) {
                 var exception = task.Exception.InnerException;
+                if (IsSilencedException(exception)) {
+                    return;
+                }
                 ExceptionDispatchInfo.Capture(exception).Throw();
             }
         }
@@ -60,6 +93,9 @@ namespace Microsoft.PythonTools.Infrastructure {
         private static void DoNotWaitThreadContinuation(Task task) {
             if (task.IsFaulted && task.Exception != null) {
                 var exception = task.Exception.InnerException;
+                if (IsSilencedException(exception)) {
+                    return;
+                }
                 ThreadPool.QueueUserWorkItem(s => ((ExceptionDispatchInfo)s).Throw(), ExceptionDispatchInfo.Capture(exception));
             }
         }


### PR DESCRIPTION
## Issues

Three Watsons, one architectural root cause (**~8,253 hits combined — the loudest signal in the Watson query**):

- [Watson #1497512](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1497512) — `ObjectDisposedException` in `DoNotWait` from `PythonAnalysisOptions.Save` (**8,088 hits**, 17.9 – 17.12)
- [Watson #1487204](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1487204) — `ConnectionLostException` in `DoNotWait` from `set_ActiveInterpreter` (**156 hits**, 17.9 – 17.12)
- [Watson #1363565](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1363565) — `ObjectDisposedException` in `Microsoft.PythonTools.Common.dll!Unknown` (**9 hits**, 16.11)

### Problem
`TaskExtensions.DoNotWait` re-throws faulted-task exceptions back onto the original `SynchronizationContext` (via `ExceptionDispatchInfo.Capture(...).Throw()`). This is the **correct** behavior for genuine bugs — but PTVS uses `.DoNotWait()` extensively on fire-and-forget LSP notify tasks (`_rpc.NotifyWithParameterObjectAsync(...).DoNotWait()`). When the LSP / Pylance pipeline is being torn down (solution close, project unload, Pylance restart), those tasks faithfully fault with `ObjectDisposedException` (JsonRpc disposed) or `ConnectionLostException` (Pylance pipe closed). `DoNotWait` then re-throws on the UI thread → crashes VS.

This pattern affects every `_rpc.*.DoNotWait()` call site, hence the enormous hit count.

## Fix
Introduce a `_silencedExceptionTypes` list containing `ObjectDisposedException` and `StreamJsonRpc.ConnectionLostException`. Before the rethrow in both `ReThrowTaskException` and `DoNotWaitThreadContinuation`, check `IsSilencedException(ex)` and early-return if matched.

Notes:
- `OperationCanceledException` is *not* in the list — canceled tasks transition to `TaskStatus.Canceled` with `IsFaulted == false`, so the existing `if (task.IsFaulted && …)` guard already skips them.
- `InvalidOperationException` and other "real bug" exceptions remain unsilenced, so the existing `TaskExtensionsTests.DoNotWait` test (which asserts `InvalidOperationException` propagation) still passes.
- `StreamJsonRpc.ConnectionLostException` is referenced fully-qualified; `Python/Product/Common/Common.csproj` already references `StreamJsonRpc`.
- This is the only branch with workspace-wide reach — all `.DoNotWait()` call sites (~128) inherit the new silencing behavior. The trade-off is acceptable because both silenced types are inherently shutdown noise; the alternative would be a try/catch at every site.

**Files changed**
- `Python/Product/Common/Infrastructure/TaskExtensions.cs`
