### PR TITLE
Fix ConvertTo-Json bug in triage pipeline assemble step

### DIFF
--- a/Build/triage/pipelines/fetch.yml
+++ b/Build/triage/pipelines/fetch.yml
@@ -183,7 +183,11 @@ jobs:
         }
 
         $titlesDst = "$(Agent.TempDirectory)/candidates-titles-only.json"
-        (ConvertTo-Json -Compress -Depth 10 -InputObject @($titles)) | Set-Content -LiteralPath $titlesDst -Encoding UTF8
+        # Pass the List directly (do NOT wrap in @()). PowerShell 7.5's
+        # ConvertTo-Json parameter binder errors with "Argument types do
+        # not match" when given @() around a List[object].
+        $json = ConvertTo-Json -Compress -Depth 10 -InputObject $titles
+        Set-Content -LiteralPath $titlesDst -Value $json -Encoding UTF8
 
         Write-Host "Wrote titles manifest: $($titles.Count) item(s). Dropped $($aborted.Count) sanitization-aborted item(s)."
 


### PR DESCRIPTION
First manual dry-run of the new `PTVS-Triage-Fetch` pipeline on AzDO ([build 14315050](https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=14315050)) failed at the *Drop sanitization-aborted items and emit titles-only manifest* step with:

```
Argument types do not match
(ConvertTo-Json -Compress -Depth 10 -InputObject @($titles))
```

## Root cause

PowerShell 7.5 (the version on Microsoft-hosted Ubuntu agents) errors when `ConvertTo-Json -InputObject` is given an `@()`-wrapped `System.Collections.Generic.List[object]`. Reproduced locally with the same PS version. Passing the List directly to `-InputObject` (no `@()` wrap) works.

## Fix

Use a temp variable + `Set-Content -Value` instead of piping. Verified produces correct output for empty / one / many items.

## Validation

- Reproduced + verified fix locally on PS 7.5
- All `Build/triage/run-tests.ps1` self-tests still pass
- Simulated the full assemble step end-to-end against a synthetic `sanitized/` directory with one valid + one sanitization-aborted item: aborted files get deleted from disk, titles manifest correctly omits the aborted one

## Upstream confirmation

The failing dry-run actually got far enough to validate the rest of the pipeline:
- ✅ `query-azdo.ps1` (WIQL + workitemsbatch) succeeded — confirms the Build Service identity already has work-item read on the area path (Phase 3b VSAccess grant must have been done already)
- ✅ `parse-diagnostics.ps1` succeeded
- ✅ `sanitize.ps1` succeeded

Only this single assemble step needed the fix; the next dry-run should run end-to-end.