### PR TITLE
Fix GH_PAT self-referential check + use hashtable splatting in triage pipeline

### DIFF
--- a/Build/triage/pipelines/fetch.yml
+++ b/Build/triage/pipelines/fetch.yml
@@ -196,6 +196,30 @@ jobs:
     artifact: sanitized-$(Build.BuildId)
 
   - task: PowerShell@2
+    displayName: 'DEBUG (temporary): introspect $(GH_PAT) without leaking value'
+    env:
+      GITHUB_TOKEN: $(GH_PAT)
+    inputs:
+      pwsh: true
+      targetType: inline
+      script: |
+        $v = $env:GITHUB_TOKEN
+        Write-Host "----- GH_PAT diagnostics (value never printed) -----"
+        Write-Host "type:           $(if ($null -eq $v) { '<null>' } else { $v.GetType().FullName })"
+        Write-Host "isNull:         $($null -eq $v)"
+        Write-Host "isEmptyString:  $($v -eq '')"
+        Write-Host "literalPlaceholder: $($v -eq '$(GH_PAT)')"
+        if ($null -ne $v -and $v -ne '') {
+            Write-Host "length:         $($v.Length)"
+            Write-Host "lengthAfterTrim: $($v.Trim().Length)"
+            Write-Host "startsWithGhp_:    $($v.StartsWith('ghp_'))"
+            Write-Host "startsWithGithubPat_: $($v.StartsWith('github_pat_'))"
+            Write-Host "hasLeadingWhitespace:  $($v.Length -ne $v.TrimStart().Length)"
+            Write-Host "hasTrailingWhitespace: $($v.Length -ne $v.TrimEnd().Length)"
+        }
+        Write-Host "---------------------------------------------------"
+
+  - task: PowerShell@2
     displayName: 'post-report-issue.ps1 — create/update weekly issue in microsoft/PTVS'
     env:
       # GH_PAT is a fine-grained GitHub PAT in the PTVS-Triage-Bridge

--- a/Build/triage/pipelines/fetch.yml
+++ b/Build/triage/pipelines/fetch.yml
@@ -183,7 +183,11 @@ jobs:
         }
 
         $titlesDst = "$(Agent.TempDirectory)/candidates-titles-only.json"
-        (ConvertTo-Json -Compress -Depth 10 -InputObject @($titles)) | Set-Content -LiteralPath $titlesDst -Encoding UTF8
+        # Pass the List directly (do NOT wrap in @()). PowerShell 7.5's
+        # ConvertTo-Json parameter binder errors with "Argument types do
+        # not match" when given @() around a List[object].
+        $json = ConvertTo-Json -Compress -Depth 10 -InputObject $titles
+        Set-Content -LiteralPath $titlesDst -Value $json -Encoding UTF8
 
         Write-Host "Wrote titles manifest: $($titles.Count) item(s). Dropped $($aborted.Count) sanitization-aborted item(s)."
 

--- a/Build/triage/pipelines/fetch.yml
+++ b/Build/triage/pipelines/fetch.yml
@@ -196,30 +196,6 @@ jobs:
     artifact: sanitized-$(Build.BuildId)
 
   - task: PowerShell@2
-    displayName: 'DEBUG (temporary): introspect $(GH_PAT) without leaking value'
-    env:
-      GITHUB_TOKEN: $(GH_PAT)
-    inputs:
-      pwsh: true
-      targetType: inline
-      script: |
-        $v = $env:GITHUB_TOKEN
-        Write-Host "----- GH_PAT diagnostics (value never printed) -----"
-        Write-Host "type:           $(if ($null -eq $v) { '<null>' } else { $v.GetType().FullName })"
-        Write-Host "isNull:         $($null -eq $v)"
-        Write-Host "isEmptyString:  $($v -eq '')"
-        Write-Host "literalPlaceholder: $($v -eq '$(GH_PAT)')"
-        if ($null -ne $v -and $v -ne '') {
-            Write-Host "length:         $($v.Length)"
-            Write-Host "lengthAfterTrim: $($v.Trim().Length)"
-            Write-Host "startsWithGhp_:    $($v.StartsWith('ghp_'))"
-            Write-Host "startsWithGithubPat_: $($v.StartsWith('github_pat_'))"
-            Write-Host "hasLeadingWhitespace:  $($v.Length -ne $v.TrimStart().Length)"
-            Write-Host "hasTrailingWhitespace: $($v.Length -ne $v.TrimEnd().Length)"
-        }
-        Write-Host "---------------------------------------------------"
-
-  - task: PowerShell@2
     displayName: 'post-report-issue.ps1 — create/update weekly issue in microsoft/PTVS'
     env:
       # GH_PAT is a fine-grained GitHub PAT in the PTVS-Triage-Bridge
@@ -237,8 +213,13 @@ jobs:
         Set-StrictMode -Version Latest
         $ErrorActionPreference = 'Stop'
 
-        if (-not $env:GITHUB_TOKEN -or $env:GITHUB_TOKEN -eq '$(GH_PAT)' -or $env:GITHUB_TOKEN.Trim().Length -lt 20) {
-            throw "GITHUB_TOKEN env var is missing or looks invalid. Confirm the 'PTVS-Triage-Bridge' variable group exists with a secret variable 'GH_PAT' and that this pipeline is authorized to use it."
+        # Sanity check: GH_PAT must be present and look like a real token.
+        # Don't compare to a literal '$(GH_PAT)' placeholder here — AzDO
+        # substitutes that macro at YAML processing time (yes, even for
+        # secrets, even inside PowerShell single-quoted strings), so any
+        # literal comparison silently becomes a self-comparison.
+        if (-not $env:GITHUB_TOKEN -or $env:GITHUB_TOKEN.Trim().Length -lt 20) {
+            throw "GITHUB_TOKEN env var is missing or looks too short. Confirm the 'PTVS-Triage-Bridge' variable group exists with a secret variable 'GH_PAT' (value pasted + saved), and that this pipeline is authorized to use it."
         }
 
         $runUrl = '$(System.CollectionUri)$(System.TeamProject)/_build/results?buildId=$(Build.BuildId)'

--- a/Build/triage/pipelines/fetch.yml
+++ b/Build/triage/pipelines/fetch.yml
@@ -223,10 +223,14 @@ jobs:
         }
 
         $runUrl = '$(System.CollectionUri)$(System.TeamProject)/_build/results?buildId=$(Build.BuildId)'
-        $scriptArgs = @(
-            '-CandidatesFile', "$(Agent.TempDirectory)/candidates-titles-only.json",
-            '-LookbackDays',   ([int] $env:LOOKBACK_DAYS),
-            '-RunUrl',         $runUrl
-        )
-        if ([bool]::Parse(($env:DRY_RUN ?? 'false'))) { $scriptArgs += '-DryRun' }
+        # Use HASHTABLE splatting (not array splatting). When you call a .ps1
+        # via @arrayName, PowerShell binds positionally — the '-Name' tokens
+        # are taken as values, not parameter names — so the wrong values end
+        # up on the wrong parameters. Hashtable splatting binds by name.
+        $scriptArgs = @{
+            CandidatesFile = "$(Agent.TempDirectory)/candidates-titles-only.json"
+            LookbackDays   = [int] $env:LOOKBACK_DAYS
+            RunUrl         = $runUrl
+        }
+        if ([bool]::Parse(($env:DRY_RUN ?? 'false'))) { $scriptArgs['DryRun'] = $true }
         & "$(Build.SourcesDirectory)/Build/triage/post-report-issue.ps1" @scriptArgs


### PR DESCRIPTION
Two more bugs surfaced when actually running `PTVS-Triage-Fetch` end to end after PR #8530 merged. Both are fixed here. Verified end-to-end against real AzDO runs in `devdiv/DevDiv`: a successful dry-run AND a successful real run (issue posted to microsoft/PTVS).

## Fix 1 — Remove self-referential `GH_PAT` sanity check

The token presence check had this clause:

```powershell
if (... -or $env:GITHUB_TOKEN -eq '$(GH_PAT)' -or ...) { throw }
```

**Intent**: catch the case where AzDO failed to substitute the secret variable.

**Bug**: AzDO substitutes `$(VARNAME)` macros inside `PowerShell@2` script content at YAML processing time — even for **secret** variables, even inside PowerShell **single-quoted** strings (because substitution happens before PowerShell ever parses the script). So both the `env:` block AND the literal comparison ended up holding the same actual PAT value, making the comparison always true on every **correctly configured** run. False positive on success.

Confirmed via a temporary debug step: the env var arrived as a 40-character string starting with `ghp_` (a valid classic PAT), and the literal-placeholder comparison still evaluated `True`.

**Fix**: drop the literal-comparison clause. The remaining null / empty / length-< 20 checks still catch the failed-substitution case (an unsubstituted `$(GH_PAT)` is only 9 chars, so the length check covers it).

## Fix 2 — Use hashtable splatting, not array splatting

Calling `post-report-issue.ps1` from the YAML used array splatting:

```powershell
$scriptArgs = @('-CandidatesFile', '/path', '-LookbackDays', 7, ...)
& '.../post-report-issue.ps1' @scriptArgs
```

When you splat an **array** into a `.ps1` script, PowerShell binds **positionally** and treats the `-Name` tokens as **values** (not parameter names). So `CandidatesFile` got bound to the literal string `'-CandidatesFile'`, and the actual path string ended up on the second positional parameter, `LookbackDays`, which is typed `[int]` — giving:

```
Cannot convert value '/home/vsts/work/_temp/candidates-titles-only.json' to type 'System.Int32'.
```

**Fix**: switch to **hashtable** splatting (`@{ Name = Value; ... }`), which binds by name.

## Verification

Verified end-to-end on real AzDO pipeline runs in `devdiv/DevDiv`:
- ✅ Dry-run completes all steps; the post-issue step's log prints the full would-be issue body
- ✅ Real run (dry-run unchecked) posts the weekly summary issue to microsoft/PTVS

(One non-code issue surfaced during testing that needed a manual fix outside this PR: the classic `GH_PAT` needed explicit SAML SSO authorization for the `microsoft` org via **Settings → Tokens → Configure SSO**. This is documented behavior of Microsoft-org-owned repos — mentioned here only as an operator note.)
