### PR TITLE
Add PTVS-Triage-Analyze workflow stub

### DIFF
--- a/.github/workflows/triage-analyze.yml
+++ b/.github/workflows/triage-analyze.yml
@@ -1,0 +1,35 @@
+# PTVS-Triage-Analyze (stub)
+#
+# This file is intentionally a no-op placeholder so the workflow appears
+# in the GitHub Actions UI on `main`, enabling a follow-up PR to land the
+# real implementation behind a green workflow_dispatch button.
+#
+# The real implementation arrives in the next commit on this branch and
+# adds:
+#   - `permissions: copilot-requests: write` for Copilot CLI auth via
+#     the auto-injected GITHUB_TOKEN
+#   - workflow_dispatch inputs (fetchBuildId / maxItems / dryRun / ...)
+#   - steps to: download the sanitized devdiv AzDO PTVS-Triage-Fetch
+#     artifact, install Copilot CLI, run an agentic per-item analysis
+#     against the PTVS source tree, post each analysis as a threaded
+#     comment on the matching weekly triage issue
+#
+# This stub itself does nothing other than print a heartbeat line so the
+# operator can verify the workflow shows up under Actions and is dispatchable.
+
+name: PTVS-Triage-Analyze
+
+on:
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  stub:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Stub heartbeat
+        run: |
+          echo "PTVS-Triage-Analyze stub workflow ran successfully."
+          echo "Real implementation lands in a follow-up commit on this branch."


### PR DESCRIPTION
## Intent

Land an empty placeholder workflow file on `main` so the **PTVS-Triage-Analyze** workflow appears in the Actions tab and can be manually triggered. GitHub only exposes the **Run workflow** (`workflow_dispatch`) button for workflows that already live on the **default branch**, so the file must land first before any operator can:

- Confirm the workflow shows up in the Actions UI
- Validate the dispatch surface (inputs render correctly, etc.)
- Verify the org-level Copilot policy gates don't block the future `permissions: copilot-requests: write` we'll add in the follow-up PR
- Issue the AzDO PAT and add the `AZDO_TRIAGE_ARTIFACT_PAT` repo secret while the workflow file is provably present

The stub itself is genuinely a no-op: a single ubuntu-latest job that prints a heartbeat line and exits. `permissions: {}` so it can't read or modify anything. No external network calls, no secrets used.

## Background

This stub is part of a two-step rollout of an agentic triage workflow that runs downstream of the existing devdiv AzDO `PTVS-Triage-Fetch` pipeline. The end state:

1. `PTVS-Triage-Fetch` (devdiv AzDO, already in production) fetches Developer Community work items under `DevDiv\Python and AI Tools`, sanitizes them for PII / secrets, publishes a `sanitized-<BuildId>` audit artifact, and posts a weekly summary issue to this repo.
2. `PTVS-Triage-Analyze` (this workflow, after the follow-up PR) will download that artifact, run GitHub Copilot CLI per item against the PTVS source tree to draft a root-cause classification + customer response, and post each analysis as a threaded comment on the summary issue.

## Follow-up items

| # | Item | Owner | When |
|---|---|---|---|
| 1 | **Follow-up PR** ships the real implementation: replaces the stub body with the production workflow, adds `Build/triage/analyze.ps1`, `find-fetch-artifact.ps1`, `post-analyses.ps1`, and `prompts/triage-prompt.md`. Already implemented and committed locally on the `agentic-workflow` branch. | @StellaHuang95 | Right after this PR merges |
| 2 | **Issue an AzDO PAT** scoped to `devdiv/DevDiv` with **Build: Read** only. Add to this repo's secrets as `AZDO_TRIAGE_ARTIFACT_PAT`. Required for the follow-up PR's workflow to authenticate against AzDO. | @StellaHuang95 | Before merging follow-up PR |
| 3 | **First dispatch with `dryRun: true`** once the follow-up PR is merged. Inspect the `analyses-<runId>` artifact to validate the prompt's output quality before posting to any public issue. | @StellaHuang95 | After follow-up PR merges |
| 4 | **Enable the weekly schedule** by uncommenting the `schedule:` block in `triage-analyze.yml` once a few manual runs look clean. | @StellaHuang95 | Phase-2, after ~3 successful manual runs |

## Validation

- YAML parses cleanly with `python -c 'import yaml; yaml.safe_load(open("...","rb"))'`
- `actionlint` clean
- `permissions: {}` -- workflow cannot read or write anything
- `pull_request` deliberately absent from `on:` (consistent with how the real workflow will be locked down)

## Test plan after merge

1. Open https://github.com/microsoft/PTVS/actions/workflows/triage-analyze.yml
2. Verify the workflow appears in the left sidebar
3. Click **Run workflow** -> **Run workflow** (no inputs to set on the stub)
4. Confirm the job runs green and prints the heartbeat line in the log

If step 4 fails for any org-policy reason, we know to fix that before the follow-up PR ships the production workflow.
