### PR TITLE
Must use only approved cryptographic hash functions

### DIFF
--- a/Python/Product/Common/Core/Extensions/StringExtensions.cs
+++ b/Python/Product/Common/Core/Extensions/StringExtensions.cs
@@ -323,7 +323,7 @@ namespace Microsoft.PythonTools.Common.Core.Extensions {
         /// </summary>
         public static string GetHashString(this string input) {
             // File name depends on the content so we can distinguish between different versions.
-            using (var hash = SHA256.Create()) {
+            using (var hash = new SHA256Cng()) {
                 return Convert
                     .ToBase64String(hash.ComputeHash(new UTF8Encoding(encoderShouldEmitUTF8Identifier: false).GetBytes(input)))
                     .Replace('/', '_').Replace('+', '-');

--- a/Python/Product/Core/ProvideRawCodeBaseAttribute.cs
+++ b/Python/Product/Core/ProvideRawCodeBaseAttribute.cs
@@ -110,7 +110,7 @@ namespace Microsoft.PythonTools.Core {
         void CalculateGuid() {
             // Maintain a stable attribute guid in every build, when assembly info is the same.
             // Logic is the same as used in ProvideCodeBaseAttribute class.
-            using (var sha2 = SHA256.Create()) {
+            using (var sha2 = new SHA256Cng()) {
                 var strongName = $"{AssemblyName},{PublicKeyToken},{Culture},{Version}";
                 var strongNameBytes = Encoding.UTF8.GetBytes(strongName);
                 var fullHash = sha2.ComputeHash(strongNameBytes);


### PR DESCRIPTION
## Summary
- Replace .NET Framework SHA256 factory usage with SHA256Cng for approved/FIPS-compliant SHA256 implementation.
- Preserve existing SHA256 digest behavior for stable GUID and filesystem hash generation.

## Validation
- msbuild Python\dirs.proj /p:VSTarget=18.0 /p:DeployExtension=true /p:RegisterOutputPackage=true