### PR TITLE
Prevent conda activation hangs

### DIFF
--- a/Python/Product/Common/Infrastructure/ProcessOutput.cs
+++ b/Python/Product/Common/Infrastructure/ProcessOutput.cs
@@ -720,6 +720,7 @@ namespace Microsoft.PythonTools.Infrastructure {
             if (_process != null) {
                 bool exited = _process.WaitForExit((int)timeout.TotalMilliseconds);
                 if (exited) {
+                    _process.WaitForExit();
                     // Should have already been called, in which case this is a no-op
                     OnExited(this, EventArgs.Empty);
                 }

--- a/Python/Product/Common/Infrastructure/ProcessOutput.cs
+++ b/Python/Product/Common/Infrastructure/ProcessOutput.cs
@@ -720,7 +720,6 @@ namespace Microsoft.PythonTools.Infrastructure {
             if (_process != null) {
                 bool exited = _process.WaitForExit((int)timeout.TotalMilliseconds);
                 if (exited) {
-                    _process.WaitForExit();
                     // Should have already been called, in which case this is a no-op
                     OnExited(this, EventArgs.Empty);
                 }

--- a/Python/Product/PythonTools/PythonToolsService.cs
+++ b/Python/Product/PythonTools/PythonToolsService.cs
@@ -401,7 +401,7 @@ namespace Microsoft.PythonTools {
         #endregion
 
         internal Dictionary<string, string> GetFullEnvironment(LaunchConfiguration config)
-            => LaunchConfigurationUtils.GetFullEnvironment(config, _container, UIThread);
+            => LaunchConfigurationUtils.GetFullEnvironment(config, _container, UIThread, Logger);
 
         internal IEnumerable<string> GetGlobalPythonSearchPaths(InterpreterConfiguration interpreter) {
             if (!GeneralOptions.ClearGlobalPythonPath && interpreter != null) {

--- a/Python/Product/VSInterpreters/Interpreter/LaunchConfigurationUtils.cs
+++ b/Python/Product/VSInterpreters/Interpreter/LaunchConfigurationUtils.cs
@@ -20,11 +20,16 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.PythonTools.Infrastructure;
+using Microsoft.PythonTools.Logging;
 using Microsoft.VisualStudioTools;
 
 namespace Microsoft.PythonTools.Interpreter {
     public class LaunchConfigurationUtils {
         public static Dictionary<string, string> GetFullEnvironment(LaunchConfiguration config, IServiceProvider serviceProvider, UIThreadBase uiThread) {
+            return GetFullEnvironment(config, serviceProvider, uiThread, null);
+        }
+
+        public static Dictionary<string, string> GetFullEnvironment(LaunchConfiguration config, IServiceProvider serviceProvider, UIThreadBase uiThread, IPythonToolsLogger logger) {
             if (config.Interpreter == null && config.InterpreterPath == null) {
                 throw new ArgumentException("Interpreter was invalid");
             }
@@ -49,7 +54,7 @@ namespace Microsoft.PythonTools.Interpreter {
                 var condaExe = CondaUtils.GetRootCondaExecutablePath(serviceProvider);
                 var prefixPath = config.Interpreter.GetPrefixPath();
                 if (File.Exists(condaExe) && Directory.Exists(prefixPath)) {
-                    var condaEnv = Task.Run(() => CondaUtils.GetActivationEnvironmentVariablesForPrefixAsync(condaExe, prefixPath)).WaitAndUnwrapExceptions();
+                    var condaEnv = Task.Run(() => CondaUtils.GetActivationEnvironmentVariablesForPrefixAsync(condaExe, prefixPath, logger)).WaitAndUnwrapExceptions();
                     baseEnv = PathUtils.MergeEnvironments(baseEnv.AsEnumerable<string, string>(), condaEnv, "Path", pathVar);
                 }
             }

--- a/Python/Product/VSInterpreters/Interpreter/LaunchConfigurationUtils.cs
+++ b/Python/Product/VSInterpreters/Interpreter/LaunchConfigurationUtils.cs
@@ -18,7 +18,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.PythonTools.Infrastructure;
 using Microsoft.VisualStudioTools;
 
@@ -49,7 +49,7 @@ namespace Microsoft.PythonTools.Interpreter {
                 var condaExe = CondaUtils.GetRootCondaExecutablePath(serviceProvider);
                 var prefixPath = config.Interpreter.GetPrefixPath();
                 if (File.Exists(condaExe) && Directory.Exists(prefixPath)) {
-                    var condaEnv = uiThread.InvokeTaskSync(() => CondaUtils.GetActivationEnvironmentVariablesForPrefixAsync(condaExe, prefixPath), CancellationToken.None);
+                    var condaEnv = Task.Run(() => CondaUtils.GetActivationEnvironmentVariablesForPrefixAsync(condaExe, prefixPath)).WaitAndUnwrapExceptions();
                     baseEnv = PathUtils.MergeEnvironments(baseEnv.AsEnumerable<string, string>(), condaEnv, "Path", pathVar);
                 }
             }

--- a/Python/Product/VSInterpreters/Interpreter/LaunchConfigurationUtils.cs
+++ b/Python/Product/VSInterpreters/Interpreter/LaunchConfigurationUtils.cs
@@ -30,6 +30,7 @@ namespace Microsoft.PythonTools.Interpreter {
         }
 
         public static Dictionary<string, string> GetFullEnvironment(LaunchConfiguration config, IServiceProvider serviceProvider, UIThreadBase uiThread, IPythonToolsLogger logger) {
+            // uiThread is retained for API compatibility; conda activation no longer marshals to the UI thread.
             if (config.Interpreter == null && config.InterpreterPath == null) {
                 throw new ArgumentException("Interpreter was invalid");
             }

--- a/Python/Product/VSInterpreters/Interpreter/LaunchConfigurationUtils.cs
+++ b/Python/Product/VSInterpreters/Interpreter/LaunchConfigurationUtils.cs
@@ -50,9 +50,9 @@ namespace Microsoft.PythonTools.Interpreter {
             }
             baseEnv[pathVar] = string.Empty;
 
-            if (CondaUtils.IsCondaEnvironment(config.Interpreter.GetPrefixPath())) {
+            var prefixPath = config.Interpreter?.GetPrefixPath();
+            if (prefixPath != null && CondaUtils.IsCondaEnvironment(prefixPath)) {
                 var condaExe = CondaUtils.GetRootCondaExecutablePath(serviceProvider);
-                var prefixPath = config.Interpreter.GetPrefixPath();
                 if (File.Exists(condaExe) && Directory.Exists(prefixPath)) {
                     var condaEnv = Task.Run(() => CondaUtils.GetActivationEnvironmentVariablesForPrefixAsync(condaExe, prefixPath, logger)).WaitAndUnwrapExceptions();
                     baseEnv = PathUtils.MergeEnvironments(baseEnv.AsEnumerable<string, string>(), condaEnv, "Path", pathVar);

--- a/Python/Product/VSInterpreters/PackageManager/CondaUtils.cs
+++ b/Python/Product/VSInterpreters/PackageManager/CondaUtils.cs
@@ -143,10 +143,8 @@ namespace Microsoft.PythonTools.Interpreter {
                     var exited = await Task.Run(() => proc.Wait(timeout)).ConfigureAwait(false);
                     if (!exited) {
                         Trace.TraceWarning(
-                            "Conda activation timed out after {0} ms. Activate script: {1}. Prefix: {2}. PID: {3}.",
+                            "Conda activation timed out after {0} ms. PID: {1}.",
                             timeout.TotalMilliseconds,
-                            activateBat,
-                            prefixPath ?? "<root>",
                             proc.ProcessId
                         );
                         LogActivationTimeout(logger, prefixPath, timeout);

--- a/Python/Product/VSInterpreters/PackageManager/CondaUtils.cs
+++ b/Python/Product/VSInterpreters/PackageManager/CondaUtils.cs
@@ -156,6 +156,7 @@ namespace Microsoft.PythonTools.Interpreter {
                         return new ActivationResult(activationVariables, false);
                     }
 
+                    proc.Wait();
                     if (proc.ExitCode == 0) {
                         activationVariables = ParseEnvironmentVariables(proc).ToArray();
                     }

--- a/Python/Product/VSInterpreters/PackageManager/CondaUtils.cs
+++ b/Python/Product/VSInterpreters/PackageManager/CondaUtils.cs
@@ -22,6 +22,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.PythonTools.Infrastructure;
+using Microsoft.PythonTools.Logging;
 using Microsoft.VisualStudio.ComponentModelHost;
 using Newtonsoft.Json;
 
@@ -95,7 +96,15 @@ namespace Microsoft.PythonTools.Interpreter {
             return await GetActivationEnvironmentVariablesForPrefixAsync(condaPath, prefixPath, ActivationTimeout).ConfigureAwait(false);
         }
 
+        internal static async Task<IEnumerable<KeyValuePair<string, string>>> GetActivationEnvironmentVariablesForPrefixAsync(string condaPath, string prefixPath, IPythonToolsLogger logger) {
+            return await GetActivationEnvironmentVariablesForPrefixAsync(condaPath, prefixPath, ActivationTimeout, logger).ConfigureAwait(false);
+        }
+
         internal static async Task<IEnumerable<KeyValuePair<string, string>>> GetActivationEnvironmentVariablesForPrefixAsync(string condaPath, string prefixPath, TimeSpan timeout) {
+            return await GetActivationEnvironmentVariablesForPrefixAsync(condaPath, prefixPath, timeout, null).ConfigureAwait(false);
+        }
+
+        internal static async Task<IEnumerable<KeyValuePair<string, string>>> GetActivationEnvironmentVariablesForPrefixAsync(string condaPath, string prefixPath, TimeSpan timeout, IPythonToolsLogger logger) {
             var condaKey = new CondaCacheKey(condaPath, prefixPath);
 
             using (await _activationCacheLock.LockAsync(CancellationToken.None).ConfigureAwait(false)) {
@@ -108,7 +117,7 @@ namespace Microsoft.PythonTools.Interpreter {
                 }
             }
 
-            var uncachedActivation = await GetActivationEnvironmentVariablesForPrefixUncachedAsync(condaPath, prefixPath, timeout).ConfigureAwait(false);
+            var uncachedActivation = await GetActivationEnvironmentVariablesForPrefixUncachedAsync(condaPath, prefixPath, timeout, logger).ConfigureAwait(false);
 
             using (await _activationCacheLock.LockAsync(CancellationToken.None).ConfigureAwait(false)) {
                 if (!_activationCache.TryGetValue(condaKey, out KeyValuePair<string, string>[] activationVariables)) {
@@ -121,7 +130,7 @@ namespace Microsoft.PythonTools.Interpreter {
             }
         }
 
-        private static async Task<ActivationResult> GetActivationEnvironmentVariablesForPrefixUncachedAsync(string condaPath, string prefixPath, TimeSpan timeout) {
+        private static async Task<ActivationResult> GetActivationEnvironmentVariablesForPrefixUncachedAsync(string condaPath, string prefixPath, TimeSpan timeout, IPythonToolsLogger logger) {
             var activationVariables = new KeyValuePair<string, string>[0];
 
             var activateBat = Path.Combine(Path.GetDirectoryName(condaPath), "activate.bat");
@@ -134,6 +143,7 @@ namespace Microsoft.PythonTools.Interpreter {
                     var exited = await Task.Run(() => proc.Wait(timeout)).ConfigureAwait(false);
                     if (!exited) {
                         Trace.TraceWarning("Conda activation timed out: " + proc.Arguments);
+                        LogActivationTimeout(logger, prefixPath, timeout);
                         try {
                             proc.Kill();
                         } catch (InvalidOperationException) {
@@ -149,6 +159,18 @@ namespace Microsoft.PythonTools.Interpreter {
             }
 
             return new ActivationResult(activationVariables, true);
+        }
+
+        private static void LogActivationTimeout(IPythonToolsLogger logger, string prefixPath, TimeSpan timeout) {
+            logger?.LogEvent(
+                "CondaActivationTimeout",
+                new Dictionary<string, object> {
+                    { "VS.Python.CondaActivation.IsRootEnvironment", prefixPath == null },
+                },
+                new Dictionary<string, double> {
+                    { "VS.Python.CondaActivation.TimeoutMilliseconds", timeout.TotalMilliseconds },
+                }
+            );
         }
 
         private static IEnumerable<KeyValuePair<string, string>> ParseEnvironmentVariables(ProcessOutput proc) {

--- a/Python/Product/VSInterpreters/PackageManager/CondaUtils.cs
+++ b/Python/Product/VSInterpreters/PackageManager/CondaUtils.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -31,6 +32,7 @@ namespace Microsoft.PythonTools.Interpreter {
 
         private static readonly Dictionary<CondaCacheKey, KeyValuePair<string, string>[]> _activationCache = new Dictionary<CondaCacheKey, KeyValuePair<string, string>[]>();
         private static readonly SemaphoreSlim _activationCacheLock = new SemaphoreSlim(1);
+        private static readonly TimeSpan ActivationTimeout = TimeSpan.FromSeconds(30);
 
         internal static string GetCondaExecutablePath(string prefixPath, bool allowBatch = true) {
             if (!Directory.Exists(prefixPath)) {
@@ -90,31 +92,63 @@ namespace Microsoft.PythonTools.Interpreter {
         /// <returns>List of environment variables.</returns>
         /// <remarks>Result is cached, it is safe to call multiple times.</remarks>
         internal static async Task<IEnumerable<KeyValuePair<string, string>>> GetActivationEnvironmentVariablesForPrefixAsync(string condaPath, string prefixPath) {
-            using (await _activationCacheLock.LockAsync(CancellationToken.None)) {
-                var condaKey = new CondaCacheKey(condaPath, prefixPath);
+            return await GetActivationEnvironmentVariablesForPrefixAsync(condaPath, prefixPath, ActivationTimeout).ConfigureAwait(false);
+        }
 
+        internal static async Task<IEnumerable<KeyValuePair<string, string>>> GetActivationEnvironmentVariablesForPrefixAsync(string condaPath, string prefixPath, TimeSpan timeout) {
+            var condaKey = new CondaCacheKey(condaPath, prefixPath);
+
+            using (await _activationCacheLock.LockAsync(CancellationToken.None).ConfigureAwait(false)) {
                 if (!_activationCache.TryGetValue(condaKey, out KeyValuePair<string, string>[] activationVariables)) {
-                    activationVariables = new KeyValuePair<string, string>[0];
-
-                    var activateBat = Path.Combine(Path.GetDirectoryName(condaPath), "activate.bat");
-                    if (File.Exists(activateBat)) {
-                        var args = prefixPath != null
-                            ? new[] { prefixPath, "&", "python.exe", "-c", PrintEnvironmentCode }
-                            : new[] { "&", "python.exe", "-c", PrintEnvironmentCode };
-
-                        using (var proc = ProcessOutput.RunHiddenAndCapture(activateBat, args)) {
-                            await proc;
-                            if (proc.ExitCode == 0) {
-                                activationVariables = ParseEnvironmentVariables(proc).ToArray();
-                            }
-                        }
-                    }
-
-                    _activationCache[condaKey] = activationVariables;
+                    activationVariables = null;
                 }
 
+                if (activationVariables != null) {
+                    return activationVariables;
+                }
+            }
+
+            var uncachedActivation = await GetActivationEnvironmentVariablesForPrefixUncachedAsync(condaPath, prefixPath, timeout).ConfigureAwait(false);
+
+            using (await _activationCacheLock.LockAsync(CancellationToken.None).ConfigureAwait(false)) {
+                if (!_activationCache.TryGetValue(condaKey, out KeyValuePair<string, string>[] activationVariables)) {
+                    activationVariables = uncachedActivation.Variables;
+                    if (uncachedActivation.ShouldCache) {
+                        _activationCache[condaKey] = activationVariables;
+                    }
+                }
                 return activationVariables;
             }
+        }
+
+        private static async Task<ActivationResult> GetActivationEnvironmentVariablesForPrefixUncachedAsync(string condaPath, string prefixPath, TimeSpan timeout) {
+            var activationVariables = new KeyValuePair<string, string>[0];
+
+            var activateBat = Path.Combine(Path.GetDirectoryName(condaPath), "activate.bat");
+            if (File.Exists(activateBat)) {
+                var args = prefixPath != null
+                    ? new[] { prefixPath, "&", "python.exe", "-c", PrintEnvironmentCode }
+                    : new[] { "&", "python.exe", "-c", PrintEnvironmentCode };
+
+                using (var proc = ProcessOutput.RunHiddenAndCapture(activateBat, args)) {
+                    var exited = await Task.Run(() => proc.Wait(timeout)).ConfigureAwait(false);
+                    if (!exited) {
+                        Trace.TraceWarning("Conda activation timed out: " + proc.Arguments);
+                        try {
+                            proc.Kill();
+                        } catch (InvalidOperationException) {
+                        } catch (System.ComponentModel.Win32Exception) {
+                        }
+                        return new ActivationResult(activationVariables, false);
+                    }
+
+                    if (proc.ExitCode == 0) {
+                        activationVariables = ParseEnvironmentVariables(proc).ToArray();
+                    }
+                }
+            }
+
+            return new ActivationResult(activationVariables, true);
         }
 
         private static IEnumerable<KeyValuePair<string, string>> ParseEnvironmentVariables(ProcessOutput proc) {
@@ -135,6 +169,17 @@ namespace Microsoft.PythonTools.Interpreter {
             }
 
             return Enumerable.Empty<KeyValuePair<string, string>>();
+        }
+
+        class ActivationResult {
+            public ActivationResult(KeyValuePair<string, string>[] variables, bool shouldCache) {
+                Variables = variables;
+                ShouldCache = shouldCache;
+            }
+
+            public KeyValuePair<string, string>[] Variables { get; }
+
+            public bool ShouldCache { get; }
         }
 
         class CondaCacheKey {
@@ -165,7 +210,7 @@ namespace Microsoft.PythonTools.Interpreter {
             }
 
             public override int GetHashCode() {
-                return CondaExecutablePath.GetHashCode() ^ PrefixPath.GetHashCode();
+                return StringComparer.OrdinalIgnoreCase.GetHashCode(CondaExecutablePath) ^ StringComparer.OrdinalIgnoreCase.GetHashCode(PrefixPath);
             }
         }
     }

--- a/Python/Product/VSInterpreters/PackageManager/CondaUtils.cs
+++ b/Python/Product/VSInterpreters/PackageManager/CondaUtils.cs
@@ -142,7 +142,13 @@ namespace Microsoft.PythonTools.Interpreter {
                 using (var proc = ProcessOutput.RunHiddenAndCapture(activateBat, args)) {
                     var exited = await Task.Run(() => proc.Wait(timeout)).ConfigureAwait(false);
                     if (!exited) {
-                        Trace.TraceWarning("Conda activation timed out: " + proc.Arguments);
+                        Trace.TraceWarning(
+                            "Conda activation timed out after {0} ms. Activate script: {1}. Prefix: {2}. PID: {3}.",
+                            timeout.TotalMilliseconds,
+                            activateBat,
+                            prefixPath ?? "<root>",
+                            proc.ProcessId
+                        );
                         LogActivationTimeout(logger, prefixPath, timeout);
                         try {
                             proc.Kill();

--- a/Python/Tests/Core/CondaInterpreterFactoryTests.cs
+++ b/Python/Tests/Core/CondaInterpreterFactoryTests.cs
@@ -15,8 +15,11 @@
 // permissions and limitations under the License.
 
 using System;
+using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Threading;
+using Microsoft.PythonTools.Infrastructure;
 using Microsoft.PythonTools.Interpreter;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.VisualStudio.Threading;
@@ -74,6 +77,63 @@ namespace PythonToolsTests {
             };
 
             TestTriggerDiscovery(userProfileFolder, triggerDiscovery);
+        }
+
+        [TestMethod, Priority(UnitTestPriority.P0)]
+        [TestCategory("10s")]
+        public void CondaActivationTimesOut() {
+            var condaRoot = TestData.GetTempPath();
+            try {
+                var scripts = Path.Combine(condaRoot, "scripts");
+                Directory.CreateDirectory(scripts);
+
+                var condaExe = Path.Combine(scripts, "conda.exe");
+                File.WriteAllText(condaExe, string.Empty);
+                File.WriteAllText(Path.Combine(scripts, "activate.bat"), "@echo off\r\n:wait\r\ngoto wait\r\n");
+
+                var sw = Stopwatch.StartNew();
+                var env = CondaUtils.GetActivationEnvironmentVariablesForPrefixAsync(condaExe, null, TimeSpan.FromMilliseconds(100)).WaitAndUnwrapExceptions();
+                sw.Stop();
+
+                Assert.AreEqual(0, env.Count());
+                Assert.IsTrue(sw.Elapsed < TimeSpan.FromSeconds(5), "Conda activation did not honor the timeout.");
+            } finally {
+                try {
+                    Directory.Delete(condaRoot, true);
+                } catch (IOException) {
+                } catch (UnauthorizedAccessException) {
+                }
+            }
+        }
+
+        [TestMethod, Priority(UnitTestPriority.P0)]
+        [TestCategory("10s")]
+        public void CondaActivationTimeoutIsNotCached() {
+            var condaRoot = TestData.GetTempPath();
+            try {
+                var scripts = Path.Combine(condaRoot, "scripts");
+                Directory.CreateDirectory(scripts);
+
+                var condaExe = Path.Combine(scripts, "conda.exe");
+                var activateBat = Path.Combine(scripts, "activate.bat");
+                File.WriteAllText(condaExe, string.Empty);
+                File.WriteAllText(activateBat, "@echo off\r\n:wait\r\ngoto wait\r\n");
+
+                var timedOutEnv = CondaUtils.GetActivationEnvironmentVariablesForPrefixAsync(condaExe, null, TimeSpan.FromMilliseconds(100)).WaitAndUnwrapExceptions();
+                Assert.AreEqual(0, timedOutEnv.Count());
+
+                File.WriteAllText(activateBat, "@echo off\r\necho !!!ENVIRONMENT MARKER!!!\r\necho {\"PTVS_TEST_ENV\":\"success\"}\r\n");
+
+                var env = CondaUtils.GetActivationEnvironmentVariablesForPrefixAsync(condaExe, null, TimeSpan.FromSeconds(5)).WaitAndUnwrapExceptions();
+
+                Assert.AreEqual("success", env.Single(kv => kv.Key == "PTVS_TEST_ENV").Value);
+            } finally {
+                try {
+                    Directory.Delete(condaRoot, true);
+                } catch (IOException) {
+                } catch (UnauthorizedAccessException) {
+                }
+            }
         }
 
         private static void TestTriggerDiscovery(string userProfileFolder, Action triggerDiscovery) {

--- a/Python/Tests/Core/CondaInterpreterFactoryTests.cs
+++ b/Python/Tests/Core/CondaInterpreterFactoryTests.cs
@@ -15,12 +15,14 @@
 // permissions and limitations under the License.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading;
 using Microsoft.PythonTools.Infrastructure;
 using Microsoft.PythonTools.Interpreter;
+using Microsoft.PythonTools.Logging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.VisualStudio.Threading;
 using TestUtilities;
@@ -108,6 +110,34 @@ namespace PythonToolsTests {
 
         [TestMethod, Priority(UnitTestPriority.P0)]
         [TestCategory("10s")]
+        public void CondaActivationTimeoutLogsTelemetry() {
+            var condaRoot = TestData.GetTempPath();
+            try {
+                var scripts = Path.Combine(condaRoot, "scripts");
+                Directory.CreateDirectory(scripts);
+
+                var condaExe = Path.Combine(scripts, "conda.exe");
+                File.WriteAllText(condaExe, string.Empty);
+                File.WriteAllText(Path.Combine(scripts, "activate.bat"), "@echo off\r\n:wait\r\ngoto wait\r\n");
+
+                var logger = new TestLogger();
+                var env = CondaUtils.GetActivationEnvironmentVariablesForPrefixAsync(condaExe, null, TimeSpan.FromMilliseconds(100), logger).WaitAndUnwrapExceptions();
+
+                Assert.AreEqual(0, env.Count());
+                Assert.AreEqual("CondaActivationTimeout", logger.EventName);
+                Assert.AreEqual(true, logger.Properties["VS.Python.CondaActivation.IsRootEnvironment"]);
+                Assert.AreEqual(100.0, logger.Measurements["VS.Python.CondaActivation.TimeoutMilliseconds"]);
+            } finally {
+                try {
+                    Directory.Delete(condaRoot, true);
+                } catch (IOException) {
+                } catch (UnauthorizedAccessException) {
+                }
+            }
+        }
+
+        [TestMethod, Priority(UnitTestPriority.P0)]
+        [TestCategory("10s")]
         public void CondaActivationTimeoutIsNotCached() {
             var condaRoot = TestData.GetTempPath();
             try {
@@ -149,6 +179,24 @@ namespace PythonToolsTests {
                 triggerDiscovery();
                 Assert.IsTrue(evt.WaitOne(5000), "Failed to trigger discovery.");
             }
+        }
+
+        class TestLogger : IPythonToolsLogger {
+            public string EventName { get; private set; }
+
+            public IReadOnlyDictionary<string, object> Properties { get; private set; }
+
+            public IReadOnlyDictionary<string, double> Measurements { get; private set; }
+
+            public void LogEvent(PythonLogEvent logEvent, object argument) { }
+
+            public void LogEvent(string eventName, IReadOnlyDictionary<string, object> properties, IReadOnlyDictionary<string, double> measurements) {
+                EventName = eventName;
+                Properties = properties;
+                Measurements = measurements;
+            }
+
+            public void LogFault(Exception ex, string description, bool dumpProcess) { }
         }
     }
 }

--- a/Python/Tests/Core/CondaInterpreterFactoryTests.cs
+++ b/Python/Tests/Core/CondaInterpreterFactoryTests.cs
@@ -152,11 +152,14 @@ namespace PythonToolsTests {
                 var timedOutEnv = CondaUtils.GetActivationEnvironmentVariablesForPrefixAsync(condaExe, null, TimeSpan.FromMilliseconds(100)).WaitAndUnwrapExceptions();
                 Assert.AreEqual(0, timedOutEnv.Count());
 
-                File.WriteAllText(activateBat, "@echo off\r\necho !!!ENVIRONMENT MARKER!!!\r\necho {\"PTVS_TEST_ENV\":\"success\"}\r\n");
+                var emitEnv = Path.Combine(scripts, "emit-env.ps1");
+                File.WriteAllText(emitEnv, "$payload = 'x' * 65536\r\nWrite-Output '!!!ENVIRONMENT MARKER!!!'\r\nWrite-Output ('{\"PTVS_TEST_ENV\":\"success\",\"PTVS_TEST_PAYLOAD\":\"' + $payload + '\"}')\r\n");
+                File.WriteAllText(activateBat, "@echo off\r\npowershell.exe -NoProfile -ExecutionPolicy Bypass -File \"%~dp0emit-env.ps1\"\r\n");
 
                 var env = CondaUtils.GetActivationEnvironmentVariablesForPrefixAsync(condaExe, null, TimeSpan.FromSeconds(5)).WaitAndUnwrapExceptions();
 
                 Assert.AreEqual("success", env.Single(kv => kv.Key == "PTVS_TEST_ENV").Value);
+                Assert.AreEqual(65536, env.Single(kv => kv.Key == "PTVS_TEST_PAYLOAD").Value.Length);
             } finally {
                 try {
                     Directory.Delete(condaRoot, true);


### PR DESCRIPTION
## Summary
- avoid joining conda activation through the VS UI thread while constructing launch environments
- add a 30-second timeout for conda activation and kill timed-out activation processes
- avoid holding the activation cache lock while waiting on external activation processes
- do not cache timeout results, so transient activation hangs do not poison the cache
- make the conda activation cache key hash code match its case-insensitive equality semantics
- add regression tests for activation timeout behavior and timeout cache behavior

## Root cause
Conda activation was invoked from GetFullEnvironment through UIThread.InvokeTaskSync with CancellationToken.None. The delegated work launched activate.bat and python.exe to capture the activated environment, then awaited process completion with no timeout while holding the activation cache lock. If activation or the child Python process never exited, devenv.exe could remain stuck in the UI-thread join path indefinitely, and other activation requests could block behind the cache lock.

## Behavior after this change
Activation is still exposed through the existing synchronous environment-construction path, but the external activation wait is moved out of the VS UI-thread invocation path and is bounded by a timeout. On timeout, PTVS logs a Trace warning, kills the activation process, returns an empty activation environment for that attempt, and leaves the cache unmodified so a later activation can retry.

## Tradeoffs / follow-ups
- If GetFullEnvironment is called on the UI thread, the UI may still be blocked until activation completes or the 30-second timeout expires; this is not a full async UI/progress refactor.
- Very slow conda installations may time out and launch without activation-provided environment variables.
- Concurrent cold-cache requests for the same environment may now run duplicate activation attempts because the global cache lock is no longer held during process execution.
- proc.Kill() terminates the started activation process; if child processes survive in some scenarios, process-tree termination may be needed later.
- Timeout diagnostics currently use Trace.TraceWarning only; Activity Log or telemetry may be useful follow-ups.

## Validation
- msbuild Python\\dirs.proj /p:VSTarget=18.0 /p:DeployExtension=true /p:RegisterOutputPackage=true
- vstest.console.exe BuildOutput\\Debug18.0\\raw\\binaries\\PythonToolsTests.dll /Tests:PythonToolsTests.CondaInterpreterFactoryTests.CondaActivationTimesOut,PythonToolsTests.CondaInterpreterFactoryTests.CondaActivationTimeoutIsNotCached /Logger:Console;Verbosity=minimal