### PR TITLE
Add visible label to Python Environments search field for accessibility (MAS 3.3.2)

### DIFF
--- a/Python/Product/EnvironmentsList/PipExtension.xaml
+++ b/Python/Product/EnvironmentsList/PipExtension.xaml
@@ -202,7 +202,6 @@
                 <Setter Property="Padding" Value="2" />
                 <Setter Property="IsEnabled" Value="{Binding IsPipInstalled,Mode=OneWay}" />
                 <Setter Property="Text" Value="{Binding SearchQuery,UpdateSourceTrigger=PropertyChanged}" />
-                <Setter Property="AutomationProperties.Name" Value="{Binding SearchWatermark,Mode=OneWay}" />
                 <Setter Property="Template">
                     <Setter.Value>
                         <ControlTemplate>
@@ -250,20 +249,6 @@
                                             </ControlTemplate>
                                         </Button.Template>
                                     </Button>
-                                    <TextBlock x:Name="Watermark"
-                                               HorizontalAlignment="Left"
-                                               VerticalAlignment="Center"
-                                               Margin="8 2"
-                                               IsHitTestVisible="False"
-                                               Foreground="{DynamicResource {x:Static wpf:Controls.GrayTextKey}}"
-                                               Text="{Binding SearchWatermark,Mode=OneWay}">
-                                        <TextBlock.Visibility>
-                                            <MultiBinding Converter="{StaticResource VisibilityIfAll}">
-                                                <Binding Path="IsPipInstalled" Mode="OneWay"  />
-                                                <Binding ElementName="SearchQueryText" Path="Text.IsEmpty" />
-                                            </MultiBinding>
-                                        </TextBlock.Visibility>
-                                    </TextBlock>
                                 </Grid>
                             </Border>
                         </ControlTemplate>
@@ -289,7 +274,15 @@
             </Style>
         </Grid.Resources>
 
-        <TextBox x:Name="SearchQueryText" Style="{StaticResource SearchBox}" />
+        <StackPanel Grid.Row="0" Orientation="Vertical">
+            <Label x:Name="SearchLabel"
+                   Padding="2 2 2 0"
+                   Target="{Binding ElementName=SearchQueryText}"
+                   Content="{Binding SearchWatermark,Mode=OneWay}" />
+            <TextBox x:Name="SearchQueryText"
+                     Style="{StaticResource SearchBox}"
+                     AutomationProperties.LabeledBy="{Binding ElementName=SearchLabel}" />
+        </StackPanel>
 
         <Grid Grid.Row="1" 
               Style="{StaticResource InfoPanel}"


### PR DESCRIPTION
## Summary

Fixes an accessibility issue (MAS 3.3.2 – Labels or Instructions) in the **Python Environments** window search field.

The "Search PyPI and installed packages" field relied solely on a watermark (placeholder) that disappears when the user starts typing. There was no persistent, visible label, so screen reader users had no reliable context about the field's purpose and sighted users lost the hint once they began typing.

## Changes

- Added a persistent, visible `<Label>` above the search box, bound to `SearchWatermark` so it shows the correct text for both pip ("Search PyPI and installed packages") and conda ("Search Conda and installed packages").
- Associated the label with the `TextBox` via `AutomationProperties.LabeledBy` so screen readers announce it.
- Removed the now-redundant in-field watermark (it duplicated the label text) and the `AutomationProperties.Name` setter (superseded by `LabeledBy`).

This mirrors the existing label + `AutomationProperties.LabeledBy` pattern already used in `ConfigurationExtension.xaml` in the same assembly.

## Testing

- Verified the XAML is well-formed. A full local build was not possible in this environment (the npm/VSSDK prebuild restore step requires network access, unrelated to this change).