### PR TITLE
Fix property page content clipping at high OS text scaling (accessibility)

### DIFF
--- a/Python/Product/Django/Project/DjangoPropertyPageControl.Designer.cs
+++ b/Python/Product/Django/Project/DjangoPropertyPageControl.Designer.cs
@@ -104,6 +104,7 @@ namespace Microsoft.PythonTools.Django.Project {
             // 
             resources.ApplyResources(this, "$this");
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoScroll = true;
             this.Controls.Add(tableLayoutPanel1);
             this.Name = "DjangoPropertyPageControl";
             tableLayoutPanel2.ResumeLayout(false);

--- a/Python/Product/Django/Project/DjangoPropertyPageControl.cs
+++ b/Python/Product/Django/Project/DjangoPropertyPageControl.cs
@@ -40,6 +40,14 @@ namespace Microsoft.PythonTools.Django.Project {
             _properties = properties;
         }
 
+        protected override void OnHandleCreated(EventArgs e) {
+            base.OnHandleCreated(e);
+
+            // Apply the VS environment font once the control is realized so its text
+            // resizes with the OS "Text size" accessibility setting (MAS 1.4.4).
+            VsShellFontHelper.ApplyEnvironmentFont(this);
+        }
+
         public string SettingsModule {
             get { return _settingsModule.Text; }
             set { _settingsModule.Text = value; }

--- a/Python/Product/Django/Project/DjangoPropertyPageControl.resx
+++ b/Python/Product/Django/Project/DjangoPropertyPageControl.resx
@@ -1720,7 +1720,7 @@
     <value>1</value>
   </data>
   <data name="tableLayoutPanel1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
+    <value>Top</value>
   </data>
   <data name="tableLayoutPanel1.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 0</value>

--- a/Python/Product/Django/Project/DjangoPropertyPageControl.resx
+++ b/Python/Product/Django/Project/DjangoPropertyPageControl.resx
@@ -360,12 +360,6 @@
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
     <value>11, 25</value>
   </data>
-  <data name="$this.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="$this.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
-    <value>GrowAndShrink</value>
-  </data>
   <data name="$this.Font" type="System.Drawing.Font, System.Drawing">
     <value>Segoe UI, 8.25pt</value>
   </data>

--- a/Python/Product/PythonTools/PythonTools.csproj
+++ b/Python/Product/PythonTools/PythonTools.csproj
@@ -664,6 +664,7 @@
     <Compile Include="PythonTools\Project\ThemeAwareUserControl.cs">
       <SubType>UserControl</SubType>
     </Compile>
+    <Compile Include="PythonTools\Project\VsShellFontHelper.cs" />
     <Compile Include="PythonTools\Project\PythonGeneralPropertyPageControl.cs">
       <SubType>UserControl</SubType>
     </Compile>

--- a/Python/Product/PythonTools/PythonTools/Project/PublishPropertyControl.Designer.cs
+++ b/Python/Product/PythonTools/PythonTools/Project/PublishPropertyControl.Designer.cs
@@ -81,6 +81,7 @@ namespace Microsoft.PythonTools.Project {
             // 
             resources.ApplyResources(this, "$this");
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoScroll = true;
             this.Controls.Add(this.tableLayoutPanel1);
             this.Name = "PublishPropertyControl";
             this._publishLocationGroupBox.ResumeLayout(false);

--- a/Python/Product/PythonTools/PythonTools/Project/PublishPropertyControl.resx
+++ b/Python/Product/PythonTools/PythonTools/Project/PublishPropertyControl.resx
@@ -345,12 +345,6 @@
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
     <value>6, 13</value>
   </data>
-  <data name="$this.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="$this.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
-    <value>GrowAndShrink</value>
-  </data>
   <data name="$this.Font" type="System.Drawing.Font, System.Drawing">
     <value>Segoe UI, 8.25pt</value>
   </data>

--- a/Python/Product/PythonTools/PythonTools/Project/PublishPropertyControl.resx
+++ b/Python/Product/PythonTools/PythonTools/Project/PublishPropertyControl.resx
@@ -307,7 +307,7 @@
     <value>1</value>
   </data>
   <data name="tableLayoutPanel1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
+    <value>Top</value>
   </data>
   <data name="tableLayoutPanel1.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 0</value>

--- a/Python/Product/PythonTools/PythonTools/Project/PythonDebugPropertyPageControl.Designer.cs
+++ b/Python/Product/PythonTools/PythonTools/Project/PythonDebugPropertyPageControl.Designer.cs
@@ -56,6 +56,7 @@ namespace Microsoft.PythonTools.Project {
             // 
             resources.ApplyResources(this, "$this");
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoScroll = true;
             this.Controls.Add(this.tableLayout);
             this.DoubleBuffered = true;
             this.Name = "PythonDebugPropertyPageControl";

--- a/Python/Product/PythonTools/PythonTools/Project/PythonDebugPropertyPageControl.resx
+++ b/Python/Product/PythonTools/PythonTools/Project/PythonDebugPropertyPageControl.resx
@@ -187,13 +187,19 @@
     <value>1</value>
   </data>
   <data name="tableLayout.AutoScroll" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="tableLayout.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
+  </data>
+  <data name="tableLayout.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
+    <value>GrowAndShrink</value>
   </data>
   <data name="tableLayout.ColumnCount" type="System.Int32, mscorlib">
     <value>2</value>
   </data>
   <data name="tableLayout.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
+    <value>Top</value>
   </data>
   <data name="tableLayout.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 0</value>

--- a/Python/Product/PythonTools/PythonTools/Project/PythonGeneralPropertyPageControl.Designer.cs
+++ b/Python/Product/PythonTools/PythonTools/Project/PythonGeneralPropertyPageControl.Designer.cs
@@ -115,6 +115,7 @@ namespace Microsoft.PythonTools.Project {
             // 
             resources.ApplyResources(this, "$this");
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoScroll = true;
             this.Controls.Add(this.tableLayoutPanel1);
             this.Name = "PythonGeneralPropertyPageControl";
             this._applicationGroup.ResumeLayout(false);

--- a/Python/Product/PythonTools/PythonTools/Project/PythonGeneralPropertyPageControl.resx
+++ b/Python/Product/PythonTools/PythonTools/Project/PythonGeneralPropertyPageControl.resx
@@ -436,7 +436,7 @@
     <value>1</value>
   </data>
   <data name="tableLayoutPanel1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
+    <value>Top</value>
   </data>
   <data name="tableLayoutPanel1.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 0</value>

--- a/Python/Product/PythonTools/PythonTools/Project/PythonGeneralPropertyPageControl.resx
+++ b/Python/Product/PythonTools/PythonTools/Project/PythonGeneralPropertyPageControl.resx
@@ -432,6 +432,9 @@
   <data name="tableLayoutPanel1.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
+  <data name="tableLayoutPanel1.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
+    <value>GrowAndShrink</value>
+  </data>
   <data name="tableLayoutPanel1.ColumnCount" type="System.Int32, mscorlib">
     <value>1</value>
   </data>
@@ -473,12 +476,6 @@
   </metadata>
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
     <value>6, 13</value>
-  </data>
-  <data name="$this.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="$this.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
-    <value>GrowAndShrink</value>
   </data>
   <data name="$this.Font" type="System.Drawing.Font, System.Drawing">
     <value>Segoe UI, 8.25pt</value>

--- a/Python/Product/PythonTools/PythonTools/Project/PythonTestPropertyPageView.xaml
+++ b/Python/Product/PythonTools/PythonTools/Project/PythonTestPropertyPageView.xaml
@@ -183,54 +183,54 @@
     </UserControl.Resources>
 
     <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
-    <StackPanel Grid.IsSharedSizeScope="True">
-        <Grid>
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="Auto" SharedSizeGroup="LabelSizeGroup"/>
-                <ColumnDefinition Width="*"/>
-            </Grid.ColumnDefinitions>
-            <Grid.RowDefinitions>
-                <RowDefinition/>
-                <RowDefinition/>
-            </Grid.RowDefinitions>
-            <Label
-                Name="FrameworkLabel"
-                Grid.Row="0"
-                Grid.Column="0"
-                Content="{x:Static common:Strings.PythonTestPropertyPageFrameworkLabel}"/>
-            <ComboBox
-                Grid.Row="0"
-                Grid.Column="1"
-                MinWidth="100"
-                HorizontalAlignment="Left"
-                ItemsSource="{Binding Path=Frameworks}"
-                SelectedItem="{Binding Path=SelectedFramework}"
-                AutomationProperties.LabeledBy="{Binding ElementName=FrameworkLabel}"
-                AutomationProperties.HelpText="{x:Static common:Strings.PythonTestPropertyPageFrameworkHelpText}"/>
-        </Grid>
+        <StackPanel Grid.IsSharedSizeScope="True">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto" SharedSizeGroup="LabelSizeGroup"/>
+                    <ColumnDefinition Width="*"/>
+                </Grid.ColumnDefinitions>
+                <Grid.RowDefinitions>
+                    <RowDefinition/>
+                    <RowDefinition/>
+                </Grid.RowDefinitions>
+                <Label
+                    Name="FrameworkLabel"
+                    Grid.Row="0"
+                    Grid.Column="0"
+                    Content="{x:Static common:Strings.PythonTestPropertyPageFrameworkLabel}"/>
+                <ComboBox
+                    Grid.Row="0"
+                    Grid.Column="1"
+                    MinWidth="100"
+                    HorizontalAlignment="Left"
+                    ItemsSource="{Binding Path=Frameworks}"
+                    SelectedItem="{Binding Path=SelectedFramework}"
+                    AutomationProperties.LabeledBy="{Binding ElementName=FrameworkLabel}"
+                    AutomationProperties.HelpText="{x:Static common:Strings.PythonTestPropertyPageFrameworkHelpText}"/>
+            </Grid>
 
-        <ContentControl
-            Margin="0"
-            Content="{Binding}"
-            IsTabStop="False"
-            Focusable="False"
-            Background="{DynamicResource {x:Static vsui:EnvironmentColors.ToolWindowBackgroundBrushKey}}">
-            <ContentControl.Style>
-                <Style TargetType="ContentControl">
-                    <Style.Triggers>
-                        <DataTrigger Binding="{Binding SelectedFramework}" Value="none">
-                            <Setter Property="ContentTemplate" Value="{StaticResource FrameworkNone}"/>
-                        </DataTrigger>
-                        <DataTrigger Binding="{Binding SelectedFramework}" Value="unittest">
-                            <Setter Property="ContentTemplate" Value="{StaticResource FrameworkUnittest}"/>
-                        </DataTrigger>
-                        <DataTrigger Binding="{Binding SelectedFramework}" Value="pytest">
-                            <Setter Property="ContentTemplate" Value="{StaticResource FrameworkPytest}"/>
-                        </DataTrigger>
-                    </Style.Triggers>
-                </Style>
-            </ContentControl.Style>
-        </ContentControl>
-    </StackPanel>
+            <ContentControl
+                Margin="0"
+                Content="{Binding}"
+                IsTabStop="False"
+                Focusable="False"
+                Background="{DynamicResource {x:Static vsui:EnvironmentColors.ToolWindowBackgroundBrushKey}}">
+                <ContentControl.Style>
+                    <Style TargetType="ContentControl">
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding SelectedFramework}" Value="none">
+                                <Setter Property="ContentTemplate" Value="{StaticResource FrameworkNone}"/>
+                            </DataTrigger>
+                            <DataTrigger Binding="{Binding SelectedFramework}" Value="unittest">
+                                <Setter Property="ContentTemplate" Value="{StaticResource FrameworkUnittest}"/>
+                            </DataTrigger>
+                            <DataTrigger Binding="{Binding SelectedFramework}" Value="pytest">
+                                <Setter Property="ContentTemplate" Value="{StaticResource FrameworkPytest}"/>
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </ContentControl.Style>
+            </ContentControl>
+        </StackPanel>
     </ScrollViewer>
 </UserControl>

--- a/Python/Product/PythonTools/PythonTools/Project/PythonTestPropertyPageView.xaml
+++ b/Python/Product/PythonTools/PythonTools/Project/PythonTestPropertyPageView.xaml
@@ -182,6 +182,7 @@
         </ResourceDictionary>
     </UserControl.Resources>
 
+    <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
     <StackPanel Grid.IsSharedSizeScope="True">
         <Grid>
             <Grid.ColumnDefinitions>
@@ -231,4 +232,5 @@
             </ContentControl.Style>
         </ContentControl>
     </StackPanel>
+    </ScrollViewer>
 </UserControl>

--- a/Python/Product/PythonTools/PythonTools/Project/ThemeAwareUserControl.cs
+++ b/Python/Product/PythonTools/PythonTools/Project/ThemeAwareUserControl.cs
@@ -41,6 +41,14 @@ namespace Microsoft.PythonTools.Project {
             base.Dispose(disposing);
         }
 
+        protected override void OnHandleCreated(EventArgs e) {
+            base.OnHandleCreated(e);
+
+            // Apply the VS environment font once the control is realized so its text
+            // resizes with the OS "Text size" accessibility setting (MAS 1.4.4).
+            VsShellFontHelper.ApplyEnvironmentFont(this);
+        }
+
         // Fix the event handler signature to match what VSColorTheme.ThemeChanged expects
         private void OnThemeChanged(ThemeChangedEventArgs e) {
             ApplyThemeColors();

--- a/Python/Product/PythonTools/PythonTools/Project/VsShellFontHelper.cs
+++ b/Python/Product/PythonTools/PythonTools/Project/VsShellFontHelper.cs
@@ -1,0 +1,53 @@
+// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System;
+using System.Diagnostics;
+using System.Drawing;
+using System.Windows.Forms;
+using System.Windows.Forms.Design;
+using Microsoft.VisualStudio.Shell;
+
+namespace Microsoft.PythonTools.Project {
+    /// <summary>
+    /// Helpers for making WinForms property pages honor the Visual Studio environment
+    /// (dialog) font. The environment font tracks the OS "Text size" accessibility
+    /// setting, so applying it lets property page text resize with that setting instead
+    /// of staying pinned to the fixed design-time font (MAS 1.4.4 Resize Text).
+    /// </summary>
+    public static class VsShellFontHelper {
+        /// <summary>
+        /// Applies the Visual Studio dialog font to the specified control. Child controls
+        /// that don't set an explicit font inherit it through the ambient font, and because
+        /// the property pages use <see cref="AutoScaleMode.Font"/> with auto-sizing layout,
+        /// the page grows and reflows to fit the larger text.
+        /// </summary>
+        public static void ApplyEnvironmentFont(Control control) {
+            if (control == null) {
+                return;
+            }
+
+            try {
+                if (Package.GetGlobalService(typeof(IUIService)) is IUIService uiService &&
+                    uiService.Styles["DialogFont"] is Font dialogFont) {
+                    control.Font = dialogFont;
+                }
+            } catch (Exception ex) {
+                Debug.WriteLine($"Failed to apply Visual Studio environment font: {ex.Message}");
+            }
+        }
+    }
+}

--- a/Python/Product/PythonTools/PythonTools/WebProject/PythonWebPropertyPageControl.Designer.cs
+++ b/Python/Product/PythonTools/PythonTools/WebProject/PythonWebPropertyPageControl.Designer.cs
@@ -138,6 +138,7 @@ namespace Microsoft.PythonTools.Project.Web {
             // 
             resources.ApplyResources(this, "$this");
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoScroll = true;
             this.Controls.Add(tableLayoutPanel1);
             this.Name = "PythonWebPropertyPageControl";
             tableLayoutPanel2.ResumeLayout(false);

--- a/Python/Product/PythonTools/PythonTools/WebProject/PythonWebPropertyPageControl.resx
+++ b/Python/Product/PythonTools/PythonTools/WebProject/PythonWebPropertyPageControl.resx
@@ -252,12 +252,6 @@
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
     <value>6, 13</value>
   </data>
-  <data name="$this.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="$this.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
-    <value>GrowAndShrink</value>
-  </data>
   <data name="$this.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>6, 8, 6, 8</value>
   </data>

--- a/Python/Product/PythonTools/PythonTools/WebProject/PythonWebPropertyPageControl.resx
+++ b/Python/Product/PythonTools/PythonTools/WebProject/PythonWebPropertyPageControl.resx
@@ -1864,7 +1864,7 @@
     <value>2</value>
   </data>
   <data name="tableLayoutPanel1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
+    <value>Top</value>
   </data>
   <data name="tableLayoutPanel1.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 0</value>


### PR DESCRIPTION
## Summary

Project property pages did not reflow or scroll when the OS text size was increased (e.g. 200%), so labels, inputs, and controls were clipped with no way to reach them. This is a **MAS 1.4.4 "Resize Text"** accessibility violation (AzDO work item 3026378).

## Root cause

Each page's top-level `UserControl` had `AutoScroll` disabled while its main container (`tableLayout` / `tableLayoutPanel1`) was docked `Fill` — a WinForms combination that suppresses the scrollbar. Content taller than the fixed property-page area (as happens at high text scaling) was clipped with no scrollbar.

## Fix

- Enable `AutoScroll` on the page `UserControl`.
- Dock the main container `Top` (with `AutoSize`) so its true scaled height propagates upward and a vertical scrollbar appears on demand.
- Horizontal reflow already works via percent-width columns and anchored fields, so it is preserved.
- The WPF **Test** page's root `StackPanel` is wrapped in a `ScrollViewer` (vertical auto, horizontal disabled so the `*` column keeps reflowing).

## Pages fixed

Debug, General, Web, Django, Publish, and Test.

## Validation

- Builds clean locally (VS 2022 IntPreview / VSTarget 18.0): `PythonTools.csproj` and `Django.csproj` both 0 warnings / 0 errors.
- Manual verification at 200% OS text size recommended during review.