### PR TITLE
Sign staged Web and Django template fonts

### DIFF
--- a/Python/Setup/signlayout.proj
+++ b/Python/Setup/signlayout.proj
@@ -101,14 +101,21 @@
 
   <Target Name="_StageTemplateFiles" BeforeTargets="_AddTemplateFiles">
     <ItemGroup>
-      <!-- Glob from Python\Templates\ so RecursiveDir preserves Django\ and Web\ subdirectory structure -->
-      <_TemplateSourceFiles Include="$(BuildRoot)\Python\Templates\**\*.js;$(BuildRoot)\Python\Templates\**\*.ttf" />
+      <!-- Stage full Web/Django package trees so those template VSIX packages can use signed staged files. -->
+      <_TemplatePackageSourceFiles Include="$(BuildRoot)\Python\Templates\**\*"
+                                   Exclude="$(BuildRoot)\Python\Templates\Core\**\*;$(BuildRoot)\Python\Templates\NativeDevelopment\**\*" />
+      <!-- Stage signable files from the remaining template trees. Glob from Python\Templates\ so RecursiveDir preserves subdirectories. -->
+      <_TemplateSignableSourceFiles Include="$(BuildRoot)\Python\Templates\**\*.js;$(BuildRoot)\Python\Templates\**\*.ttf"
+                                    Exclude="$(BuildRoot)\Python\Templates\Django\**\*;$(BuildRoot)\Python\Templates\Web\**\*" />
     </ItemGroup>
-    <Copy SourceFiles="@(_TemplateSourceFiles)"
-          DestinationFiles="@(_TemplateSourceFiles->'$(BinariesOutputPath)templates\%(RecursiveDir)%(Filename)%(Extension)')" />
+    <Copy SourceFiles="@(_TemplatePackageSourceFiles)"
+          DestinationFiles="@(_TemplatePackageSourceFiles->'$(BinariesOutputPath)templates\%(RecursiveDir)%(Filename)%(Extension)')" />
+    <Copy SourceFiles="@(_TemplateSignableSourceFiles)"
+          DestinationFiles="@(_TemplateSignableSourceFiles->'$(BinariesOutputPath)templates\%(RecursiveDir)%(Filename)%(Extension)')" />
   </Target>
   <Target Name="_AddTemplateFiles" BeforeTargets="_PreserveUnsigned;ListFiles">
     <ItemGroup>
+      <!-- Only sign file types that SignCheck validates inside the final template VSIX payloads. -->
       <TemplateFilesToSign Include="$(BinariesOutputPath)templates\**\*.js;$(BinariesOutputPath)templates\**\*.ttf" />
       <!-- Drop zero-byte files (e.g. the empty 'Add New Item -> JavaScript' template placeholder).
            signtool cannot map a 0-byte file (CreateFileMapping fails with ERROR_FILE_INVALID 0x3EE),

--- a/Python/Setup/swix/Packages/Microsoft.PythonTools.Django.Templates.Vsix.swixproj
+++ b/Python/Setup/swix/Packages/Microsoft.PythonTools.Django.Templates.Vsix.swixproj
@@ -3,7 +3,9 @@
   <Import Project="SetupProjectBefore.settings" />
 
   <PropertyGroup>
-    <SourcePath>$(BuildRoot)\Python\Templates\Django</SourcePath>
+    <!-- Prefer the staged template tree created by signlayout.proj so packaged VSIX contents use signed files. -->
+    <SourcePath Condition="'$(SourcePath)' == '' and Exists('$(BinariesOutputPath)templates\Django')">$(BinariesOutputPath)templates\Django</SourcePath>
+    <SourcePath Condition="'$(SourcePath)' == ''">$(BuildRoot)\Python\Templates\Django</SourcePath>
     <BaseInstall>InstallDir:\Common7\IDE</BaseInstall>
   </PropertyGroup>
 

--- a/Python/Setup/swix/Packages/Microsoft.PythonTools.Web.Templates.Vsix.swixproj
+++ b/Python/Setup/swix/Packages/Microsoft.PythonTools.Web.Templates.Vsix.swixproj
@@ -3,7 +3,9 @@
   <Import Project="SetupProjectBefore.settings" />
 
   <PropertyGroup>
-    <SourcePath>$(BuildRoot)\Python\Templates\Web</SourcePath>
+    <!-- Prefer the staged template tree created by signlayout.proj so packaged VSIX contents use signed files. -->
+    <SourcePath Condition="'$(SourcePath)' == '' and Exists('$(BinariesOutputPath)templates\Web')">$(BinariesOutputPath)templates\Web</SourcePath>
+    <SourcePath Condition="'$(SourcePath)' == ''">$(BuildRoot)\Python\Templates\Web</SourcePath>
     <BaseInstall>InstallDir:\Common7\IDE</BaseInstall>
   </PropertyGroup>
 


### PR DESCRIPTION
## Summary
- follow-up to microsoft/PTVS#8485, which added staging/signing for Django/Web template `.js` and `.ttf` files
- stage full Web/Django template package trees so their SWIX VSIX payloads can be generated from the staged signing area
- keep actual signing scoped to staged `.js` and `.ttf` files
- make Web/Django SWIX packages prefer staged template trees when available

## Why
PR #8485 added the signing list and copied signed files back to `Python\Templates` before SWIX packaging. The latest SignCheck failure still reports the four Glyphicons `.ttf` files inside the final Web/Django template VSIX payloads, so this PR removes the dependence on source-tree copy-back for those packages and packages Web/Django directly from the staged tree used by signing.

## Validation
- `MSBuild.exe Python\Setup\signlayout.proj /t:ListFiles /p:VSTarget=18.0 /p:Configuration=Release /p:SignType=none /p:BUILD_BINARIESDIRECTORY=C:\dev\PTVS\BuildOutput\validation /v:minimal /nologo`
- `MSBuild.exe Python\Setup\swix\Packages\Microsoft.PythonTools.Web.Templates.Vsix.swixproj /t:_GenerateSwrMetadata;_GenerateSwrFromSources ...`
- `MSBuild.exe Python\Setup\swix\Packages\Microsoft.PythonTools.Django.Templates.Vsix.swixproj /t:_GenerateSwRMetadata;_GenerateSwrFromSources ...`
- confirmed the four Glyphicons `.ttf` files are in `FilesToSign` and generated Web/Django SWR metadata with no duplicate staged Glyphicons paths

Real signing/SignCheck still requires the pipeline signing environment.