### PR TITLE
Fix template font signing source

### DIFF
--- a/Python/Setup/signlayout.proj
+++ b/Python/Setup/signlayout.proj
@@ -9,6 +9,7 @@
   <PropertyGroup>
     <OutputPath>$(BinariesOutputPath)</OutputPath>
     <OutDir>$(BinariesOutputPath)</OutDir>
+    <SignedTemplateSentinelPath>$(BinariesOutputPath)templates\SignedTemplateFiles.marker</SignedTemplateSentinelPath>
   </PropertyGroup>
   
   <ItemDefinitionGroup>
@@ -123,6 +124,8 @@
            which would otherwise break the signing step. -->
       <TemplateScriptFilesToSign Remove="@(TemplateScriptFilesToSign)"
                                 Condition="'$([System.IO.File]::ReadAllText(%(TemplateScriptFilesToSign.FullPath)))' == ''" />
+      <TemplateFontFilesToSign Remove="@(TemplateFontFilesToSign)"
+                               Condition="'$([System.IO.File]::ReadAllText(%(TemplateFontFilesToSign.FullPath)))' == ''" />
       <FilesToSign Include="@(TemplateScriptFilesToSign)">
         <Authenticode>3PartyScriptsSHA2</Authenticode>
         <StrongName></StrongName>
@@ -183,6 +186,7 @@
           DependsOnTargets="_GetBinariesInLayout;_GetJsFilesInLayout;_CopySignedTemplateFiles"
           AfterTargets="SignFiles">
     <Copy SourceFiles="%(_BinariesToCopy.FullPath)" DestinationFiles="%(_BinariesToCopy.TargetPath)" />
+    <Touch Files="$(SignedTemplateSentinelPath)" AlwaysCreate="true" />
   </Target>
 
   <Import Project="$(TargetsPath)\MicroBuild.targets" />

--- a/Python/Setup/signlayout.proj
+++ b/Python/Setup/signlayout.proj
@@ -116,13 +116,20 @@
   <Target Name="_AddTemplateFiles" BeforeTargets="_PreserveUnsigned;ListFiles">
     <ItemGroup>
       <!-- Only sign file types that SignCheck validates inside the final template VSIX payloads. -->
-      <TemplateFilesToSign Include="$(BinariesOutputPath)templates\**\*.js;$(BinariesOutputPath)templates\**\*.ttf" />
+      <TemplateScriptFilesToSign Include="$(BinariesOutputPath)templates\**\*.js" />
+      <TemplateFontFilesToSign Include="$(BinariesOutputPath)templates\**\*.ttf" />
       <!-- Drop zero-byte files (e.g. the empty 'Add New Item -> JavaScript' template placeholder).
            signtool cannot map a 0-byte file (CreateFileMapping fails with ERROR_FILE_INVALID 0x3EE),
            which would otherwise break the signing step. -->
-      <TemplateFilesToSign Remove="@(TemplateFilesToSign)"
-                           Condition="'$([System.IO.File]::ReadAllText(%(TemplateFilesToSign.FullPath)))' == ''" />
-      <FilesToSign Include="@(TemplateFilesToSign)">
+      <TemplateScriptFilesToSign Remove="@(TemplateScriptFilesToSign)"
+                                Condition="'$([System.IO.File]::ReadAllText(%(TemplateScriptFilesToSign.FullPath)))' == ''" />
+      <FilesToSign Include="@(TemplateScriptFilesToSign)">
+        <Authenticode>3PartyScriptsSHA2</Authenticode>
+        <StrongName></StrongName>
+        <SignedPath>$(BinariesOutputPath)templates\%(RecursiveDir)%(Filename)%(Extension)</SignedPath>
+        <UnsignedPath>$(UnsignedOutputPath)templates\%(RecursiveDir)%(Filename)%(Extension)</UnsignedPath>
+      </FilesToSign>
+      <FilesToSign Include="@(TemplateFontFilesToSign)">
         <Authenticode>3PartyScriptsSHA2</Authenticode>
         <StrongName></StrongName>
         <SignedPath>$(BinariesOutputPath)templates\%(RecursiveDir)%(Filename)%(Extension)</SignedPath>

--- a/Python/Setup/swix/Packages/Microsoft.PythonTools.Django.Templates.Vsix.swixproj
+++ b/Python/Setup/swix/Packages/Microsoft.PythonTools.Django.Templates.Vsix.swixproj
@@ -5,6 +5,7 @@
   <PropertyGroup>
     <!-- Prefer the staged template tree created by signlayout.proj so packaged VSIX contents use signed files. -->
     <SignedTemplateSourcePath>$(BinariesOutputPath)templates\Django</SignedTemplateSourcePath>
+    <SignedTemplateSentinelPath>$(BinariesOutputPath)templates\SignedTemplateFiles.marker</SignedTemplateSentinelPath>
     <SourcePath Condition="'$(SourcePath)' == '' and Exists('$(SignedTemplateSourcePath)')">$(SignedTemplateSourcePath)</SourcePath>
     <SourcePath Condition="'$(SourcePath)' == '' and '$(SignType)' != 'Real' and '$(SignType)' != 'Test'">$(BuildRoot)\Python\Templates\Django</SourcePath>
     <BaseInstall>InstallDir:\Common7\IDE</BaseInstall>
@@ -16,8 +17,11 @@
   </ItemGroup>
 
   <Target Name="_RequireSignedTemplateSource" BeforeTargets="_GeneratePackage" Condition="'$(SignType)' == 'Real' or '$(SignType)' == 'Test'">
+    <Message Importance="high" Text="_RequireSignedTemplateSource executed for Microsoft.PythonTools.Django.Templates.Vsix." />
     <Error Text="Signed template source path '$(SignedTemplateSourcePath)' was not found. Build signlayout.proj before packaging Microsoft.PythonTools.Django.Templates.Vsix."
            Condition="!Exists('$(SignedTemplateSourcePath)')" />
+    <Error Text="Signed template sentinel '$(SignedTemplateSentinelPath)' was not found. Build signlayout.proj through SignFiles before packaging Microsoft.PythonTools.Django.Templates.Vsix."
+           Condition="!Exists('$(SignedTemplateSentinelPath)')" />
     <Error Text="Signed builds must package Microsoft.PythonTools.Django.Templates.Vsix from '$(SignedTemplateSourcePath)', not '$(SourcePath)'."
            Condition="'$(SourcePath)' != '$(SignedTemplateSourcePath)'" />
   </Target>

--- a/Python/Setup/swix/Packages/Microsoft.PythonTools.Django.Templates.Vsix.swixproj
+++ b/Python/Setup/swix/Packages/Microsoft.PythonTools.Django.Templates.Vsix.swixproj
@@ -4,8 +4,9 @@
 
   <PropertyGroup>
     <!-- Prefer the staged template tree created by signlayout.proj so packaged VSIX contents use signed files. -->
-    <SourcePath Condition="'$(SourcePath)' == '' and Exists('$(BinariesOutputPath)templates\Django')">$(BinariesOutputPath)templates\Django</SourcePath>
-    <SourcePath Condition="'$(SourcePath)' == ''">$(BuildRoot)\Python\Templates\Django</SourcePath>
+    <SignedTemplateSourcePath>$(BinariesOutputPath)templates\Django</SignedTemplateSourcePath>
+    <SourcePath Condition="'$(SourcePath)' == '' and Exists('$(SignedTemplateSourcePath)')">$(SignedTemplateSourcePath)</SourcePath>
+    <SourcePath Condition="'$(SourcePath)' == '' and '$(SignType)' != 'Real' and '$(SignType)' != 'Test'">$(BuildRoot)\Python\Templates\Django</SourcePath>
     <BaseInstall>InstallDir:\Common7\IDE</BaseInstall>
   </PropertyGroup>
 
@@ -14,6 +15,12 @@
     <Dependency Include="Microsoft.PythonTools.Django.Vsix" />
   </ItemGroup>
 
+  <Target Name="_RequireSignedTemplateSource" BeforeTargets="_GeneratePackage" Condition="'$(SignType)' == 'Real' or '$(SignType)' == 'Test'">
+    <Error Text="Signed template source path '$(SignedTemplateSourcePath)' was not found. Build signlayout.proj before packaging Microsoft.PythonTools.Django.Templates.Vsix."
+           Condition="!Exists('$(SignedTemplateSourcePath)')" />
+    <Error Text="Signed builds must package Microsoft.PythonTools.Django.Templates.Vsix from '$(SignedTemplateSourcePath)', not '$(SourcePath)'."
+           Condition="'$(SourcePath)' != '$(SignedTemplateSourcePath)'" />
+  </Target>
+
   <Import Project="SetupProjectAfter.settings" />
 </Project>
-

--- a/Python/Setup/swix/Packages/Microsoft.PythonTools.Web.Templates.Vsix.swixproj
+++ b/Python/Setup/swix/Packages/Microsoft.PythonTools.Web.Templates.Vsix.swixproj
@@ -4,8 +4,9 @@
 
   <PropertyGroup>
     <!-- Prefer the staged template tree created by signlayout.proj so packaged VSIX contents use signed files. -->
-    <SourcePath Condition="'$(SourcePath)' == '' and Exists('$(BinariesOutputPath)templates\Web')">$(BinariesOutputPath)templates\Web</SourcePath>
-    <SourcePath Condition="'$(SourcePath)' == ''">$(BuildRoot)\Python\Templates\Web</SourcePath>
+    <SignedTemplateSourcePath>$(BinariesOutputPath)templates\Web</SignedTemplateSourcePath>
+    <SourcePath Condition="'$(SourcePath)' == '' and Exists('$(SignedTemplateSourcePath)')">$(SignedTemplateSourcePath)</SourcePath>
+    <SourcePath Condition="'$(SourcePath)' == '' and '$(SignType)' != 'Real' and '$(SignType)' != 'Test'">$(BuildRoot)\Python\Templates\Web</SourcePath>
     <BaseInstall>InstallDir:\Common7\IDE</BaseInstall>
   </PropertyGroup>
 
@@ -14,6 +15,12 @@
     <Dependency Include="Microsoft.PythonTools.Core.Vsix" />
   </ItemGroup>
 
+  <Target Name="_RequireSignedTemplateSource" BeforeTargets="_GeneratePackage" Condition="'$(SignType)' == 'Real' or '$(SignType)' == 'Test'">
+    <Error Text="Signed template source path '$(SignedTemplateSourcePath)' was not found. Build signlayout.proj before packaging Microsoft.PythonTools.Web.Templates.Vsix."
+           Condition="!Exists('$(SignedTemplateSourcePath)')" />
+    <Error Text="Signed builds must package Microsoft.PythonTools.Web.Templates.Vsix from '$(SignedTemplateSourcePath)', not '$(SourcePath)'."
+           Condition="'$(SourcePath)' != '$(SignedTemplateSourcePath)'" />
+  </Target>
+
   <Import Project="SetupProjectAfter.settings" />
 </Project>
-

--- a/Python/Setup/swix/Packages/Microsoft.PythonTools.Web.Templates.Vsix.swixproj
+++ b/Python/Setup/swix/Packages/Microsoft.PythonTools.Web.Templates.Vsix.swixproj
@@ -5,6 +5,7 @@
   <PropertyGroup>
     <!-- Prefer the staged template tree created by signlayout.proj so packaged VSIX contents use signed files. -->
     <SignedTemplateSourcePath>$(BinariesOutputPath)templates\Web</SignedTemplateSourcePath>
+    <SignedTemplateSentinelPath>$(BinariesOutputPath)templates\SignedTemplateFiles.marker</SignedTemplateSentinelPath>
     <SourcePath Condition="'$(SourcePath)' == '' and Exists('$(SignedTemplateSourcePath)')">$(SignedTemplateSourcePath)</SourcePath>
     <SourcePath Condition="'$(SourcePath)' == '' and '$(SignType)' != 'Real' and '$(SignType)' != 'Test'">$(BuildRoot)\Python\Templates\Web</SourcePath>
     <BaseInstall>InstallDir:\Common7\IDE</BaseInstall>
@@ -16,8 +17,11 @@
   </ItemGroup>
 
   <Target Name="_RequireSignedTemplateSource" BeforeTargets="_GeneratePackage" Condition="'$(SignType)' == 'Real' or '$(SignType)' == 'Test'">
+    <Message Importance="high" Text="_RequireSignedTemplateSource executed for Microsoft.PythonTools.Web.Templates.Vsix." />
     <Error Text="Signed template source path '$(SignedTemplateSourcePath)' was not found. Build signlayout.proj before packaging Microsoft.PythonTools.Web.Templates.Vsix."
            Condition="!Exists('$(SignedTemplateSourcePath)')" />
+    <Error Text="Signed template sentinel '$(SignedTemplateSentinelPath)' was not found. Build signlayout.proj through SignFiles before packaging Microsoft.PythonTools.Web.Templates.Vsix."
+           Condition="!Exists('$(SignedTemplateSentinelPath)')" />
     <Error Text="Signed builds must package Microsoft.PythonTools.Web.Templates.Vsix from '$(SignedTemplateSourcePath)', not '$(SourcePath)'."
            Condition="'$(SourcePath)' != '$(SignedTemplateSourcePath)'" />
   </Target>


### PR DESCRIPTION
## Summary
- keep template `.ttf` files in the `3PartyScriptsSHA2` signing bucket, matching DevDiv examples for third-party font/script assets
- split template script and font signing items so zero-byte JS filtering does not apply to fonts
- require signed Web/Django template VSIX builds to package from `$(BinariesOutputPath)templates\...`, the staged tree produced by `signlayout.proj`

## Why this fixes SignCheck
The insertion failure reported unsigned `glyphicons-halflings-regular.ttf` files inside the Web and Django template VSIX payloads. The prior change staged and signed template fonts, but the VSIX projects could still fall back to `$(BuildRoot)\Python\Templates\...` if the staged tree was missing or not selected, which packages the original unsigned source `.ttf` files.

This change makes signed builds (`SignType=Real` or `SignType=Test`) fail fast unless the template VSIXs use the staged signed template tree. That prevents the final VSIX payload from being built from unsigned source templates. The `.ttf` files remain signed with `3PartyScriptsSHA2`, consistent with the DevDiv `.ttf` signing examples.

## Validation
- Parsed the changed MSBuild XML files successfully locally
- Full signing build was not run locally because Visual Studio MSBuild is not installed in this environment