### PR TITLE
Fix missing Pylance diagnostics in Visual Studio

### DIFF
--- a/Python/Product/PythonTools/PythonTools/LanguageServerClient/PythonLanguageClient.cs
+++ b/Python/Product/PythonTools/PythonTools/LanguageServerClient/PythonLanguageClient.cs
@@ -215,7 +215,8 @@ namespace Microsoft.PythonTools.LanguageServerClient {
             // Client context cannot be created here since the is no workspace yet
             // and hence we don't know if this is workspace or a loose files case.
             _server = new LanguageServer(Site, JoinableTaskContext, this.OnSendToServer);
-            InitializationOptions = null;
+
+            InitializationOptions = new { disablePullDiagnostics = true };
 
             var customTarget = new PythonLanguageClientCustomTarget(Site, JoinableTaskContext);
             CustomMessageTarget = customTarget;


### PR DESCRIPTION
## Context

Pylance enables LSP pull diagnostics when the client advertises
`textDocument.diagnostic.dynamicRegistration`.

Visual Studio advertises this capability, causing Pylance to stop publishing
diagnostics through `textDocument/publishDiagnostics` and instead wait for the
client to pull them. PTVS does not currently surface these pulled diagnostics,
so errors such as unresolved imports produce neither editor squiggles nor Error
List entries.

## Fix

Set the Pylance initialization option `disablePullDiagnostics` to `true`.

This keeps Pylance on the existing push-diagnostics path, which Visual Studio
already routes to editor squiggles and the Error List.

## Validation

Built `PythonTools.csproj` successfully for Debug/VS 18.

Fixes #8558