### PR TITLE
Upgrade compliance BinSkim scanner to 4.4.9

### DIFF
--- a/azure-pipelines-compliance.yml
+++ b/azure-pipelines-compliance.yml
@@ -152,6 +152,8 @@ jobs:
   - task: BinSkim@4
     displayName: Run BinSkim
     inputs:
+      toolVersion: Exact
+      exactToolVersion: '4.4.9'
       # Use the same files copied for ApiScan
       TargetPattern: binskimPattern
       AnalyzeTargetBinskim: |


### PR DESCRIPTION
## Summary

- Pin the standalone PTVS-Compliance pipeline to BinSkim scanner version `4.4.9`.
- Keep the Azure DevOps task at `BinSkim@4`; only the scanner binary version changes.

## Context

BinSkim scanner version `1.9.5` is deprecated on July 30, 2026 because it includes a vulnerable `msdia140.dll`. PTVS-Compliance invokes the Guardian BinSkim task directly rather than through 1ES Pipeline Templates, so this pipeline requires an explicit upgrade.

The July 20 PTVS-Compliance run `26201.1` (build `14704086`) confirmed that the current unpinned configuration resolves `Latest` to the deprecated scanner:

```text
Installed Microsoft.CodeAnalysis.BinSkim 1.9.5
Running BinSkim 1.9.5
```

The installed `BinSkim@4.289.0` task represents a custom scanner version with `toolVersion: Exact` and the companion `exactToolVersion` input, so this PR uses that supported form to select `4.4.9`.

The primary `azure-pipelines.yml` pipeline is unpinned and uses 1ES Pipeline Templates, so it does not require the same change.

## Validation

- Confirmed the DevDiv `BinSkim@4.289.0` task schema supports `Exact` plus `exactToolVersion`.
- Confirmed BinSkim `4.4.9` is present in the Guardian internal feed.
- Confirmed the YAML has no editor/schema diagnostics.
- Verified the branch diff contains only the two scanner-version inputs.

The next compliance run should report `Running BinSkim 4.4.9` in the BinSkim task log.