### PR TITLE
Fix Python 3.13 mixed-mode debugger crash by computing line numbers in-process

### DIFF
--- a/Python/Product/Debugger.Concord/Debugger.Concord.csproj
+++ b/Python/Product/Debugger.Concord/Debugger.Concord.csproj
@@ -127,6 +127,7 @@
     <Compile Include="Proxies\Structs\PyFrameObject311.cs" />
     <Compile Include="Proxies\Structs\PyFunctionObject.cs" />
     <Compile Include="Proxies\Structs\PyInterpreterFrame.cs" />
+    <Compile Include="Proxies\Structs\PyLineTable.cs" />
     <Compile Include="Proxies\Structs\PyRuntimeState.cs" />
     <Compile Include="Proxies\Structs\PyEllipsisObject.cs" />
     <Compile Include="Proxies\Structs\PyComplexObject.cs" />

--- a/Python/Product/Debugger.Concord/Proxies/Structs/PyCodeObject311.cs
+++ b/Python/Product/Debugger.Concord/Proxies/Structs/PyCodeObject311.cs
@@ -34,6 +34,7 @@ namespace Microsoft.PythonTools.Debugger.Concord.Proxies.Structs {
             public StructField<PointerProxy<PyBytesObject>> co_localspluskinds;
             public StructField<ArrayProxy<SByteProxy>> co_code_adaptive;
             public StructField<Int32Proxy> _co_firsttraceable;
+            public StructField<PointerProxy<PyBytesObject>> co_linetable;
         }
 
         private readonly Fields _fields;
@@ -57,6 +58,8 @@ namespace Microsoft.PythonTools.Debugger.Concord.Proxies.Structs {
         public ArrayProxy<SByteProxy> co_code_adaptive => GetFieldProxy(_fields.co_code_adaptive);
 
         public Int32Proxy _co_firsttraceable => GetFieldProxy(_fields._co_firsttraceable);
+
+        public PointerProxy<PyBytesObject> co_linetable => GetFieldProxy(_fields.co_linetable);
 
         public PyCodeObject311(DkmProcess process, ulong address)
             : base(process, address) {

--- a/Python/Product/Debugger.Concord/Proxies/Structs/PyFrameObject.cs
+++ b/Python/Product/Debugger.Concord/Proxies/Structs/PyFrameObject.cs
@@ -77,12 +77,29 @@ namespace Microsoft.PythonTools.Debugger.Concord.Proxies.Structs {
 
         public int ComputeLineNumber(DkmInspectionSession inspectionSession, DkmStackWalkFrame frame, DkmEvaluationFlags flags) {
             var setLineNumber = f_lineno.Read();
-            if (setLineNumber == 0 && flags != DkmEvaluationFlags.None) {
-                // We need to use the CppExpressionEvaluator to compute the line number from
-                // our frame object. This function here: https://github.com/python/cpython/blob/46710ca5f263936a2e36fa5d0f140cf9f50b2618/Objects/frameobject.c#L40-L41
-                //
-                // However only do this when stopped at a breakpoint and evaluating the frame. Otherwise we it will fail and cause stepping
-                // to think the frame we eval is where we should stop.
+            if (setLineNumber != 0) {
+                // The frame already has a valid (cached) line number, use it directly.
+                return setLineNumber;
+            }
+
+            // Compute the line number entirely from debuggee memory: the frame's current
+            // instruction offset decoded against the code object's line table. This mirrors
+            // CPython's PyFrame_GetLineNumber (return f_lineno if set, else compute from the
+            // interpreter frame) and avoids a func-eval per frame. The old approach evaluated
+            // PyFrame_GetLineNumber in the debuggee for every Python frame every time execution
+            // stopped, which is slow and can hang or crash the debugger - especially for GUI
+            // apps that pump messages - on Python 3.11+ where f_lineno is 0 while executing.
+            var computedLineNumber = TryComputeLineNumberFromInstruction();
+            if (computedLineNumber > 0) {
+                return computedLineNumber;
+            }
+
+            if (flags != DkmEvaluationFlags.None) {
+                // Fallback only: ask the interpreter to compute the line number. This runs
+                // code in the debuggee (func-eval), so only do it when stopped at a breakpoint
+                // and evaluating the frame. Otherwise it will fail and cause stepping to think
+                // the frame we eval is where we should stop.
+                // https://github.com/python/cpython/blob/46710ca5f263936a2e36fa5d0f140cf9f50b2618/Objects/frameobject.c#L40-L41
                 var evaluator = new CppExpressionEvaluator(inspectionSession, 10, frame, DkmEvaluationFlags.TreatAsExpression);
                 var funcAddr = Process.GetPythonRuntimeInfo().DLLs.Python.GetFunctionAddress("PyFrame_GetLineNumber");
                 var frameAddr = Address;
@@ -95,6 +112,15 @@ namespace Microsoft.PythonTools.Debugger.Concord.Proxies.Structs {
             }
 
             return setLineNumber;
+        }
+
+        /// <summary>
+        /// Attempts to compute the current line number without executing any code in the
+        /// debuggee. Returns 0 when unavailable (e.g. Python &lt; 3.11), in which case the
+        /// caller falls back to evaluating PyFrame_GetLineNumber in the debuggee.
+        /// </summary>
+        protected virtual int TryComputeLineNumberFromInstruction() {
+            return 0;
         }
 
         public abstract ArrayProxy<PointerProxy<PyObject>> f_localsplus { get; }

--- a/Python/Product/Debugger.Concord/Proxies/Structs/PyFrameObject311.cs
+++ b/Python/Product/Debugger.Concord/Proxies/Structs/PyFrameObject311.cs
@@ -68,5 +68,10 @@ namespace Microsoft.PythonTools.Debugger.Concord.Proxies.Structs {
         public override ArrayProxy<PointerProxy<PyObject>> f_localsplus => GetFrame().f_localsplus;
         public override Int32Proxy f_lineno => GetFieldProxy(_fields.f_lineno);
 
+        protected override int TryComputeLineNumberFromInstruction() {
+            var interpreterFrame = f_frame.TryRead();
+            return interpreterFrame != null ? interpreterFrame.ComputeLineNumber() : 0;
+        }
+
     }
 }

--- a/Python/Product/Debugger.Concord/Proxies/Structs/PyInterpreterFrame.cs
+++ b/Python/Product/Debugger.Concord/Proxies/Structs/PyInterpreterFrame.cs
@@ -35,6 +35,13 @@ namespace Microsoft.PythonTools.Debugger.Concord.Proxies.Structs {
             public StructField<PointerProxy<PyInterpreterFrame>> previous;
             public StructField<ArrayProxy<PointerProxy<PyObject>>> localsplus;
             public StructField<CharProxy> owner;
+            // Pointer to the current bytecode instruction. Renamed from prev_instr to
+            // instr_ptr in 3.13 (and it now points at the current instruction rather
+            // than the previous one), but the offset math for the line table is identical.
+            [FieldProxy(MaxVersion = PythonLanguageVersion.V312)]
+            public StructField<PointerProxy> prev_instr;
+            [FieldProxy(MinVersion = PythonLanguageVersion.V313)]
+            public StructField<PointerProxy> instr_ptr;
         }
 
         private const int FRAME_OWNED_BY_THREAD = 0;
@@ -76,6 +83,119 @@ namespace Microsoft.PythonTools.Debugger.Concord.Proxies.Structs {
         }
 
         public PointerProxy<PyInterpreterFrame> previous => GetFieldProxy(_fields.previous);
+
+        /// <summary>
+        /// Computes the current source line number for this frame without executing any
+        /// code in the debuggee. This mirrors CPython's <c>_PyInterpreterFrame_GetLine</c>
+        /// (<c>PyCode_Addr2Line</c>): it finds the current bytecode offset from the frame's
+        /// instruction pointer and decodes the code object's line table (PEP 626).
+        /// Returns 0 if the line number cannot be determined (caller should fall back).
+        /// </summary>
+        public int ComputeLineNumber() {
+            if (Process.GetPythonRuntimeInfo().LanguageVersion < PythonLanguageVersion.V311) {
+                return 0;
+            }
+
+            var code = f_code.TryRead() as PyCodeObject311;
+            if (code == null) {
+                return 0;
+            }
+
+            // _PyCode_CODE(co) == &co->co_code_adaptive[0] - the start of the bytecode.
+            ulong codeStart = code.co_code_adaptive.Address;
+
+            // The current instruction pointer: prev_instr (3.11/3.12) or instr_ptr (3.13+).
+            ulong instrPtr = _fields.instr_ptr.Process != null
+                ? GetFieldProxy(_fields.instr_ptr).Read()
+                : GetFieldProxy(_fields.prev_instr).Read();
+            if (instrPtr == 0 || instrPtr < codeStart) {
+                return 0;
+            }
+
+            // Byte offset into the bytecode (addrq passed to PyCode_Addr2Line).
+            int addrq = (int)(instrPtr - codeStart);
+
+            byte[] lineTable = code.co_linetable.TryRead()?.ToBytes();
+            if (lineTable == null || lineTable.Length == 0) {
+                return 0;
+            }
+
+            int line = Addr2Line(lineTable, code.co_firstlineno.Read(), addrq);
+            return line > 0 ? line : 0;
+        }
+
+        // Managed port of CPython's PyCode_Addr2Line (Objects/codeobject.c). Only the
+        // forward scan is needed since addrq is always resolved from a fresh range.
+        private static int Addr2Line(byte[] lineTable, int firstLineNo, int addrq) {
+            if (addrq < 0) {
+                return firstLineNo;
+            }
+
+            int loNext = 0;
+            int limit = lineTable.Length;
+            int arEnd = 0;
+            int computedLine = firstLineNo;
+            int arLine = -1;
+
+            while (arEnd <= addrq) {
+                if (loNext >= limit) {
+                    return -1;
+                }
+
+                byte first = lineTable[loNext];
+                computedLine += GetLineDelta(lineTable, loNext);
+                arLine = IsNoLineMarker(first) ? -1 : computedLine;
+                arEnd += ((first & 7) + 1) * sizeof(ushort); // sizeof(_Py_CODEUNIT) == 2
+
+                // Skip to the next entry; only the first byte of an entry has bit 7 set.
+                do {
+                    loNext++;
+                } while (loNext < limit && (lineTable[loNext] & 128) == 0);
+            }
+
+            return arLine;
+        }
+
+        private static bool IsNoLineMarker(byte b) {
+            return (b >> 3) == 0x1f;
+        }
+
+        private static int GetLineDelta(byte[] lineTable, int index) {
+            int code = (lineTable[index] >> 3) & 15;
+            switch (code) {
+                case 15: // PY_CODE_LOCATION_INFO_NONE
+                    return 0;
+                case 13: // PY_CODE_LOCATION_INFO_NO_COLUMNS
+                case 14: // PY_CODE_LOCATION_INFO_LONG
+                    int p = index + 1;
+                    return ReadSignedVarint(lineTable, ref p);
+                case 10: // PY_CODE_LOCATION_INFO_ONE_LINE0
+                    return 0;
+                case 11: // PY_CODE_LOCATION_INFO_ONE_LINE1
+                    return 1;
+                case 12: // PY_CODE_LOCATION_INFO_ONE_LINE2
+                    return 2;
+                default: // short forms (same line)
+                    return 0;
+            }
+        }
+
+        private static int ReadVarint(byte[] data, ref int p) {
+            uint read = data[p++];
+            uint val = read & 63;
+            int shift = 0;
+            while ((read & 64) != 0 && p < data.Length) {
+                read = data[p++];
+                shift += 6;
+                val |= (read & 63) << shift;
+            }
+            return (int)val;
+        }
+
+        private static int ReadSignedVarint(byte[] data, ref int p) {
+            uint uval = (uint)ReadVarint(data, ref p);
+            return ((uval & 1) != 0) ? -(int)(uval >> 1) : (int)(uval >> 1);
+        }
 
         private bool OwnedByThread() {
             if (Process.GetPythonRuntimeInfo().LanguageVersion <= PythonLanguageVersion.V310) {

--- a/Python/Product/Debugger.Concord/Proxies/Structs/PyInterpreterFrame.cs
+++ b/Python/Product/Debugger.Concord/Proxies/Structs/PyInterpreterFrame.cs
@@ -108,93 +108,29 @@ namespace Microsoft.PythonTools.Debugger.Concord.Proxies.Structs {
             ulong instrPtr = _fields.instr_ptr.Process != null
                 ? GetFieldProxy(_fields.instr_ptr).Read()
                 : GetFieldProxy(_fields.prev_instr).Read();
-            if (instrPtr == 0 || instrPtr < codeStart) {
+            if (instrPtr == 0) {
                 return 0;
             }
 
-            // Byte offset into the bytecode (addrq passed to PyCode_Addr2Line).
-            int addrq = (int)(instrPtr - codeStart);
+            int firstLineNo = code.co_firstlineno.Read();
+
+            // Byte offset into the bytecode (addrq passed to PyCode_Addr2Line). On a freshly
+            // created 3.11/3.12 frame, prev_instr points one _Py_CODEUNIT before the first
+            // instruction, so the offset is negative. CPython's PyCode_Addr2Line maps a
+            // negative offset to co_firstlineno; handle it here (before reading the line
+            // table) so we don't fall back to the func-eval this whole path avoids.
+            long addrq = (long)instrPtr - (long)codeStart;
+            if (addrq < 0) {
+                return firstLineNo;
+            }
 
             byte[] lineTable = code.co_linetable.TryRead()?.ToBytes();
             if (lineTable == null || lineTable.Length == 0) {
                 return 0;
             }
 
-            int line = Addr2Line(lineTable, code.co_firstlineno.Read(), addrq);
+            int line = PyLineTable.Addr2Line(lineTable, firstLineNo, (int)addrq);
             return line > 0 ? line : 0;
-        }
-
-        // Managed port of CPython's PyCode_Addr2Line (Objects/codeobject.c). Only the
-        // forward scan is needed since addrq is always resolved from a fresh range.
-        private static int Addr2Line(byte[] lineTable, int firstLineNo, int addrq) {
-            if (addrq < 0) {
-                return firstLineNo;
-            }
-
-            int loNext = 0;
-            int limit = lineTable.Length;
-            int arEnd = 0;
-            int computedLine = firstLineNo;
-            int arLine = -1;
-
-            while (arEnd <= addrq) {
-                if (loNext >= limit) {
-                    return -1;
-                }
-
-                byte first = lineTable[loNext];
-                computedLine += GetLineDelta(lineTable, loNext);
-                arLine = IsNoLineMarker(first) ? -1 : computedLine;
-                arEnd += ((first & 7) + 1) * sizeof(ushort); // sizeof(_Py_CODEUNIT) == 2
-
-                // Skip to the next entry; only the first byte of an entry has bit 7 set.
-                do {
-                    loNext++;
-                } while (loNext < limit && (lineTable[loNext] & 128) == 0);
-            }
-
-            return arLine;
-        }
-
-        private static bool IsNoLineMarker(byte b) {
-            return (b >> 3) == 0x1f;
-        }
-
-        private static int GetLineDelta(byte[] lineTable, int index) {
-            int code = (lineTable[index] >> 3) & 15;
-            switch (code) {
-                case 15: // PY_CODE_LOCATION_INFO_NONE
-                    return 0;
-                case 13: // PY_CODE_LOCATION_INFO_NO_COLUMNS
-                case 14: // PY_CODE_LOCATION_INFO_LONG
-                    int p = index + 1;
-                    return ReadSignedVarint(lineTable, ref p);
-                case 10: // PY_CODE_LOCATION_INFO_ONE_LINE0
-                    return 0;
-                case 11: // PY_CODE_LOCATION_INFO_ONE_LINE1
-                    return 1;
-                case 12: // PY_CODE_LOCATION_INFO_ONE_LINE2
-                    return 2;
-                default: // short forms (same line)
-                    return 0;
-            }
-        }
-
-        private static int ReadVarint(byte[] data, ref int p) {
-            uint read = data[p++];
-            uint val = read & 63;
-            int shift = 0;
-            while ((read & 64) != 0 && p < data.Length) {
-                read = data[p++];
-                shift += 6;
-                val |= (read & 63) << shift;
-            }
-            return (int)val;
-        }
-
-        private static int ReadSignedVarint(byte[] data, ref int p) {
-            uint uval = (uint)ReadVarint(data, ref p);
-            return ((uval & 1) != 0) ? -(int)(uval >> 1) : (int)(uval >> 1);
         }
 
         private bool OwnedByThread() {

--- a/Python/Product/Debugger.Concord/Proxies/Structs/PyLineTable.cs
+++ b/Python/Product/Debugger.Concord/Proxies/Structs/PyLineTable.cs
@@ -1,0 +1,116 @@
+﻿// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+namespace Microsoft.PythonTools.Debugger.Concord.Proxies.Structs {
+    /// <summary>
+    /// Managed port of CPython's location-table (PEP 626) decoder used to map a bytecode
+    /// offset to a source line without executing any code in the debuggee. The
+    /// <c>co_linetable</c> format is shared by CPython 3.11, 3.12 and 3.13.
+    /// See CPython <c>Objects/codeobject.c</c> (<c>PyCode_Addr2Line</c> / <c>advance</c>).
+    /// </summary>
+    internal static class PyLineTable {
+        // Location info codes stored in the high nibble of an entry's first byte.
+        private const int PY_CODE_LOCATION_INFO_ONE_LINE0 = 10;
+        private const int PY_CODE_LOCATION_INFO_ONE_LINE1 = 11;
+        private const int PY_CODE_LOCATION_INFO_ONE_LINE2 = 12;
+        private const int PY_CODE_LOCATION_INFO_NO_COLUMNS = 13;
+        private const int PY_CODE_LOCATION_INFO_LONG = 14;
+        private const int PY_CODE_LOCATION_INFO_NONE = 15;
+
+        /// <summary>
+        /// Returns the source line for the bytecode byte offset <paramref name="addrq"/>, or
+        /// -1 if the offset maps to a range with no source location (a NONE marker) or lies
+        /// past the end of the table. A negative offset returns <paramref name="firstLineNo"/>,
+        /// matching CPython's behavior for an entry frame whose instruction pointer sits just
+        /// before the first instruction.
+        /// </summary>
+        public static int Addr2Line(byte[] lineTable, int firstLineNo, int addrq) {
+            if (lineTable == null) {
+                return -1;
+            }
+
+            // Mirrors PyCode_Addr2Line: a negative query maps to the code's first line.
+            if (addrq < 0) {
+                return firstLineNo;
+            }
+
+            int loNext = 0;
+            int limit = lineTable.Length;
+            int arEnd = 0;
+            int computedLine = firstLineNo;
+            int arLine = -1;
+
+            while (arEnd <= addrq) {
+                if (loNext >= limit) {
+                    return -1;
+                }
+
+                byte first = lineTable[loNext];
+                computedLine += GetLineDelta(lineTable, loNext);
+                arLine = IsNoLineMarker(first) ? -1 : computedLine;
+                arEnd += ((first & 7) + 1) * sizeof(ushort); // sizeof(_Py_CODEUNIT) == 2
+
+                // Skip to the next entry; only the first byte of an entry has bit 7 set.
+                do {
+                    loNext++;
+                } while (loNext < limit && (lineTable[loNext] & 128) == 0);
+            }
+
+            return arLine;
+        }
+
+        private static bool IsNoLineMarker(byte b) {
+            return (b >> 3) == 0x1f;
+        }
+
+        private static int GetLineDelta(byte[] lineTable, int index) {
+            int code = (lineTable[index] >> 3) & 15;
+            switch (code) {
+                case PY_CODE_LOCATION_INFO_NONE:
+                    return 0;
+                case PY_CODE_LOCATION_INFO_NO_COLUMNS:
+                case PY_CODE_LOCATION_INFO_LONG:
+                    int p = index + 1;
+                    return ReadSignedVarint(lineTable, ref p);
+                case PY_CODE_LOCATION_INFO_ONE_LINE0:
+                    return 0;
+                case PY_CODE_LOCATION_INFO_ONE_LINE1:
+                    return 1;
+                case PY_CODE_LOCATION_INFO_ONE_LINE2:
+                    return 2;
+                default: // short forms (same line)
+                    return 0;
+            }
+        }
+
+        private static int ReadVarint(byte[] data, ref int p) {
+            uint read = data[p++];
+            uint val = read & 63;
+            int shift = 0;
+            while ((read & 64) != 0 && p < data.Length) {
+                read = data[p++];
+                shift += 6;
+                val |= (read & 63) << shift;
+            }
+            return (int)val;
+        }
+
+        private static int ReadSignedVarint(byte[] data, ref int p) {
+            uint uval = (uint)ReadVarint(data, ref p);
+            return ((uval & 1) != 0) ? -(int)(uval >> 1) : (int)(uval >> 1);
+        }
+    }
+}

--- a/Python/Tests/DebuggerTests/DebuggerTests.csproj
+++ b/Python/Tests/DebuggerTests/DebuggerTests.csproj
@@ -69,6 +69,7 @@
     <Reference Include="System.XML" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="PyLineTableTests.cs" />
     <Compile Include="TaskExtensions.cs" />
     <Compile Include="MiniDumpWriter.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
@@ -81,6 +82,10 @@
     <ProjectReference Include="..\..\Product\Debugger\Debugger.csproj">
       <Project>{DECC7971-FA58-4DB0-9561-BFFADD393BBD}</Project>
       <Name>Debugger</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\Product\Debugger.Concord\Debugger.Concord.csproj">
+      <Project>{515F701E-336D-4D58-AF4B-E976BC33C957}</Project>
+      <Name>Debugger.Concord</Name>
     </ProjectReference>
     <ProjectReference Include="..\..\..\Common\Tests\Utilities\TestUtilities.csproj">
       <Project>{D092D54E-FF29-4D32-9AEE-4EF704C92F67}</Project>

--- a/Python/Tests/DebuggerTests/PyLineTableTests.cs
+++ b/Python/Tests/DebuggerTests/PyLineTableTests.cs
@@ -1,0 +1,146 @@
+﻿// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System;
+using System.Linq;
+using Microsoft.PythonTools.Debugger.Concord.Proxies.Structs;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace DebuggerTests {
+    /// <summary>
+    /// Locks down the managed port of CPython's location-table (PEP 626) decoder
+    /// (<see cref="PyLineTable"/>) against data recorded from real 3.11, 3.12 and 3.13
+    /// runtimes. Each case stores the function's <c>co_firstlineno</c>, the raw
+    /// <c>co_linetable</c> bytes, and the authoritative <c>(start, end, line)</c> ranges
+    /// produced by <c>code.co_lines()</c> (a line of -1 means the range has no source
+    /// location, i.e. a NONE marker). The decoder must reproduce those lines for every
+    /// bytecode offset.
+    /// </summary>
+    [TestClass]
+    public class PyLineTableTests {
+        private sealed class LineTableCase {
+            public string Version { get; }
+            public string FunctionName { get; }
+            public int FirstLineNo { get; }
+            public byte[] LineTable { get; }
+            // Each entry is { startOffset, endOffset, expectedLine } in bytecode bytes.
+            // expectedLine == NoLine (-1) marks a range with no source location.
+            public int[][] Ranges { get; }
+
+            public LineTableCase(string version, string functionName, int firstLineNo, string lineTableHex, int[][] ranges) {
+                Version = version;
+                FunctionName = functionName;
+                FirstLineNo = firstLineNo;
+                LineTable = FromHex(lineTableHex);
+                Ranges = ranges;
+            }
+        }
+
+        private const int NoLine = -1;
+
+        private static byte[] FromHex(string hex) {
+            var bytes = new byte[hex.Length / 2];
+            for (int i = 0; i < bytes.Length; i++) {
+                bytes[i] = Convert.ToByte(hex.Substring(i * 2, 2), 16);
+            }
+            return bytes;
+        }
+
+        // Recorded from CPython 3.11.9, 3.12.7 and 3.13.14. See Addr2Line summary above.
+        private static readonly LineTableCase[] Cases = {
+            new LineTableCase("3.11.9", "simple", 4, "8000d80809884189058041d80809884189058041d80b0c8048",
+                new[] { new[] { 0x0, 0x2, 4 }, new[] { 0x2, 0x4, 5 }, new[] { 0x4, 0x6, 5 }, new[] { 0x6, 0xA, 5 }, new[] { 0xA, 0xC, 5 }, new[] { 0xC, 0xE, 6 }, new[] { 0xE, 0x10, 6 }, new[] { 0x10, 0x14, 6 }, new[] { 0x14, 0x16, 6 }, new[] { 0x16, 0x18, 7 }, new[] { 0x18, 0x1A, 7 } }),
+            new LineTableCase("3.11.9", "branchy", 9, "8000d80c0d8045dd0d12903189588c58f000040517f0000405178801d80b0c8871893590418a3a883ad80c119051894a88458845e00c119051894a88458845f002030513d810159801910988058805f8dd0b1cf000010513f000010513f000010513d81012880588058805f003010513f8f8f8e00b10804c",
+                new[] { new[] { 0x0, 0x2, 9 }, new[] { 0x2, 0x4, 10 }, new[] { 0x4, 0x6, 10 }, new[] { 0x6, 0x12, 11 }, new[] { 0x12, 0x14, 11 }, new[] { 0x14, 0x18, 11 }, new[] { 0x18, 0x22, 11 }, new[] { 0x22, 0x24, 11 }, new[] { 0x24, 0x26, 11 }, new[] { 0x26, 0x28, 11 }, new[] { 0x28, 0x2A, 12 }, new[] { 0x2A, 0x2C, 12 }, new[] { 0x2C, 0x30, 12 }, new[] { 0x30, 0x32, 12 }, new[] { 0x32, 0x38, 12 }, new[] { 0x38, 0x3A, 12 }, new[] { 0x3A, 0x3C, 13 }, new[] { 0x3C, 0x3E, 13 }, new[] { 0x3E, 0x42, 13 }, new[] { 0x42, 0x44, 13 }, new[] { 0x44, 0x46, 13 }, new[] { 0x46, 0x48, 15 }, new[] { 0x48, 0x4A, 15 }, new[] { 0x4A, 0x4E, 15 }, new[] { 0x4E, 0x50, 15 }, new[] { 0x50, 0x52, 15 }, new[] { 0x52, 0x54, 16 }, new[] { 0x54, 0x56, 17 }, new[] { 0x56, 0x58, 17 }, new[] { 0x58, 0x5C, 17 }, new[] { 0x5C, 0x5E, 17 }, new[] { 0x5E, 0x60, 17 }, new[] { 0x60, 0x62, -1 }, new[] { 0x62, 0x6E, 18 }, new[] { 0x6E, 0x70, 18 }, new[] { 0x70, 0x72, 18 }, new[] { 0x72, 0x74, 18 }, new[] { 0x74, 0x76, 19 }, new[] { 0x76, 0x78, 19 }, new[] { 0x78, 0x7A, 19 }, new[] { 0x7A, 0x7C, 19 }, new[] { 0x7C, 0x7E, 18 }, new[] { 0x7E, 0x80, -1 }, new[] { 0x80, 0x82, -1 }, new[] { 0x82, 0x84, -1 }, new[] { 0x84, 0x86, 20 }, new[] { 0x86, 0x88, 20 } }),
+            new LineTableCase("3.11.9", "comprehension", 22, "8000d80e2dd00e2d9865d00e2dd10e2dd40e2d8047d80c27d00c279877d00c27d10c27d40c278045d80b10804c",
+                new[] { new[] { 0x0, 0x2, 22 }, new[] { 0x2, 0x4, 23 }, new[] { 0x4, 0x6, 23 }, new[] { 0x6, 0x8, 23 }, new[] { 0x8, 0xA, 23 }, new[] { 0xA, 0xE, 23 }, new[] { 0xE, 0x18, 23 }, new[] { 0x18, 0x1A, 23 }, new[] { 0x1A, 0x1C, 24 }, new[] { 0x1C, 0x1E, 24 }, new[] { 0x1E, 0x20, 24 }, new[] { 0x20, 0x22, 24 }, new[] { 0x22, 0x26, 24 }, new[] { 0x26, 0x30, 24 }, new[] { 0x30, 0x32, 24 }, new[] { 0x32, 0x34, 25 }, new[] { 0x34, 0x36, 25 } }),
+            new LineTableCase("3.11.9", "multiline", 27, "8000f006000f10d80e0ff103010f10e00e0ff105020f108046f006000c12804d",
+                new[] { new[] { 0x0, 0x2, 27 }, new[] { 0x2, 0x4, 30 }, new[] { 0x4, 0x6, 31 }, new[] { 0x6, 0xA, 30 }, new[] { 0xA, 0xC, 32 }, new[] { 0xC, 0x10, 30 }, new[] { 0x10, 0x12, 30 }, new[] { 0x12, 0x14, 33 }, new[] { 0x14, 0x16, 33 } }),
+            new LineTableCase("3.12.7", "simple", 4, "8000d80809884189058041d80809884189058041d80b0c8048",
+                new[] { new[] { 0x0, 0x2, 4 }, new[] { 0x2, 0xC, 5 }, new[] { 0xC, 0x16, 6 }, new[] { 0x16, 0x1A, 7 } }),
+            new LineTableCase("3.12.7", "branchy", 9, "8000d80c0d8045dc0d1290318e588801d80b0c8871893590418a3ad80c119051894a8945e00c119051894a8945f009000e16f00a030513d81015980191098805f006000c11804cf8f405000c1df200010513d810128905d80b10804cf005010513fa",
+                new[] { new[] { 0x0, 0x2, 9 }, new[] { 0x2, 0x6, 10 }, new[] { 0x6, 0x22, 11 }, new[] { 0x22, 0x32, 12 }, new[] { 0x32, 0x3E, 13 }, new[] { 0x3E, 0x4A, 15 }, new[] { 0x4A, 0x4C, 11 }, new[] { 0x4C, 0x4E, 16 }, new[] { 0x4E, 0x58, 17 }, new[] { 0x58, 0x5C, 20 }, new[] { 0x5C, 0x5E, -1 }, new[] { 0x5E, 0x6E, 18 }, new[] { 0x6E, 0x74, 19 }, new[] { 0x74, 0x78, 20 }, new[] { 0x78, 0x7A, 18 }, new[] { 0x7A, 0x80, -1 } }),
+            new LineTableCase("3.12.7", "comprehension", 22, "8000d91e23d30e2d99659811a071a831a375887190318b7598658047d00e2dd91f26d30c27997798218851900190419105895898778045d00c27d80b10804cf9f205000f2ef9da0c27",
+                new[] { new[] { 0x0, 0x2, 22 }, new[] { 0x2, 0x32, 23 }, new[] { 0x32, 0x58, 24 }, new[] { 0x58, 0x5C, 25 }, new[] { 0x5C, 0x60, -1 }, new[] { 0x60, 0x66, 23 }, new[] { 0x66, 0x6A, -1 }, new[] { 0x6A, 0x70, 24 } }),
+            new LineTableCase("3.12.7", "multiline", 27, "8000f006000f10d80e0ff103010f10e00e0ff105020f108046f006000c12804d",
+                new[] { new[] { 0x0, 0x2, 27 }, new[] { 0x2, 0x4, 30 }, new[] { 0x4, 0x6, 31 }, new[] { 0x6, 0xA, 30 }, new[] { 0xA, 0xC, 32 }, new[] { 0xC, 0x12, 30 }, new[] { 0x12, 0x16, 33 } }),
+            new LineTableCase("3.13.14", "simple", 4, "8000d8080989058041d80809884189058041d80b0c8048",
+                new[] { new[] { 0x0, 0x2, 4 }, new[] { 0x2, 0xA, 5 }, new[] { 0xA, 0x14, 6 }, new[] { 0x14, 0x18, 7 } }),
+            new LineTableCase("3.13.14", "branchy", 9, "8000d80c0d8045dc0d1290318e588801d80b0c8871893590418b3ad80c11894a8a45e00c11894a8a45f109000e16f00a030513d8101591098805f006000c11804cf8f405000c1df300010513d810128905d80b10804cf005010513fa",
+                new[] { new[] { 0x0, 0x2, 9 }, new[] { 0x2, 0x6, 10 }, new[] { 0x6, 0x22, 11 }, new[] { 0x22, 0x34, 12 }, new[] { 0x34, 0x40, 13 }, new[] { 0x40, 0x4C, 15 }, new[] { 0x4C, 0x50, 11 }, new[] { 0x50, 0x52, 16 }, new[] { 0x52, 0x5A, 17 }, new[] { 0x5A, 0x5E, 20 }, new[] { 0x5E, 0x60, -1 }, new[] { 0x60, 0x72, 18 }, new[] { 0x72, 0x78, 19 }, new[] { 0x78, 0x7C, 20 }, new[] { 0x7C, 0x7E, 18 }, new[] { 0x7E, 0x84, -1 } }),
+            new LineTableCase("3.13.14", "comprehension", 22, "8000d91e23d30e2d9a659811a831a1758b7588718c7599658047d00e2dd91f26d30c279a7798219001904191058a5899778045d00c27d80b10804cf9f205000f2ef9da0c27",
+                new[] { new[] { 0x0, 0x2, 22 }, new[] { 0x2, 0x38, 23 }, new[] { 0x38, 0x62, 24 }, new[] { 0x62, 0x66, 25 }, new[] { 0x66, 0x6A, -1 }, new[] { 0x6A, 0x70, 23 }, new[] { 0x70, 0x74, -1 }, new[] { 0x74, 0x7A, 24 } }),
+            new LineTableCase("3.13.14", "multiline", 27, "8000f006000f10d80e0ff103010f10e00e0ff105020f108046f006000c12804d",
+                new[] { new[] { 0x0, 0x2, 27 }, new[] { 0x2, 0x4, 30 }, new[] { 0x4, 0x6, 31 }, new[] { 0x6, 0xA, 30 }, new[] { 0xA, 0xC, 32 }, new[] { 0xC, 0x12, 30 }, new[] { 0x12, 0x16, 33 } }),
+        };
+
+        [TestMethod, Priority(0)]
+        public void Addr2Line_MatchesRecordedRuntimeLineTables() {
+            foreach (var c in Cases) {
+                foreach (var range in c.Ranges) {
+                    int start = range[0], end = range[1], expected = range[2];
+                    for (int offset = start; offset < end; offset += 2) {
+                        int actual = PyLineTable.Addr2Line(c.LineTable, c.FirstLineNo, offset);
+                        Assert.AreEqual(expected, actual,
+                            $"{c.Version} {c.FunctionName}: offset 0x{offset:X} expected line {expected} but got {actual}");
+                    }
+                }
+            }
+        }
+
+        [TestMethod, Priority(0)]
+        public void Addr2Line_NoLineRangesDecodeToNoLine() {
+            // The recorded data must actually exercise NONE markers, and each must decode to -1.
+            int noLineRanges = 0;
+            foreach (var c in Cases) {
+                foreach (var range in c.Ranges.Where(r => r[2] == NoLine)) {
+                    noLineRanges++;
+                    for (int offset = range[0]; offset < range[1]; offset += 2) {
+                        Assert.AreEqual(NoLine, PyLineTable.Addr2Line(c.LineTable, c.FirstLineNo, offset),
+                            $"{c.Version} {c.FunctionName}: offset 0x{offset:X} should have no source line");
+                    }
+                }
+            }
+            Assert.IsTrue(noLineRanges > 0, "Expected the recorded line tables to include NONE markers.");
+        }
+
+        [TestMethod, Priority(0)]
+        public void Addr2Line_NegativeOffsetReturnsFirstLine() {
+            // CPython's PyCode_Addr2Line maps a negative offset to co_firstlineno; this is the
+            // entry-frame case (3.11/3.12 prev_instr points just before the first instruction).
+            foreach (var c in Cases) {
+                Assert.AreEqual(c.FirstLineNo, PyLineTable.Addr2Line(c.LineTable, c.FirstLineNo, -1),
+                    $"{c.Version} {c.FunctionName}: negative offset should return the first line");
+                Assert.AreEqual(c.FirstLineNo, PyLineTable.Addr2Line(c.LineTable, c.FirstLineNo, -2),
+                    $"{c.Version} {c.FunctionName}: negative offset should return the first line");
+            }
+        }
+
+        [TestMethod, Priority(0)]
+        public void Addr2Line_OffsetPastEndReturnsNoLine() {
+            foreach (var c in Cases) {
+                int lastEnd = c.Ranges[c.Ranges.Length - 1][1];
+                Assert.AreEqual(NoLine, PyLineTable.Addr2Line(c.LineTable, c.FirstLineNo, lastEnd + 0x100),
+                    $"{c.Version} {c.FunctionName}: offset past the end should have no source line");
+            }
+        }
+
+        [TestMethod, Priority(0)]
+        public void Addr2Line_NullTableReturnsNoLine() {
+            Assert.AreEqual(NoLine, PyLineTable.Addr2Line(null, 5, 0));
+        }
+    }
+}


### PR DESCRIPTION
## Problem

Mixed-mode (Python/Native) debugging crashes Visual Studio when debugging a C++ app that embeds CPython 3.11+ (reported against 3.13). When a breakpoint is hit in a GUI app that pumps messages, VS becomes unresponsive and then crashes. A console build of the same app doesn't crash but stepping from Python into native code misbehaves. Python 3.9 worked previously.

## Root cause

When building the call stack, `PyFrameObject.ComputeLineNumber` needs the current line for each Python frame. On 3.11+ the frame's `f_lineno` is `0` during execution (the line is computed lazily), so the code fell back to a **per-frame func-eval in the debuggee** on every stop:

```
((int(*)(void*))PyFrame_GetLineNumber)(frameAddr)
```

Executing debuggee code (a func-eval) while constructing the call stack is unsafe in a GUI process: the func-eval runs the interpreter, which pumps messages / re-enters, causing reentrancy and deadlock that hangs and crashes VS. It also perturbs the step engine, which explains the broken Python→native stepping in the console case. On 3.9 the line number was read directly from the frame, so no func-eval happened and it worked.

## Fix

Compute the line number **in-process using memory reads only**, mirroring CPython's `PyCode_Addr2Line` / `_PyInterpreterFrame_GetLine`:

- Add the interpreter frame's instruction pointer to the `PyInterpreterFrame` proxy (`instr_ptr` on 3.13+, `prev_instr` on 3.11/3.12).
- Derive the bytecode offset as `instr_ptr - co_code_adaptive` and walk `co_linetable` (a managed port of CPython's location-table decoder) to get the line.
- `PyFrameObject.ComputeLineNumber` now returns `f_lineno` when it's already set, otherwise decodes the line table in-process, and only falls back to the old func-eval as a last resort.

This path only feeds `CallStackFilter` (display), never step decisions, so stepping behavior is unaffected — but it removes the debuggee func-eval that caused the crash.

## Files

- `Python/Product/Debugger.Concord/Proxies/Structs/PyInterpreterFrame.cs` — add `prev_instr`/`instr_ptr` fields and `ComputeLineNumber()` (Addr2Line decoder).
- `Python/Product/Debugger.Concord/Proxies/Structs/PyCodeObject311.cs` — add `co_linetable`.
- `Python/Product/Debugger.Concord/Proxies/Structs/PyFrameObject.cs` — prefer `f_lineno`, then in-process decode, then legacy func-eval fallback.
- `Python/Product/Debugger.Concord/Proxies/Structs/PyFrameObject311.cs` — override to decode from the interpreter frame.

## Testing

Manually verified against a C++ GUI app embedding CPython 3.13 (the `Examples/PythonNative` sample) in VS 18 (2026 preview): breakpoints in both Python and native code are hit, stepping between Python and native works, and Visual Studio no longer hangs or crashes.

## Notes

- This addresses the Issue-1 GUI crash and the console stepping side-effect. The separate report about combining native debugging + debugpy attach in the *same* VS instance is architectural (the native debugger freezes the process debugpy needs running) and is not changed here.
