### PR TITLE
Opt out of IntelliSense-ready deferral for the Python profiling session editor

### DIFF
--- a/Python/Product/Profiling/PythonProfilingPackage.cs
+++ b/Python/Product/Profiling/PythonProfilingPackage.cs
@@ -58,7 +58,7 @@ namespace Microsoft.PythonTools.Profiling {
     // set the window to dock where Toolbox/Performance Explorer dock by default
     [ProvideToolWindow(typeof(PerfToolWindow), Orientation = ToolWindowOrientation.Left, Style = VsDockStyle.Tabbed, Window = EnvDTE.Constants.vsWindowKindToolbox)]
     [ProvideFileFilter("{81da0100-e6db-4783-91ea-c38c3fa1b81e}", "/1", "#113", 100)]
-    [ProvideEditorExtension(typeof(ProfilingSessionEditorFactory), ".pyperf", 50,
+    [ProvideEditorExtension2(typeof(ProfilingSessionEditorFactory), ".pyperf", 50,
           ProjectGuid = "{81da0100-e6db-4783-91ea-c38c3fa1b81e}",
           NameResourceID = 105,
           DefaultName = "PythonPerfSession")]


### PR DESCRIPTION
The .pyperf profiling session editor doesn't use CodeModel, so it has no reason to wait for IntelliSense before opening. Switching from ProvideEditorExtension to ProvideEditorExtension2 adds DeferUntilIntellisenseIsReady=dword:00000000 under the Editors\{factory} key, opting the editor out of the deferral so it opens immediately.

With the arguments used here the two attributes produce identical registration; the only difference is that added value. The code paths where they diverge (params extensions, template-dir escaping, linked-editor GUID, common view attributes) aren't exercised.

*Cowritten with Copilot (Claude Opus 4.8)*