### PR TITLE
Fix Pylance settings handling on Dev18

### DIFF
--- a/Build/18.0/packages.config
+++ b/Build/18.0/packages.config
@@ -85,6 +85,7 @@
   <package id="Microsoft.Extensions.Logging.Abstractions" version = "8.0.2" /> <!-- 5.0.0 -> 8.0.2 -->
   <package id="System.Threading.Tasks.Extensions" version="4.6.0"/>
   <package id="System.Memory" version="4.6.0"/>
+  <package id="System.Text.Json" version="8.0.5"/>
   <package id="Microsoft.VisualStudio.RpcContracts" version = "17.15.25-pre" /> <!-- 17.15.26-pre -->
   <package id="Microsoft.DiaSymReader.Pdb2Pdb" version = "1.1.0-beta2-26280-01" /> <!-- 1.1.0-beta2-21181-01 -> 1.1.0-beta2-24172-02 -->
   <package id="Microsoft.TestPlatform.ObjectModel" version = "17.14.1" /> <!-- 17.4.0-preview-20221003-03 -> 17.14.1 -->

--- a/Python/Product/PythonTools/PythonTools.csproj
+++ b/Python/Product/PythonTools/PythonTools.csproj
@@ -246,7 +246,7 @@
     <Reference Include="System.Text.Json, Version=8.0.0.5, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51" Condition="'$(VSTarget)' == '18.0'">
       <HintPath>$(PackagesPath)\System.Text.Json.8.0.5\lib\net462\System.Text.Json.dll</HintPath>
       <Private>false</Private>
-      <SpecificVersion>true</SpecificVersion>
+      <SpecificVersion>false</SpecificVersion>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.RpcContracts" />
   </ItemGroup>

--- a/Python/Product/PythonTools/PythonTools.csproj
+++ b/Python/Product/PythonTools/PythonTools.csproj
@@ -243,6 +243,11 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Memory" />
+    <Reference Include="System.Text.Json, Version=8.0.0.5, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51" Condition="'$(VSTarget)' == '18.0'">
+      <HintPath>$(PackagesPath)\System.Text.Json.8.0.5\lib\net462\System.Text.Json.dll</HintPath>
+      <Private>false</Private>
+      <SpecificVersion>true</SpecificVersion>
+    </Reference>
     <Reference Include="Microsoft.VisualStudio.RpcContracts" />
   </ItemGroup>
   <ItemGroup>

--- a/Python/Product/PythonTools/PythonTools/LanguageServerClient/LanguageServerSettings.cs
+++ b/Python/Product/PythonTools/PythonTools/LanguageServerClient/LanguageServerSettings.cs
@@ -53,91 +53,91 @@ namespace Microsoft.PythonTools.LanguageServerClient {
                 /// <summary>
                 /// Paths to look for typeshed modules.
                 /// </summary>
-                public string[] typeshedPaths;
+                public string[] typeshedPaths { get; set; }
 
                 /// <summary>
                 /// Path to directory containing custom type stub files.
                 /// </summary>
-                public string stubPath;
+                public string stubPath { get; set; }
 
                 /// <summary>
                 /// Allows a user to override the severity levels for individual diagnostics.
                 /// Typically specified in mspythonconfig.json.
                 /// </summary>
-                public Dictionary<string, string> diagnosticSeverityOverrides;
+                public Dictionary<string, string> diagnosticSeverityOverrides { get; set; }
 
                 /// <summary>
                 /// Analyzes and reports errors on only open files or the entire workspace.
                 /// "enum": ["openFilesOnly", "workspace"]
                 /// </summary>
-                public string diagnosticMode;
+                public string diagnosticMode { get; set; }
 
                 /// <summary>
                 /// Specifies the level of logging for the Output panel.
                 /// "enum": ["Error", "Warning", "Information", "Trace"]
                 /// </summary>
-                public string logLevel;
+                public string logLevel { get; set; }
 
                 /// <summary>
                 /// Automatically add common search paths like 'src'.
                 /// </summary>
-                public bool? autoSearchPaths;
+                public bool? autoSearchPaths { get; set; }
 
                 /// <summary>
                 /// Defines the default rule set for type checking.
                 /// </summary>
-                public string typeCheckingMode;
+                public string typeCheckingMode { get; set; }
 
                 /// <summary>
                 /// Use library implementations to extract type information when type stub is not present.
                 /// </summary>
-                public bool? useLibraryCodeForTypes;
+                public bool? useLibraryCodeForTypes { get; set; }
 
                 /// <summary>
                 /// Additional import search resolution paths.
                 /// </summary>
-                public string[] extraPaths;
+                public string[] extraPaths { get; set; }
 
                 /// <summary>
                 /// Automatically add brackets for functions.
                 /// </summary>
-                public bool completeFunctionParens;
+                public bool completeFunctionParens { get; set; }
 
                 /// <summary>
                 /// Offer auto-import completions.
                 /// </summary>
-                public bool autoImportCompletions;
+                public bool autoImportCompletions { get; set; }
 
                 /// <summary>
                 /// Index installed third party libraries and user files for language features such as auto-import, add import, workspace symbols and etc.
                 /// </summary>
-                public bool? indexing;
+                public bool? indexing { get; set; }
 
                 /// <summary>
                 /// Allow using '.', '(' as commit characters when applicable.
                 /// </summary>
-                public bool? extraCommitChars;
+                public bool? extraCommitChars { get; set; }
 
-                public PythonAnalysisInlayHintsSettings inlayHints;
+                public PythonAnalysisInlayHintsSettings inlayHints { get; set; }
 
-                public string importFormat;
+                public string importFormat { get; set; }
 
                 /// <summary>
                 /// Tokens that identify comments that should show up in the task list pane
                 /// </summary>
-                public TaskListToken[] taskListTokens;
+                public TaskListToken[] taskListTokens { get; set; }
 
                 public class PythonAnalysisInlayHintsSettings {
 
                     /// <summary>
                     /// Enable/disable inlay hints for variable types:\n```python\nfoo ' :list[str] ' = [\"a\"]\n \n```\n
                     /// </summary>
-                    public bool variableTypes;
+                    public bool variableTypes { get; set; }
 
                     /// <summary>
                     /// Enable/disable inlay hints for function return types:\n```python\ndef foo(x:int) ' -> int ':\n\treturn x\n```\n"
                     /// </summary>
-                    public bool functionReturnTypes;
+                    public bool functionReturnTypes { get; set; }
                 }
 
                 public class TaskListToken {
@@ -145,34 +145,34 @@ namespace Microsoft.PythonTools.LanguageServerClient {
                     /// <summary>
                     /// The text of the token.
                     /// </summary>
-                    public string text;
+                    public string text { get; set; }
 
                     /// <summary>
                     /// The priority of the token.
                     /// This comes from the CommentTaskPriority enum in Microsoft.VisualStudio.Shell
                     /// </summary>
-                    public string priority;
+                    public string priority { get; set; }
                 }
 
             }
             /// <summary>
             /// Analysis settings.
             /// </summary>
-            public PythonAnalysisSettings analysis;
+            public PythonAnalysisSettings analysis { get; set; }
 
             /// <summary>
             /// Path to Python, you can use a custom version of Python.
             /// </summary>
-            public string pythonPath;
+            public string pythonPath { get; set; }
 
             /// <summary>
             /// Path to folder with a list of Virtual Environments.
             /// </summary>
-            public string venvPath;
+            public string venvPath { get; set; }
         }
         /// <summary>
         /// Python section.
         /// </summary>
-        public PythonSettings python;
+        public PythonSettings python { get; set; }
     }
 }

--- a/Python/Product/PythonTools/PythonTools/LanguageServerClient/PythonLanguageClient.cs
+++ b/Python/Product/PythonTools/PythonTools/LanguageServerClient/PythonLanguageClient.cs
@@ -258,8 +258,8 @@ namespace Microsoft.PythonTools.LanguageServerClient {
             Debug.WriteLine("Settings Changed");
             return InvokeDidChangeConfigurationAsync(new LSP.DidChangeConfigurationParams() {
                 // Pylance will ask us for per workspace configuration settings. We can send
-                // default workspace settings here.
-                Settings = GetSettings()
+                // section-keyed default settings here for clients without configuration support.
+                Settings = new { python = GetSettings() }
             });
         }
 

--- a/Python/Product/PythonTools/PythonTools/LanguageServerClient/PythonLanguageClientCustomTarget.cs
+++ b/Python/Product/PythonTools/PythonTools/LanguageServerClient/PythonLanguageClientCustomTarget.cs
@@ -23,6 +23,7 @@ using System.Linq;
 using Microsoft.PythonTools.Logging;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Threading;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using StreamJsonRpc;
 using Task = System.Threading.Tasks.Task;
@@ -95,43 +96,39 @@ namespace Microsoft.PythonTools.LanguageServerClient {
         /// </summary>
         internal event AsyncEventHandler<WorkspaceFoldersArgs> WorkspaceFolders;
 
-        [JsonRpcMethod("telemetry/event")]
-        public void OnTelemetryEvent(JToken arg) {
-            if (!(arg is JObject telemetry)) {
+        [JsonRpcMethod("telemetry/event", UseSingleObjectParameterDeserialization = true)]
+        public void OnTelemetryEvent(object arg) {
+            PylanceTelemetryEvent telemetry;
+            try {
+                telemetry = Deserialize<PylanceTelemetryEvent>(arg);
+            } catch (JsonException) {
                 return;
             }
 
-            Trace.WriteLine(telemetry.ToString());
-            try {
-                var te = telemetry.ToObject<PylanceTelemetryEvent>();
-                if (te == null) {
-                    return;
-                }
+            if (telemetry == null) {
+                return;
+            }
 
-                if (te.Exception == null) {
-                    _logger.LogEvent(te.EventName, te.Properties, te.Measurements);
-                } else {
-                    _logger.LogFault(new PylanceException(te.EventName, te.Exception.stack), te.EventName, false);
-                }
+            Trace.WriteLine(arg);
+            if (telemetry.Exception == null) {
+                _logger?.LogEvent(telemetry.EventName, telemetry.Properties, telemetry.Measurements);
+            } else {
+                _logger?.LogFault(new PylanceException(telemetry.EventName, telemetry.Exception.stack), telemetry.EventName, false);
+            }
 
-                // Special case language_server/analysis_complete. We need this for testing so we 
-                // know when it's okay to try to bring up intellisense
-                if (te.EventName == "language_server/analysis_complete") {
-                    AnalysisComplete.Invoke(this, EventArgs.Empty);
-                }
-            } catch {
-
+            // Special case language_server/analysis_complete. We need this for testing so we
+            // know when it's okay to try to bring up intellisense
+            if (telemetry.EventName == "language_server/analysis_complete") {
+                AnalysisComplete.Invoke(this, EventArgs.Empty);
             }
         }
 
         [JsonRpcMethod("python/beginProgress")]
-#pragma warning disable IDE0060 // Remove unused parameter
-        public void OnBeginProgressAsync(JToken arg) {
-#pragma warning restore IDE0060 // Remove unused parameter
+        public void OnBeginProgressAsync() {
         }
 
         [JsonRpcMethod("python/reportProgress")]
-        public async Task OnReportProgressAsync(JToken arg) {
+        public async Task OnReportProgressAsync(object arg) {
             if (arg != null) {
                 await _joinableTaskContext.Factory.SwitchToMainThreadAsync();
 
@@ -143,7 +140,7 @@ namespace Microsoft.PythonTools.LanguageServerClient {
         }
 
         [JsonRpcMethod("python/endProgress")]
-        public async Task OnEndProgressAsync(JToken arg) {
+        public async Task OnEndProgressAsync() {
             await _joinableTaskContext.Factory.SwitchToMainThreadAsync();
 
             // TODO: localize text
@@ -151,15 +148,18 @@ namespace Microsoft.PythonTools.LanguageServerClient {
             statusBar?.SetText("Python analysis done");
         }
 
-        [JsonRpcMethod("client/registerCapability")]
-        public void OnRegisterCapability(JToken arg) {
-            var regParams = arg.ToObject<VisualStudio.LanguageServer.Protocol.RegistrationParams>();
+        [JsonRpcMethod("client/registerCapability", UseSingleObjectParameterDeserialization = true)]
+        public void OnRegisterCapability(object arg) {
+            var regParams = Deserialize<VisualStudio.LanguageServer.Protocol.RegistrationParams>(arg);
+            if (regParams?.Registrations == null) {
+                return;
+            }
+
             if (regParams.Registrations.Any(p => p.Method == "workspace/didChangeWorkspaceFolders")) {
                 _joinableTaskContext.Factory.RunAsync(async () => this.WorkspaceFolderChangeRegistered.Invoke(this, EventArgs.Empty));
             }
             var watchedFilesReg = regParams.Registrations.FirstOrDefault(p => p.Method == "workspace/didChangeWatchedFiles");
-            if (watchedFilesReg != null) { 
-                var optionsObj = watchedFilesReg.RegisterOptions as JObject;
+            if (watchedFilesReg?.RegisterOptions is JObject optionsObj) {
                 var options = optionsObj.ToObject<DidChangeWatchedFilesRegistrationOptions>();
                 if (options != null) {
                     _joinableTaskContext.Factory.RunAsync(async () => this.WatchedFilesRegistered.Invoke(this, options));
@@ -167,19 +167,26 @@ namespace Microsoft.PythonTools.LanguageServerClient {
             }
         }
 
-        [JsonRpcMethod("workspace/configuration")]
-        public async Task<object> OnWorkspaceConfiguration(JToken arg) {
-            try {
-                var reqParams = arg.ToObject<WorkspaceConfiguration.ConfigurationParams>();
-                if (this.WorkspaceConfiguration != null && reqParams != null) {
-                    var eventArgs = new ConfigurationArgs { requestParams = reqParams, requestResult = null };
-                    await this.WorkspaceConfiguration.InvokeAsync(this, eventArgs);
-                    return eventArgs.requestResult;
-                }
-                return null;
-            } catch {
+        [JsonRpcMethod("workspace/configuration", UseSingleObjectParameterDeserialization = true)]
+        public async Task<object> OnWorkspaceConfiguration(object arg) {
+            var reqParams = Deserialize<WorkspaceConfiguration.ConfigurationParams>(arg);
+            if (this.WorkspaceConfiguration != null && reqParams != null) {
+                var eventArgs = new ConfigurationArgs { requestParams = reqParams, requestResult = null };
+                await this.WorkspaceConfiguration.InvokeAsync(this, eventArgs);
+                return eventArgs.requestResult;
+            }
+            return null;
+        }
+
+        private static T Deserialize<T>(object arg) where T : class {
+            if (arg == null) {
                 return null;
             }
+
+            // Dev18 supplies System.Text.Json values; older formatters supply JToken.
+            return arg is JToken token
+                ? token.ToObject<T>()
+                : JsonConvert.DeserializeObject<T>(arg.ToString());
         }
 
         [JsonRpcMethod("workspace/workspaceFolders")]

--- a/Python/Product/PythonTools/PythonTools/LanguageServerClient/PythonLanguageClientCustomTarget.cs
+++ b/Python/Product/PythonTools/PythonTools/LanguageServerClient/PythonLanguageClientCustomTarget.cs
@@ -119,7 +119,7 @@ namespace Microsoft.PythonTools.LanguageServerClient {
             // Special case language_server/analysis_complete. We need this for testing so we
             // know when it's okay to try to bring up intellisense
             if (telemetry.EventName == "language_server/analysis_complete") {
-                AnalysisComplete.Invoke(this, EventArgs.Empty);
+AnalysisComplete?.Invoke(this, EventArgs.Empty);
             }
         }
 

--- a/Python/Product/PythonTools/PythonTools/LanguageServerClient/PythonSignatureHelpMiddleLayer.cs
+++ b/Python/Product/PythonTools/PythonTools/LanguageServerClient/PythonSignatureHelpMiddleLayer.cs
@@ -1,11 +1,17 @@
 using System;
+#if DEV18_OR_LATER
+using System.Text.Json;
+#else
 using System.Globalization;
+#endif
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.PythonTools.Editor;
 using Microsoft.VisualStudio.LanguageServer.Client;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
+#if !DEV18_OR_LATER
 using Newtonsoft.Json.Linq;
+#endif
 
 namespace Microsoft.PythonTools.LanguageServerClient {
 #if !DEV18_OR_LATER
@@ -13,7 +19,7 @@ namespace Microsoft.PythonTools.LanguageServerClient {
 #endif
     internal sealed class PythonSignatureHelpMiddleLayer :
 #if DEV18_OR_LATER
-        ILanguageClientMiddleLayer2<JToken> {
+        ILanguageClientMiddleLayer2<JsonDocument> {
 #else
         ILanguageClientMiddleLayer {
 #endif
@@ -26,6 +32,43 @@ namespace Microsoft.PythonTools.LanguageServerClient {
         public bool CanHandle(string methodName) =>
             string.Equals(methodName, Methods.TextDocumentSignatureHelpName, StringComparison.Ordinal);
 
+#if DEV18_OR_LATER
+        public Task<JsonDocument> HandleRequestAsync(string methodName, JsonDocument methodParam, Func<JsonDocument, Task<JsonDocument>> sendRequest) {
+            if (ShouldSuppressAutomaticSignatureHelp(methodParam)) {
+                return Task.FromResult<JsonDocument>(null);
+            }
+
+            return sendRequest(methodParam);
+        }
+
+        public Task HandleNotificationAsync(string methodName, JsonDocument methodParam, Func<JsonDocument, Task> sendNotification) =>
+            sendNotification(methodParam);
+
+        private bool ShouldSuppressAutomaticSignatureHelp(JsonDocument methodParam) {
+            var languagePreferences = Volatile.Read(ref _languagePreferences);
+            if (languagePreferences == null || languagePreferences.AutoListParams || methodParam == null) {
+                return false;
+            }
+
+            var request = methodParam.RootElement;
+            if (request.ValueKind != JsonValueKind.Object ||
+                !request.TryGetProperty("context", out var context) ||
+                context.ValueKind != JsonValueKind.Object ||
+                !context.TryGetProperty("triggerKind", out var triggerKindElement) ||
+                triggerKindElement.ValueKind != JsonValueKind.Number ||
+                !context.TryGetProperty("isRetrigger", out var isRetrigger) ||
+                (isRetrigger.ValueKind != JsonValueKind.True && isRetrigger.ValueKind != JsonValueKind.False) ||
+                isRetrigger.GetBoolean() ||
+                (context.TryGetProperty("activeSignatureHelp", out var activeSignatureHelp) &&
+                    activeSignatureHelp.ValueKind != JsonValueKind.Null) ||
+                !triggerKindElement.TryGetInt32(out var triggerKind)) {
+                return false;
+            }
+
+            return triggerKind == (int)SignatureHelpTriggerKind.TriggerCharacter ||
+                triggerKind == (int)SignatureHelpTriggerKind.ContentChange;
+        }
+#else
         public Task<JToken> HandleRequestAsync(string methodName, JToken methodParam, Func<JToken, Task<JToken>> sendRequest) {
             if (ShouldSuppressAutomaticSignatureHelp(methodParam)) {
                 return Task.FromResult<JToken>(JValue.CreateNull());
@@ -63,6 +106,7 @@ namespace Microsoft.PythonTools.LanguageServerClient {
             return triggerKind == (int)SignatureHelpTriggerKind.TriggerCharacter ||
                 triggerKind == (int)SignatureHelpTriggerKind.ContentChange;
         }
+#endif
     }
 #if !DEV18_OR_LATER
 #pragma warning restore CS0618


### PR DESCRIPTION
## Summary

Fixes #8578.

Checking **Automatically add brackets to functions** persisted correctly in Visual Studio, but Dev18 did not deliver the enabled setting to Pylance. As a result, Pylance continued returning plain completion text such as `getcwd` instead of a snippet such as `getcwd($0)`.

## Root cause

Dev18 uses System.Text.Json for eligible language clients, exposing three serialization and binding mismatches in the PTVS/Pylance configuration path:

- Pylance sends `workspace/configuration` parameters as one object (`{ "items": [...] }`), but the custom StreamJsonRpc handler did not opt into whole-object parameter binding, so the request was rejected with `-32602`.
- PTVS's outbound settings DTO used public fields. System.Text.Json does not serialize those fields by default, so the settings payload became `{}` even when the option was enabled.
- The fallback `workspace/didChangeConfiguration` payload placed analysis settings directly under `settings.analysis`, while Pylance expects the section under `settings.python.analysis`.

Latest `main` also introduced a `JToken` signature-help middle layer. On Dev18, that type selects the Newtonsoft formatter for the whole language client, which conflicts with the STJ-compatible path needed for PTVS's initialize interception. The Dev18 implementation therefore uses `JsonDocument`, while the existing Dev17 `JToken` implementation remains unchanged.

## Fix

- Enable whole-object binding for object-shaped custom RPC messages, including `workspace/configuration`.
- Deserialize custom payloads through a serializer-neutral helper that accepts both Newtonsoft and Dev18 STJ values.
- Convert outbound Pylance settings fields to properties so both serializers emit the same JSON contract.
- Send fallback configuration under the required `python` section.
- Keep Dev18 signature-help interception on the System.Text.Json middle-layer contract while preserving the prior Dev17 path.
- Align the custom Pylance progress notification handler signatures with their protocol shapes.

## Risk

Risk is low because the changes are limited to the Pylance language-client serialization and custom RPC boundary:

- Wire names and setting values are unchanged; the settings that were previously omitted are now serialized.
- Whole-object binding is applied only to methods whose protocol parameters are object-shaped.
- The fallback envelope now matches Pylance's documented section lookup.
- Dev17 retains its existing signature-help implementation through conditional compilation.
- Completion insertion behavior is not changed; this only allows Pylance to receive the existing option and return the intended snippet.

## Validation

The fix was manually verified on Dev18: after enabling the option, function completions included parentheses as expected. No tests were added for this change.