### PR TITLE
Fix stale Pylance resolution in cached builds

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -2,5 +2,4 @@
 # registry=https://pkgs.dev.azure.com/devdiv/_packaging/Pylance/npm/registry/ 
 registry=https://pkgs.dev.azure.com/azure-public/vside/_packaging/msft_consumption/npm/registry/
                         
-always-auth=true
 package-lock=false

--- a/Build/PreBuild.ps1
+++ b/Build/PreBuild.ps1
@@ -137,8 +137,8 @@ try {
         "Pylance version = $pylanceVersion"
         "Pylance release type = $pylanceReleaseType"
 
-        # Get all the versions in the feed in descending order
-        $versions = npm view @pylance/pylance versions --json | ConvertFrom-Json
+        # CI prefers cached data for installs, but "latest" must refresh registry metadata.
+        $versions = npm view @pylance/pylance versions --json --prefer-offline=false --prefer-online=true | ConvertFrom-Json
         [array]::Reverse($versions)
 
         # Find the highest version with an appropriate patch number.

--- a/Build/templates/restore_packages.yml
+++ b/Build/templates/restore_packages.yml
@@ -78,9 +78,9 @@ steps:
   - task: Cache@2
     displayName: 'Cache node_modules'
     inputs:
-      key: 'node_modules | "$(Agent.OS)" | package.json | ${{ parameters.pylanceVersion }} | ${{ parameters.pylanceReleaseType }}'
+      key: 'node_modules | "$(Agent.OS)" | "${{ parameters.pylanceVersion }}" | "${{ parameters.pylanceReleaseType }}" | package.json'
       restoreKeys: |
-        node_modules | "$(Agent.OS)" | package.json
+        node_modules | "$(Agent.OS)" | "${{ parameters.pylanceVersion }}" | "${{ parameters.pylanceReleaseType }}"
         node_modules | "$(Agent.OS)"
       path: '$(Build.SourcesDirectory)\\node_modules'
 
@@ -88,9 +88,9 @@ steps:
   - task: Cache@2
     displayName: 'Cache npm'
     inputs:
-      key: 'npm | "$(Agent.OS)" | package.json | ${{ parameters.pylanceVersion }} | ${{ parameters.pylanceReleaseType }}'
+      key: 'npm | "$(Agent.OS)" | "${{ parameters.pylanceVersion }}" | "${{ parameters.pylanceReleaseType }}" | package.json'
       restoreKeys: |
-        npm | "$(Agent.OS)" | package.json
+        npm | "$(Agent.OS)" | "${{ parameters.pylanceVersion }}" | "${{ parameters.pylanceReleaseType }}"
         npm | "$(Agent.OS)"
       path: '$(Pipeline.Workspace)\\npm-cache'
 
@@ -98,7 +98,7 @@ steps:
   - task: Cache@2
     displayName: 'Cache PyPI wheels'
     inputs:
-      key: 'pypi-wheels | "$(Agent.OS)" | ${{ parameters.debugpyVersion }}'
+      key: 'pypi-wheels | "$(Agent.OS)" | "${{ parameters.debugpyVersion }}"'
       restoreKeys: |
         pypi-wheels | "$(Agent.OS)"
       path: '$(Pipeline.Workspace)\\pypi-wheel-cache'

--- a/Build/templates/restore_packages.yml
+++ b/Build/templates/restore_packages.yml
@@ -17,6 +17,12 @@ parameters:
 
 steps:
 
+  # Pylance releases require Node.js 24 or newer.
+  - task: NodeTool@0
+    displayName: 'Use Node.js 24'
+    inputs:
+      versionSpec: '24.x'
+
   # Point NuGet HTTP cache to a pipeline-controlled location so we can cache it between runs.
   # packages.config restores don't use the global-packages folder, but they do use the HTTP cache
   # to avoid re-downloading packages from the feed.


### PR DESCRIPTION
## Issue

PTVS nightly builds have remained on Pylance `2025.12.104` even though newer stable and prerelease versions were published and available in the `msft_consumption` feed. For example, [build 14744946](https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=14744946&view=logs&j=3dc8fd7e-4368-5a92-293e-d53cefc8c4b3&t=f8123f9a-9210-546c-dd5c-fd8e614fd0e3) requested `latest`/`preview` but selected and installed `2025.12.104`.

The behavior started after the caching changes in [#8418](https://github.com/microsoft/PTVS/pull/8418). The cache landed on February 26, 2026; `2026.1.100` reached the feed on February 27, but the February 28 nightly and every later nightly continued selecting `2025.12.104`.

## Root cause

- The restore task sets `npm_config_prefer_offline=true` to accelerate installs. That also affected `npm view`, causing it to bypass staleness checks and read an old cached package-version catalog.
- Azure pipeline caches are immutable, so the catalog containing `2025.12.104` continued to be restored even after newer versions reached the feed.
- Broad restore keys omitted the requested stable/preview channel, allowing partial restores across channels.
- Exact versions such as `2026.3.1` were inserted into Cache@2 keys without quotes. Cache@2 interpreted the dotted value as a file path and failed with `File not found: 2026.3.1` before package restoration began. The same issue applied to explicit debugpy versions.

The pyrx publication path itself is healthy: newer versions are present in `msft_consumption`, and the release pipeline successfully queued PTVS with the exact released version.

## Fix

- Force `npm view` to refresh registry metadata when resolving `latest`, while retaining the npm cache for package downloads.
- Quote Pylance and debugpy version parameters in Cache@2 keys so dotted versions are treated as literal strings.
- Place the Pylance version and release channel before the mutable `package.json` segment and keep partial cache restores within the same requested channel.

With the current feed contents, the corrected lookup resolves stable `2026.3.1` and preview `2026.2.109`. Future releases will be discovered from the feed rather than from stale cached metadata.

## Validation

- Parsed the updated PowerShell and YAML successfully.
- Ran latest-version discovery with `npm_config_prefer_offline=true`; the command-level freshness override resolved stable `2026.3.1` and preview `2026.2.109`.
- Confirmed the branch contains only the two intended PTVS files.
## Follow-up: Node 24 requirement

[PR build 14750001](https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=14750001&view=logs&s=6884a131-87da-5381-61f3-d7acc3b91d76&j=3dc8fd7e-4368-5a92-293e-d53cefc8c4b3) confirmed that fresh resolution works: it selected and installed Pylance `2026.3.1`. The restore task then failed because the agent supplied Node `12.22.12`, while current Pylance packages declare `engines.node >=24`. npm wrote the unsupported-engine warning to stderr, and PowerShell@1 treated that output as a task error despite npm exiting successfully.

The shared restore template now selects Node `24.x` before invoking npm. This satisfies the current stable and preview Pylance packages instead of suppressing a genuine compatibility warning.
npm 11 also exposed the repository's obsolete `always-auth=true` project setting. npm 11 reports it as an unknown configuration on stderr, which caused the same PowerShell task failure after the Node upgrade. The setting has been removed; `npmAuthenticate@0` continues to inject registry-scoped credentials.
[PR build 14750412](https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=14750412) validates the complete fix: Node 24 setup succeeded, `Restore packages` completed successfully, Pylance `2026.3.1` was installed, and debugpy `1.8.21` was installed without npm configuration or engine warnings.