### PR TITLE
Enable Dev18 Python profiling through Diagnostics Hub

### DIFF
--- a/Build/PreBuild.ps1
+++ b/Build/PreBuild.ps1
@@ -31,9 +31,13 @@ param (
     [Parameter()]
     [string] $debugpyVersion = "latest", 
 
-    # The version of etwtrace we should download, defaults to "latest"
+    # The etwtrace release that includes Python 3.12 through 3.14 wheels.
     [Parameter()]
-    [string] $etwtraceVersion = "latest",
+    [string] $etwtraceVersion = "0.1b9",
+
+    # The last etwtrace release that includes Python 3.9 through 3.11 wheels.
+    [Parameter()]
+    [string] $etwtraceLegacyVersion = "0.1b8",
     
     # Run in interactive mode for azure feed authentication, defaults to false
     [Parameter()]
@@ -51,16 +55,21 @@ function Install-Package {
     param(
         [string] $packageName,
         [string] $version,
-        [string] $outdir
+        [string] $outdir,
+        [string] $installDir
     )
 
     Write-Host "Installing $packageName $version"
 
-    $argList = "install_pypi_package.py", $packageName, $version, "`"$outdir`""
+    if (-not $installDir) {
+        $installDir = $outdir
+    }
+
+    $argList = "install_pypi_package.py", $packageName, $version, "`"$installDir`""
     Start-Process -Wait -NoNewWindow "$outdir\python\tools\python.exe" -ErrorAction Stop -ArgumentList $argList | Write-Host
 
     $installedVersion = ""
-    $versionPyFile = Join-Path $outdir "$packageName\_version.py"
+    $versionPyFile = Join-Path $installDir "$packageName\_version.py"
     foreach ($line in Get-Content $versionPyFile) {
         if ($line.Trim().StartsWith("`"version`"")) {
             $installedVersion = $line.split(":")[1].Trim(" `"") # trim spaces and double quotes
@@ -277,14 +286,26 @@ try {
     }
 
     "-----"
-    # install etwtrace
+    # Install a coherent legacy payload for Python 3.9 through 3.11. Newer
+    # etwtrace releases only publish wheels for currently supported Pythons.
+    $legacyEtwTraceOutDir = Join-Path $outdir "etwtrace-legacy"
+    if (Test-Path -Path $legacyEtwTraceOutDir) {
+        Remove-Item -Recurse -Force -Path $legacyEtwTraceOutDir
+    }
+    Install-Package "etwtrace" $etwtraceLegacyVersion $outdir $legacyEtwTraceOutDir | Out-Null
+
+    # Install the current payload for Python 3.12 and later.
     Install-Package "etwtrace" $etwtraceVersion $outdir | Out-Null
 
     # Delete an unsigned file from etwtrace that shouldn't be there.
-    # Remove this step once https://github.com/microsoft/python-etwtrace/issues/7 is closed.
-    $fileToDelete = "$outdir\etwtrace\test\DiagnosticsHub.InstrumentationCollector.dll"
-    if (Test-Path -Path $fileToDelete) {
-        Remove-Item -Path $fileToDelete | Out-Null
+    $filesToDelete = @(
+        "$outdir\etwtrace\test\DiagnosticsHub.InstrumentationCollector.dll",
+        "$legacyEtwTraceOutDir\etwtrace\test\DiagnosticsHub.InstrumentationCollector.dll"
+    )
+    foreach ($fileToDelete in $filesToDelete) {
+        if (Test-Path -Path $fileToDelete) {
+            Remove-Item -Path $fileToDelete | Out-Null
+        }
     }
 
 } finally {

--- a/Build/install_pypi_package.py
+++ b/Build/install_pypi_package.py
@@ -24,7 +24,7 @@ from packaging.utils import canonicalize_name, parse_wheel_filename
 from packaging.version import parse as version_parser
 
 # only install wheels for these python versions
-PYTHON_VERSIONS = ("cp38", "cp39", "cp310", "cp311", "cp312", "cp313")
+PYTHON_VERSIONS = ("cp38", "cp39", "cp310", "cp311", "cp312", "cp313", "cp314")
 
 # don't install wheels for these platforms
 EXCLUDED_PLATFORMS = ("manylinux", "macosx")

--- a/Python/Product/Profiling/Profiling.csproj
+++ b/Python/Product/Profiling/Profiling.csproj
@@ -73,6 +73,7 @@
     <Compile Include="Profiling\PythonInterpreterView.cs" />
     <Compile Include="Profiling\ProjectTargetView.cs" />
     <Compile Include="Guids.cs" />
+    <Compile Include="ProvidePythonProfilingFeatureFlagAttribute.cs" />
     <Compile Include="Profiling\BaseHierarchyNode.cs" />
     <Compile Include="Profiling\LaunchProfiling.xaml.cs">
       <DependentUpon>LaunchProfiling.xaml</DependentUpon>
@@ -131,6 +132,10 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="proflaun.py">
+      <IncludeInVSIX>true</IncludeInVSIX>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="diaghub_profile.py">
       <IncludeInVSIX>true</IncludeInVSIX>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
@@ -195,8 +200,15 @@
         <VSIXSubPath>etwtrace\%(RecursiveDir)</VSIXSubPath>
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </EtwTraceFiles>
-      <Content Include="@(EtwTraceFiles)" />
-      <FileWrites Include="@(EtwTraceFiles)" />
+      <EtwTraceLegacyFiles Include="$(PackagesPath)etwtrace-legacy\etwtrace\**\*" />
+      <EtwTraceLegacyFiles>
+        <IncludeInVSIX>true</IncludeInVSIX>
+        <Link>etwtrace_legacy\etwtrace\%(RecursiveDir)%(Filename)%(Extension)</Link>
+        <VSIXSubPath>etwtrace_legacy\etwtrace\%(RecursiveDir)</VSIXSubPath>
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </EtwTraceLegacyFiles>
+      <Content Include="@(EtwTraceFiles);@(EtwTraceLegacyFiles)" />
+      <FileWrites Include="@(EtwTraceFiles);@(EtwTraceLegacyFiles)" />
     </ItemGroup>
   </Target>
   <Import Project="..\ProjectAfter.settings" />

--- a/Python/Product/Profiling/Profiling/CommandArgumentBuilder.cs
+++ b/Python/Product/Profiling/Profiling/CommandArgumentBuilder.cs
@@ -24,34 +24,22 @@ namespace Microsoft.PythonTools.Profiling {
     using System.Windows;
     using Microsoft.PythonTools.Infrastructure;
     using Microsoft.PythonTools.Interpreter;
+    using Microsoft.VisualStudio.Shell;
+    using Microsoft.VisualStudio.Shell.Interop;
 
     internal class CommandArgumentBuilder {
 
         /// <summary>
         /// Constructs a <see cref="PythonProfilingCommandArgs"/> based on the provided profiling target.
         /// </summary>
-        public PythonProfilingCommandArgs BuildCommandArgsFromTarget(ProfilingTarget target, PythonProfilingPackage pythonProfilingPackage) {
+        public PythonProfilingCommandArgs BuildCommandArgsFromTarget(ProfilingTarget target, IServiceProvider serviceProvider) {
             if (target == null) {
                 return null;
             }
 
             try {
-                var joinableTaskFactory = pythonProfilingPackage.JoinableTaskFactory;
-
-                PythonProfilingCommandArgs command = null;
-
-                joinableTaskFactory.Run(async () => {
-                    await joinableTaskFactory.SwitchToMainThreadAsync();
-
-                    var name = target.GetProfilingName(pythonProfilingPackage, out var save);
-                    var explorer = await pythonProfilingPackage.ShowPerformanceExplorerAsync();
-                    var session = explorer.Sessions.AddTarget(target, name, save);
-
-                    command = SelectBuilder(target, session, pythonProfilingPackage);
-
-                });
-
-                return command;
+                ThreadHelper.ThrowIfNotOnUIThread();
+                return SelectBuilder(target, serviceProvider);
             } catch (Exception ex) {
                 Debug.Fail($"Error building command: {ex.Message}");
                 throw;
@@ -61,24 +49,24 @@ namespace Microsoft.PythonTools.Profiling {
         /// <summary>
         /// Select the appropriate builder based on the provided profiling target.
         /// </summary>
-        private PythonProfilingCommandArgs SelectBuilder(ProfilingTarget target, SessionNode session, PythonProfilingPackage pythonProfilingPackage) {
+        private PythonProfilingCommandArgs SelectBuilder(ProfilingTarget target, IServiceProvider serviceProvider) {
             var projectTarget = target.ProjectTarget;
             var standaloneTarget = target.StandaloneTarget;
 
             if (projectTarget != null) {
-                return BuildProjectCommandArgs(projectTarget, session, pythonProfilingPackage);
+                return BuildProjectCommandArgs(projectTarget, serviceProvider);
             } else if (standaloneTarget != null) {
-                return BuildStandaloneCommandArgs(standaloneTarget, session);
+                return BuildStandaloneCommandArgs(standaloneTarget, serviceProvider);
             }
             return null;
         }
 
-        private PythonProfilingCommandArgs BuildProjectCommandArgs(ProjectTarget projectTarget, SessionNode session, PythonProfilingPackage pythonProfilingPackage) {
-            if (pythonProfilingPackage == null) {
+        private PythonProfilingCommandArgs BuildProjectCommandArgs(ProjectTarget projectTarget, IServiceProvider serviceProvider) {
+            if (serviceProvider == null) {
                 return null;
             }
 
-            var solution = pythonProfilingPackage.Solution;
+            var solution = serviceProvider.GetService(typeof(SVsSolution)) as IVsSolution;
             if (solution == null) { 
                 return null;
             }
@@ -94,7 +82,7 @@ namespace Microsoft.PythonTools.Profiling {
             try {
                 config = project?.GetLaunchConfigurationOrThrow();
             } catch (NoInterpretersException ex) {
-                PythonToolsPackage.OpenNoInterpretersHelpPage(session._serviceProvider, ex.HelpPage);
+                PythonToolsPackage.OpenNoInterpretersHelpPage(serviceProvider, ex.HelpPage);
                 return null;
             } catch (MissingInterpreterException ex) {
                 MessageBox.Show(ex.Message, Strings.ProductTitle);
@@ -120,23 +108,11 @@ namespace Microsoft.PythonTools.Profiling {
                 }
             }
 
-            var pythonExePath = config.GetInterpreterPath();
-            var scriptPath = string.Join(" ", ProcessOutput.QuoteSingleArgument(config.ScriptName), config.ScriptArguments);
-            var workingDir = config.WorkingDirectory;
-            var envVars = session._serviceProvider.GetPythonToolsService().GetFullEnvironment(config);
-
-            var command = new PythonProfilingCommandArgs {
-                PythonExePath = pythonExePath,
-                ScriptPath = scriptPath,
-                WorkingDir = workingDir,
-                Args = Array.Empty<string>(),
-                EnvVars = envVars
-            };
-            return command;
+            return BuildDiagnosticsHubCommand(config, serviceProvider);
         }
 
-        private PythonProfilingCommandArgs BuildStandaloneCommandArgs(StandaloneTarget standaloneTarget, SessionNode session) {
-            if (standaloneTarget == null) {
+        private PythonProfilingCommandArgs BuildStandaloneCommandArgs(StandaloneTarget standaloneTarget, IServiceProvider serviceProvider) {
+            if (standaloneTarget == null || serviceProvider == null) {
                 return null;
             }
 
@@ -147,7 +123,7 @@ namespace Microsoft.PythonTools.Profiling {
             }
 
             if (standaloneTarget.PythonInterpreter != null) {
-                var registry = session._serviceProvider.GetComponentModel().GetService<IInterpreterRegistryService>();
+                var registry = serviceProvider.GetComponentModel().GetService<IInterpreterRegistryService>();
                 var interpreter = registry.FindConfiguration(standaloneTarget.PythonInterpreter.Id);
                 if (interpreter == null) {
                     return null;
@@ -161,22 +137,24 @@ namespace Microsoft.PythonTools.Profiling {
             config.ScriptArguments = standaloneTarget.Arguments;
             config.WorkingDirectory = standaloneTarget.WorkingDirectory;
 
-            var argsInput = standaloneTarget.Arguments;
-            var parsedArgs = string.IsNullOrWhiteSpace(argsInput)
-                        ? Array.Empty<string>()
-                        : argsInput.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+            return BuildDiagnosticsHubCommand(config, serviceProvider);
+        }
 
-            var envVars = session._serviceProvider.GetPythonToolsService().GetFullEnvironment(config);
+        private static PythonProfilingCommandArgs BuildDiagnosticsHubCommand(LaunchConfiguration config, IServiceProvider serviceProvider) {
+            var targetCommandLine = ProcessOutput.QuoteSingleArgument(config.ScriptName);
+            if (!string.IsNullOrWhiteSpace(config.ScriptArguments)) {
+                targetCommandLine = string.Join(" ", targetCommandLine, config.ScriptArguments);
+            }
 
             return new PythonProfilingCommandArgs {
                 PythonExePath = config.GetInterpreterPath(),
-                WorkingDir = standaloneTarget.WorkingDirectory,
-                ScriptPath = standaloneTarget.Script,
-                Args = parsedArgs,
-                EnvVars = envVars
+                WorkingDir = config.WorkingDirectory,
+                ScriptPath = PythonToolsInstallPath.GetFile("diaghub_profile.py", typeof(CommandArgumentBuilder).Assembly),
+                // DiagnosticsHub joins this array into the interpreter command line.
+                // Keep the user's original argument string intact after the quoted script.
+                Args = new[] { targetCommandLine },
+                EnvVars = serviceProvider.GetPythonToolsService().GetFullEnvironment(config)
             };
         }
     }
 }
-
-

--- a/Python/Product/Profiling/Profiling/PythonProfilerCommandService.cs
+++ b/Python/Product/Profiling/Profiling/PythonProfilerCommandService.cs
@@ -21,18 +21,22 @@ namespace Microsoft.PythonTools.Profiling {
     using System.Threading.Tasks;
     using System.Windows;
     using Microsoft.VisualStudio.Shell;
-    using Microsoft.VisualStudio.Shell.Interop;
-    using Microsoft.VisualStudio.Threading;
 
     /// <summary>
     /// Implements a service to collect user input for profiling and convert to a <see cref="PythonProfilingCommandArgs"/>.
     /// </summary>
     [Export(typeof(IPythonProfilerCommandService))]
-    class PythonProfilerCommandService : IPythonProfilerCommandService {
+    [PartCreationPolicy(CreationPolicy.Shared)]
+    public sealed class PythonProfilerCommandService : IPythonProfilerCommandService {
         private readonly CommandArgumentBuilder _commandArgumentBuilder;
+        private readonly IServiceProvider _serviceProvider;
         private readonly UserInputDialog _userInputDialog;
 
-        public PythonProfilerCommandService() {
+        [ImportingConstructor]
+        public PythonProfilerCommandService(
+            [Import(typeof(SVsServiceProvider))] IServiceProvider serviceProvider
+        ) {
+            _serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
             _commandArgumentBuilder = new CommandArgumentBuilder();
             _userInputDialog = new UserInputDialog();
         }
@@ -45,39 +49,18 @@ namespace Microsoft.PythonTools.Profiling {
         /// </returns>
         public async Task<IPythonProfilingCommandArgs> GetCommandArgsFromUserInput() {
             try {
-                var pythonProfilingPackage = await GetPythonProfilingPackageAsync();
-                if (pythonProfilingPackage == null) {
-                    return null;
-                    
-                }
-                var targetView = new ProfilingTargetView(pythonProfilingPackage);
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                var targetView = new ProfilingTargetView(_serviceProvider);
 
-                if (_userInputDialog.ShowDialog(targetView, pythonProfilingPackage)) {
+                if (_userInputDialog.ShowDialog(targetView, _serviceProvider)) {
                     var target = targetView.GetTarget();
-                    return _commandArgumentBuilder.BuildCommandArgsFromTarget(target, pythonProfilingPackage);
+                    return _commandArgumentBuilder.BuildCommandArgsFromTarget(target, _serviceProvider);
                 }
             } catch (Exception ex) {
                 Debug.Fail($"Error displaying user input dialog: {ex.Message}");
                 MessageBox.Show($"An unexpected error occurred: {ex.Message}", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
             }
 
-            return null;
-        }
-
-        private async Task<PythonProfilingPackage> GetPythonProfilingPackageAsync() {
-            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-
-            var shell = await ServiceProvider.GetGlobalServiceAsync(typeof(SVsShell)) as IVsShell;
-            if (shell != null) {
-                var packageGuid = typeof(PythonProfilingPackage).GUID;
-                int hr = shell.LoadPackage(ref packageGuid, out var packageObj);
-
-                Debug.WriteLine($"LoadPackage result: {hr}"); // Log HRESULT result
-
-                if (packageObj != null) {
-                    return packageObj as PythonProfilingPackage;
-                }
-            }
             return null;
         }
     }

--- a/Python/Product/Profiling/Profiling/UserInputDialog.cs
+++ b/Python/Product/Profiling/Profiling/UserInputDialog.cs
@@ -15,9 +15,11 @@
 // permissions and limitations under the License.
 
 namespace Microsoft.PythonTools.Profiling {
+    using System;
+
     internal class UserInputDialog {
-        public bool ShowDialog(ProfilingTargetView targetView, PythonProfilingPackage pythonProfilingPackage) {
-            var dialog = new LaunchProfiling(pythonProfilingPackage, targetView);
+        public bool ShowDialog(ProfilingTargetView targetView, IServiceProvider serviceProvider) {
+            var dialog = new LaunchProfiling(serviceProvider, targetView);
             return dialog.ShowModal() ?? false;
         }
     }

--- a/Python/Product/Profiling/ProvidePythonProfilingFeatureFlagAttribute.cs
+++ b/Python/Product/Profiling/ProvidePythonProfilingFeatureFlagAttribute.cs
@@ -1,0 +1,35 @@
+// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE,
+// OR NON-INFRINGEMENT.
+//
+// See the Apache License 2.0 for the specific language governing permissions
+// and limitations under the License.
+
+using System;
+using Microsoft.VisualStudio.Shell;
+
+namespace Microsoft.PythonTools.Profiling {
+    [AttributeUsage(AttributeTargets.Class)]
+    internal sealed class ProvidePythonProfilingFeatureFlagAttribute : RegistrationAttribute {
+        private const string FeatureFlagKey = @"FeatureFlags\DiagnosticsHub\PythonProfilingEnabled";
+
+        public override void Register(RegistrationContext context) {
+            using (var key = context.CreateKey(FeatureFlagKey)) {
+                key.SetValue("Value", 1);
+            }
+        }
+
+        public override void Unregister(RegistrationContext context) {
+            context.RemoveValue(FeatureFlagKey, "Value");
+        }
+    }
+}

--- a/Python/Product/Profiling/PythonProfilingPackage.cs
+++ b/Python/Product/Profiling/PythonProfilingPackage.cs
@@ -64,6 +64,9 @@ namespace Microsoft.PythonTools.Profiling {
           DefaultName = "PythonPerfSession")]
     [ProvideAutomationObject("PythonProfiling")]
     [ProvideService(typeof(PythonProfilingPackage), IsAsyncQueryable = true)]
+#if DEV18
+    [ProvidePythonProfilingFeatureFlag]
+#endif
     internal sealed class PythonProfilingPackage : AsyncPackage {
         internal static PythonProfilingPackage Instance;
         private static ProfiledProcess _profilingProcess;   // process currently being profiled
@@ -193,12 +196,14 @@ namespace Microsoft.PythonTools.Profiling {
                 return;
             }
 
-            // Used for manually testing the user input service.
-            //MessageBox.Show("Test starts");
-            //var tempUserInputService = new PythonProfilerCommandService();
-            //var tempResult = tempUserInputService.GetCommandArgsFromUserInput();
-            //MessageBox.Show("Test ends");
-
+#if DEV18
+            try {
+                var dte = (EnvDTE.DTE)GetService(typeof(EnvDTE.DTE));
+                dte.ExecuteCommand("Debug.DiagnosticsHub.Launch");
+            } catch (Exception ex) when (!ex.IsCriticalException()) {
+                MessageBox.Show(Strings.ProfilingSupportMissingError, Strings.ProductTitle);
+            }
+#else
             var targetView = new ProfilingTargetView(this);
             var dialog = new LaunchProfiling(this, targetView);
             var res = dialog.ShowModal() ?? false;
@@ -208,6 +213,7 @@ namespace Microsoft.PythonTools.Profiling {
                     ProfileTarget(target);
                 }
             }
+#endif
         }
 
         internal SessionNode ProfileTarget(ProfilingTarget target, bool openReport = true) {

--- a/Python/Product/Profiling/diaghub_profile.py
+++ b/Python/Product/Profiling/diaghub_profile.py
@@ -1,0 +1,112 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the Apache License, Version 2.0.
+
+import os
+import runpy
+import subprocess
+import sys
+
+
+_CHILD_MARKER = "PTVS_DIAGHUB_PROFILE_CHILD"
+
+
+def _load_legacy_collector():
+    import ctypes
+
+    collector_root = os.getenv("DIAGHUB_INSTR_COLLECTOR_ROOT")
+    runtime_name = os.getenv("DIAGHUB_INSTR_RUNTIME_NAME")
+    if not collector_root or not runtime_name:
+        raise RuntimeError(
+            "Python profiling must be launched from the Visual Studio "
+            "Performance Profiler."
+        )
+
+    if sys.winver.endswith("-32"):
+        architecture = "x86"
+    elif sys.winver.endswith("-arm64"):
+        architecture = "arm64"
+    else:
+        architecture = "amd64"
+
+    collector_path = os.path.join(collector_root, architecture, runtime_name)
+    collector = ctypes.WinDLL(collector_path)
+    collector.ChildAttach.argtypes = []
+    collector.ChildAttach.restype = ctypes.c_int
+    if not collector.ChildAttach():
+        raise RuntimeError("Failed to attach Python to the profiling session.")
+    return collector
+
+
+def _run_profiled_child():
+    environment = os.environ.copy()
+    environment["DIAGHUB_PARENT_INITIALIZED"] = "1"
+    environment[_CHILD_MARKER] = "1"
+    command = [sys.executable, os.path.abspath(__file__), *sys.argv[1:]]
+    return subprocess.call(command, env=environment)
+
+
+def _run_target(arguments):
+    sys.argv[:] = arguments
+    if sys.argv[0] == "-m" and len(sys.argv) >= 2:
+        runpy.run_module(sys.argv.pop(1), run_name="__main__")
+    else:
+        runpy.run_path(sys.argv[0], run_name="__main__")
+
+
+def main():
+    if not ((3, 9) <= sys.version_info[:2] <= (3, 14)):
+        print(
+            "Visual Studio Python profiling supports Python 3.9 through 3.14.",
+            file=sys.stderr,
+        )
+        return 2
+
+    if len(sys.argv) < 2:
+        print("A Python script is required for profiling.", file=sys.stderr)
+        return 2
+
+    if os.getenv(_CHILD_MARKER) != "1":
+        return _run_profiled_child()
+
+    package_root = os.path.dirname(os.path.abspath(__file__))
+    is_legacy = sys.version_info[:2] <= (3, 11)
+    if is_legacy:
+        package_root = os.path.join(package_root, "etwtrace_legacy")
+    sys.path.insert(0, package_root)
+
+    try:
+        # etwtrace 0.1b8 expects Visual Studio to load and attach the collector.
+        # Keep this reference alive while the extension uses the collector.
+        collector = _load_legacy_collector() if is_legacy else None
+        from etwtrace import DiagnosticsHubTracer
+        tracer = DiagnosticsHubTracer()
+    except ImportError as exc:
+        print(
+            "Visual Studio does not include an etwtrace binary for "
+            f"Python {sys.version_info[0]}.{sys.version_info[1]} "
+            f"({sys.winver}).",
+            file=sys.stderr,
+        )
+        print(str(exc), file=sys.stderr)
+        return 2
+
+    arguments = sys.argv[1:]
+    if arguments[0] != "-m":
+        arguments[0] = os.path.abspath(arguments[0])
+        sys.path[0] = os.path.dirname(arguments[0])
+
+    if not hasattr(tracer, "_data"):
+        # etwtrace 0.1b8 only initializes this field for its test collector.
+        tracer._data = []
+    tracer.ignore(os.path.abspath(__file__))
+    # Keep profiling and the compatibility collector alive until interpreter
+    # shutdown. Worker threads may retain native profile callbacks after the
+    # top-level script returns.
+    tracer._collector_keepalive = collector
+    tracer.enable()
+    _run_target(arguments)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/Python/Product/Profiling/diaghub_profile.py
+++ b/Python/Product/Profiling/diaghub_profile.py
@@ -1,6 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the Apache License, Version 2.0.
 
+import json
 import os
 import runpy
 import subprocess
@@ -8,6 +9,7 @@ import sys
 
 
 _CHILD_MARKER = "PTVS_DIAGHUB_PROFILE_CHILD"
+_TARGET_ARGUMENTS = "PTVS_DIAGHUB_TARGET_ARGUMENTS"
 
 
 def _load_legacy_collector():
@@ -37,36 +39,62 @@ def _load_legacy_collector():
     return collector
 
 
-def _run_profiled_child():
+def _is_supported_version(version):
+    return (3, 9) <= tuple(version[:2]) <= (3, 14)
+
+
+def _has_valid_target(arguments):
+    return bool(arguments) and (arguments[0] != "-m" or len(arguments) >= 2)
+
+
+def _run_profiled_child(arguments):
     environment = os.environ.copy()
     environment["DIAGHUB_PARENT_INITIALIZED"] = "1"
     environment[_CHILD_MARKER] = "1"
-    command = [sys.executable, os.path.abspath(__file__), *sys.argv[1:]]
-    return subprocess.call(command, env=environment)
+    environment[_TARGET_ARGUMENTS] = json.dumps(arguments)
+    command = [sys.executable, os.path.abspath(__file__)]
+    return subprocess.call(command, env=environment, shell=False)
+
+
+def _get_profiled_arguments():
+    try:
+        arguments = json.loads(os.environ[_TARGET_ARGUMENTS])
+    except (KeyError, TypeError, json.JSONDecodeError):
+        return None
+    if not isinstance(arguments, list) or not all(
+        isinstance(argument, str) for argument in arguments
+    ):
+        return None
+    return arguments
 
 
 def _run_target(arguments):
-    sys.argv[:] = arguments
-    if sys.argv[0] == "-m" and len(sys.argv) >= 2:
-        runpy.run_module(sys.argv.pop(1), run_name="__main__")
+    if arguments[0] == "-m" and len(arguments) >= 2:
+        module_name = arguments[1]
+        sys.argv[:] = [module_name, *arguments[2:]]
+        sys.path[0] = os.getcwd()
+        runpy.run_module(module_name, run_name="__main__", alter_sys=True)
     else:
+        sys.argv[:] = arguments
         runpy.run_path(sys.argv[0], run_name="__main__")
 
 
 def main():
-    if not ((3, 9) <= sys.version_info[:2] <= (3, 14)):
+    if not _is_supported_version(sys.version_info):
         print(
             "Visual Studio Python profiling supports Python 3.9 through 3.14.",
             file=sys.stderr,
         )
         return 2
 
-    if len(sys.argv) < 2:
-        print("A Python script is required for profiling.", file=sys.stderr)
+    is_child = os.getenv(_CHILD_MARKER) == "1"
+    arguments = _get_profiled_arguments() if is_child else sys.argv[1:]
+    if not _has_valid_target(arguments):
+        print("A Python script or module is required for profiling.", file=sys.stderr)
         return 2
 
-    if os.getenv(_CHILD_MARKER) != "1":
-        return _run_profiled_child()
+    if not is_child:
+        return _run_profiled_child(arguments)
 
     package_root = os.path.dirname(os.path.abspath(__file__))
     is_legacy = sys.version_info[:2] <= (3, 11)
@@ -80,9 +108,9 @@ def main():
         collector = _load_legacy_collector() if is_legacy else None
         from etwtrace import DiagnosticsHubTracer
         tracer = DiagnosticsHubTracer()
-    except ImportError as exc:
+    except (ImportError, OSError, RuntimeError, AttributeError) as exc:
         print(
-            "Visual Studio does not include an etwtrace binary for "
+            "Visual Studio could not start Python profiling for "
             f"Python {sys.version_info[0]}.{sys.version_info[1]} "
             f"({sys.winver}).",
             file=sys.stderr,
@@ -90,7 +118,6 @@ def main():
         print(str(exc), file=sys.stderr)
         return 2
 
-    arguments = sys.argv[1:]
     if arguments[0] != "-m":
         arguments[0] = os.path.abspath(arguments[0])
         sys.path[0] = os.path.dirname(arguments[0])

--- a/Python/Product/PythonTools/PythonTools.csproj
+++ b/Python/Product/PythonTools/PythonTools.csproj
@@ -246,7 +246,7 @@
     <Reference Include="System.Text.Json, Version=8.0.0.5, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51" Condition="'$(VSTarget)' == '18.0'">
       <HintPath>$(PackagesPath)\System.Text.Json.8.0.5\lib\net462\System.Text.Json.dll</HintPath>
       <Private>false</Private>
-      <SpecificVersion>false</SpecificVersion>
+      <SpecificVersion>true</SpecificVersion>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.RpcContracts" />
   </ItemGroup>

--- a/Python/Tests/ProfilingTests/ProfilingTests.cs
+++ b/Python/Tests/ProfilingTests/ProfilingTests.cs
@@ -36,6 +36,44 @@ namespace ProfilingTests {
             AssertListener.Initialize();
         }
 
+        [TestMethod, Priority(UnitTestPriority.P1)]
+        public async Task DiagnosticsHubProfileBootstrap() {
+            var python = PythonPaths.Python39_x64 ??
+                PythonPaths.Python39 ??
+                PythonPaths.LatestVersion;
+            if (python == null) {
+                Assert.Inconclusive("Python 3.9 or later is required.");
+            }
+
+            var productDirectory = Path.GetDirectoryName(typeof(IPythonProfiling).Assembly.Location);
+            var bootstrap = Path.Combine(productDirectory, "diaghub_profile.py");
+            var tests = Path.Combine(
+                Path.GetDirectoryName(typeof(ProfilingTests).Assembly.Location),
+                "diaghub_profile_tests.py"
+            );
+
+            Assert.IsTrue(File.Exists(bootstrap), "Did not find " + bootstrap);
+            Assert.IsTrue(File.Exists(tests), "Did not find " + tests);
+
+            using (var process = ProcessOutput.Run(
+                python.InterpreterPath,
+                new[] { tests, bootstrap },
+                Environment.CurrentDirectory,
+                Enumerable.Empty<KeyValuePair<string, string>>(),
+                false,
+                null
+            )) {
+                var exitCode = await process;
+                foreach (var line in process.StandardErrorLines) {
+                    Trace.TraceError("STDERR: " + line);
+                }
+                foreach (var line in process.StandardOutputLines) {
+                    Trace.TraceInformation("STDOUT: " + line);
+                }
+                Assert.AreEqual(0, exitCode);
+            }
+        }
+
         // Update the test from version 3.1/3.4 to 3.5-3.7. 
         /*
         [TestMethod, Priority(UnitTestPriority.P1)]

--- a/Python/Tests/ProfilingTests/ProfilingTests.csproj
+++ b/Python/Tests/ProfilingTests/ProfilingTests.csproj
@@ -74,6 +74,11 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
+    <Content Include="diaghub_profile_tests.py">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="..\..\Product\Profiling\Profiling.csproj">
       <Project>{C42B194E-3333-45E8-BB26-D69D1A51EF0B}</Project>
       <Name>Profiling</Name>

--- a/Python/Tests/ProfilingTests/diaghub_profile_tests.py
+++ b/Python/Tests/ProfilingTests/diaghub_profile_tests.py
@@ -1,0 +1,112 @@
+import importlib.util
+import json
+import os
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+
+
+BOOTSTRAP_PATH = sys.argv[1]
+
+
+def load_bootstrap(path):
+    spec = importlib.util.spec_from_file_location("diaghub_profile", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class DiagnosticsHubProfileTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.bootstrap = load_bootstrap(BOOTSTRAP_PATH)
+
+    def test_supported_versions(self):
+        self.assertFalse(self.bootstrap._is_supported_version((3, 8)))
+        self.assertTrue(self.bootstrap._is_supported_version((3, 9)))
+        self.assertTrue(self.bootstrap._is_supported_version((3, 14)))
+        self.assertFalse(self.bootstrap._is_supported_version((3, 15)))
+
+    def test_target_validation(self):
+        self.assertFalse(self.bootstrap._has_valid_target([]))
+        self.assertFalse(self.bootstrap._has_valid_target(["-m"]))
+        self.assertTrue(self.bootstrap._has_valid_target(["script.py"]))
+        self.assertTrue(self.bootstrap._has_valid_target(["-m", "module"]))
+
+    def test_profiled_arguments_round_trip(self):
+        arguments = ["script.py", "value with spaces", "--flag=value"]
+        old_value = os.environ.get(self.bootstrap._TARGET_ARGUMENTS)
+        try:
+            os.environ[self.bootstrap._TARGET_ARGUMENTS] = json.dumps(arguments)
+            self.assertEqual(arguments, self.bootstrap._get_profiled_arguments())
+            os.environ[self.bootstrap._TARGET_ARGUMENTS] = "{}"
+            self.assertIsNone(self.bootstrap._get_profiled_arguments())
+        finally:
+            if old_value is None:
+                os.environ.pop(self.bootstrap._TARGET_ARGUMENTS, None)
+            else:
+                os.environ[self.bootstrap._TARGET_ARGUMENTS] = old_value
+
+    def test_script_execution_preserves_arguments(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output = Path(temp_dir, "result.json")
+            script = Path(temp_dir, "target.py")
+            script.write_text(
+                "import json, os, sys\n"
+                "with open(os.environ['PTVS_TEST_OUTPUT'], 'w') as stream:\n"
+                "    json.dump({'argv': sys.argv}, stream)\n",
+                encoding="utf-8",
+            )
+
+            old_argv = sys.argv[:]
+            old_output = os.environ.get("PTVS_TEST_OUTPUT")
+            try:
+                os.environ["PTVS_TEST_OUTPUT"] = str(output)
+                self.bootstrap._run_target([str(script), "value with spaces"])
+            finally:
+                sys.argv[:] = old_argv
+                if old_output is None:
+                    os.environ.pop("PTVS_TEST_OUTPUT", None)
+                else:
+                    os.environ["PTVS_TEST_OUTPUT"] = old_output
+
+            result = json.loads(output.read_text(encoding="utf-8"))
+            self.assertEqual([str(script), "value with spaces"], result["argv"])
+
+    def test_module_execution_matches_python_m(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output = Path(temp_dir, "result.json")
+            module = Path(temp_dir, "sample_module.py")
+            module.write_text(
+                "import json, os, sys\n"
+                "with open(os.environ['PTVS_TEST_OUTPUT'], 'w') as stream:\n"
+                "    json.dump({'argv': sys.argv, 'path0': sys.path[0]}, stream)\n",
+                encoding="utf-8",
+            )
+
+            old_argv = sys.argv[:]
+            old_path = sys.path[:]
+            old_directory = os.getcwd()
+            old_output = os.environ.get("PTVS_TEST_OUTPUT")
+            try:
+                os.chdir(temp_dir)
+                os.environ["PTVS_TEST_OUTPUT"] = str(output)
+                self.bootstrap._run_target(["-m", "sample_module", "argument"])
+            finally:
+                os.chdir(old_directory)
+                sys.argv[:] = old_argv
+                sys.path[:] = old_path
+                if old_output is None:
+                    os.environ.pop("PTVS_TEST_OUTPUT", None)
+                else:
+                    os.environ["PTVS_TEST_OUTPUT"] = old_output
+
+            result = json.loads(output.read_text(encoding="utf-8"))
+            self.assertEqual("sample_module.py", Path(result["argv"][0]).name)
+            self.assertEqual(["argument"], result["argv"][1:])
+            self.assertEqual(str(Path(temp_dir)), result["path0"])
+
+
+if __name__ == "__main__":
+    unittest.main(argv=[sys.argv[0]])


### PR DESCRIPTION
## Context

Python profiling in Dev18 is currently unavailable. The legacy PTVS path depends on `VSPerfMon.exe` and `VSPerfCmd.exe`, which were removed from the Dev18 shipping manifest, and its native bridge only understands CPython layouts through Python 3.10. This is the PTVS half of moving basic function instrumentation to the existing Diagnostics Hub Python target and `microsoft/python-etwtrace` pipeline. It addresses the user-visible failure tracked by #8276.

This PR is **not standalone**. It requires companion Diagnostics Hub changes to:

- load the PTVS profiling command service without the failing dynamic-MEF handoff;
- treat `TargetProperties.Python` as script instrumentation instead of opening the native executable/PDB planner;
- resolve script module paths and function IDs correctly in DataWarehouse.

Those companion changes are currently on the DiagnosticsHub branch `feature/ptvs-python-profiling`.

## PTVS changes

- Route **Debug > Launch Python Profiling** to the Dev18 Diagnostics Hub launcher while preserving the legacy behavior for older VS targets.
- Register the currently hidden `PythonProfilingEnabled` Diagnostics Hub feature flag for Dev18.
- Expose a package-independent `PythonProfilerCommandService` that Diagnostics Hub can construct dynamically with the global VS service provider.
- Rework command construction so Diagnostics Hub owns the session/report while PTVS supplies the selected interpreter, script, arguments, working directory, and environment.
- Add `diaghub_profile.py`, which:
  - launches a dedicated profiled child process to satisfy Diagnostics Hub's child-attach contract;
  - activates `etwtrace` for the lifetime of the interpreter, including worker threads;
  - supports both script and `-m` execution;
  - preserves target arguments and import behavior;
  - reports unsupported interpreter/wheel combinations clearly.
- Package coherent `etwtrace` payloads:
  - `0.1b8` for CPython 3.9-3.11;
  - `0.1b9` for CPython 3.12-3.14.
- Include CPython 3.14 wheels in the fat package restore.
- Force the intended Dev18 `System.Text.Json` assembly reference to remove the existing MSB3277 conflict warning.

## Runtime flow

```text
PTVS target dialog
  -> Diagnostics Hub PythonTarget
  -> Instrumentation collector starts a root Python bootstrap
  -> bootstrap launches a profiled child Python process
  -> etwtrace attaches through DiagnosticsHub.InstrumentationCollector.dll
  -> Python function definitions and enter/exit events are written to .diagsession
  -> DataWarehouse resolves function IDs for the Instrumentation call tree
```

## Manual validation

Validated in a Dev18 Experimental instance with the companion Diagnostics Hub changes:

- the **Python Script** target opens the PTVS profiling dialog;
- Python 3.9 x64 launches and completes profiling;
- no native executable/PDB selection dialog appears;
- a `.diagsession` report is produced;
- user functions such as `main`, `calculate_batch`, `transform`, and `wait_for_io` resolve with call counts, total time, and self time;
- the targeted Dev18 Profiling project and full PTVS traversal build succeed.`r`n- focused bootstrap tests pass on Python 3.9 and 3.14 and through the existing ProfilingTests MSTest project.

## Current limitations

- The launch page does not yet auto-select **Python Script** and **Instrumentation**; users must select both.
- Python 3.9 x64 is the manually validated runtime. The intended 3.9-3.14 matrix still needs automated and manual coverage.
- No public x86 `etwtrace` wheels are available, so 32-bit Python is not supported by this path.
- ARM64 and free-threaded Python builds are not yet validated.
- This does not restore the legacy `.vsp`/Performance Explorer pipeline.
- Attach-to-process, remote/WSL, multiprocessing descendants, native extension internals, line profiling, and memory profiling remain out of scope.
- Focused bootstrap behavior is covered; cross-repo collector/analyzer integration and the full interpreter/architecture matrix still need dedicated coverage.

## Cross-repo rollout note

The DataWarehouse label fix was locally validated with an unsigned Release analyzer copied to both destinations listed by DiagnosticsHub's `DataWarehouseManaged.list`. Production validation requires the normal signed Diagnostics Hub build/insertion pipeline.

