### PR TITLE
Limit Dev18 Python profiling to Python 3.12-3.14

### DIFF
--- a/Build/PreBuild.ps1
+++ b/Build/PreBuild.ps1
@@ -34,10 +34,6 @@ param (
     # The etwtrace release that includes Python 3.12 through 3.14 wheels.
     [Parameter()]
     [string] $etwtraceVersion = "0.1b9",
-
-    # The last etwtrace release that includes Python 3.9 through 3.11 wheels.
-    [Parameter()]
-    [string] $etwtraceLegacyVersion = "0.1b8",
     
     # Run in interactive mode for azure feed authentication, defaults to false
     [Parameter()]
@@ -55,21 +51,16 @@ function Install-Package {
     param(
         [string] $packageName,
         [string] $version,
-        [string] $outdir,
-        [string] $installDir
+        [string] $outdir
     )
 
     Write-Host "Installing $packageName $version"
 
-    if (-not $installDir) {
-        $installDir = $outdir
-    }
-
-    $argList = "install_pypi_package.py", $packageName, $version, "`"$installDir`""
+    $argList = "install_pypi_package.py", $packageName, $version, "`"$outdir`""
     Start-Process -Wait -NoNewWindow "$outdir\python\tools\python.exe" -ErrorAction Stop -ArgumentList $argList | Write-Host
 
     $installedVersion = ""
-    $versionPyFile = Join-Path $installDir "$packageName\_version.py"
+    $versionPyFile = Join-Path $outdir "$packageName\_version.py"
     foreach ($line in Get-Content $versionPyFile) {
         if ($line.Trim().StartsWith("`"version`"")) {
             $installedVersion = $line.split(":")[1].Trim(" `"") # trim spaces and double quotes
@@ -286,26 +277,13 @@ try {
     }
 
     "-----"
-    # Install a coherent legacy payload for Python 3.9 through 3.11. Newer
-    # etwtrace releases only publish wheels for currently supported Pythons.
-    $legacyEtwTraceOutDir = Join-Path $outdir "etwtrace-legacy"
-    if (Test-Path -Path $legacyEtwTraceOutDir) {
-        Remove-Item -Recurse -Force -Path $legacyEtwTraceOutDir
-    }
-    Install-Package "etwtrace" $etwtraceLegacyVersion $outdir $legacyEtwTraceOutDir | Out-Null
-
-    # Install the current payload for Python 3.12 and later.
+    # Install etwtrace for the supported Python versions.
     Install-Package "etwtrace" $etwtraceVersion $outdir | Out-Null
 
     # Delete an unsigned file from etwtrace that shouldn't be there.
-    $filesToDelete = @(
-        "$outdir\etwtrace\test\DiagnosticsHub.InstrumentationCollector.dll",
-        "$legacyEtwTraceOutDir\etwtrace\test\DiagnosticsHub.InstrumentationCollector.dll"
-    )
-    foreach ($fileToDelete in $filesToDelete) {
-        if (Test-Path -Path $fileToDelete) {
-            Remove-Item -Path $fileToDelete | Out-Null
-        }
+    $fileToDelete = "$outdir\etwtrace\test\DiagnosticsHub.InstrumentationCollector.dll"
+    if (Test-Path -Path $fileToDelete) {
+        Remove-Item -Path $fileToDelete | Out-Null
     }
 
 } finally {

--- a/Python/Product/Profiling/Profiling.csproj
+++ b/Python/Product/Profiling/Profiling.csproj
@@ -200,15 +200,8 @@
         <VSIXSubPath>etwtrace\%(RecursiveDir)</VSIXSubPath>
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </EtwTraceFiles>
-      <EtwTraceLegacyFiles Include="$(PackagesPath)etwtrace-legacy\etwtrace\**\*" />
-      <EtwTraceLegacyFiles>
-        <IncludeInVSIX>true</IncludeInVSIX>
-        <Link>etwtrace_legacy\etwtrace\%(RecursiveDir)%(Filename)%(Extension)</Link>
-        <VSIXSubPath>etwtrace_legacy\etwtrace\%(RecursiveDir)</VSIXSubPath>
-        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      </EtwTraceLegacyFiles>
-      <Content Include="@(EtwTraceFiles);@(EtwTraceLegacyFiles)" />
-      <FileWrites Include="@(EtwTraceFiles);@(EtwTraceLegacyFiles)" />
+      <Content Include="@(EtwTraceFiles)" />
+      <FileWrites Include="@(EtwTraceFiles)" />
     </ItemGroup>
   </Target>
   <Import Project="..\ProjectAfter.settings" />

--- a/Python/Product/Profiling/Profiling/PythonProfilerCommandService.cs
+++ b/Python/Product/Profiling/Profiling/PythonProfilerCommandService.cs
@@ -127,6 +127,9 @@ namespace Microsoft.PythonTools.Profiling {
                         : null;
                     return Version.TryParse(versionText, out version) ? version : null;
                 }
+            } catch (ArgumentException ex) {
+                Debug.WriteLine($"Failed to query Python version: {ex.Message}");
+                return null;
             } catch (Win32Exception ex) {
                 Debug.WriteLine($"Failed to query Python version: {ex.Message}");
                 return null;

--- a/Python/Product/Profiling/Profiling/PythonProfilerCommandService.cs
+++ b/Python/Product/Profiling/Profiling/PythonProfilerCommandService.cs
@@ -16,10 +16,13 @@
 
 namespace Microsoft.PythonTools.Profiling {
     using System;
+    using System.ComponentModel;
     using System.ComponentModel.Composition;
     using System.Diagnostics;
+    using System.Linq;
     using System.Threading.Tasks;
     using System.Windows;
+    using Microsoft.PythonTools.Infrastructure;
     using Microsoft.VisualStudio.Shell;
 
     /// <summary>
@@ -28,6 +31,10 @@ namespace Microsoft.PythonTools.Profiling {
     [Export(typeof(IPythonProfilerCommandService))]
     [PartCreationPolicy(CreationPolicy.Shared)]
     public sealed class PythonProfilerCommandService : IPythonProfilerCommandService {
+        private const int MinimumSupportedPythonMinorVersion = 12;
+        private const int MaximumSupportedPythonMinorVersion = 14;
+        private static readonly TimeSpan InterpreterVersionTimeout = TimeSpan.FromSeconds(10);
+
         private readonly CommandArgumentBuilder _commandArgumentBuilder;
         private readonly IServiceProvider _serviceProvider;
         private readonly UserInputDialog _userInputDialog;
@@ -54,7 +61,38 @@ namespace Microsoft.PythonTools.Profiling {
 
                 if (_userInputDialog.ShowDialog(targetView, _serviceProvider)) {
                     var target = targetView.GetTarget();
-                    return _commandArgumentBuilder.BuildCommandArgsFromTarget(target, _serviceProvider);
+                    var commandArgs = _commandArgumentBuilder.BuildCommandArgsFromTarget(target, _serviceProvider);
+                    if (commandArgs == null) {
+                        return null;
+                    }
+
+                    var pythonVersion = await GetPythonVersionAsync(commandArgs.PythonExePath);
+                    await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+                    if (pythonVersion == null) {
+                        MessageBox.Show(
+                            Strings.ProfilingInterpreterVersionUnavailable.FormatUI(commandArgs.PythonExePath),
+                            Strings.ProductTitle,
+                            MessageBoxButton.OK,
+                            MessageBoxImage.Error
+                        );
+                        return null;
+                    }
+
+                    if (!IsSupportedPythonVersion(pythonVersion)) {
+                        MessageBox.Show(
+                            Strings.ProfilingUnsupportedPythonVersion.FormatUI(
+                                pythonVersion.Major,
+                                pythonVersion.Minor
+                            ),
+                            Strings.ProductTitle,
+                            MessageBoxButton.OK,
+                            MessageBoxImage.Warning
+                        );
+                        return null;
+                    }
+
+                    return commandArgs;
                 }
             } catch (Exception ex) {
                 Debug.Fail($"Error displaying user input dialog: {ex.Message}");
@@ -62,6 +100,40 @@ namespace Microsoft.PythonTools.Profiling {
             }
 
             return null;
+        }
+
+        private static bool IsSupportedPythonVersion(Version version) {
+            return version.Major == 3 &&
+                version.Minor >= MinimumSupportedPythonMinorVersion &&
+                version.Minor <= MaximumSupportedPythonMinorVersion;
+        }
+
+        private static async Task<Version> GetPythonVersionAsync(string interpreterPath) {
+            try {
+                using (var output = ProcessOutput.RunHiddenAndCapture(
+                    interpreterPath,
+                    "-c",
+                    "import sys; print('{}.{}'.format(sys.version_info[0], sys.version_info[1]))"
+                )) {
+                    var exited = await Task.Run(() => output.Wait(InterpreterVersionTimeout));
+                    if (!exited) {
+                        output.Kill();
+                        return null;
+                    }
+
+                    Version version;
+                    var versionText = output.ExitCode == 0
+                        ? output.StandardOutputLines.FirstOrDefault()
+                        : null;
+                    return Version.TryParse(versionText, out version) ? version : null;
+                }
+            } catch (Win32Exception ex) {
+                Debug.WriteLine($"Failed to query Python version: {ex.Message}");
+                return null;
+            } catch (InvalidOperationException ex) {
+                Debug.WriteLine($"Failed to query Python version: {ex.Message}");
+                return null;
+            }
         }
     }
 }

--- a/Python/Product/Profiling/Strings.Designer.cs
+++ b/Python/Product/Profiling/Strings.Designer.cs
@@ -470,6 +470,15 @@ namespace Microsoft.PythonTools.Profiling {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Visual Studio could not determine the version of the selected Python interpreter &apos;{0}&apos;. Verify that it is a valid Python interpreter and try again..
+        /// </summary>
+        public static string ProfilingInterpreterVersionUnavailable {
+            get {
+                return ResourceManager.GetString("ProfilingInterpreterVersionUnavailable", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Profiling session has not been configured. Configure now and launch?.
         /// </summary>
         public static string ProfilingSessionNotConfigured {
@@ -487,6 +496,15 @@ namespace Microsoft.PythonTools.Profiling {
             }
         }
         
+        /// <summary>
+        ///   Looks up a localized string similar to Python {0}.{1} is not supported for profiling. Visual Studio Python profiling supports Python 3.12 through 3.14. Select a supported interpreter and try again..
+        /// </summary>
+        public static string ProfilingUnsupportedPythonVersion {
+            get {
+                return ResourceManager.GetString("ProfilingUnsupportedPythonVersion", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Could not find interpreter for project {0}.
         /// </summary>

--- a/Python/Product/Profiling/Strings.resx
+++ b/Python/Product/Profiling/Strings.resx
@@ -197,6 +197,12 @@ Error:
   <data name="ProfilingSupportMissingError" xml:space="preserve">
     <value>Profiling support seems to be missing or corrupt. Try repairing your Visual Studio installation.</value>
   </data>
+  <data name="ProfilingInterpreterVersionUnavailable" xml:space="preserve">
+    <value>Visual Studio could not determine the version of the selected Python interpreter '{0}'. Verify that it is a valid Python interpreter and try again.</value>
+  </data>
+  <data name="ProfilingUnsupportedPythonVersion" xml:space="preserve">
+    <value>Python {0}.{1} is not supported for profiling. Visual Studio Python profiling supports Python 3.12 through 3.14. Select a supported interpreter and try again.</value>
+  </data>
   <data name="ProfilingSessionNotConfigured" xml:space="preserve">
     <value>Profiling session has not been configured. Configure now and launch?</value>
   </data>

--- a/Python/Product/Profiling/diaghub_profile.py
+++ b/Python/Product/Profiling/diaghub_profile.py
@@ -12,35 +12,8 @@ _CHILD_MARKER = "PTVS_DIAGHUB_PROFILE_CHILD"
 _TARGET_ARGUMENTS = "PTVS_DIAGHUB_TARGET_ARGUMENTS"
 
 
-def _load_legacy_collector():
-    import ctypes
-
-    collector_root = os.getenv("DIAGHUB_INSTR_COLLECTOR_ROOT")
-    runtime_name = os.getenv("DIAGHUB_INSTR_RUNTIME_NAME")
-    if not collector_root or not runtime_name:
-        raise RuntimeError(
-            "Python profiling must be launched from the Visual Studio "
-            "Performance Profiler."
-        )
-
-    if sys.winver.endswith("-32"):
-        architecture = "x86"
-    elif sys.winver.endswith("-arm64"):
-        architecture = "arm64"
-    else:
-        architecture = "amd64"
-
-    collector_path = os.path.join(collector_root, architecture, runtime_name)
-    collector = ctypes.WinDLL(collector_path)
-    collector.ChildAttach.argtypes = []
-    collector.ChildAttach.restype = ctypes.c_int
-    if not collector.ChildAttach():
-        raise RuntimeError("Failed to attach Python to the profiling session.")
-    return collector
-
-
 def _is_supported_version(version):
-    return (3, 9) <= tuple(version[:2]) <= (3, 14)
+    return (3, 12) <= tuple(version[:2]) <= (3, 14)
 
 
 def _has_valid_target(arguments):
@@ -82,7 +55,7 @@ def _run_target(arguments):
 def main():
     if not _is_supported_version(sys.version_info):
         print(
-            "Visual Studio Python profiling supports Python 3.9 through 3.14.",
+            "Visual Studio Python profiling supports Python 3.12 through 3.14.",
             file=sys.stderr,
         )
         return 2
@@ -96,16 +69,9 @@ def main():
     if not is_child:
         return _run_profiled_child(arguments)
 
-    package_root = os.path.dirname(os.path.abspath(__file__))
-    is_legacy = sys.version_info[:2] <= (3, 11)
-    if is_legacy:
-        package_root = os.path.join(package_root, "etwtrace_legacy")
-    sys.path.insert(0, package_root)
+    sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
     try:
-        # etwtrace 0.1b8 expects Visual Studio to load and attach the collector.
-        # Keep this reference alive while the extension uses the collector.
-        collector = _load_legacy_collector() if is_legacy else None
         from etwtrace import DiagnosticsHubTracer
         tracer = DiagnosticsHubTracer()
     except (ImportError, OSError, RuntimeError, AttributeError) as exc:
@@ -122,14 +88,7 @@ def main():
         arguments[0] = os.path.abspath(arguments[0])
         sys.path[0] = os.path.dirname(arguments[0])
 
-    if not hasattr(tracer, "_data"):
-        # etwtrace 0.1b8 only initializes this field for its test collector.
-        tracer._data = []
     tracer.ignore(os.path.abspath(__file__))
-    # Keep profiling and the compatibility collector alive until interpreter
-    # shutdown. Worker threads may retain native profile callbacks after the
-    # top-level script returns.
-    tracer._collector_keepalive = collector
     tracer.enable()
     _run_target(arguments)
     return 0


### PR DESCRIPTION
## Context

Python profiling is currently unavailable in Dev18 because the legacy PTVS path depends on `VSPerfMon.exe` and `VSPerfCmd.exe`, which are no longer shipped. #8591 began an exploratory effort to make profiling work again by routing PTVS through the Diagnostics Hub Python target and `microsoft/python-etwtrace`.

This is exploratory enablement rather than a regression in a working Dev18 user scenario. We have no known user complaints about Dev18 Python profiling, and the feature was already broken before this work. The priority is therefore to establish a reliable, supportable path for current Python versions rather than restore every historical interpreter at substantially higher release and compliance cost.

## Why PTVS originally included two etwtrace versions

`etwtrace` contains native `.pyd` extensions compiled for specific CPython ABIs. A `cp312` extension cannot load into Python 3.11, for example.

- `etwtrace 0.1b8` is the last release that contains wheels for Python 3.9, 3.10, and 3.11. PTVS installed it into a separate `etwtrace_legacy` directory and used extra collector-loading compatibility code for those interpreters.
- `etwtrace 0.1b9` contains the current Python 3.12, 3.13, and 3.14 wheels and is the payload used by the new Diagnostics Hub path.

The bootstrap selected the legacy directory for Python 3.9-3.11 and the current directory for Python 3.12-3.14.

## Why the insertion failed

The Dev18 insertion SymbolCheck found 24 newly introduced native binaries under `etwtrace_legacy`:

- Eight `etwtrace 0.1b8` Windows wheels were merged into the legacy payload.
- Each wheel contains three native extensions: `_etwtrace`, `_etwinstrument`, and `_vsinstrument`.
- The wheels contain no matching PDB files.
- PTVS's symbol archival step only stages explicitly listed PTVS build outputs; it never staged these prebuilt dependency binaries or their symbols.
- The Windows PDB identities embedded in the 24 `.pyd` files are not archived on MSDL.

As a result, the PTVS build and release could succeed while the Visual Studio insertion correctly failed its symbol policy. This is not a transient policy issue or a portable-PDB false positive; the exact Windows PDBs required by the shipped binaries are unavailable to the insertion.

## What would be required to keep Python 3.9-3.11 profiling

Adding `*.pyd` to PTVS's symbol publishing list is not sufficient because the matching PDBs are absent. A compliant legacy payload would require one of the following:

1. Recover the exact PDBs produced alongside the published `0.1b8` wheels and archive each matching `.pyd`/PDB pair to MSDL.
2. If those artifacts no longer exist, produce a new legacy `etwtrace` release from the `0.1b8` line:
   - Build the required CPython 3.9-3.11 architecture matrix in an official pipeline.
   - Retain the exact Windows PDB generated for every `.pyd`.
   - Sign and publish the new wheel binaries.
   - Archive the matching binary/PDB pairs before insertion.
   - Publish the new version to the approved internal feed and update PTVS to consume it.
   - Filter the legacy restore so it does not also package the unnecessary Python 3.12 and 3.13 wheels from `0.1b8`.

That is primarily a producer/release-pipeline investment, not a small PTVS packaging fix. It also preserves a second native payload and compatibility path indefinitely.

## Changes

- Remove the `etwtrace 0.1b8` restore and the `etwtrace_legacy` VSIX payload.
- Package only `etwtrace 0.1b9` for Python 3.12-3.14.
- Remove the legacy collector compatibility path from `diaghub_profile.py`.
- Make the Python bootstrap explicitly reject versions outside 3.12-3.14.
- Probe the selected interpreter version before returning a command to Diagnostics Hub.
  - Python 3.9-3.11 now receives a clear warning with the detected version and supported range.
  - PTVS returns no launch command, so Diagnostics Hub does not create an empty session.
  - An invalid or unreadable interpreter also produces an actionable error instead of starting a session that cannot collect data.
- Keep the Python-side version check as a defense-in-depth guard.

## Why this is the best fix for the exploratory item

- It restores a reliable path for the currently supported Python 3.12-3.14 matrix.
- It avoids bypassing a valid symbol-compliance failure.
- It removes 24 unarchived native binaries and the old collector compatibility path.
- It avoids investing in reconstruction of a 2024 dependency release and its missing symbol-production pipeline for a Dev18 feature that was already unavailable and has no known user complaints.
- It makes the unsupported behavior explicit before collection rather than producing an empty `.diagsession`.
- Legacy support can still be reconsidered independently if usage data or customer demand justifies the upstream build, signing, and symbol archival work.

## User impact

- Dev18 Python profiling supports Python 3.12, 3.13, and 3.14.
- Python 3.9, 3.10, and 3.11 users receive a clear warning before a profiling session starts.
- Editing, running, and debugging older Python versions are unaffected.
- The legacy profiler behavior in older Visual Studio releases is unaffected.

## Manual validation

- Built and deployed PTVS to the Dev18 Canary experimental hive.
- Confirmed an older interpreter is rejected with the new warning and no empty session is created.
- Confirmed Python 3.14 proceeds through profiling and reports user functions when the target defines and calls functions.
- Confirmed the profiling VSIX contains the Python 3.12-3.14 `etwtrace` binaries and no `etwtrace_legacy` entries.
