### PR TITLE
Onboard compliance pipeline to CFS network isolation

### DIFF
--- a/azure-pipelines-compliance.yml
+++ b/azure-pipelines-compliance.yml
@@ -29,222 +29,238 @@ schedules:
     - main
   always: true
 
-jobs:
+resources:
+  repositories:
+    - repository: 1ESPipelineTemplates
+      type: git
+      name: 1ESPipelineTemplates/1ESPipelineTemplates
+      ref: refs/tags/release
 
-- job: Compliance
-  timeoutInMinutes: 0   # maximum timeout, some compliance tasks take a long time to run
+extends:
+  template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
+  parameters:
+    pool:
+      name: VSEng-MicroBuildVSStable
+      os: windows
+    settings:
+      networkIsolationPolicy: Permissive,CFSClean
+    stages:
+      - stage: compliance
+        displayName: Compliance
+        jobs:
+          - job: Compliance
+            timeoutInMinutes: 0   # maximum timeout, some compliance tasks take a long time to run
 
-  # The agent pool the build will run on
-  pool:
-    name: VSEng-MicroBuildVSStable
-    demands: 
-    - msbuild
-    - VisualStudio_18.0
+            # The agent pool the build will run on
+            pool:
+              name: VSEng-MicroBuildVSStable
+              demands:
+              - msbuild
+              - VisualStudio_18.0
 
-  # Job variables
-  variables:
-    - name: CopyTestData
-      value: false
+            # Job variables
+            variables:
+              - name: CopyTestData
+                value: false
 
-    # PTVS variable group
-    # This contains variables shared between various PTVS pipelines
-    - group: PTVS-Dev18
+              # PTVS variable group
+              # This contains variables shared between various PTVS pipelines
+              - group: PTVS-Dev18
 
-  steps:
+            steps:
 
-  # Check out code clean from source control
-  - checkout: self
-    clean: true
+            # Check out code clean from source control
+            - checkout: self
+              clean: true
 
-  # Install plugins needed for swixproj/vsmanproj and signing
-  # We don't use Build/templates/install_microbuild_plugins.yml here because this project doesn't need to real sign
-  - task: MicroBuildSwixPlugin@3
-    displayName: 'Install microbuild swix plugin'
+            # Install plugins needed for swixproj/vsmanproj and signing
+            # We don't use Build/templates/install_microbuild_plugins.yml here because this project doesn't need to real sign
+            - task: MicroBuildSwixPlugin@3
+              displayName: 'Install microbuild swix plugin'
 
-  # Restore packages and install dependencies (pylance, debugpy)
-  - template: Build/templates/restore_packages.yml
-    parameters:
-      pylanceVersion: ${{ parameters.pylanceVersion }}
-      debugpyVersion: ${{ parameters.debugpyVersion }}
+            # Restore packages and install dependencies (pylance, debugpy)
+            - template: /Build/templates/restore_packages.yml@self
+              parameters:
+                pylanceVersion: ${{ parameters.pylanceVersion }}
+                debugpyVersion: ${{ parameters.debugpyVersion }}
 
-  # Clean the Guardian temp files
-  - powershell: Get-ChildItem -Path $env:TEMP -Filter 'MpCmdRun.*' -Recurse -ErrorAction SilentlyContinue | Remove-Item -Recurse -Force
-    displayName: Clean guardian temp files
-    continueOnError: true
+            # Clean the Guardian temp files
+            - powershell: Get-ChildItem -Path $env:TEMP -Filter 'MpCmdRun.*' -Recurse -ErrorAction SilentlyContinue | Remove-Item -Recurse -Force
+              displayName: Clean guardian temp files
+              continueOnError: true
 
-  - powershell: npm i -g npm@8
-    displayName: downgrade npm
- 
-  # Update node
-  # See https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/tool/node-js?view=azure-devops
-  - task: NodeTool@0
-    displayName: Update node
-    inputs:
-      versionSpec: '14.x'
+            # Update node
+            # See https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/tool/node-js?view=azure-devops
+            - task: NodeTool@0
+              displayName: Update node
+              inputs:
+                versionSpec: '14.x'
 
-  - task: UsePythonVersion@0
-    displayName: 'Use Python 3.x'
+            - task: UsePythonVersion@0
+              displayName: 'Use Python 3.x'
 
-  # Initialize CodeQL before the build
-  # See https://devdiv.visualstudio.com/DevDiv/_wiki/wikis/DevDiv.wiki/1761/Static-Analysis and
-  # https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/codeql/configuring-codeql3000-ado-pipelines
-  - task: CodeQL3000Init@0
-    displayName: Initialize CodeQL
-    inputs:
-      Enabled: true
-      Language: python,csharp,cpp
-      TSAEnabled: true
-      TSAOptionsPath: $(Build.SourcesDirectory)\TsaConfig.json
-    condition: succeededOrFailed()
-    continueOnError: True
+            # Initialize CodeQL before the build
+            # See https://devdiv.visualstudio.com/DevDiv/_wiki/wikis/DevDiv.wiki/1761/Static-Analysis and
+            # https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/codeql/configuring-codeql3000-ado-pipelines
+            - task: CodeQL3000Init@0
+              displayName: Initialize CodeQL
+              inputs:
+                Enabled: true
+                Language: python,csharp,cpp
+                TSAEnabled: true
+                TSAOptionsPath: $(Build.SourcesDirectory)\TsaConfig.json
+              condition: succeededOrFailed()
+              continueOnError: True
 
-  # Build and publish logs
-  - template: Build/templates/build.yml
+            # Build and publish logs
+            - template: /Build/templates/build.yml@self
 
-  # Finalize CodeQL after the build
-  - task: CodeQL3000Finalize@0
-    displayName: Finalize CodeQL
-    condition: succeededOrFailed()
-    continueOnError: True
+            # Finalize CodeQL after the build
+            - task: CodeQL3000Finalize@0
+              displayName: Finalize CodeQL
+              condition: succeededOrFailed()
+              continueOnError: True
 
-  # Anti-Malware Scan of build sources and/or artifacts
-  # See https://eng.ms/docs/security-compliance-identity-and-management-scim/security/azure-security/cloudai-security-fundamentals-engineering/security-integration/guardian-wiki/sdl-azdo-extension/antimalware-scan-build-task
-  - task: AntiMalware@4
-    displayName: 'Run Antivirus on Source'
-    inputs:
-      FileDirPath: $(Build.SourcesDirectory)
-    condition: succeededOrFailed()
-    continueOnError: True
-  - task: AntiMalware@4
-    displayName: Run Antivirus on Binaries
-    inputs:
-      FileDirPath: $(Build.BinariesDirectory)
-    condition: succeededOrFailed()
-    continueOnError: True
+            # Anti-Malware Scan of build sources and/or artifacts
+            # See https://eng.ms/docs/security-compliance-identity-and-management-scim/security/azure-security/cloudai-security-fundamentals-engineering/security-integration/guardian-wiki/sdl-azdo-extension/antimalware-scan-build-task
+            - task: AntiMalware@4
+              displayName: 'Run Antivirus on Source'
+              inputs:
+                FileDirPath: $(Build.SourcesDirectory)
+              condition: succeededOrFailed()
+              continueOnError: True
+            - task: AntiMalware@4
+              displayName: Run Antivirus on Binaries
+              inputs:
+                FileDirPath: $(Build.BinariesDirectory)
+              condition: succeededOrFailed()
+              continueOnError: True
 
-  # Copy files for Scanning
-  - task: CopyFiles@2
-    displayName: 'Copy Files for Scanning'
-    inputs:
-      SourceFolder: $(Build.BinariesDirectory)
-      Contents: |
-        layout\Microsoft.CookiecutterTools\Microsoft.CookiecutterTools.*
-        layout\Microsoft.PythonTools.Core\Microsoft.PythonTools.*
-        layout\Microsoft.PythonTools.Core\PyDebugAttach*.*
-        layout\Microsoft.PythonTools.Debugger.VCLauncher\Microsoft.PythonTools.*
-        layout\Microsoft.PythonTools.Django\Microsoft.PythonTools.*
-        layout\Microsoft.PythonTools.Profiling\Microsoft.PythonTools.*
-        layout\Microsoft.PythonTools.Profiling\VsPyProf*.*
-      TargetFolder: $(Agent.TempDirectory)\FilesToScan
+            # Copy files for Scanning
+            - task: CopyFiles@2
+              displayName: 'Copy Files for Scanning'
+              inputs:
+                SourceFolder: $(Build.BinariesDirectory)
+                Contents: |
+                  layout\Microsoft.CookiecutterTools\Microsoft.CookiecutterTools.*
+                  layout\Microsoft.PythonTools.Core\Microsoft.PythonTools.*
+                  layout\Microsoft.PythonTools.Core\PyDebugAttach*.*
+                  layout\Microsoft.PythonTools.Debugger.VCLauncher\Microsoft.PythonTools.*
+                  layout\Microsoft.PythonTools.Django\Microsoft.PythonTools.*
+                  layout\Microsoft.PythonTools.Profiling\Microsoft.PythonTools.*
+                  layout\Microsoft.PythonTools.Profiling\VsPyProf*.*
+                TargetFolder: $(Agent.TempDirectory)\FilesToScan
 
-  # Analyze python files for common vulnerabilities
-  # See https://eng.ms/docs/security-compliance-identity-and-management-scim/security/azure-security/cloudai-security-fundamentals-engineering/security-integration/guardian-wiki/sdl-azdo-extension/bandit-build-task
-  - task: Bandit@1
-    displayName: 'Run Bandit'
-    inputs:
-      targetsType: banditPattern
-      targetsBandit: '$(Build.SourcesDirectory)\Python\Product'
-    condition: succeededOrFailed()
-    continueOnError: True
+            # Analyze python files for common vulnerabilities
+            # See https://eng.ms/docs/security-compliance-identity-and-management-scim/security/azure-security/cloudai-security-fundamentals-engineering/security-integration/guardian-wiki/sdl-azdo-extension/bandit-build-task
+            - task: Bandit@1
+              displayName: 'Run Bandit'
+              inputs:
+                targetsType: banditPattern
+                targetsBandit: '$(Build.SourcesDirectory)\Python\Product'
+              condition: succeededOrFailed()
+              continueOnError: True
 
-  # Analyze binaries for security vulnerabilities
-  # See https://eng.ms/docs/security-compliance-identity-and-management-scim/security/azure-security/cloudai-security-fundamentals-engineering/security-integration/guardian-wiki/sdl-azdo-extension/binskim-build-task
-  - task: BinSkim@4
-    displayName: Run BinSkim
-    inputs:
-      toolVersion: Exact
-      exactToolVersion: '4.4.9'
-      # Use the same files copied for ApiScan
-      TargetPattern: binskimPattern
-      AnalyzeTargetBinskim: |
-        $(Agent.TempDirectory)\FilesToScan\*.dll 
-        $(Agent.TempDirectory)\FilesToScan\*.exe
-    condition: succeededOrFailed()
-    continueOnError: True
+            # Analyze binaries for security vulnerabilities
+            # See https://eng.ms/docs/security-compliance-identity-and-management-scim/security/azure-security/cloudai-security-fundamentals-engineering/security-integration/guardian-wiki/sdl-azdo-extension/binskim-build-task
+            - task: BinSkim@4
+              displayName: Run BinSkim
+              inputs:
+                toolVersion: Exact
+                exactToolVersion: '4.4.9'
+                # Use the same files copied for ApiScan
+                TargetPattern: binskimPattern
+                AnalyzeTargetBinskim: |
+                  $(Agent.TempDirectory)\FilesToScan\*.dll
+                  $(Agent.TempDirectory)\FilesToScan\*.exe
+              condition: succeededOrFailed()
+              continueOnError: True
 
-  # Run component governance detection
-  # See http://aka.ms/cgdocs for more info
-  - task: ComponentGovernanceComponentDetection@0
-    displayName: Run Component Detection
-    inputs:
-      scanType: 'Register'
-      verbosity: 'Verbose'
-      alertWarningLevel: 'High'
-    condition: succeededOrFailed()
-    continueOnError: True
+            # Run component governance detection
+            # See http://aka.ms/cgdocs for more info
+            - task: ComponentGovernanceComponentDetection@0
+              displayName: Run Component Detection
+              inputs:
+                scanType: 'Register'
+                verbosity: 'Verbose'
+                alertWarningLevel: 'High'
+              condition: succeededOrFailed()
+              continueOnError: True
 
-  # Analyze source and build output text files for credentials
-  # See https://eng.ms/docs/security-compliance-identity-and-management-scim/security/azure-security/cloudai-security-fundamentals-engineering/security-integration/guardian-wiki/sdl-azdo-extension/credscan-azure-devops-build-task
-  - task: CredScan@2
-    displayName: Run CredScan
-    inputs:
-      toolMajorVersion: V2
-    condition: succeededOrFailed()
-    continueOnError: True
+            # Analyze source and build output text files for credentials
+            # See https://eng.ms/docs/security-compliance-identity-and-management-scim/security/azure-security/cloudai-security-fundamentals-engineering/security-integration/guardian-wiki/sdl-azdo-extension/credscan-azure-devops-build-task
+            - task: CredScan@2
+              displayName: Run CredScan
+              inputs:
+                toolMajorVersion: V2
+              condition: succeededOrFailed()
+              continueOnError: True
 
-  # Scan C/C++ for security vulnerabilities
-  # See https://eng.ms/docs/security-compliance-identity-and-management-scim/security/azure-security/cloudai-security-fundamentals-engineering/security-integration/guardian-wiki/sdl-azdo-extension/flawfinder-build-task
-  - task: Flawfinder@2
-    displayName: 'Run Flawfinder'
-    condition: succeededOrFailed()
-    continueOnError: True
+            # Scan C/C++ for security vulnerabilities
+            # See https://eng.ms/docs/security-compliance-identity-and-management-scim/security/azure-security/cloudai-security-fundamentals-engineering/security-integration/guardian-wiki/sdl-azdo-extension/flawfinder-build-task
+            - task: Flawfinder@2
+              displayName: 'Run Flawfinder'
+              condition: succeededOrFailed()
+              continueOnError: True
 
-  # Scan text elements including code, code comments, and content/web pages, for sensitive terms based on legal, cultural, or geopolitical reasons
-  # See https://eng.ms/docs/security-compliance-identity-and-management-scim/security/azure-security/cloudai-security-fundamentals-engineering/security-integration/guardian-wiki/sdl-azdo-extension/policheck-build-task
-  - task: PoliCheck@2
-    displayName: Run PoliCheck
-    inputs:
-      optionsFC: 1 # Enables scanning of comments
-      optionsUEPATH: $(Build.SourcesDirectory)\Build\PoliCheckExclusions.xml
-    condition: succeededOrFailed()
-    continueOnError: True
+            # Scan text elements including code, code comments, and content/web pages, for sensitive terms based on legal, cultural, or geopolitical reasons
+            # See https://eng.ms/docs/security-compliance-identity-and-management-scim/security/azure-security/cloudai-security-fundamentals-engineering/security-integration/guardian-wiki/sdl-azdo-extension/policheck-build-task
+            - task: PoliCheck@2
+              displayName: Run PoliCheck
+              inputs:
+                optionsFC: 1 # Enables scanning of comments
+                optionsUEPATH: $(Build.SourcesDirectory)\Build\PoliCheckExclusions.xml
+              condition: succeededOrFailed()
+              continueOnError: True
 
-  # Analyze unmanaged C/C++ code for security vulnerabilities
-  # https://eng.ms/docs/security-compliance-identity-and-management-scim/security/azure-security/cloudai-security-fundamentals-engineering/security-integration/guardian-wiki/sdl-azdo-extension/prefast-build-task
-  - task: SDLNativeRules@2
-    displayName: Run PREfast SDL Native Rules for MSBuild
-    condition: succeededOrFailed()
-    continueOnError: True
+            # Analyze unmanaged C/C++ code for security vulnerabilities
+            # https://eng.ms/docs/security-compliance-identity-and-management-scim/security/azure-security/cloudai-security-fundamentals-engineering/security-integration/guardian-wiki/sdl-azdo-extension/prefast-build-task
+            - task: SDLNativeRules@2
+              displayName: Run PREfast SDL Native Rules for MSBuild
+              condition: succeededOrFailed()
+              continueOnError: True
 
-  - task: MicroBuildCleanup@1
-    displayName: MicroBuild cleanup
-    continueOnError: True
+            - task: MicroBuildCleanup@1
+              displayName: MicroBuild cleanup
+              continueOnError: True
 
-  # Generate security analysis report
-  # See https://eng.ms/docs/security-compliance-identity-and-management-scim/security/azure-security/cloudai-security-fundamentals-engineering/security-integration/guardian-wiki/sdl-azdo-extension/security-analysis-report-build-task
-  - task: SdtReport@1
-    displayName: Create Security Analysis Report
-    inputs:
-      AllTools: true
-      BinSkimBreakOn: WarningAbove
-      PoliCheckBreakOn: Severity4Above
-      RoslynAnalyzersBreakOn: WarningAbove
-    condition: succeededOrFailed()
-    continueOnError: True
+            # Generate security analysis report
+            # See https://eng.ms/docs/security-compliance-identity-and-management-scim/security/azure-security/cloudai-security-fundamentals-engineering/security-integration/guardian-wiki/sdl-azdo-extension/security-analysis-report-build-task
+            - task: SdtReport@1
+              displayName: Create Security Analysis Report
+              inputs:
+                AllTools: true
+                BinSkimBreakOn: WarningAbove
+                PoliCheckBreakOn: Severity4Above
+                RoslynAnalyzersBreakOn: WarningAbove
+              condition: succeededOrFailed()
+              continueOnError: True
 
-  # Publish security analysis logs
-  - task: PublishSecurityAnalysisLogs@2
-    displayName: Publish Security Analysis Logs
-    condition: succeededOrFailed()
-    continueOnError: True
+            # Publish security analysis logs
+            - task: PublishSecurityAnalysisLogs@2
+              displayName: Publish Security Analysis Logs
+              condition: succeededOrFailed()
+              continueOnError: True
 
-  # Copy sdt logs for publishing
-  - task: CopyFiles@2
-    displayName: Save SDT logs to Staging Directory
-    inputs:
-      SourceFolder: $(Agent.BuildDirectory)\_sdt
-      TargetFolder: $(Build.StagingDirectory)
+            # Copy sdt logs for publishing
+            - task: CopyFiles@2
+              displayName: Save SDT logs to Staging Directory
+              inputs:
+                SourceFolder: $(Agent.BuildDirectory)\_sdt
+                TargetFolder: $(Build.StagingDirectory)
 
-  # Publish staging artifacts
-  - task: PublishBuildArtifacts@1
-    displayName: Publish Staging Directory
-    inputs:
-      PathtoPublish: $(Build.StagingDirectory)
+            # Publish staging artifacts
+            - task: 1ES.PublishBuildArtifacts@1
+              displayName: Publish Staging Directory
+              inputs:
+                PathtoPublish: $(Build.StagingDirectory)
+                ArtifactName: drop
+                sbomEnabled: false
 
-  # Upload results to TSA
-  # See https://eng.ms/docs/security-compliance-identity-and-management-scim/security/azure-security/cloudai-security-fundamentals-engineering/security-integration/guardian-wiki/sdl-azdo-extension/tsa-upload-build-task
-  - task: TSAUpload@2
-    displayName: TSA Upload
-    inputs:
-      GdnPublishTsaOnboard: True
-      GdnPublishTsaConfigFile: $(Build.SourcesDirectory)\TsaConfig.json
+            # Upload results to TSA
+            # See https://eng.ms/docs/security-compliance-identity-and-management-scim/security/azure-security/cloudai-security-fundamentals-engineering/security-integration/guardian-wiki/sdl-azdo-extension/tsa-upload-build-task
+            - task: TSAUpload@2
+              displayName: TSA Upload
+              inputs:
+                GdnPublishTsaOnboard: True
+                GdnPublishTsaConfigFile: $(Build.SourcesDirectory)\TsaConfig.json


### PR DESCRIPTION
## Context

The compliance pipeline was not using the official 1ES pipeline template, so it did not run the Network Isolation start/stop tasks or enforce the CFS package-feed policy. Although the shared restore path already authenticates to Azure Artifacts feeds, the pipeline also performed a global `npm` installation that could bypass the repository `.npmrc` and contact the public npm registry.

## Changes

- Migrate `azure-pipelines-compliance.yml` to `v1/1ES.Official.PipelineTemplate.yml`.
- Enable the non-TCB Network Isolation policy with `Permissive,CFSClean`.
- Remove the redundant `npm i -g npm@8` step.
- Preserve the existing compliance job, scan tasks, ordering, pool demands, variables, and schedule.
- Resolve repository templates explicitly with `@self` under the external 1ES template.
- Use `1ES.PublishBuildArtifacts@1` for the existing compliance-log artifact.

## Expected result

Pipeline runs should include the 1ES Network Isolation tasks, restore dependencies through authenticated Azure Artifacts feeds, and prevent package tools from reaching public registries. Post-merge pipeline telemetry will be used to confirm clean policy enforcement and compliance lock-in.

## Validation

- Parsed the updated YAML successfully and verified the expected 1ES stage/job structure.
- Checked the diff for whitespace errors.
- Reviewed local template resolution and 1ES artifact-publishing compatibility.

An Azure DevOps run is required after merge to validate template expansion and Network Isolation telemetry in the hosted environment.