### PR TITLE
Restore Pylance document synchronization on Dev18

### DIFF
--- a/Python/Product/PythonTools/PythonTools.csproj
+++ b/Python/Product/PythonTools/PythonTools.csproj
@@ -339,6 +339,7 @@
     <Compile Include="PythonTools\LanguageServerClient\ReplDocument.cs" />
     <Compile Include="PythonTools\LanguageServerClient\ResultConverter.cs" />
     <Compile Include="PythonTools\LanguageServerClient\StreamHacking\MessageParser.cs" />
+    <Compile Include="PythonTools\LanguageServerClient\StreamHacking\PylanceInitializeResponseStream.cs" />
     <Compile Include="PythonTools\LanguageServerClient\StreamHacking\StreamData.cs" />
     <Compile Include="PythonTools\LanguageServerClient\StreamHacking\StreamIntercepter.cs" />
     <Compile Include="PythonTools\LanguageServerClient\WorkspaceConfiguration\ConfigurationArgs.cs" />

--- a/Python/Product/PythonTools/PythonTools/LanguageServerClient/LanguageServer.cs
+++ b/Python/Product/PythonTools/PythonTools/LanguageServerClient/LanguageServer.cs
@@ -95,7 +95,7 @@ namespace Microsoft.PythonTools.LanguageServerClient {
                 }
 
                 if (!process.HasExited) {
-                    // Create a connection where we wrap the stdin stream so that we can intercept all messages
+                    // Intercept outgoing messages and, on Dev18, normalize the Pylance initialize response.
 #if DEV18
                     var serverOutput = new PylanceInitializeResponseStream(process.StandardOutput.BaseStream);
 #else

--- a/Python/Product/PythonTools/PythonTools/LanguageServerClient/LanguageServer.cs
+++ b/Python/Product/PythonTools/PythonTools/LanguageServerClient/LanguageServer.cs
@@ -96,8 +96,13 @@ namespace Microsoft.PythonTools.LanguageServerClient {
 
                 if (!process.HasExited) {
                     // Create a connection where we wrap the stdin stream so that we can intercept all messages
+#if DEV18
+                    var serverOutput = new PylanceInitializeResponseStream(process.StandardOutput.BaseStream);
+#else
+                    var serverOutput = process.StandardOutput.BaseStream;
+#endif
                     return new Connection(
-                        process.StandardOutput.BaseStream,
+                        serverOutput,
                         new StreamIntercepter(process.StandardInput.BaseStream, _serverSendHandler, (a) => { }));
                 }
             }

--- a/Python/Product/PythonTools/PythonTools/LanguageServerClient/StreamHacking/PylanceInitializeResponseStream.cs
+++ b/Python/Product/PythonTools/PythonTools/LanguageServerClient/StreamHacking/PylanceInitializeResponseStream.cs
@@ -1,0 +1,238 @@
+﻿// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION, ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for the specific language governing
+// permissions and limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.PythonTools.LanguageServerClient.StreamHacking {
+    /// <summary>
+    /// Normalizes Pylance's numeric text synchronization capability for affected Dev18 LSP clients.
+    /// All server output is passed through unchanged after the initialize response.
+    /// </summary>
+    internal sealed class PylanceInitializeResponseStream : Stream {
+        private const string ContentLengthHeader = "Content-Length:";
+        private const int MaxHeaderLength = 16 * 1024;
+
+        private readonly Stream _baseStream;
+        private readonly List<byte> _inputBuffer = new List<byte>();
+        private readonly SemaphoreSlim _readLock = new SemaphoreSlim(1, 1);
+        private byte[] _pendingOutput = Array.Empty<byte>();
+        private int _pendingOutputOffset;
+        private int _disposed;
+        private bool _initializeResponseProcessed;
+
+        public PylanceInitializeResponseStream(Stream baseStream) {
+            _baseStream = baseStream ?? throw new ArgumentNullException(nameof(baseStream));
+        }
+
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => throw new NotSupportedException();
+        public override long Position {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        public override int Read(byte[] buffer, int offset, int count) =>
+            ReadAsync(buffer, offset, count, CancellationToken.None).GetAwaiter().GetResult();
+
+        public override async Task<int> ReadAsync(
+            byte[] buffer,
+            int offset,
+            int count,
+            CancellationToken cancellationToken) {
+            ValidateReadArguments(buffer, offset, count);
+            if (count == 0) {
+                return 0;
+            }
+            ThrowIfDisposed();
+
+            await _readLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+            try {
+                ThrowIfDisposed();
+                if (_pendingOutputOffset >= _pendingOutput.Length) {
+                    if (_initializeResponseProcessed && _inputBuffer.Count == 0) {
+                        return await _baseStream.ReadAsync(buffer, offset, count, cancellationToken).ConfigureAwait(false);
+                    }
+
+                    _pendingOutput = await ReadNextFrameAsync(cancellationToken).ConfigureAwait(false);
+                    _pendingOutputOffset = 0;
+                    if (!_initializeResponseProcessed) {
+                        _pendingOutput = NormalizeInitializeResponse(_pendingOutput);
+                    }
+                }
+
+                if (_pendingOutput.Length == 0) {
+                    return 0;
+                }
+
+                var bytesToCopy = Math.Min(count, _pendingOutput.Length - _pendingOutputOffset);
+                Buffer.BlockCopy(_pendingOutput, _pendingOutputOffset, buffer, offset, bytesToCopy);
+                _pendingOutputOffset += bytesToCopy;
+                return bytesToCopy;
+            } finally {
+                _readLock.Release();
+            }
+        }
+
+        private async Task<byte[]> ReadNextFrameAsync(CancellationToken cancellationToken) {
+            while (true) {
+                if (TryTakeFrame(out var frame)) {
+                    return frame;
+                }
+                if (_inputBuffer.Count > MaxHeaderLength && FindHeaderEnd(_inputBuffer) < 0) {
+                    throw new InvalidDataException("Pylance returned an LSP header that exceeds the maximum supported length.");
+                }
+
+                var buffer = new byte[8192];
+                var count = await _baseStream.ReadAsync(buffer, 0, buffer.Length, cancellationToken).ConfigureAwait(false);
+                if (count == 0) {
+                    if (_inputBuffer.Count == 0) {
+                        return Array.Empty<byte>();
+                    }
+
+                    throw new EndOfStreamException("Pylance output ended in the middle of an LSP message.");
+                }
+
+                for (var i = 0; i < count; i++) {
+                    _inputBuffer.Add(buffer[i]);
+                }
+            }
+        }
+
+        private bool TryTakeFrame(out byte[] frame) {
+            frame = null;
+            var headerEnd = FindHeaderEnd(_inputBuffer);
+            if (headerEnd < 0) {
+                return false;
+            }
+            if (headerEnd > MaxHeaderLength) {
+                throw new InvalidDataException("Pylance returned an LSP header that exceeds the maximum supported length.");
+            }
+
+            var contentLength = ParseContentLength(_inputBuffer, headerEnd);
+            var frameLengthLong = (long)headerEnd + 4 + contentLength;
+            if (frameLengthLong > int.MaxValue) {
+                throw new InvalidDataException("Pylance returned an LSP message that is too large.");
+            }
+
+            var frameLength = (int)frameLengthLong;
+            if (_inputBuffer.Count < frameLength) {
+                return false;
+            }
+
+            frame = _inputBuffer.GetRange(0, frameLength).ToArray();
+            _inputBuffer.RemoveRange(0, frameLength);
+            return true;
+        }
+
+        private byte[] NormalizeInitializeResponse(byte[] frame) {
+            var headerEnd = FindHeaderEnd(frame);
+            var contentLength = ParseContentLength(frame, headerEnd);
+            var messageJson = Encoding.UTF8.GetString(frame, headerEnd + 4, contentLength);
+            var message = JObject.Parse(messageJson);
+            if (message["id"] == null || (message["result"] == null && message["error"] == null)) {
+                return frame;
+            }
+
+            _initializeResponseProcessed = true;
+            var textDocumentSync = message["result"]?["capabilities"]?["textDocumentSync"];
+            if (textDocumentSync?.Type != JTokenType.Integer) {
+                return frame;
+            }
+
+            var syncKind = textDocumentSync.Value<int>();
+            textDocumentSync.Replace(new JObject {
+                ["openClose"] = true,
+                ["change"] = syncKind,
+                ["save"] = new JObject {
+                    ["includeText"] = false
+                }
+            });
+            return MessageParser.Serialize(message).bytes;
+        }
+
+        private void ThrowIfDisposed() {
+            if (Volatile.Read(ref _disposed) != 0) {
+                throw new ObjectDisposedException(nameof(PylanceInitializeResponseStream));
+            }
+        }
+
+        private static int FindHeaderEnd(IList<byte> buffer) {
+            for (var i = 3; i < buffer.Count; i++) {
+                if (buffer[i - 3] == '\r' &&
+                    buffer[i - 2] == '\n' &&
+                    buffer[i - 1] == '\r' &&
+                    buffer[i] == '\n') {
+                    return i - 3;
+                }
+            }
+
+            return -1;
+        }
+
+        private static int ParseContentLength(IList<byte> frame, int headerEnd) {
+            if (headerEnd < 0) {
+                throw new InvalidDataException("Pylance returned an invalid LSP header.");
+            }
+
+            var headerBytes = new byte[headerEnd];
+            for (var i = 0; i < headerEnd; i++) {
+                headerBytes[i] = frame[i];
+            }
+
+            var header = Encoding.ASCII.GetString(headerBytes);
+            foreach (var line in header.Split(new[] { "\r\n" }, StringSplitOptions.RemoveEmptyEntries)) {
+                if (line.StartsWith(ContentLengthHeader, StringComparison.OrdinalIgnoreCase) &&
+                    int.TryParse(line.Substring(ContentLengthHeader.Length).Trim(), out var contentLength) &&
+                    contentLength >= 0) {
+                    return contentLength;
+                }
+            }
+
+            throw new InvalidDataException("Pylance returned an LSP message without a valid Content-Length header.");
+        }
+
+        private static void ValidateReadArguments(byte[] buffer, int offset, int count) {
+            if (buffer == null) {
+                throw new ArgumentNullException(nameof(buffer));
+            }
+            if (offset < 0 || count < 0 || buffer.Length - offset < count) {
+                throw new ArgumentOutOfRangeException();
+            }
+        }
+
+        public override void Flush() {
+        }
+
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+        protected override void Dispose(bool disposing) {
+            if (disposing && Interlocked.Exchange(ref _disposed, 1) == 0) {
+                _baseStream.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/Python/Product/PythonTools/PythonTools/LanguageServerClient/StreamHacking/PylanceInitializeResponseStream.cs
+++ b/Python/Product/PythonTools/PythonTools/LanguageServerClient/StreamHacking/PylanceInitializeResponseStream.cs
@@ -150,12 +150,13 @@ namespace Microsoft.PythonTools.LanguageServerClient.StreamHacking {
             var contentLength = ParseContentLength(frame, headerEnd);
             var messageJson = Encoding.UTF8.GetString(frame, headerEnd + 4, contentLength);
             var message = JObject.Parse(messageJson);
-            if (message["id"] == null || (message["result"] == null && message["error"] == null)) {
+            var capabilities = message["result"]?["capabilities"] as JObject;
+            if (message["id"] == null || capabilities == null) {
                 return frame;
             }
 
             _initializeResponseProcessed = true;
-            var textDocumentSync = message["result"]?["capabilities"]?["textDocumentSync"];
+            var textDocumentSync = capabilities["textDocumentSync"];
             if (textDocumentSync?.Type != JTokenType.Integer) {
                 return frame;
             }


### PR DESCRIPTION
## Summary

- Normalize Pylance's numeric `textDocumentSync` capability into the equivalent options object for affected Dev18 clients.
- Limit the workaround to Pylance and Dev18; other language servers, Visual Studio versions, and post-initialization traffic are unchanged.
- Restore completion, diagnostics, Quick Info, and definition navigation while preserving the System.Text.Json migration from #8587 and automatic completion parentheses.

## Root cause

Pylance returns the valid LSP shorthand `"textDocumentSync": 2`, meaning incremental synchronization. It has used this representation for years, so the recent Pylance update and PTVS #8587 were not the source of the regression.

The regression was introduced by the VSLanguageServerClient generated-capability migration in [commit d97ea9c64](https://devdiv.visualstudio.com/DevDiv/_git/VSLanguageServerClient/commit/d97ea9c64fdae1183d779c5029e311e8e8e4cd70) ([PR 760545](https://devdiv.visualstudio.com/DevDiv/_git/VSLanguageServerClient/pullrequest/760545)). The generated union retains the numeric value as `TextDocumentSyncKind.Incremental`. The `didChange` path accepts either the enum or `TextDocumentSyncOptions`, but the `didOpen`, `didClose`, and `didSave` paths only inspect `TextDocumentSyncOptions`.

Consequently, VSL does not register `didOpen` for Pylance. Because the document is never marked open, subsequent `didChange` notifications are discarded as well. Pylance then has no current editor contents:

- completion requests are answered from stale/incomplete document state, so `import sys` omits the `sys` module;
- diagnostics configured for open files never run, so unresolved imports produce neither squiggles nor Error List entries;
- hover responses are computed against stale document state and their ranges cannot be mapped reliably to the current editor snapshot, so Quick Info is absent or VSL throws an invalid-range exception;
- definition requests are evaluated without the current document, so local symbols may return no usable navigation target.

VSL has an equivalent normalization in [commit ac604b1b8](https://devdiv.visualstudio.com/DevDiv/_git/VSLanguageServerClient/commit/ac604b1b8cf82b698ca0c175cf9de814ee897247), but at the time of investigation that commit was only on `feature/dynamic-registration-redesign`, not `main` or `release/18.10`.

## PTVS workaround

VSL performs the initialize exchange directly, before PTVS language-client middle layers can intercept the response. This change therefore wraps only the Pylance stdout stream on Dev18 and, for the initialize response only, expands:

```json
"textDocumentSync": 2
```

into the semantically equivalent form:

```json
"textDocumentSync": {
  "openClose": true,
  "change": 2,
  "save": { "includeText": false }
}
```

The stream handles normal LSP framing, preserves any notifications preceding the initialize response, recalculates the UTF-8 `Content-Length`, and switches to direct pass-through immediately after initialization. It does not inspect or alter completions, diagnostics, hover or definition responses, document updates, or any later server traffic.

## Compatibility with the VSL fix

The two fixes can safely coexist. Once VSL's fix ships, it will receive the already-expanded, valid options object and use it directly; its numeric-to-object normalization is not applied a second time. This does not create duplicate registrations or change synchronization behavior. The PTVS workaround can be removed later after fixed VSL builds are the only supported Dev18 clients.

## Validation

Validated in the Dev18 Experimental Instance with Pylance `2026.2.109`:

- `import sys` offers `sys` in completion results;
- `import xxxx` produces an editor squiggle and an Error List diagnostic;
- Quick Info appears for Python symbols without an invalid-range exception;
- F12 and **Go To Definition** navigate to local Python definitions;
- automatic completion parentheses still work;
- LSP tracing contains `didOpen`, `didChange`, and `publishDiagnostics` traffic.

No tests were added or modified.

Fixes #8592
Fixes #8593
Fixes #8594
Fixes #8596
