### PR TITLE
Remove orphaned Python refactoring commands

### DIFF
--- a/Python/Product/PythonTools/PkgCmdID.cs
+++ b/Python/Product/PythonTools/PkgCmdID.cs
@@ -26,10 +26,6 @@ namespace Microsoft.PythonTools {
         public const uint cmdidSendToRepl = 0x103;
         public const uint cmdidFillParagraph = 0x105;
         public const uint cmdidDiagnostics = 0x106;
-        public const uint cmdidRemoveImports = 0x107;
-        public const uint cmdidRemoveImportsCurrentScope = 0x108;
-        public const uint cmdidRefactorRenameIntegratedShell = 0x109;
-        public const uint cmdidExtractMethodIntegratedShell = 0x10a;
         public const uint cmdidImportWizard = 0x10d;
         public const uint cmdidImportCoverage = 0x10f;
 

--- a/Python/Product/PythonTools/PythonTools.vsct
+++ b/Python/Product/PythonTools/PythonTools.vsct
@@ -69,20 +69,6 @@ permissions and limitations under the License.
       </Menu>
 
       <!-- Context Menus -->
-      <Menu guid="guidPythonToolsCmdSet" id="RefactoringCtxMenuIntShell" priority="0x0300" type="Context">
-        <Parent guid="guidSHLMainMenu" id="IDG_VS_CODEWIN_LANGUAGE" />
-        <Strings>
-          <ButtonText>&amp;Refactor</ButtonText>
-        </Strings>
-      </Menu>
-
-      <Menu guid="guidPythonToolsCmdSet" id="RemoveImportsMenu" priority="0x0100" type="Context">
-        <Parent guid="guidSHLMainMenu" id="IDG_VS_CODEWIN_LANGUAGE" />
-        <Strings>
-          <ButtonText>Rem&amp;ove Imports</ButtonText>
-        </Strings>
-      </Menu>
-
       <Menu guid="guidPythonToolsCmdSet" id="DebuggerPythonContextMenu" priority="0x0301" type="Context">
         <Parent guid="guidVSDebugGroup" id="IDG_DEBUG_DISPLAY"/>
         <Strings>
@@ -239,16 +225,6 @@ permissions and limitations under the License.
       </Group>
       <Group guid="guidPythonToolsCmdSet" id="WindowCommandsGroup" priority="0x0300">
         <Parent guid="guidPythonToolsCmdSet" id="PythonMenu"/>
-      </Group>
-
-      <!--
-          Refactoring groups
-      -->
-      <Group guid="guidPythonToolsCmdSet" id="RefactoringCommon" priority="0x0600">
-        <Parent guid="guidPythonToolsCmdSet" id="RefactoringCtxMenuIntShell"/>
-      </Group>
-      <Group guid="guidPythonToolsCmdSet" id="RemoveImportsGroup" priority="0x0000">
-        <Parent guid="guidPythonToolsCmdSet" id="RemoveImportsMenu"/>
       </Group>
 
       <!--
@@ -509,39 +485,6 @@ permissions and limitations under the License.
           <LocCanonicalName>Import Existing Project</LocCanonicalName>
         </Strings>
       </Button>
-
-
-
-      <Button guid="guidPythonToolsCmdSet" id="cmdidRemoveImportsCurrentScope" priority="0x200" type="Button">
-        <Parent guid="guidPythonToolsCmdSet" id="RemoveImportsGroup"/>
-        <Icon guid="ImageCatalogGuid" id="RemoveNamespace" />
-        <CommandFlag>DynamicVisibility</CommandFlag>
-        <CommandFlag>DefaultInvisible</CommandFlag>
-        <CommandFlag>IconIsMoniker</CommandFlag>
-        <CommandFlag>CommandWellOnly</CommandFlag>
-        <Strings>
-          <ButtonText>Current &amp;Scope</ButtonText>
-          <ToolTipText>Remove unused imports in the current scope.</ToolTipText>
-          <CanonicalName>Current Scope</CanonicalName>
-          <LocCanonicalName>Current Scope</LocCanonicalName>
-        </Strings>
-      </Button>
-
-      <Button guid="guidPythonToolsCmdSet" id="cmdidRemoveImports" priority="0x200" type="Button">
-        <Parent guid="guidPythonToolsCmdSet" id="RemoveImportsGroup"/>
-        <Icon guid="ImageCatalogGuid" id="RemoveNamespace" />
-        <CommandFlag>DynamicVisibility</CommandFlag>
-        <CommandFlag>DefaultInvisible</CommandFlag>
-        <CommandFlag>IconIsMoniker</CommandFlag>
-        <CommandFlag>CommandWellOnly</CommandFlag>
-        <Strings>
-          <ButtonText>&amp;All Scopes</ButtonText>
-          <ToolTipText>Remove unused imports in all scopes.</ToolTipText>
-          <CanonicalName>All Scopes</CanonicalName>
-          <LocCanonicalName>All Scopes</LocCanonicalName>
-        </Strings>
-      </Button>
-
       <Button guid="guidPythonToolsCmdSet" id="cmdidDebugReplWindow" priority="0x0950" type="Button">
         <Parent guid="guidPythonToolsCmdSet" id="WindowCommandsGroup"/>
         <Icon guid="ImageCatalogGuid" id="PYInteractiveWindow" />
@@ -735,35 +678,6 @@ permissions and limitations under the License.
         <Strings>
           <ButtonText>Custom Commands</ButtonText>
           <ToolTipText>Custom Commands</ToolTipText>
-        </Strings>
-      </Button>
-
-      <!--================================================================================================================-->
-      <!--========================================== Integrated Shell Commands ===========================================-->
-      <!--================================================================================================================-->
-      <Button guid="guidPythonToolsCmdSet" id="cmdidExtractMethod" priority="0x200" type="Button">
-        <Parent guid="guidPythonToolsCmdSet" id="RefactoringCommon"/>
-        <CommandFlag>DynamicVisibility</CommandFlag>
-        <CommandFlag>DefaultInvisible</CommandFlag>
-        <CommandFlag>CommandWellOnly</CommandFlag>
-        <Strings>
-          <ButtonText>Extract &amp;Method...</ButtonText>
-          <ToolTipText>Extract Method...</ToolTipText>
-          <CanonicalName>Refactor Extract Method</CanonicalName>
-          <LocCanonicalName>Refactor Extract Method</LocCanonicalName>
-        </Strings>
-      </Button>
-
-      <Button guid="guidPythonToolsCmdSet" id="cmdidRefactorRename" priority="0x100" type="Button">
-        <Parent guid="guidPythonToolsCmdSet" id="RefactoringCommon"/>
-        <CommandFlag>DynamicVisibility</CommandFlag>
-        <CommandFlag>DefaultInvisible</CommandFlag>
-        <CommandFlag>CommandWellOnly</CommandFlag>
-        <Strings>
-          <ButtonText>&amp;Rename...</ButtonText>
-          <ToolTipText>Rename...</ToolTipText>
-          <CanonicalName>Refactor Rename</CanonicalName>
-          <LocCanonicalName>Refactor Rename</LocCanonicalName>
         </Strings>
       </Button>
 
@@ -1171,7 +1085,6 @@ permissions and limitations under the License.
     <KeyBinding guid="guidPythonToolsCmdSet" id="cmdidReplWindow" key1="K" mod1="Control" key2="I" editor="guidVSStd97"/>
     <KeyBinding guid="guidPythonToolsCmdSet" id="cmdidInterpreterList" key1="K" mod1="Control" key2="VK_OEM_3" editor="guidVSStd97"/>
     <KeyBinding guid="guidPythonToolsCmdSet" id="cmdidInterpreterList" key1="K" mod1="Control" key2="VK_OEM_3" mod2="Control" editor="guidVSStd97"/>
-    <KeyBinding guid="guidPythonToolsCmdSet" id="cmdidRemoveImports" key1="K" mod1="Control" key2="J" mod2="Control" editor="guidVSStd97"/>
     <KeyBinding guid="guidPythonToolsCmdSet" id="comboIdCurrentEnvironment" key1="K" mod1="Control" key2="E" editor="guidVSStd97"/>
   </KeyBindings>
 
@@ -1194,10 +1107,6 @@ permissions and limitations under the License.
       <IDSymbol name="cmdidSendToRepl" value="0x0103"/>
       <IDSymbol name="cmdidFillParagraph" value="0x0105"/>
       <IDSymbol name="cmdidDiagnostics" value ="0x0106" />
-      <IDSymbol name="cmdidRemoveImports" value ="0x0107" />
-      <IDSymbol name="cmdidRemoveImportsCurrentScope" value ="0x0108" />
-      <IDSymbol name="cmdidRefactorRename" value ="0x0109" />
-      <IDSymbol name="cmdidExtractMethod" value ="0x010a" />
       <IDSymbol name="cmdidImportWizard" value ="0x010d" />
       <IDSymbol name="cmdidImportCoverage" value ="0x010f" />
 
@@ -1254,8 +1163,6 @@ permissions and limitations under the License.
       <IDSymbol name="PythonDebugMenuGroup" value="0x1013" />
       <IDSymbol name="WindowCommandsGroup" value="0x1014" />
       <IDSymbol name="CodeFileGroup" value="0x1053" />
-      <IDSymbol name="RemoveImportsGroup" value ="0x1054" />
-      <IDSymbol name="RefactoringCommon" value="0x1055" />
       <IDSymbol name="DocWinTabGroup" value="0x1056" />
       <IDSymbol name="DebuggerPythonContextGroup" value="0x1058" />
       <IDSymbol name="CodeFileGroup2" value="0x1059" />
@@ -1279,8 +1186,6 @@ permissions and limitations under the License.
       <!-- Menus -->
       <IDSymbol name="PythonMenu" value="0x2000"/>
       <IDSymbol name="ToolsMenu" value="0x2001" />
-      <IDSymbol name="RemoveImportsMenu" value ="0x2002" />
-      <IDSymbol name="RefactoringCtxMenuIntShell" value="0x2003"/>
       <IDSymbol name="DebuggerPythonContextMenu" value="0x2004" />
       <IDSymbol name="CustomProjectCommandsMenu" value="0x2005" />
       <IDSymbol name="EnvironmentsContainerMenu" value="0x2006" />


### PR DESCRIPTION
## Summary

- Remove the legacy Python **Refactor** submenu containing **Rename...** and **Extract Method...**.
- Remove the legacy **Remove Imports** submenu, its two commands, and its old keyboard binding.
- Preserve Visual Studio's supported LSP **Quick Actions and Refactorings** surface, where Pylance-provided Rename and Extract Method continue to work.

## Root cause

The implementations behind these Python-specific command IDs were removed in [commit 9a7204ec](https://github.com/microsoft/PTVS/commit/9a7204ec681b) as PTVS moved away from its legacy analyzer/refactoring path. Their VS command-table declarations were left behind, however:

- the `Refactor` context menu still advertised `Rename...` and `Extract Method...`;
- the `Remove Imports` context menu still advertised `Current Scope` and `All Scopes`;
- `Ctrl+K, Ctrl+J` still targeted the deleted Remove Imports command.

These entries looked actionable, but no package command handler existed for their command IDs, so selecting them did nothing. This is independent of the Dev18 document-synchronization regression addressed by #8601.

## Fix

Remove the orphaned menus, groups, buttons, command IDs, and key binding from `PythonTools.vsct`, and remove the corresponding unused constants from `PkgCmdID.cs`.

This does not remove or intercept language-server code actions. Pylance-backed Rename and Extract Method remain available through Visual Studio's standard **Quick Actions and Refactorings** UI.

## Remove Unused Imports follow-up

The modern Pylance **Remove Unused Imports** Quick Action has a separate visibility/presentation problem tracked by #7978. Manual tracing showed that Pylance can return `Remove unused import` and `Remove all unused imports` actions, but Visual Studio does not consistently present them. Reintroducing dead PTVS command IDs would not fix that LSP integration issue, so it is intentionally kept out of this cleanup.

## Validation

Validated in the Dev18 Experimental Instance with Pylance `2026.2.109`:

- the obsolete Python `Refactor` and `Remove Imports` context submenus are absent;
- Pylance-backed Rename works through Quick Actions;
- Pylance-backed Extract Method works through Quick Actions;
- the Dev18 Core VSIX build succeeds.

No tests were added or modified.

Fixes #8595
