### PR TITLE
Apply VS environment font to Python launcher options pages (a11y resize)

### DIFF
--- a/Python/Product/PythonTools/PythonTools/Project/DefaultPythonLauncherOptions.cs
+++ b/Python/Product/PythonTools/PythonTools/Project/DefaultPythonLauncherOptions.cs
@@ -33,6 +33,16 @@ namespace Microsoft.PythonTools.Project {
             _mixedMode.Visible = true;
         }
 
+        protected override void OnHandleCreated(EventArgs e) {
+            base.OnHandleCreated(e);
+
+            // Apply the Visual Studio environment font so this launcher's text resizes with
+            // the OS "Text size" accessibility setting (MAS 1.4.4 Resize Text). This control is
+            // hosted inside the Debug property page but is a separate UserControl (not a
+            // ThemeAwareUserControl), so it must opt in to the environment font explicitly.
+            VsShellFontHelper.ApplyEnvironmentFont(this);
+        }
+
         #region ILauncherOptionsControl Members
 
         public void SaveSettings() {

--- a/Python/Product/PythonTools/PythonTools/WebProject/PythonWebLauncherOptions.cs
+++ b/Python/Product/PythonTools/PythonTools/WebProject/PythonWebLauncherOptions.cs
@@ -72,6 +72,18 @@ namespace Microsoft.PythonTools.Project.Web {
             _properties = properties;
         }
 
+        protected override void OnHandleCreated(EventArgs e) {
+            base.OnHandleCreated(e);
+
+            // Apply the Visual Studio environment font so this launcher's text resizes with
+            // the OS "Text size" accessibility setting (MAS 1.4.4 Resize Text). This control is
+            // hosted inside the Debug property page but is a separate UserControl (not a
+            // ThemeAwareUserControl), so it must opt in to the environment font explicitly.
+            // Used by the Web and Django (Flask) launchers, whose taller layout previously
+            // clipped and rendered at the fixed design-time font size.
+            VsShellFontHelper.ApplyEnvironmentFont(this);
+        }
+
         #region ILauncherOptions Members
 
         public void SaveSettings() {


### PR DESCRIPTION
## Summary

The Debug property page hosts a launcher-options `UserControl` swapped in at runtime (`DefaultPythonLauncherOptions` for standard projects, `PythonWebLauncherOptions` for Web/Django/Flask). Fix #8567 applied the VS environment font only to the property-page frames via `ThemeAwareUserControl`, so these launcher controls still rendered at the fixed design-time font and did not resize with the OS **Text size** setting (MAS 1.4.4 Resize Text). This was visible on Flask projects (taller `PythonWebLauncherOptions`) but not standard projects.

## Change

Override `OnHandleCreated` in both launcher controls to call `VsShellFontHelper.ApplyEnvironmentFont(this)`. Their existing `AutoSize` layout plus the Debug page's `AutoScroll` then reflow and scroll the enlarged content.

- `Python/Product/PythonTools/PythonTools/Project/DefaultPythonLauncherOptions.cs`
- `Python/Product/PythonTools/PythonTools/WebProject/PythonWebLauncherOptions.cs`

## Testing

- Built `PythonTools.csproj` (VS 18) successfully.
- Manually verified the Flask launcher options page reflows/scrolls when increasing the OS Text size.

Addresses work item 3026378.
