### PR TITLE
Fix DebuggerTests engine reference

### DIFF
--- a/Python/Tests/DebuggerTests/DebuggerTests.csproj
+++ b/Python/Tests/DebuggerTests/DebuggerTests.csproj
@@ -61,6 +61,9 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.VisualStudio.Debugger.Engine">
+      <HintPath>$(PackagesPath)\Microsoft.VisualStudio.Debugger.Engine\ref\net45\Microsoft.VisualStudio.Debugger.Engine.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="System" />
     <Reference Include="System.Core">


### PR DESCRIPTION
## Summary
- add a direct `Microsoft.VisualStudio.Debugger.Engine` reference to `DebuggerTests`
- resolve CS0012 for `DkmNativeModuleInstance` exposed by the `PythonDLLs.GetPythonLanguageVersion` API

## Validation
- `git diff --check`
- targeted VS 18 build progressed without the reported CS0012, but the local dependency build is blocked earlier by an unrelated missing `System.Text.Json` reference in `PythonTools`